### PR TITLE
fix: dev install with Node.js 10

### DIFF
--- a/package.json
+++ b/package.json
@@ -70,7 +70,7 @@
     "pull-stream": "^3.6.8",
     "sinon": "^5.0.7",
     "libp2p-webrtc-star": "~0.15.0",
-    "wrtc": "0.1.1"
+    "wrtc": "~0.1.1"
   },
   "contributors": [
     "Chris Bratlien <chrisbratlien@gmail.com>",


### PR DESCRIPTION
This adds `~` to the `wrtc` devDependency so that we get version 0.1.5 when installing (which has prebuilt binaries for Node.js 10).

fixes #204

I'm currently getting the following test failures, which I'm also getting when running the tests against master with Node.js 9 and wrtc 0.1.1.

```
  1) transports
       TCP + WebSockets + WebRTCStar
         nodeAll.dial nodeWStar using PeerInfo:
     Uncaught AssertionError: expected [Error: Circuit not enabled and all transports failed to dial peer QmZMmzaApGcrdB1iM7okN6ywHkevsxo2NotXPCrX44vHkp!] to not exist
      at nodeAll.dial (test/transports.node.js:497:28)
      at Dialer.switch.dial [as callback] (src/index.js:239:27)
      at waterfall (node_modules/libp2p-switch/src/dial.js:110:12)
      at node_modules/async/internal/once.js:12:16
      at next (node_modules/async/waterfall.js:21:29)
      at node_modules/async/internal/onlyOnce.js:12:16
      at waterfall (node_modules/libp2p-switch/src/dial.js:151:7)
      at node_modules/async/internal/once.js:12:16
      at next (node_modules/async/waterfall.js:21:29)
      at node_modules/async/internal/onlyOnce.js:12:16
      at waterfall (node_modules/libp2p-switch/src/dial.js:189:16)
      at node_modules/async/internal/once.js:12:16
      at next (node_modules/async/waterfall.js:21:29)
      at node_modules/async/internal/onlyOnce.js:12:16
      at nextTransport (node_modules/libp2p-switch/src/dial.js:322:18)
      at switch.transport.dial (node_modules/libp2p-switch/src/dial.js:339:18)
      at dialer.dialMany (node_modules/libp2p-switch/src/transport.js:69:16)
      at f (node_modules/once/once.js:25:25)
      at map (node_modules/libp2p-switch/src/limit-dialer/index.js:61:14)
      at node_modules/async/internal/map.js:32:9
      at node_modules/async/internal/once.js:12:16
      at iteratorCallback (node_modules/async/eachOf.js:60:13)
      at node_modules/async/internal/onlyOnce.js:12:16
      at Object.callback (node_modules/async/internal/map.js:29:13)
      at node_modules/async/internal/queue.js:101:31
      at node_modules/async/internal/onlyOnce.js:12:16
      at _dialWithTimeout (node_modules/libp2p-switch/src/limit-dialer/queue.js:44:16)
      at Timeout.timeoutCallback [as _onTimeout] (node_modules/async/timeout.js:74:13)

  2) transports
       TCP + WebSockets + WebRTCStar
         nodeAll.hangUp nodeWStar using PeerInfo:

      Uncaught AssertionError: expected [ Array(2) ] to have a length of 3 but got 2
      + expected - actual

      -2
      +3
      
      at forEach (test/transports.node.js:455:61)
      at Array.forEach (<anonymous>)
      at check (test/transports.node.js:454:28)
      at Timeout.setTimeout [as _onTimeout] (test/transports.node.js:506:26)
```