### PR TITLE
Add ability to pass a connection protector for private networking

### DIFF
--- a/README.md
+++ b/README.md
@@ -115,6 +115,7 @@ const SECIO = require('libp2p-secio')
 const MulticastDNS = require('libp2p-mdns')
 const DHT = require('libp2p-kad-dht')
 const defaultsDeep = require('@nodeutils/defaults-deep')
+const Protector = require('libp2p-pnet')
 
 class Node extends libp2p {
   constructor (_peerInfo, _peerBook, _options) {
@@ -135,6 +136,7 @@ class Node extends libp2p {
         connEncryption: [
           SECIO
         ],
+        connProtector: new Protector(/*protector specific opts*/),
         peerDiscovery: [
           MulticastDNS
         ],
@@ -428,6 +430,16 @@ Each one of these values is [an exponential moving-average instance](https://git
 
 Stats are not updated in real-time. Instead, measurements are buffered and stats are updated at an interval. The maximum interval can be defined through the `Switch` constructor option `stats.computeThrottleTimeout`, defined in miliseconds.
 
+### Private Networks
+
+#### Enforcement
+
+Libp2p provides support for connection protection, such as for private networks. You can enforce network protection by setting the environment variable `LIBP2P_FORCE_PNET=1`. When this variable is on, if no protector is set via `options.connProtector`, Libp2p will throw an error upon creation.
+
+#### Protectors
+
+Some available network protectors:
+* [libp2p-pnet](https://github.com/libp2p/js-libp2p-pnet)
 
 ## Development
 

--- a/src/config.js
+++ b/src/config.js
@@ -13,6 +13,9 @@ const OptionsSchema = Joi.object({
     transport: Joi.array().items(ModuleSchema).min(1).required(),
     streamMuxer: Joi.array().items(ModuleSchema).allow(null),
     connEncryption: Joi.array().items(ModuleSchema).allow(null),
+    connProtector: Joi.object().keys({
+      protect: Joi.func().required()
+    }).unknown(),
     peerDiscovery: Joi.array().items(ModuleSchema).allow(null),
     dht: ModuleSchema.allow(null)
   }).required(),

--- a/src/index.js
+++ b/src/index.js
@@ -75,6 +75,13 @@ class Node extends EventEmitter {
       })
     }
 
+    // Attach private network protector
+    if (this._modules.connProtector) {
+      this._switch.protector = this._modules.connProtector
+    } else if (process.env.LIBP2P_FORCE_PNET) {
+      throw new Error('Private network is enforced, but no protector was provided')
+    }
+
     // dht provided components (peerRouting, contentRouting, dht)
     if (this._config.EXPERIMENTAL.dht) {
       const DHT = this._modules.dht

--- a/test/node.js
+++ b/test/node.js
@@ -1,5 +1,6 @@
 'use strict'
 
+require('./pnet.node')
 require('./transports.node')
 require('./stream-muxing.node')
 require('./peer-discovery.node')

--- a/test/pnet.node.js
+++ b/test/pnet.node.js
@@ -1,0 +1,90 @@
+/* eslint-env mocha */
+'use strict'
+
+const chai = require('chai')
+chai.use(require('dirty-chai'))
+const expect = chai.expect
+const PeerInfo = require('peer-info')
+const PeerId = require('peer-id')
+const waterfall = require('async/waterfall')
+const WS = require('libp2p-websockets')
+const defaultsDeep = require('@nodeutils/defaults-deep')
+
+const Libp2p = require('../src')
+
+describe('private network', () => {
+  let config
+
+  before((done) => {
+    waterfall([
+      (cb) => PeerId.create({ bits: 512 }, cb),
+      (peerId, cb) => PeerInfo.create(peerId, cb),
+      (peerInfo, cb) => {
+        config = {
+          peerInfo,
+          modules: {
+            transport: [ WS ]
+          }
+        }
+        cb()
+      }
+    ], () => done())
+  })
+
+  describe('enforced network protection', () => {
+    before(() => {
+      process.env.LIBP2P_FORCE_PNET = 1
+    })
+
+    after(() => {
+      delete process.env.LIBP2P_FORCE_PNET
+    })
+
+    it('should throw an error without a provided protector', () => {
+      expect(() => {
+        return new Libp2p(config)
+      }).to.throw('Private network is enforced, but no protector was provided')
+    })
+
+    it('should create a libp2p node with a provided protector', () => {
+      let node
+      let protector = {
+        psk: '123',
+        tag: '/psk/1.0.0',
+        protect: () => { }
+      }
+
+      expect(() => {
+        let options = defaultsDeep(config, {
+          modules: {
+            connProtector: protector
+          }
+        })
+
+        node = new Libp2p(options)
+        return node
+      }).to.not.throw()
+      expect(node._switch.protector).to.deep.equal(protector)
+    })
+
+    it('should throw an error if the protector does not have a protect method', () => {
+      expect(() => {
+        let options = defaultsDeep(config, {
+          modules: {
+            connProtector: { }
+          }
+        })
+
+        return new Libp2p(options)
+      }).to.throw()
+    })
+  })
+
+  describe('network protection not enforced', () => {
+    it('should not throw an error with no provided protector', () => {
+      expect(() => {
+        return new Libp2p(config)
+      }).to.not.throw()
+    })
+  })
+})


### PR DESCRIPTION
This adds the ability to specify a connection protector (private networking) via the new libp2p configuration.  Once https://github.com/libp2p/js-libp2p-pnet/pull/1 is released, we will be able to add that as a protector, such as through js-ipfs.

This will require an update to the libp2p-switch version once [js-libp2p-switch#266](https://github.com/libp2p/js-libp2p-switch/pull/266) is released.