### PR TITLE
fix: dht get options

### DIFF
--- a/package.json
+++ b/package.json
@@ -59,7 +59,7 @@
     "dirty-chai": "^2.0.1",
     "electron-webrtc": "~0.3.0",
     "libp2p-circuit": "~0.2.0",
-    "libp2p-kad-dht": "~0.10.1",
+    "libp2p-kad-dht": "~0.10.3",
     "libp2p-mdns": "~0.12.0",
     "libp2p-mplex": "~0.8.0",
     "libp2p-railing": "~0.9.2",

--- a/src/dht.js
+++ b/src/dht.js
@@ -9,29 +9,29 @@ module.exports = (node) => {
 
       node._dht.put(key, value, callback)
     },
-    get: (key, maxTimeout, callback) => {
-      if (typeof maxTimeout === 'function') {
-        callback = maxTimeout
-        maxTimeout = null
+    get: (key, options, callback) => {
+      if (typeof options === 'function') {
+        callback = options
+        options = {}
       }
 
       if (!node._dht) {
         return callback(new Error('DHT is not available'))
       }
 
-      node._dht.get(key, maxTimeout, callback)
+      node._dht.get(key, options, callback)
     },
-    getMany: (key, nVals, maxTimeout, callback) => {
-      if (typeof maxTimeout === 'function') {
-        callback = maxTimeout
-        maxTimeout = null
+    getMany: (key, nVals, options, callback) => {
+      if (typeof options === 'function') {
+        callback = options
+        options = {}
       }
 
       if (!node._dht) {
         return callback(new Error('DHT is not available'))
       }
 
-      node._dht.getMany(key, nVals, maxTimeout, callback)
+      node._dht.getMany(key, nVals, options, callback)
     }
   }
 }

--- a/test/dht.node.js
+++ b/test/dht.node.js
@@ -53,14 +53,14 @@ describe('.dht', () => {
       })
     })
 
-    it('should be able to dht.get a value from the DHT with a maxTimeout', (done) => {
+    it('should be able to dht.get a value from the DHT with options', (done) => {
       const key = Buffer.from('/v/hello')
       const value = Buffer.from('world')
 
       nodeA.dht.put(key, value, (err) => {
         expect(err).to.not.exist()
 
-        nodeA.dht.get(key, 3000, (err, res) => {
+        nodeA.dht.get(key, { maxTimeout: 3000 }, (err, res) => {
           expect(err).to.not.exist()
           expect(res).to.eql(value)
           done()
@@ -68,7 +68,7 @@ describe('.dht', () => {
       })
     })
 
-    it('should be able to dht.get a value from the DHT with no maxTimeout defined', (done) => {
+    it('should be able to dht.get a value from the DHT with no options defined', (done) => {
       const key = Buffer.from('/v/hello')
       const value = Buffer.from('world')
 
@@ -83,14 +83,14 @@ describe('.dht', () => {
       })
     })
 
-    it('should be able to dht.getMany a value from the DHT with a maxTimeout', (done) => {
+    it('should be able to dht.getMany a value from the DHT with options', (done) => {
       const key = Buffer.from('/v/hello')
       const value = Buffer.from('world')
 
       nodeA.dht.put(key, value, (err) => {
         expect(err).to.not.exist()
 
-        nodeA.dht.getMany(key, 1, (err, res) => {
+        nodeA.dht.getMany(key, 1, { maxTimeout: 3000 }, (err, res) => {
           expect(err).to.not.exist()
           expect(res).to.exist()
           done()
@@ -98,7 +98,7 @@ describe('.dht', () => {
       })
     })
 
-    it('should be able to dht.getMany a value from the DHT with no maxTimeout defined', (done) => {
+    it('should be able to dht.getMany a value from the DHT with no options defined', (done) => {
       const key = Buffer.from('/v/hello')
       const value = Buffer.from('world')
 


### PR DESCRIPTION
Changed `dht.get` and `dht.getMany` `maxTimeout` parameter to an `options` parameter with the `maxTimeout` property as discussed [here](https://github.com/libp2p/js-libp2p/pull/248#pullrequestreview-156962993).

In spite of not breaking the tests here, we should wait for the merging and release of the following PR:

- [x] [js-libp2p-kad-dht#40](https://github.com/libp2p/js-libp2p-kad-dht/pull/40)