### PR TITLE
chore: add maxNumProviders to findprovs

### DIFF
--- a/README.md
+++ b/README.md
@@ -261,11 +261,11 @@ Required keys in the `options` object:
 - `key`: Buffer
 - `options`: object of options
 - `options.maxTimeout`: Number milliseconds
+- `options.maxNumProviders` maximum number of providers to find
 
 #### `libp2p.contentRouting.provide(key, callback)`
 
 - `key`: Buffer
-
 
 #### `libp2p.handle(protocol, handlerFunc [, matchFunc])`
 

--- a/package.json
+++ b/package.json
@@ -67,7 +67,7 @@
     "libp2p-circuit": "~0.3.0",
     "libp2p-delegated-content-routing": "~0.2.2",
     "libp2p-delegated-peer-routing": "~0.2.2",
-    "libp2p-kad-dht": "libp2p/js-libp2p-kad-dht#chore/add-max-num-providers-to-find-providers",
+    "libp2p-kad-dht": "~0.11.1",
     "libp2p-mdns": "~0.12.0",
     "libp2p-mplex": "~0.8.2",
     "libp2p-secio": "~0.10.1",

--- a/package.json
+++ b/package.json
@@ -67,7 +67,7 @@
     "libp2p-circuit": "~0.3.0",
     "libp2p-delegated-content-routing": "~0.2.2",
     "libp2p-delegated-peer-routing": "~0.2.2",
-    "libp2p-kad-dht": "~0.10.6",
+    "libp2p-kad-dht": "libp2p/js-libp2p-kad-dht#chore/add-max-num-providers-to-find-providers",
     "libp2p-mdns": "~0.12.0",
     "libp2p-mplex": "~0.8.2",
     "libp2p-secio": "~0.10.1",

--- a/src/content-routing.js
+++ b/src/content-routing.js
@@ -20,6 +20,7 @@ module.exports = (node) => {
      * @param {CID} key The CID key of the content to find
      * @param {object} options
      * @param {number} options.maxTimeout How long the query should run
+     * @param {number} options.maxNumProviders - maximum number of providers to find
      * @param {function(Error, Result<Array>)} callback
      * @returns {void}
      */

--- a/test/content-routing.node.js
+++ b/test/content-routing.node.js
@@ -107,6 +107,22 @@ describe('.contentRouting', () => {
         })
       })
 
+      it('nodeE.contentRouting.findProviders with limited number of providers', (done) => {
+        parallel([
+          (cb) => nodeA.contentRouting.provide(cid, cb),
+          (cb) => nodeB.contentRouting.provide(cid, cb),
+          (cb) => nodeC.contentRouting.provide(cid, cb)
+        ], (err) => {
+          expect(err).to.not.exist()
+
+          nodeE.contentRouting.findProviders(cid, { maxNumProviders: 2 }, (err, providers) => {
+            expect(err).to.not.exist()
+            expect(providers).to.have.length(2)
+            done()
+          })
+        })
+      })
+
       it('nodeC.contentRouting.findProviders for non existing record (timeout)', (done) => {
         const cid = new CID('QmTp9VkYvnHyrqKQuFPiuZkiX9gPcqj6x5LJ1rmWuSnnnn')
 


### PR DESCRIPTION
In the context of [libp2p/js-libp2p-kad-dht#54](https://github.com/libp2p/js-libp2p-kad-dht/issues/54). 

Needs:

- [x] [libp2p/js-libp2p-kad-dht#55](https://github.com/libp2p/js-libp2p-kad-dht/pull/55)