### PR TITLE
docs(examples): fix peer-content routing example scripts

### DIFF
--- a/examples/peer-and-content-routing/1.js
+++ b/examples/peer-and-content-routing/1.js
@@ -53,7 +53,7 @@ parallel([
     (cb) => node1.dial(node2.peerInfo, cb),
     (cb) => node2.dial(node3.peerInfo, cb),
     // Set up of the cons might take time
-    (cb) => setTimeout(cb, 100)
+    (cb) => setTimeout(cb, 300)
   ], (err) => {
     if (err) { throw err }
 

--- a/examples/peer-and-content-routing/2.js
+++ b/examples/peer-and-content-routing/2.js
@@ -54,7 +54,7 @@ parallel([
     (cb) => node1.dial(node2.peerInfo, cb),
     (cb) => node2.dial(node3.peerInfo, cb),
     // Set up of the cons might take time
-    (cb) => setTimeout(cb, 100)
+    (cb) => setTimeout(cb, 300)
   ], (err) => {
     if (err) { throw err }
 


### PR DESCRIPTION
Related to #126.

Increase the added delay to let the peer establish connections from `100 ms` to `300 ms`.