### PR TITLE
fix: dont call callback before it's properly set

### DIFF
--- a/src/content-routing.js
+++ b/src/content-routing.js
@@ -24,10 +24,6 @@ module.exports = (node) => {
      * @returns {void}
      */
     findProviders: (key, options, callback) => {
-      if (!routers.length) {
-        return callback(errCode(new Error('No content routers available'), 'NO_ROUTERS_AVAILABLE'))
-      }
-
       if (typeof options === 'function') {
         callback = options
         options = {}
@@ -35,6 +31,10 @@ module.exports = (node) => {
         options = {
           maxTimeout: options
         }
+      }
+
+      if (!routers.length) {
+        return callback(errCode(new Error('No content routers available'), 'NO_ROUTERS_AVAILABLE'))
       }
 
       const tasks = routers.map((router) => {

--- a/src/peer-routing.js
+++ b/src/peer-routing.js
@@ -22,13 +22,13 @@ module.exports = (node) => {
      * @returns {void}
      */
     findPeer: (id, options, callback) => {
-      if (!routers.length) {
-        callback(errCode(new Error('No peer routers available'), 'NO_ROUTERS_AVAILABLE'))
-      }
-
       if (typeof options === 'function') {
         callback = options
         options = {}
+      }
+
+      if (!routers.length) {
+        callback(errCode(new Error('No peer routers available'), 'NO_ROUTERS_AVAILABLE'))
       }
 
       const tasks = routers.map((router) => {

--- a/test/content-routing.node.js
+++ b/test/content-routing.node.js
@@ -367,4 +367,29 @@ describe('.contentRouting', () => {
       })
     })
   })
+
+  describe('no routers', () => {
+    let nodeA
+    before((done) => {
+      createNode('/ip4/0.0.0.0/tcp/0', (err, node) => {
+        expect(err).to.not.exist()
+        nodeA = node
+        done()
+      })
+    })
+
+    it('.findProviders should return an error with no options', (done) => {
+      nodeA.contentRouting.findProviders('a cid', (err) => {
+        expect(err).to.exist()
+        done()
+      })
+    })
+
+    it('.findProviders should return an error with options', (done) => {
+      nodeA.contentRouting.findProviders('a cid', { maxTimeout: 5000 }, (err) => {
+        expect(err).to.exist()
+        done()
+      })
+    })
+  })
 })

--- a/test/peer-routing.node.js
+++ b/test/peer-routing.node.js
@@ -266,4 +266,29 @@ describe('.peerRouting', () => {
       })
     })
   })
+
+  describe('no routers', () => {
+    let nodeA
+    before((done) => {
+      createNode('/ip4/0.0.0.0/tcp/0', (err, node) => {
+        expect(err).to.not.exist()
+        nodeA = node
+        done()
+      })
+    })
+
+    it('.findPeer should return an error with no options', (done) => {
+      nodeA.peerRouting.findPeer('a cid', (err) => {
+        expect(err).to.exist()
+        done()
+      })
+    })
+
+    it('.findPeer should return an error with options', (done) => {
+      nodeA.peerRouting.findPeer('a cid', { maxTimeout: 5000 }, (err) => {
+        expect(err).to.exist()
+        done()
+      })
+    })
+  })
 })


### PR DESCRIPTION
It was possible for `callback` to be called in the peer and content routers before its type was properly checked. This adds tests and fixes the issue.