### PR TITLE
refactor: use different defaultsDeep and clean up some code

### DIFF
--- a/README.md
+++ b/README.md
@@ -113,7 +113,7 @@ const MPLEX = require('libp2p-mplex')
 const SECIO = require('libp2p-secio')
 const MulticastDNS = require('libp2p-mdns')
 const DHT = require('libp2p-kad-dht')
-const defaultsDeep = require('lodash.defaultsdeep')
+const defaultsDeep = require('@nodeutils/defaults-deep')
 
 class Node extends libp2p {
   constructor (_peerInfo, _peerBook, _options) {
@@ -172,10 +172,8 @@ class Node extends libp2p {
       },
     }
 
-    // overload any defaults of your bundle using https://lodash.com/docs/4.17.5#defaultsDeep
-    defaultsDeep(_options, defaults)
-
-    super(options)
+    // overload any defaults of your bundle using https://github.com/nodeutils/defaults-deep
+    super(defaultsDeep(_options, defaults))
   }
 }
 

--- a/examples/transports/1.js
+++ b/examples/transports/1.js
@@ -4,7 +4,7 @@ const libp2p = require('libp2p')
 const TCP = require('libp2p-tcp')
 const PeerInfo = require('peer-info')
 const waterfall = require('async/waterfall')
-const defaultsDeep = require('lodash.defaultsdeep')
+const defaultsDeep = require('@nodeutils/defaults-deep')
 
 class MyBundle extends libp2p {
   constructor (_options) {
@@ -16,8 +16,7 @@ class MyBundle extends libp2p {
       }
     }
 
-    defaultsDeep(_options, defaults)
-    super(_options)
+    super(defaultsDeep(_options, defaults))
   }
 }
 

--- a/examples/transports/2.js
+++ b/examples/transports/2.js
@@ -4,7 +4,7 @@ const libp2p = require('libp2p')
 const TCP = require('libp2p-tcp')
 const PeerInfo = require('peer-info')
 const waterfall = require('async/waterfall')
-const defaultsDeep = require('lodash.defaultsdeep')
+const defaultsDeep = require('@nodeutils/defaults-deep')
 const parallel = require('async/parallel')
 const pull = require('pull-stream')
 
@@ -18,8 +18,7 @@ class MyBundle extends libp2p {
       }
     }
 
-    defaultsDeep(_options, defaults)
-    super(_options)
+    super(defaultsDeep(_options, defaults))
   }
 }
 

--- a/examples/transports/3.js
+++ b/examples/transports/3.js
@@ -5,7 +5,7 @@ const TCP = require('libp2p-tcp')
 const WebSockets = require('libp2p-websockets')
 const PeerInfo = require('peer-info')
 const waterfall = require('async/waterfall')
-const defaultsDeep = require('lodash.defaultsdeep')
+const defaultsDeep = require('@nodeutils/defaults-deep')
 const parallel = require('async/parallel')
 const pull = require('pull-stream')
 
@@ -20,8 +20,7 @@ class MyBundle extends libp2p {
       }
     }
 
-    defaultsDeep(_options, defaults)
-    super(_options)
+    super(defaultsDeep(_options, defaults))
   }
 }
 

--- a/examples/transports/README.md
+++ b/examples/transports/README.md
@@ -10,10 +10,10 @@ A more complete definition of what is a transport can be found on the [interface
 
 When using libp2p, you always want to create your own libp2p Bundle, that is, pick your set of modules and create your network stack with the properties you need. In this example, we will create a bundle with TCP. You can find the complete solution on the file [1.js](./1.js).
 
-You will need 4 deps total, so go ahead and install all of them with: 
+You will need 5 deps total, so go ahead and install all of them with:
 
 ```bash
-> npm install libp2p libp2p-tcp peer-info async
+> npm install libp2p libp2p-tcp peer-info async @nodeutils/defaults-deep
 ```
 
 Then, on your favorite text editor create a file with the `.js` extension. I've called mine `1.js`.
@@ -27,7 +27,7 @@ const libp2p = require('libp2p')
 const TCP = require('libp2p-tcp')
 const PeerInfo = require('peer-info')
 const waterfall = require('async/waterfall')
-const defaultsDeep = require('lodash.defaultsdeep')
+const defaultsDeep = require('@nodeutils/defaults-deep')
 
 // This MyBundle class is your libp2p bundle packed with TCP
 class MyBundle extends libp2p {
@@ -42,8 +42,7 @@ class MyBundle extends libp2p {
       }
     }
 
-    defaultsDeep(_options, defaults)
-    super(_options)
+    super(defaultsDeep(_options, defaults))
   }
 }
 ```
@@ -140,7 +139,7 @@ Now we are going to use `async/parallel` to create two nodes, print their addres
 const parallel = require('async/parallel')
 ```
 
-Then, 
+Then,
 
 ```js
 parallel([
@@ -213,8 +212,7 @@ class MyBundle extends libp2p {
       }
     }
 
-    defaultsDeep(_options, defaults)
-    super(_options)
+    super(defaultsDeep(_options, defaults))
   }
 }
 ```

