### PR TITLE
fix not started yet

### DIFF
--- a/package.json
+++ b/package.json
@@ -50,7 +50,7 @@
     "libp2p-connection-manager": "~0.0.2",
     "libp2p-floodsub": "~0.15.1",
     "libp2p-ping": "~0.8.3",
-    "libp2p-switch": "github:libp2p/js-libp2p-switch#fix/many-conns",
+    "libp2p-switch": "~0.41.3",
     "libp2p-websockets": "~0.12.0",
     "mafmt": "^6.0.2",
     "multiaddr": "^5.0.2",

--- a/package.json
+++ b/package.json
@@ -50,7 +50,7 @@
     "libp2p-connection-manager": "~0.0.2",
     "libp2p-floodsub": "~0.15.1",
     "libp2p-ping": "~0.8.3",
-    "libp2p-switch": "~0.41.2",
+    "libp2p-switch": "github:libp2p/js-libp2p-switch#fix/many-conns",
     "libp2p-websockets": "~0.12.0",
     "mafmt": "^6.0.2",
     "multiaddr": "^5.0.2",

--- a/src/index.js
+++ b/src/index.js
@@ -469,12 +469,12 @@ class Node extends EventEmitter {
         cb()
       },
       (cb) => {
-        // Ensures idempotency for restarts
-        this._switch.transport.removeAll(cb)
-      },
-      (cb) => {
         this.connectionManager.stop()
         this._switch.stop(cb)
+      },
+      (cb) => {
+        // Ensures idempotent restarts
+        this._switch.transport.removeAll(cb)
       }
     ], (err) => {
       if (err) {

--- a/src/index.js
+++ b/src/index.js
@@ -2,10 +2,10 @@
 
 const FSM = require('fsm-event')
 const EventEmitter = require('events').EventEmitter
-const assert = require('assert')
 const debug = require('debug')
 const log = debug('libp2p')
 log.error = debug('libp2p:error')
+const errCode = require('err-code')
 
 const each = require('async/each')
 const series = require('async/series')
@@ -24,7 +24,12 @@ const pubsub = require('./pubsub')
 const getPeerInfo = require('./get-peer-info')
 const validateConfig = require('./config').validate
 
-const NOT_STARTED_ERROR_MESSAGE = 'The libp2p node is not started yet'
+const notStarted = (action, state) => {
+  return errCode(
+    new Error(`libp2p cannot ${action} when not started; state is ${state}`),
+    'ERR_NODE_NOT_STARTED'
+  )
+}
 
 /**
  * @fires Node#error Emitted when an error occurs
@@ -217,8 +222,6 @@ class Node extends EventEmitter {
    * @returns {void}
    */
   dial (peer, callback) {
-    assert(this.isStarted(), NOT_STARTED_ERROR_MESSAGE)
-
     this.dialProtocol(peer, null, callback)
   }
 
@@ -233,7 +236,9 @@ class Node extends EventEmitter {
    * @returns {void}
    */
   dialProtocol (peer, protocol, callback) {
-    assert(this.isStarted(), NOT_STARTED_ERROR_MESSAGE)
+    if (!this.isStarted()) {
+      return callback(notStarted('dial', this.state._state))
+    }
 
     if (typeof protocol === 'function') {
       callback = protocol
@@ -261,7 +266,9 @@ class Node extends EventEmitter {
    * @returns {void}
    */
   dialFSM (peer, protocol, callback) {
-    assert(this.isStarted(), NOT_STARTED_ERROR_MESSAGE)
+    if (!this.isStarted()) {
+      return callback(notStarted('dial', this.state._state))
+    }
 
     if (typeof protocol === 'function') {
       callback = protocol
@@ -282,8 +289,6 @@ class Node extends EventEmitter {
   }
 
   hangUp (peer, callback) {
-    assert(this.isStarted(), NOT_STARTED_ERROR_MESSAGE)
-
     this._getPeerInfo(peer, (err, peerInfo) => {
       if (err) { return callback(err) }
 
@@ -293,7 +298,7 @@ class Node extends EventEmitter {
 
   ping (peer, callback) {
     if (!this.isStarted()) {
-      return callback(new Error(NOT_STARTED_ERROR_MESSAGE))
+      return callback(notStarted('ping', this.state._state))
     }
 
     this._getPeerInfo(peer, (err, peerInfo) => {

--- a/test/fsm.spec.js
+++ b/test/fsm.spec.js
@@ -114,5 +114,29 @@ describe('libp2p state machine (fsm)', () => {
 
       node.start()
     })
+
+    it('should not dial when the node is stopped', (done) => {
+      node.on('stop', () => {
+        node.dial(null, (err) => {
+          expect(err).to.exist()
+          expect(err.code).to.eql('ERR_NODE_NOT_STARTED')
+          done()
+        })
+      })
+
+      node.stop()
+    })
+
+    it('should not dial (fsm) when the node is stopped', (done) => {
+      node.on('stop', () => {
+        node.dialFSM(null, null, (err) => {
+          expect(err).to.exist()
+          expect(err.code).to.eql('ERR_NODE_NOT_STARTED')
+          done()
+        })
+      })
+
+      node.stop()
+    })
   })
 })

--- a/test/stream-muxing.node.js
+++ b/test/stream-muxing.node.js
@@ -215,7 +215,7 @@ describe('stream muxing', () => {
 
         nodeA.dial(nodeB.peerInfo, (err) => {
           expect(err).to.not.exist()
-          expect(Object.keys(nodeA._switch.muxedConns)).to.have.length(0)
+          expect(nodeA._switch.connection.getAll()).to.have.length(0)
           cb()
         })
       },

--- a/test/transports.browser.js
+++ b/test/transports.browser.js
@@ -313,7 +313,7 @@ describe('transports', () => {
         function check () {
           const peers = node1.peerBook.getAll()
           expect(Object.keys(peers)).to.have.length(1)
-          expect(nodeA._switch.connection.getAll()).to.have.length(0)
+          expect(node1._switch.connection.getAll()).to.have.length(0)
           done()
         }
       })

--- a/test/transports.browser.js
+++ b/test/transports.browser.js
@@ -102,7 +102,7 @@ describe('transports', () => {
         function check () {
           const peers = nodeA.peerBook.getAll()
           expect(Object.keys(peers)).to.have.length(1)
-          expect(Object.keys(nodeA._switch.muxedConns)).to.have.length(0)
+          expect(nodeA._switch.connection.getAll()).to.have.length(0)
           done()
         }
       })
@@ -142,7 +142,7 @@ describe('transports', () => {
           const peers = nodeA.peerBook.getAll()
           expect(err).to.not.exist()
           expect(Object.keys(peers)).to.have.length(1)
-          expect(Object.keys(nodeA._switch.muxedConns)).to.have.length(0)
+          expect(nodeA._switch.connection.getAll()).to.have.length(0)
           done()
         }
       })
@@ -153,16 +153,17 @@ describe('transports', () => {
         expect(err).to.not.exist()
 
         connFSM.once('muxed', () => {
-          expect(nodeA._switch.muxedConns).to.have.any.keys(
-            peerB.id.toB58String()
-          )
+          expect(
+            nodeA._switch.connection.getAllById(peerB.id.toB58String())
+          ).to.have.length(1)
 
           connFSM.once('error', done)
           connFSM.once('close', () => {
             // ensure the connection is closed
-            expect(nodeA._switch.muxedConns).to.not.have.any.keys([
-              peerB.id.toB58String()
-            ])
+            expect(
+              nodeA._switch.connection.getAllById(peerB.id.toB58String())
+            ).to.have.length(0)
+
             done()
           })
 
@@ -312,7 +313,7 @@ describe('transports', () => {
         function check () {
           const peers = node1.peerBook.getAll()
           expect(Object.keys(peers)).to.have.length(1)
-          expect(Object.keys(node1._switch.muxedConns)).to.have.length(0)
+          expect(nodeA._switch.connection.getAll()).to.have.length(0)
           done()
         }
       })
@@ -326,7 +327,7 @@ describe('transports', () => {
 
         function check () {
           // Verify both nodes are connected to node 3
-          if (node1._switch.muxedConns[b58Id] && node2._switch.muxedConns[b58Id]) {
+          if (node1._switch.connection.getAllById(b58Id) && node2._switch.connection.getAllById(b58Id)) {
             done()
           }
         }
@@ -417,7 +418,7 @@ describe('transports', () => {
         function check () {
           const peers = node1.peerBook.getAll()
           expect(Object.keys(peers)).to.have.length(1)
-          expect(Object.keys(node1._switch.muxedConns)).to.have.length(0)
+          expect(node1._switch.connection.getAll()).to.have.length(0)
           done()
         }
       })
@@ -430,8 +431,8 @@ describe('transports', () => {
 
       function check () {
         if (++counter === 3) {
-          expect(Object.keys(node1._switch.muxedConns).length).to.equal(1)
-          expect(Object.keys(node2._switch.muxedConns).length).to.equal(1)
+          expect(node1._switch.connection.getAll()).to.have.length(1)
+          expect(node2._switch.connection.getAll()).to.have.length(1)
           done()
         }
       }

--- a/test/transports.node.js
+++ b/test/transports.node.js
@@ -91,14 +91,13 @@ describe('transports', () => {
             (cb) => {
               const peers = nodeA.peerBook.getAll()
               expect(Object.keys(peers)).to.have.length(1)
-              expect(Object.keys(nodeA._switch.muxedConns)).to.have.length(0)
+              expect(nodeA._switch.connection.getAll()).to.have.length(0)
               cb()
             },
             (cb) => {
               const peers = nodeB.peerBook.getAll()
               expect(Object.keys(peers)).to.have.length(1)
-
-              expect(Object.keys(nodeB._switch.muxedConns)).to.have.length(0)
+              expect(nodeB._switch.connection.getAll()).to.have.length(0)
               cb()
             }
           ], done)
@@ -117,15 +116,13 @@ describe('transports', () => {
             (cb) => {
               const peers = nodeA.peerBook.getAll()
               expect(Object.keys(peers)).to.have.length(1)
-
-              expect(Object.keys(nodeA._switch.muxedConns)).to.have.length(1)
+              expect(nodeA._switch.connection.getAll()).to.have.length(1)
               cb()
             },
             (cb) => {
               const peers = nodeB.peerBook.getAll()
               expect(Object.keys(peers)).to.have.length(1)
-
-              expect(Object.keys(nodeA._switch.muxedConns)).to.have.length(1)
+              expect(nodeA._switch.connection.getAll()).to.have.length(1)
               cb()
             }
           ], () => tryEcho(conn, done))
@@ -143,15 +140,13 @@ describe('transports', () => {
             (cb) => {
               const peers = nodeA.peerBook.getAll()
               expect(Object.keys(peers)).to.have.length(1)
-
-              expect(Object.keys(nodeA._switch.muxedConns)).to.have.length(0)
+              expect(nodeA._switch.connection.getAll()).to.have.length(0)
               cb()
             },
             (cb) => {
               const peers = nodeB.peerBook.getAll()
               expect(Object.keys(peers)).to.have.length(1)
-
-              expect(Object.keys(nodeB._switch.muxedConns)).to.have.length(0)
+              expect(nodeB._switch.connection.getAll()).to.have.length(0)
               cb()
             }
           ], done)
@@ -170,13 +165,13 @@ describe('transports', () => {
             (cb) => {
               const peers = nodeA.peerBook.getAll()
               expect(Object.keys(peers)).to.have.length(1)
-              expect(Object.keys(nodeA._switch.muxedConns)).to.have.length(1)
+              expect(nodeA._switch.connection.getAll()).to.have.length(1)
               cb()
             },
             (cb) => {
               const peers = nodeB.peerBook.getAll()
               expect(Object.keys(peers)).to.have.length(1)
-              expect(Object.keys(nodeA._switch.muxedConns)).to.have.length(1)
+              expect(nodeA._switch.connection.getAll()).to.have.length(1)
               cb()
             }
           ], () => tryEcho(conn, done))
@@ -194,13 +189,13 @@ describe('transports', () => {
             (cb) => {
               const peers = nodeA.peerBook.getAll()
               expect(Object.keys(peers)).to.have.length(1)
-              expect(Object.keys(nodeA._switch.muxedConns)).to.have.length(0)
+              expect(nodeA._switch.connection.getAll()).to.have.length(0)
               cb()
             },
             (cb) => {
               const peers = nodeB.peerBook.getAll()
               expect(Object.keys(peers)).to.have.length(1)
-              expect(Object.keys(nodeB._switch.muxedConns)).to.have.length(0)
+              expect(nodeB._switch.connection.getAll()).to.have.length(0)
               cb()
             }
           ], done)
@@ -213,16 +208,16 @@ describe('transports', () => {
         expect(err).to.not.exist()
 
         connFSM.once('muxed', () => {
-          expect(nodeA._switch.muxedConns).to.have.any.keys(
-            nodeB.peerInfo.id.toB58String()
-          )
+          expect(
+            nodeA._switch.connection.getAllById(nodeB.peerInfo.id.toB58String())
+          ).to.have.length(1)
 
           connFSM.once('error', done)
           connFSM.once('close', () => {
             // ensure the connection is closed
-            expect(nodeA._switch.muxedConns).to.not.have.any.keys([
-              nodeB.peerInfo.id.toB58String()
-            ])
+            expect(
+              nodeA._switch.connection.getAllById(nodeB.peerInfo.id.toB58String())
+            ).to.have.length(0)
             done()
           })
 
@@ -235,9 +230,9 @@ describe('transports', () => {
       nodeA.dialFSM(nodeB.peerInfo, '/echo/1.0.0', (err, connFSM) => {
         expect(err).to.not.exist()
         connFSM.once('connection', (conn) => {
-          expect(nodeA._switch.muxedConns).to.have.all.keys([
-            nodeB.peerInfo.id.toB58String()
-          ])
+          expect(
+            nodeA._switch.connection.getAllById(nodeB.peerInfo.id.toB58String())
+          ).to.have.length(1)
           tryEcho(conn, () => {
             connFSM.close()
           })
@@ -245,9 +240,9 @@ describe('transports', () => {
         connFSM.once('error', done)
         connFSM.once('close', () => {
           // ensure the connection is closed
-          expect(nodeA._switch.muxedConns).to.not.have.any.keys([
-            nodeB.peerInfo.id.toB58String()
-          ])
+          expect(
+            nodeA._switch.connection.getAllById(nodeB.peerInfo.id.toB58String())
+          ).to.have.length(0)
           done()
         })
       })
@@ -309,13 +304,13 @@ describe('transports', () => {
             (cb) => {
               const peers = nodeTCP.peerBook.getAll()
               expect(Object.keys(peers)).to.have.length(1)
-              expect(Object.keys(nodeTCP._switch.muxedConns)).to.have.length(1)
+              expect(nodeTCP._switch.connection.getAll()).to.have.length(1)
               cb()
             },
             (cb) => {
               const peers = nodeTCPnWS.peerBook.getAll()
               expect(Object.keys(peers)).to.have.length(1)
-              expect(Object.keys(nodeTCPnWS._switch.muxedConns)).to.have.length(1)
+              expect(nodeTCPnWS._switch.connection.getAll()).to.have.length(1)
               cb()
             }
           ], done)
@@ -333,14 +328,13 @@ describe('transports', () => {
             (cb) => {
               const peers = nodeTCP.peerBook.getAll()
               expect(Object.keys(peers)).to.have.length(1)
-              expect(Object.keys(nodeTCP._switch.muxedConns)).to.have.length(0)
-
+              expect(nodeTCP._switch.connection.getAll()).to.have.length(0)
               cb()
             },
             (cb) => {
               const peers = nodeTCPnWS.peerBook.getAll()
               expect(Object.keys(peers)).to.have.length(1)
-              expect(Object.keys(nodeTCPnWS._switch.muxedConns)).to.have.length(0)
+              expect(nodeTCPnWS._switch.connection.getAll()).to.have.length(0)
               cb()
             }
           ], done)
@@ -360,13 +354,13 @@ describe('transports', () => {
             (cb) => {
               const peers = nodeTCPnWS.peerBook.getAll()
               expect(Object.keys(peers)).to.have.length(2)
-              expect(Object.keys(nodeTCPnWS._switch.muxedConns)).to.have.length(1)
+              expect(nodeTCPnWS._switch.connection.getAll()).to.have.length(1)
               cb()
             },
             (cb) => {
               const peers = nodeWS.peerBook.getAll()
               expect(Object.keys(peers)).to.have.length(1)
-              expect(Object.keys(nodeWS._switch.muxedConns)).to.have.length(1)
+              expect(nodeWS._switch.connection.getAll()).to.have.length(1)
               cb()
             }
           ], done)
@@ -384,14 +378,14 @@ describe('transports', () => {
             (cb) => {
               const peers = nodeTCPnWS.peerBook.getAll()
               expect(Object.keys(peers)).to.have.length(2)
-              expect(Object.keys(nodeTCPnWS._switch.muxedConns)).to.have.length(0)
+              expect(nodeTCPnWS._switch.connection.getAll()).to.have.length(0)
 
               cb()
             },
             (cb) => {
               const peers = nodeWS.peerBook.getAll()
               expect(Object.keys(peers)).to.have.length(1)
-              expect(Object.keys(nodeWS._switch.muxedConns)).to.have.length(0)
+              expect(nodeWS._switch.connection.getAll()).to.have.length(0)
               cb()
             }
           ], done)
@@ -516,7 +510,7 @@ describe('transports', () => {
       let i = 1;
       [nodeAll, otherNode].forEach((node) => {
         expect(Object.keys(node.peerBook.getAll())).to.have.length(i-- ? peers : 1)
-        expect(Object.keys(node._switch.muxedConns)).to.have.length(muxed)
+        expect(node._switch.connection.getAll()).to.have.length(muxed)
       })
       callback()
     }
@@ -678,7 +672,7 @@ describe('transports', () => {
       let i = 1;
       [nodeAll, otherNode].forEach((node) => {
         expect(Object.keys(node.peerBook.getAll())).to.have.length(i-- ? peers : 1)
-        expect(Object.keys(node._switch.muxedConns)).to.have.length(muxed)
+        expect(node._switch.connection.getAll()).to.have.length(muxed)
       })
       done()
     }

--- a/test/turbolence.node.js
+++ b/test/turbolence.node.js
@@ -77,7 +77,7 @@ describe('Turbolence tests', () => {
     function check () {
       const peers = nodeA.peerBook.getAll()
       expect(Object.keys(peers)).to.have.length(1)
-      expect(Object.keys(nodeA.switch.muxedConns)).to.have.length(0)
+      expect(nodeA._switch.connection.getAll()).to.have.length(0)
       done()
     }
   })


### PR DESCRIPTION
This does a few things:

* Update deps
* Updates to the latest switch and fixes test usage due to the update 
* Removes transports from the switch, after it stops, instead of before
* Passes not started errors to the callbacks rather than throwing assertion errors

depends on https://github.com/libp2p/js-libp2p-switch/pull/291
related to https://github.com/ipfs/js-ipfs/issues/1761