### PR TITLE
feat: allow configurable validators and selectors to the dht

### DIFF
--- a/src/config.js
+++ b/src/config.js
@@ -32,9 +32,11 @@ const OptionsSchema = Joi.object({
       })
     }).default(),
     dht: Joi.object().keys({
-      kBucketSize: Joi.number().allow(null),
-      enabledDiscovery: Joi.boolean().default(true)
-    }),
+      kBucketSize: Joi.number().default(20),
+      enabledDiscovery: Joi.boolean().default(true),
+      validators: Joi.object().allow(null),
+      selectors: Joi.object().allow(null)
+    }).default(),
     EXPERIMENTAL: Joi.object().keys({
       dht: Joi.boolean().default(false),
       pubsub: Joi.boolean().default(false)

--- a/src/index.js
+++ b/src/index.js
@@ -105,8 +105,8 @@ class Node extends EventEmitter {
         kBucketSize: this._config.dht.kBucketSize,
         enabledDiscovery,
         datastore: this.datastore,
-        validators: this._config.dht.validators || {},
-        selectors: this._config.dht.selectors || {}
+        validators: this._config.dht.validators,
+        selectors: this._config.dht.selectors
       })
     }
 

--- a/src/index.js
+++ b/src/index.js
@@ -102,9 +102,11 @@ class Node extends EventEmitter {
       const enabledDiscovery = this._config.dht.enabledDiscovery !== false
 
       this._dht = new DHT(this._switch, {
-        kBucketSize: this._config.dht.kBucketSize || 20,
+        kBucketSize: this._config.dht.kBucketSize,
         enabledDiscovery,
-        datastore: this.datastore
+        datastore: this.datastore,
+        validators: this._config.dht.validators || {},
+        selectors: this._config.dht.selectors || {}
       })
     }
 

--- a/test/config.spec.js
+++ b/test/config.spec.js
@@ -11,6 +11,7 @@ const WS = require('libp2p-websockets')
 const Bootstrap = require('libp2p-bootstrap')
 const DelegatedPeerRouter = require('libp2p-delegated-peer-routing')
 const DelegatedContentRouter = require('libp2p-delegated-content-routing')
+const DHT = require('libp2p-kad-dht')
 
 const validateConfig = require('../src/config').validate
 
@@ -91,6 +92,10 @@ describe('configuration', () => {
           pubsub: false,
           dht: false
         },
+        dht: {
+          kBucketSize: 20,
+          enabledDiscovery: true
+        },
         relay: {
           enabled: true
         }
@@ -142,5 +147,50 @@ describe('configuration', () => {
     }
 
     expect(() => validateConfig(options)).to.throw()
+  })
+
+  it('should add defaults, validators and selectors for dht', () => {
+    const selectors = {}
+    const validators = {}
+
+    const options = {
+      peerInfo,
+      modules: {
+        transport: [WS],
+        dht: DHT
+      },
+      config: {
+        EXPERIMENTAL: {
+          dht: true
+        },
+        dht: {
+          selectors,
+          validators
+        }
+      }
+    }
+    const expected = {
+      peerInfo,
+      modules: {
+        transport: [WS],
+        dht: DHT
+      },
+      config: {
+        EXPERIMENTAL: {
+          pubsub: false,
+          dht: true
+        },
+        relay: {
+          enabled: true
+        },
+        dht: {
+          kBucketSize: 20,
+          enabledDiscovery: true,
+          selectors,
+          validators
+        }
+      }
+    }
+    expect(validateConfig(options)).to.deep.equal(expected)
   })
 })

--- a/test/transports.node.js
+++ b/test/transports.node.js
@@ -427,7 +427,7 @@ describe('transports', () => {
           cb()
         }),
         (cb) => {
-          const wstar = new WRTCStar({wrtc: wrtc})
+          const wstar = new WRTCStar({ wrtc: wrtc })
 
           createNode([
             '/ip4/0.0.0.0/tcp/0',
@@ -474,7 +474,7 @@ describe('transports', () => {
         }),
 
         (cb) => {
-          const wstar = new WRTCStar({wrtc: wrtc})
+          const wstar = new WRTCStar({ wrtc: wrtc })
 
           createNode([
             '/ip4/127.0.0.1/tcp/24642/ws/p2p-webrtc-star'


### PR DESCRIPTION
Allow configurable validators and selectors. Users of `libp2p` with `libp2p-kad-dht` must be able to set their own validators and selectors. 

For instance, this is important for `js-ipfs` to use `/ipns/` namespaces in the DHT