### PR TITLE
Update to new URL format

### DIFF
--- a/examples/libp2p-in-the-browser/1/src/create-node.js
+++ b/examples/libp2p-in-the-browser/1/src/create-node.js
@@ -10,7 +10,7 @@ function createNode (callback) {
     }
 
     const peerIdStr = peerInfo.id.toB58String()
-    const ma = `/dns4/star-signal.cloud.ipfs.team/wss/p2p-webrtc-star/ipfs/${peerIdStr}`
+    const ma = `/dns4/star-signal.cloud.ipfs.team/tcp/443/wss/p2p-webrtc-star/ipfs/${peerIdStr}`
 
     peerInfo.multiaddrs.add(ma)
 


### PR DESCRIPTION
Fixes this error when trying to run `libp2p-in-the-browser`

```
bundle.js:26971 Uncaught Error: invalid multiaddr: /dns4/star-signal.cloud.ipfs.team/wss/p2p-webrtc-star/ipfs/QmRyD2DLGSMryhoXTc7HBGbesSi9fSCmEnWUq4y6W3PjCL
    at cleanUrlSIO (bundle.js:26971)
```