### PR TITLE
feat: add datastore to config

### DIFF
--- a/package.json
+++ b/package.json
@@ -63,6 +63,7 @@
     "cids": "~0.5.3",
     "dirty-chai": "^2.0.1",
     "electron-webrtc": "~0.3.0",
+    "interface-datastore": "~0.6.0",
     "libp2p-bootstrap": "~0.9.3",
     "libp2p-circuit": "~0.2.1",
     "libp2p-delegated-content-routing": "~0.2.2",

--- a/src/config.js
+++ b/src/config.js
@@ -7,6 +7,7 @@ const ModuleSchema = Joi.alternatives().try(Joi.func(), Joi.object())
 const OptionsSchema = Joi.object({
   // TODO: create proper validators for the generics
   connectionManager: Joi.object(),
+  datastore: Joi.object(),
   peerInfo: Joi.object().required(),
   peerBook: Joi.object(),
   modules: Joi.object().keys({

--- a/src/index.js
+++ b/src/index.js
@@ -41,6 +41,7 @@ class Node extends EventEmitter {
     // and add default values where appropriate
     _options = validateConfig(_options)
 
+    this.datastore = _options.datastore
     this.peerInfo = _options.peerInfo
     this.peerBook = _options.peerBook || new PeerBook()
 
@@ -100,9 +101,7 @@ class Node extends EventEmitter {
       this._dht = new DHT(this._switch, {
         kBucketSize: this._config.dht.kBucketSize || 20,
         enabledDiscovery,
-        // TODO make datastore an option of libp2p itself so
-        // that other things can use it as well
-        datastore: dht.datastore
+        datastore: this.datastore
       })
     }
 

--- a/test/dht.node.js
+++ b/test/dht.node.js
@@ -6,14 +6,18 @@ const chai = require('chai')
 chai.use(require('dirty-chai'))
 const expect = chai.expect
 
+const MemoryStore = require('interface-datastore').MemoryDatastore
+
 const createNode = require('./utils/create-node')
 
 describe('.dht', () => {
   describe('enabled', () => {
     let nodeA
+    const datastore = new MemoryStore()
 
     before(function (done) {
       createNode('/ip4/0.0.0.0/tcp/0', {
+        datastore,
         config: {
           EXPERIMENTAL: {
             dht: true


### PR DESCRIPTION
In the context of the awesome endeavour for enabling the DHT by default in `js-ipfs`, `libp2p` must receive an option with a `datastore` to be used [js-ipfs#856#issuecomment-434601550](https://github.com/ipfs/js-ipfs/pull/856#issuecomment-434601550)