--- a/package.json
+++ b/package.json
@@ -49,6 +49,7 @@
     "peer-info": "~0.14.1"
   },
   "devDependencies": {
+    "@nodeutils/defaults-deep": "^1.1.0",
     "aegir": "^14.0.0",
     "chai": "^4.1.2",
     "cids": "~0.5.3",
@@ -65,7 +66,6 @@
     "libp2p-webrtc-star": "~0.15.3",
     "libp2p-websocket-star": "~0.8.1",
     "libp2p-websocket-star-rendezvous": "~0.2.3",
-    "lodash.defaultsdeep": "^4.6.0",
     "lodash.times": "^4.3.2",
     "pull-goodbye": "0.0.2",
     "pull-serializer": "~0.3.2",

--- a/src/index.js
+++ b/src/index.js
@@ -157,7 +157,7 @@ class Node extends EventEmitter {
 
         // all transports need to be setup before discover starts
         if (this._modules.peerDiscovery && this._config.peerDiscovery) {
-          each(this._modules.peerDiscovery, (D, cb) => {
+          each(this._modules.peerDiscovery, (D, _cb) => {
             // If enabled then start it
             if (this._config.peerDiscovery[D.tag].enabled) {
               let d
@@ -171,9 +171,9 @@ class Node extends EventEmitter {
 
               d.on('peer', (peerInfo) => this.emit('peer:discovery', peerInfo))
               this._discovery.push(d)
-              d.start(cb)
+              d.start(_cb)
             } else {
-              cb()
+              _cb()
             }
           }, cb)
         } else {
@@ -204,13 +204,11 @@ class Node extends EventEmitter {
         // detect which multiaddrs we don't have a transport for and remove them
         const multiaddrs = this.peerInfo.multiaddrs.toArray()
 
-        this._transport.forEach((transport) => {
-          multiaddrs.forEach((multiaddr) => {
-            if (!multiaddr.toString().match(/\/p2p-circuit($|\/)/) &&
-                !this._transport.find((transport) => transport.filter(multiaddr).length > 0)) {
-              this.peerInfo.multiaddrs.delete(multiaddr)
-            }
-          })
+        multiaddrs.forEach((multiaddr) => {
+          if (!multiaddr.toString().match(/\/p2p-circuit($|\/)/) &&
+              !this._transport.find((transport) => transport.filter(multiaddr).length > 0)) {
+            this.peerInfo.multiaddrs.delete(multiaddr)
+          }
         })
         cb()
       },

--- a/test/utils/bundle-browser.js
+++ b/test/utils/bundle-browser.js
@@ -8,7 +8,7 @@ const SPDY = require('libp2p-spdy')
 const MPLEX = require('libp2p-mplex')
 const KadDHT = require('libp2p-kad-dht')
 const SECIO = require('libp2p-secio')
-const defaultsDeep = require('lodash.defaultsdeep')
+const defaultsDeep = require('@nodeutils/defaults-deep')
 const libp2p = require('../..')
 
 function mapMuxers (list) {
@@ -43,18 +43,16 @@ class Node extends libp2p {
       modules: {
         transport: [
           wrtcStar,
-          wsStar
+          wsStar,
+          new WS()
         ],
         streamMuxer: getMuxers(_options.muxer),
         connEncryption: [
           SECIO
         ],
         peerDiscovery: [
-          // NOTE: defaultsDeep clones these references making the listeners be
-          // attached to a clone and not the original. See the below how
-          // to attach instances.
-          // wrtcStar.discovery,
-          // wsStar.discovery,
+          wrtcStar.discovery,
+          wsStar.discovery,
           Bootstrap
         ],
         peerRouting: [],
@@ -89,14 +87,7 @@ class Node extends libp2p {
       }
     }
 
-    defaultsDeep(_options, defaults)
-
-    // NOTE: defaultsDeep clones instances and screws things up
-    _options.modules.transport.push(new WS()) // Test with transport instance
-    _options.modules.peerDiscovery.push(wrtcStar.discovery)
-    _options.modules.peerDiscovery.push(wsStar.discovery)
-
-    super(_options)
+    super(defaultsDeep(_options, defaults))
   }
 }
 

--- a/test/utils/bundle-nodejs.js
+++ b/test/utils/bundle-nodejs.js
@@ -8,7 +8,7 @@ const SPDY = require('libp2p-spdy')
 const KadDHT = require('libp2p-kad-dht')
 const MPLEX = require('libp2p-mplex')
 const SECIO = require('libp2p-secio')
-const defaultsDeep = require('lodash.defaultsdeep')
+const defaultsDeep = require('@nodeutils/defaults-deep')
 const libp2p = require('../..')
 
 function mapMuxers (list) {
@@ -85,12 +85,7 @@ class Node extends libp2p {
       }
     }
 
-    defaultsDeep(_options, defaults)
-
-    // NOTE: defaultsDeep clones instances and screws things up
-    // _options.modules.transport.push(new TCP()) // Test with transport instance
-
-    super(_options)
+    super(defaultsDeep(_options, defaults))
   }
 }
 


### PR DESCRIPTION

## defaultsDeep
This includes updates to the already changed examples.

This leverages `@nodeutils/defaults-deep` instead of `lodash.defaultsdeep`. This ensures that cloning of objects does not happen. This will also make sure that an array passed within options, will not be stomped on by defaults. Passed arrays win over defaults.

Example:
```js
const options = {
  modules: {
    peerDiscovery: [Bootstrap, wsStar.discovery]
  }
}

const defaults = {
  modules: {
    peerDiscovery: [MulticastDNS]
  }
}

return defaultsDeep(options, defaults)
```
will result in a returned object deeply equivalent to the options.

## code updates
* Clarifies some nested callback naming
* Removes redundant looping over transports

