### PR TITLE
Remove non-prepared link in document

### DIFF
--- a/README.md
+++ b/README.md
@@ -40,9 +40,9 @@ We've come a long way, but this project is still in Alpha, lots of development i
   - [Install](#install)
   - [Usage](#usage)
   - [API](#api)
-- [Development](#development)
-  - [Tests](#tests)
   - [Packages](#packages)
+- Development (WIP)
+  - Tests
 - [Contribute](#contribute)
 - [License](#license)
 


### PR DESCRIPTION
It seems development part is not exist in this document, so removed link and commented as WIP. I'm not sure this is working in progress so please let me know if I'm wrong.
Also, `package` part seems it is under `usage` menu in current document.

Please look on. Thanks.