### PR TITLE
feat: enable relay by default (no hop)

### DIFF
--- a/README.md
+++ b/README.md
@@ -166,7 +166,7 @@ class Node extends libp2p {
           // .. other discovery module options.
         },
         relay: {                      // Circuit Relay options
-          enabled: false,
+          enabled: true,
           hop: {
             enabled: false,
             active: false

--- a/src/config.js
+++ b/src/config.js
@@ -24,7 +24,7 @@ const OptionsSchema = Joi.object({
   config: Joi.object().keys({
     peerDiscovery: Joi.object().allow(null),
     relay: Joi.object().keys({
-      enabled: Joi.boolean().default(false),
+      enabled: Joi.boolean().default(true),
       hop: Joi.object().keys({
         enabled: Joi.boolean().default(false),
         active: Joi.boolean().default(false)

--- a/test/config.spec.js
+++ b/test/config.spec.js
@@ -92,7 +92,7 @@ describe('configuration', () => {
           dht: false
         },
         relay: {
-          enabled: false
+          enabled: true
         }
       }
     }


### PR DESCRIPTION
This change enables circuit relay by default, hop is still disabled, to help improve default connectivity.

Resolves https://github.com/libp2p/js-libp2p/issues/253