### PR TITLE
add callback to pubsub.unsubscribe and test (#300)

### DIFF
--- a/src/pubsub.js
+++ b/src/pubsub.js
@@ -44,7 +44,9 @@ module.exports = (node) => {
         floodSub.unsubscribe(topic)
       }
 
-      setImmediate(() => callback())
+      if (typeof callback === 'function') {
+        setImmediate(() => callback())
+      }
     },
 
     publish: (topic, data, callback) => {

--- a/src/pubsub.js
+++ b/src/pubsub.js
@@ -33,7 +33,7 @@ module.exports = (node) => {
       subscribe(callback)
     },
 
-    unsubscribe: (topic, handler) => {
+    unsubscribe: (topic, handler, callback) => {
       if (!node.isStarted() && !floodSub.started) {
         throw new Error(NOT_STARTED_YET)
       }
@@ -43,6 +43,8 @@ module.exports = (node) => {
       if (floodSub.listenerCount(topic) === 0) {
         floodSub.unsubscribe(topic)
       }
+
+      setImmediate(() => callback())
     },
 
     publish: (topic, data, callback) => {

--- a/test/pubsub.node.js
+++ b/test/pubsub.node.js
@@ -5,6 +5,7 @@
 
 const chai = require('chai')
 chai.use(require('dirty-chai'))
+chai.use(require('chai-checkmark'))
 const expect = chai.expect
 const parallel = require('async/parallel')
 const waterfall = require('async/waterfall')
@@ -53,6 +54,7 @@ function stopTwo (nodes, callback) {
 describe('.pubsub', () => {
   describe('.pubsub on (default)', (done) => {
     it('start two nodes and send one message, then unsubscribe', (done) => {
+      expect(4).checks(done)
       const data = Buffer.from('test')
       const handler = (msg, nodes, cb) => {
         expect(msg.data).to.eql(data)
@@ -67,9 +69,8 @@ describe('.pubsub', () => {
               expect(err).to.not.exist()
             })
             nodes[0].pubsub.unsubscribe('pubsub', handler, (err) => {
-              expect(err).to.not.exist()
-              console.log('\tunsubscribed!')
               done()
+              expect(err).to.not.exist()
             })
           })
         },

--- a/test/pubsub.node.js
+++ b/test/pubsub.node.js
@@ -62,17 +62,16 @@ describe('.pubsub', () => {
         (cb) => startTwo(cb),
         (nodes, cb) => {
           nodes[0].pubsub.subscribe('pubsub', (msg, nodes, cb) => handler, (err) => {
+            expect(err).to.not.exist()
+            setTimeout(() => nodes[1].pubsub.publish('pubsub', data, (err) => {
               expect(err).to.not.exist()
-              setTimeout(() => nodes[1].pubsub.publish('pubsub', data, (err) => {
-                expect(err).to.not.exist()
-              }), 500)
-              setTimeout(() => nodes[0].pubsub.unsubscribe('pubsub', handler, (err) => {
-                expect(err).to.not.exist()
-                console.log("\tunsubscribed!")
-                done()
-              }), 600)
-            }
-          )
+            }), 500)
+            setTimeout(() => nodes[0].pubsub.unsubscribe('pubsub', handler, (err) => {
+              expect(err).to.not.exist()
+              console.log('tunsubscribed!')
+              done()
+            }), 600)
+          })
         },
         (nodes, cb) => stopTwo(nodes, cb)
       ], done)

--- a/test/pubsub.node.js
+++ b/test/pubsub.node.js
@@ -9,7 +9,6 @@ chai.use(require('chai-checkmark'))
 const expect = chai.expect
 const parallel = require('async/parallel')
 const series = require('async/series')
-const waterfall = require('async/waterfall')
 const _times = require('lodash.times')
 
 const createNode = require('./utils/create-node')

--- a/test/pubsub.node.js
+++ b/test/pubsub.node.js
@@ -69,12 +69,12 @@ describe('.pubsub', () => {
               expect(err).to.not.exist()
             })
             nodes[0].pubsub.unsubscribe('pubsub', handler, (err) => {
-              done()
               expect(err).to.not.exist()
             })
           })
         },
-        (nodes, cb) => stopTwo(nodes, cb)
+        (nodes, cb) => stopTwo(nodes, cb),
+        done()
       ], done)
     })
   })

--- a/test/pubsub.node.js
+++ b/test/pubsub.node.js
@@ -63,14 +63,14 @@ describe('.pubsub', () => {
         (nodes, cb) => {
           nodes[0].pubsub.subscribe('pubsub', (msg, nodes, cb) => handler, (err) => {
             expect(err).to.not.exist()
-            setTimeout(() => nodes[1].pubsub.publish('pubsub', data, (err) => {
+            nodes[1].pubsub.publish('pubsub', data, (err) => {
               expect(err).to.not.exist()
-            }), 500)
-            setTimeout(() => nodes[0].pubsub.unsubscribe('pubsub', handler, (err) => {
+            })
+            nodes[0].pubsub.unsubscribe('pubsub', handler, (err) => {
               expect(err).to.not.exist()
-              console.log('tunsubscribed!')
+              console.log('\tunsubscribed!')
               done()
-            }), 600)
+            })
           })
         },
         (nodes, cb) => stopTwo(nodes, cb)

--- a/test/pubsub.node.js
+++ b/test/pubsub.node.js
@@ -77,7 +77,8 @@ describe('.pubsub', () => {
         // publish on the second
         (cb) => nodes[1].pubsub.publish('pubsub', data, cb),
         // unsubscribe on the first
-        (cb) => nodes[0].pubsub.unsubscribe('pubsub', handler, cb),
+        (cb) => setTimeout(cb, 500),
+	(cb) => nodes[0].pubsub.unsubscribe('pubsub', handler, cb),
         // Stop both nodes
         (cb) => stopTwo(nodes, cb)
       ], (err) => {


### PR DESCRIPTION
As per the issue I opened: https://github.com/libp2p/js-libp2p/issues/300

Upon `pubsub.unsubscribe`, the node was successfully unsubscribing, however the callback was never being called, so there was no explicit way to confirm success.

I have changed `unsubscribe` as to call the callback, so it now complies with the interface-ipfs-core spec. I have also added a test.

Let me know if any changes are needed, thanks!