### PR TITLE
fix: prevent "The libp2p node is not started yet" when stopping

### DIFF
--- a/src/index.js
+++ b/src/index.js
@@ -224,8 +224,6 @@ class Node extends EventEmitter {
    * Stop the libp2p node by closing its listeners and open connections
    */
   stop (callback) {
-    this._isStarted = false
-
     if (this.modules.discovery) {
       this.modules.discovery.forEach((discovery) => {
         setImmediate(() => discovery.stop(() => {}))
@@ -244,7 +242,10 @@ class Node extends EventEmitter {
         this.emit('stop')
         cb()
       }
-    ], callback)
+    ], (err) => {
+      this._isStarted = false
+      callback(err)
+    })
   }
 
   isStarted () {


### PR DESCRIPTION
When issuing a `node.stop()`, some asynchronous actions may still be happening, which sometimes originates random "The libp2p node is not started yet" errors.

This prevents that by assuming the node is only stopped after the stopping process is complete.