### PR TITLE
fix: improve get peer info errors

### DIFF
--- a/src/get-peer-info.js
+++ b/src/get-peer-info.js
@@ -3,7 +3,7 @@
 const PeerId = require('peer-id')
 const PeerInfo = require('peer-info')
 const multiaddr = require('multiaddr')
-const setImmediate = require('async/setImmediate')
+const errCode = require('err-code')
 
 module.exports = (node) => {
   /*
@@ -20,16 +20,21 @@ module.exports = (node) => {
         try {
           peer = multiaddr(peer)
         } catch (err) {
-          return setImmediate(() => callback(err))
+          return callback(
+            errCode(err, 'ERR_INVALID_MULTIADDR')
+          )
         }
       }
 
       const peerIdB58Str = peer.getPeerId()
 
       if (!peerIdB58Str) {
-        return setImmediate(() => {
-          callback(new Error('peer multiaddr instance or string must include peerId'))
-        })
+        return callback(
+          errCode(
+            new Error('peer multiaddr instance or string must include peerId'),
+            'ERR_INVALID_MULTIADDR'
+          )
+        )
       }
 
       try {
@@ -48,9 +53,14 @@ module.exports = (node) => {
         return node.peerRouting.findPeer(peer, callback)
       }
     } else {
-      return setImmediate(() => callback(new Error('peer type not recognized')))
+      return callback(
+        errCode(
+          new Error(`${p} is not a valid peer type`),
+          'ERR_INVALID_PEER_TYPE'
+        )
+      )
     }
 
-    setImmediate(() => callback(null, p))
+    callback(null, p)
   }
 }

--- a/test/get-peer-info.spec.js
+++ b/test/get-peer-info.spec.js
@@ -11,7 +11,7 @@ describe('getPeerInfo', () => {
   it('should callback with error for invalid string multiaddr', (done) => {
     getPeerInfo(null)('INVALID MULTIADDR', (err) => {
       expect(err).to.exist()
-      expect(err.message).to.contain('must start with a "/"')
+      expect(err.code).to.eql('ERR_INVALID_MULTIADDR')
       done()
     })
   })
@@ -19,7 +19,15 @@ describe('getPeerInfo', () => {
   it('should callback with error for invalid non-peer multiaddr', (done) => {
     getPeerInfo(null)('/ip4/8.8.8.8/tcp/1080', (err) => {
       expect(err).to.exist()
-      expect(err.message).to.equal('peer multiaddr instance or string must include peerId')
+      expect(err.code).to.equal('ERR_INVALID_MULTIADDR')
+      done()
+    })
+  })
+
+  it('should callback with error for invalid non-peer multiaddr', (done) => {
+    getPeerInfo(null)(undefined, (err) => {
+      expect(err).to.exist()
+      expect(err.code).to.eql('ERR_INVALID_PEER_TYPE')
       done()
     })
   })


### PR DESCRIPTION
* removes setImmediate from get-peer-info as it's not needed.
* Adds error codes to get-peer-info errors
* attempts to provide more info to users about invalid peer types

relates to #280 