### PR TITLE
fix: start kad dht random walk

### DIFF
--- a/README.md
+++ b/README.md
@@ -162,7 +162,8 @@ class Node extends libp2p {
           }
         },
         dht: {
-          kBucketSize: 20
+          kBucketSize: 20,
+          enabledDiscovery: true      // Allows to disable discovery (enabled by default)
         },
         // Enable/Disable Experimental features
         EXPERIMENTAL: {               // Experimental features ("behind a flag")

--- a/package.json
+++ b/package.json
@@ -59,7 +59,7 @@
     "dirty-chai": "^2.0.1",
     "electron-webrtc": "~0.3.0",
     "libp2p-circuit": "~0.2.1",
-    "libp2p-kad-dht": "~0.10.3",
+    "libp2p-kad-dht": "~0.10.5",
     "libp2p-mdns": "~0.12.0",
     "libp2p-mplex": "~0.8.2",
     "libp2p-railing": "~0.9.2",

--- a/src/config.js
+++ b/src/config.js
@@ -29,7 +29,8 @@ const OptionsSchema = Joi.object({
       })
     }).default(),
     dht: Joi.object().keys({
-      kBucketSize: Joi.number().allow(null)
+      kBucketSize: Joi.number().allow(null),
+      enabledDiscovery: Joi.boolean().default(true)
     }),
     EXPERIMENTAL: Joi.object().keys({
       dht: Joi.boolean().default(false),

--- a/src/index.js
+++ b/src/index.js
@@ -265,7 +265,9 @@ class Node extends EventEmitter {
       },
       (cb) => {
         if (this._dht) {
-          return this._dht.stop(cb)
+          return this._dht.randomWalk.stop(() => {
+            this._dht.stop(cb)
+          })
         }
         cb()
       },

--- a/src/index.js
+++ b/src/index.js
@@ -85,8 +85,11 @@ class Node extends EventEmitter {
     // dht provided components (peerRouting, contentRouting, dht)
     if (this._config.EXPERIMENTAL.dht) {
       const DHT = this._modules.dht
+      const enabledDiscovery = this._config.dht.enabledDiscovery !== false
+
       this._dht = new DHT(this._switch, {
         kBucketSize: this._config.dht.kBucketSize || 20,
+        enabledDiscovery,
         // TODO make datastore an option of libp2p itself so
         // that other things can use it as well
         datastore: dht.datastore
@@ -203,10 +206,7 @@ class Node extends EventEmitter {
         // have to set started here because DHT requires libp2p is already started
         this._isStarted = true
         if (this._dht) {
-          this._dht.start(() => {
-            this._dht.randomWalk.start()
-            cb()
-          })
+          this._dht.start(cb)
         } else {
           cb()
         }
@@ -265,9 +265,7 @@ class Node extends EventEmitter {
       },
       (cb) => {
         if (this._dht) {
-          return this._dht.randomWalk.stop(() => {
-            this._dht.stop(cb)
-          })
+          return this._dht.stop(cb)
         }
         cb()
       },

--- a/src/index.js
+++ b/src/index.js
@@ -203,7 +203,10 @@ class Node extends EventEmitter {
         // have to set started here because DHT requires libp2p is already started
         this._isStarted = true
         if (this._dht) {
-          this._dht.start(cb)
+          this._dht.start(() => {
+            this._dht.randomWalk.start()
+            cb()
+          })
         } else {
           cb()
         }

--- a/test/create.spec.js
+++ b/test/create.spec.js
@@ -28,10 +28,12 @@ describe('libp2p creation', () => {
       sinon.spy(sw, 'start')
       sinon.spy(cm, 'start')
       sinon.spy(dht, 'start')
+      sinon.spy(dht.randomWalk, 'start')
       sinon.spy(pub, 'start')
       sinon.spy(sw, 'stop')
       sinon.spy(cm, 'stop')
       sinon.spy(dht, 'stop')
+      sinon.spy(dht.randomWalk, 'stop')
       sinon.spy(pub, 'stop')
       sinon.spy(node, 'emit')
 
@@ -41,6 +43,7 @@ describe('libp2p creation', () => {
           expect(sw.start.calledOnce).to.equal(true)
           expect(cm.start.calledOnce).to.equal(true)
           expect(dht.start.calledOnce).to.equal(true)
+          expect(dht.randomWalk.start.calledOnce).to.equal(true)
           expect(pub.start.calledOnce).to.equal(true)
           expect(node.emit.calledWith('start')).to.equal(true)
 
@@ -53,6 +56,7 @@ describe('libp2p creation', () => {
         expect(sw.stop.calledOnce).to.equal(true)
         expect(cm.stop.calledOnce).to.equal(true)
         expect(dht.stop.calledOnce).to.equal(true)
+        expect(dht.randomWalk.stop.called).to.equal(true)
         expect(pub.stop.calledOnce).to.equal(true)
         expect(node.emit.calledWith('stop')).to.equal(true)
 

--- a/test/utils/bundle-browser.js
+++ b/test/utils/bundle-browser.js
@@ -79,7 +79,8 @@ class Node extends libp2p {
           }
         },
         dht: {
-          kBucketSize: 20
+          kBucketSize: 20,
+          enabledDiscovery: true
         },
         EXPERIMENTAL: {
           dht: false,

--- a/test/utils/bundle-nodejs.js
+++ b/test/utils/bundle-nodejs.js
@@ -72,7 +72,8 @@ class Node extends libp2p {
           }
         },
         dht: {
-          kBucketSize: 20
+          kBucketSize: 20,
+          enabledDiscovery: true
         },
         EXPERIMENTAL: {
           dht: false,


### PR DESCRIPTION
Currently the DHT's `randomWalk` was not being started. Accordingly, a peer did not find other peers in the network unless we connect them manually.

Needs:

- [x] [js-libp2p-kad-dht#42](https://github.com/libp2p/js-libp2p-kad-dht/pull/42)