### PR TITLE
fix: callback with error for invalid or non-peer multiaddr

### DIFF
--- a/src/get-peer-info.js
+++ b/src/get-peer-info.js
@@ -3,6 +3,7 @@
 const PeerId = require('peer-id')
 const PeerInfo = require('peer-info')
 const multiaddr = require('multiaddr')
+const setImmediate = require('async/setImmediate')
 
 module.exports = (node) => {
   /*
@@ -16,12 +17,19 @@ module.exports = (node) => {
     // Multiaddr instance or Multiaddr String
     } else if (multiaddr.isMultiaddr(peer) || typeof peer === 'string') {
       if (typeof peer === 'string') {
-        peer = multiaddr(peer)
+        try {
+          peer = multiaddr(peer)
+        } catch (err) {
+          return setImmediate(() => callback(err))
+        }
       }
 
       const peerIdB58Str = peer.getPeerId()
+
       if (!peerIdB58Str) {
-        throw new Error(`peer multiaddr instance or string must include peerId`)
+        return setImmediate(() => {
+          callback(new Error('peer multiaddr instance or string must include peerId'))
+        })
       }
 
       try {

--- a/test/get-peer-info.spec.js
+++ b/test/get-peer-info.spec.js
@@ -1,0 +1,26 @@
+/* eslint-env mocha */
+'use strict'
+
+const chai = require('chai')
+chai.use(require('dirty-chai'))
+const expect = chai.expect
+
+const getPeerInfo = require('../src/get-peer-info')
+
+describe('getPeerInfo', () => {
+  it('should callback with error for invalid string multiaddr', (done) => {
+    getPeerInfo(null)('INVALID MULTIADDR', (err) => {
+      expect(err).to.exist()
+      expect(err.message).to.contain('must start with a "/"')
+      done()
+    })
+  })
+
+  it('should callback with error for invalid non-peer multiaddr', (done) => {
+    getPeerInfo(null)('/ip4/8.8.8.8/tcp/1080', (err) => {
+      expect(err).to.exist()
+      expect(err.message).to.equal('peer multiaddr instance or string must include peerId')
+      done()
+    })
+  })
+})


### PR DESCRIPTION
1. `multiaddr(input)` can throw, so put a try/catch around this
2. Do not throw, but callback with error for multiaddr which is not a peer info multiaddr