### PR TITLE
fix: start and stop connection manager with libp2p

### DIFF
--- a/README.md
+++ b/README.md
@@ -165,6 +165,9 @@ class Node extends libp2p {
             active: false
           }
         },
+        dht: {
+          kBucketSize: 20
+        },
         // Enable/Disable Experimental features
         EXPERIMENTAL: {               // Experimental features ("behind a flag")
           pubsub: false,

--- a/package.json
+++ b/package.json
@@ -33,7 +33,8 @@
   },
   "homepage": "https://github.com/libp2p/js-libp2p",
   "browser": {
-    "joi": "joi-browser"
+    "joi": "joi-browser",
+    "./test/utils/bundle-nodejs": "./test/utils/bundle-browser"
   },
   "dependencies": {
     "async": "^2.6.1",
@@ -73,6 +74,7 @@
     "pull-serializer": "~0.3.2",
     "pull-stream": "^3.6.8",
     "sinon": "^6.1.3",
+    "webrtcsupport": "^2.2.0",
     "wrtc": "~0.1.6"
   },
   "contributors": [

--- a/src/index.js
+++ b/src/index.js
@@ -146,7 +146,10 @@ class Node extends EventEmitter {
     })
 
     series([
-      (cb) => this._switch.start(cb),
+      (cb) => {
+        this.connectionManager.start()
+        this._switch.start(cb)
+      },
       (cb) => {
         if (ws) {
           // always add dialing on websockets
@@ -256,7 +259,10 @@ class Node extends EventEmitter {
         }
         cb()
       },
-      (cb) => this._switch.stop(cb),
+      (cb) => {
+        this.connectionManager.stop()
+        this._switch.stop(cb)
+      },
       (cb) => {
         this.emit('stop')
         cb()

--- a/test/create.spec.js
+++ b/test/create.spec.js
@@ -1,0 +1,79 @@
+/* eslint-env mocha */
+'use strict'
+
+const chai = require('chai')
+chai.use(require('dirty-chai'))
+const expect = chai.expect
+const series = require('async/series')
+const createNode = require('./utils/create-node')
+const sinon = require('sinon')
+
+describe('libp2p creation', () => {
+  it('should be able to start and stop successfully', (done) => {
+    createNode([], {
+      config: {
+        EXPERIMENTAL: {
+          dht: true,
+          pubsub: true
+        }
+      }
+    }, (err, node) => {
+      expect(err).to.not.exist()
+
+      let sw = node._switch
+      let cm = node.connectionManager
+      let dht = node._dht
+      let pub = node._floodSub
+
+      sinon.spy(sw, 'start')
+      sinon.spy(cm, 'start')
+      sinon.spy(dht, 'start')
+      sinon.spy(pub, 'start')
+      sinon.spy(sw, 'stop')
+      sinon.spy(cm, 'stop')
+      sinon.spy(dht, 'stop')
+      sinon.spy(pub, 'stop')
+      sinon.spy(node, 'emit')
+
+      series([
+        (cb) => node.start(cb),
+        (cb) => {
+          expect(sw.start.calledOnce).to.equal(true)
+          expect(cm.start.calledOnce).to.equal(true)
+          expect(dht.start.calledOnce).to.equal(true)
+          expect(pub.start.calledOnce).to.equal(true)
+          expect(node.emit.calledWith('start')).to.equal(true)
+
+          cb()
+        },
+        (cb) => node.stop(cb)
+      ], (err) => {
+        expect(err).to.not.exist()
+
+        expect(sw.stop.calledOnce).to.equal(true)
+        expect(cm.stop.calledOnce).to.equal(true)
+        expect(dht.stop.calledOnce).to.equal(true)
+        expect(pub.stop.calledOnce).to.equal(true)
+        expect(node.emit.calledWith('stop')).to.equal(true)
+
+        done()
+      })
+    })
+  })
+
+  it('should not create disabled modules', (done) => {
+    createNode([], {
+      config: {
+        EXPERIMENTAL: {
+          dht: false,
+          pubsub: false
+        }
+      }
+    }, (err, node) => {
+      expect(err).to.not.exist()
+      expect(node._dht).to.not.exist()
+      expect(node._floodSub).to.not.exist()
+      done()
+    })
+  })
+})

--- a/test/utils/bundle-browser.js
+++ b/test/utils/bundle-browser.js
@@ -78,6 +78,9 @@ class Node extends libp2p {
             active: false
           }
         },
+        dht: {
+          kBucketSize: 20
+        },
         EXPERIMENTAL: {
           dht: false,
           pubsub: false


### PR DESCRIPTION
Resolves #224 

This will start the connection manager on `libp2p.start` and stop it on `libp2p.stop`. Previously users would need to start and stop it themselves.