### PR TITLE
fix: use symbol instead of constructor name

### DIFF
--- a/src/index.js
+++ b/src/index.js
@@ -342,7 +342,7 @@ class Node extends EventEmitter {
       }
 
       if (t.filter(multiaddrs).length > 0) {
-        this._switch.transport.add(t.tag || t.constructor.name, t)
+        this._switch.transport.add(t.tag || t[Symbol.toStringTag], t)
       } else if (WebSockets.isWebSockets(t)) {
         // TODO find a cleaner way to signal that a transport is always used
         // for dialing, even if no listener


### PR DESCRIPTION
Fixes #291 

constructor.name will gets modified by minifiers. Symbol.toStringTag does not, let's use that.  All transports are using `class-is` and are setting their class names to support this change.