### PR TITLE
feat: conditionally emit errors

### DIFF
--- a/src/index.js
+++ b/src/index.js
@@ -51,7 +51,10 @@ class Node extends EventEmitter {
     this._transport = [] // Transport instances/references
     this._discovery = [] // Discovery service instances/references
 
+    // create the switch, and listen for errors
     this._switch = new Switch(this.peerInfo, this.peerBook, _options.switch)
+    this._switch.on('error', (...args) => this.emit('error', ...args))
+
     this.stats = this._switch.stats
     this.connectionManager = new ConnectionManager(this, _options.connectionManager)
 
@@ -160,6 +163,21 @@ class Node extends EventEmitter {
       log.error(err)
       this.emit('error', err)
     })
+  }
+
+  /**
+   * Overrides EventEmitter.emit to conditionally emit errors
+   * if there is a handler. If not, errors will be logged.
+   * @param {string} eventName
+   * @param  {...any} args
+   * @returns {void}
+   */
+  emit (eventName, ...args) {
+    if (eventName === 'error' && !this._events.error) {
+      log.error(...args)
+    } else {
+      super.emit(eventName, ...args)
+    }
   }
 
   /**

--- a/test/create.spec.js
+++ b/test/create.spec.js
@@ -80,4 +80,25 @@ describe('libp2p creation', () => {
       done()
     })
   })
+
+  it('should not throw errors from switch if node has no error listeners', (done) => {
+    createNode([], {}, (err, node) => {
+      expect(err).to.not.exist()
+
+      node._switch.emit('error', new Error('bad things'))
+      done()
+    })
+  })
+
+  it('should emit errors from switch if node has error listeners', (done) => {
+    const error = new Error('bad things')
+    createNode([], {}, (err, node) => {
+      expect(err).to.not.exist()
+      node.once('error', (err) => {
+        expect(err).to.eql(error)
+        done()
+      })
+      node._switch.emit('error', error)
+    })
+  })
 })


### PR DESCRIPTION
The latest switch state machine updates have switch emit errors. If this happens we need to catch them. This PR updates libp2p to listen from them and log the errors out, unless there is an event listener on libp2p for errors, in which case they will be bubbled up.