### PR TITLE
chore: update libp2p-switch

### DIFF
--- a/package.json
+++ b/package.json
@@ -40,7 +40,7 @@
     "async": "^2.6.0",
     "libp2p-floodsub": "^0.15.0",
     "libp2p-ping": "~0.8.0",
-    "libp2p-switch": "~0.39.2",
+    "libp2p-switch": "~0.40.4",
     "mafmt": "^6.0.0",
     "multiaddr": "^5.0.0",
     "peer-book": "~0.8.0",


### PR DESCRIPTION
This PR just updates libp2p-switch when we are able to get switch all the way to IPFS we will support `create-react-app` out-of-box.

Related PR and Issues: 

- https://github.com/libp2p/js-libp2p-switch/pull/259
- https://github.com/ipfs/js-ipfs/issues/1321#issuecomment-393085880