### PR TITLE
chore: upgrade libp2p-mplex

### DIFF
--- a/package.json
+++ b/package.json
@@ -61,7 +61,7 @@
     "libp2p-circuit": "~0.2.1",
     "libp2p-kad-dht": "~0.10.3",
     "libp2p-mdns": "~0.12.0",
-    "libp2p-mplex": "~0.8.0",
+    "libp2p-mplex": "~0.8.2",
     "libp2p-railing": "~0.9.2",
     "libp2p-secio": "~0.10.0",
     "libp2p-spdy": "~0.12.1",


### PR DESCRIPTION
Fixes `websocket` stress tests with [js-libp2p-mplex#84](https://github.com/libp2p/js-libp2p-mplex/pull/84)