### PR TITLE
chore: update latest webrtc

### DIFF
--- a/ci/Jenkinsfile
+++ b/ci/Jenkinsfile
@@ -1,2 +1,2 @@
 // Warning: This file is automatically synced from https://github.com/ipfs/ci-sync so if you want to change it, please change it there and ask someone to sync all repositories.
-javascript(['nodejs_versions': ['8.11.3']])
+javascript()

--- a/package.json
+++ b/package.json
@@ -73,7 +73,7 @@
     "pull-serializer": "~0.3.2",
     "pull-stream": "^3.6.8",
     "sinon": "^5.0.7",
-    "wrtc": "0.1.1"
+    "wrtc": "~0.1.6"
   },
   "contributors": [
     "Chris Bratlien <chrisbratlien@gmail.com>",


### PR DESCRIPTION
This should resolve #204 and #194.

The latest node-webrtc, 0.1.6, fixed [an issue](https://github.com/js-platform/node-webrtc/pull/419) that was causing wrtc to fail.

I've verified this locally, and it looked good on the initial [build of jenkins](https://ci.ipfs.team/blue/organizations/jenkins/libp2p%2Fjs-libp2p/detail/chore%2Fupdate-wrtc/1/pipeline/17) aside from an out of space issue. Jenkins is not having a good day/evening. I will re-run the build tomorrow so we get a clean green.