### PR TITLE
chore: enable dht by default

### DIFF
--- a/README.md
+++ b/README.md
@@ -175,12 +175,12 @@ class Node extends libp2p {
         },
         dht: {
           kBucketSize: 20,
+          enabled: true,
           enabledDiscovery: true      // Allows to disable discovery (enabled by default)
         },
         // Enable/Disable Experimental features
         EXPERIMENTAL: {               // Experimental features ("behind a flag")
-          pubsub: false,
-          dht: false
+          pubsub: false
         }
       }
     }

--- a/src/config.js
+++ b/src/config.js
@@ -33,12 +33,12 @@ const OptionsSchema = Joi.object({
     }).default(),
     dht: Joi.object().keys({
       kBucketSize: Joi.number().default(20),
+      enabled: Joi.boolean().default(true),
       enabledDiscovery: Joi.boolean().default(true),
       validators: Joi.object().allow(null),
       selectors: Joi.object().allow(null)
     }).default(),
     EXPERIMENTAL: Joi.object().keys({
-      dht: Joi.boolean().default(false),
       pubsub: Joi.boolean().default(false)
     }).default()
   }).default()
@@ -48,7 +48,7 @@ module.exports.validate = (options) => {
   options = Joi.attempt(options, OptionsSchema)
 
   // Ensure dht is correct
-  if (options.config.EXPERIMENTAL.dht) {
+  if (options.config.dht.enabled) {
     Joi.assert(options.modules.dht, ModuleSchema.required())
   }
 

--- a/src/index.js
+++ b/src/index.js
@@ -102,7 +102,7 @@ class Node extends EventEmitter {
     }
 
     // dht provided components (peerRouting, contentRouting, dht)
-    if (this._config.EXPERIMENTAL.dht) {
+    if (this._config.dht.enabled) {
       const DHT = this._modules.dht
       const enabledDiscovery = this._config.dht.enabledDiscovery !== false
 

--- a/test/config.spec.js
+++ b/test/config.spec.js
@@ -63,7 +63,8 @@ describe('configuration', () => {
       peerInfo,
       modules: {
         transport: [ WS ],
-        peerDiscovery: [ Bootstrap ]
+        peerDiscovery: [ Bootstrap ],
+        dht: DHT
       },
       config: {
         peerDiscovery: {
@@ -79,7 +80,8 @@ describe('configuration', () => {
       peerInfo,
       modules: {
         transport: [ WS ],
-        peerDiscovery: [ Bootstrap ]
+        peerDiscovery: [ Bootstrap ],
+        dht: DHT
       },
       config: {
         peerDiscovery: {
@@ -89,11 +91,11 @@ describe('configuration', () => {
           }
         },
         EXPERIMENTAL: {
-          pubsub: false,
-          dht: false
+          pubsub: false
         },
         dht: {
           kBucketSize: 20,
+          enabled: true,
           enabledDiscovery: true
         },
         relay: {
@@ -115,7 +117,8 @@ describe('configuration', () => {
         transport: [ WS ],
         peerDiscovery: [ Bootstrap ],
         peerRouting: [ peerRouter ],
-        contentRouting: [ contentRouter ]
+        contentRouting: [ contentRouter ],
+        dht: DHT
       },
       config: {
         peerDiscovery: {
@@ -160,9 +163,6 @@ describe('configuration', () => {
         dht: DHT
       },
       config: {
-        EXPERIMENTAL: {
-          dht: true
-        },
         dht: {
           selectors,
           validators
@@ -177,14 +177,14 @@ describe('configuration', () => {
       },
       config: {
         EXPERIMENTAL: {
-          pubsub: false,
-          dht: true
+          pubsub: false
         },
         relay: {
           enabled: true
         },
         dht: {
           kBucketSize: 20,
+          enabled: true,
           enabledDiscovery: true,
           selectors,
           validators

--- a/test/content-routing.node.js
+++ b/test/content-routing.node.js
@@ -30,13 +30,7 @@ describe('.contentRouting', () => {
     before(function (done) {
       this.timeout(5 * 1000)
       const tasks = _times(5, () => (cb) => {
-        createNode('/ip4/0.0.0.0/tcp/0', {
-          config: {
-            EXPERIMENTAL: {
-              dht: true
-            }
-          }
-        }, (err, node) => {
+        createNode('/ip4/0.0.0.0/tcp/0', (err, node) => {
           expect(err).to.not.exist()
           node.start((err) => cb(err, node))
         })
@@ -159,6 +153,9 @@ describe('.contentRouting', () => {
               contentRouting: [ delegate ]
             },
             config: {
+              dht: {
+                enabled: false
+              },
               relay: {
                 enabled: true,
                 hop: {
@@ -320,9 +317,6 @@ describe('.contentRouting', () => {
                   enabled: true,
                   active: false
                 }
-              },
-              EXPERIMENTAL: {
-                dht: true
               }
             }
           })
@@ -387,7 +381,13 @@ describe('.contentRouting', () => {
   describe('no routers', () => {
     let nodeA
     before((done) => {
-      createNode('/ip4/0.0.0.0/tcp/0', (err, node) => {
+      createNode('/ip4/0.0.0.0/tcp/0', {
+        config: {
+          dht: {
+            enabled: false
+          }
+        }
+      }, (err, node) => {
         expect(err).to.not.exist()
         nodeA = node
         done()

--- a/test/create.spec.js
+++ b/test/create.spec.js
@@ -13,8 +13,10 @@ describe('libp2p creation', () => {
     createNode([], {
       config: {
         EXPERIMENTAL: {
-          dht: true,
           pubsub: true
+        },
+        dht: {
+          enabled: true
         }
       }
     }, (err, node) => {
@@ -69,13 +71,11 @@ describe('libp2p creation', () => {
     createNode([], {
       config: {
         EXPERIMENTAL: {
-          dht: false,
           pubsub: false
         }
       }
     }, (err, node) => {
       expect(err).to.not.exist()
-      expect(node._dht).to.not.exist()
       expect(node._floodSub).to.not.exist()
       done()
     })

--- a/test/dht.node.js
+++ b/test/dht.node.js
@@ -17,12 +17,7 @@ describe('.dht', () => {
 
     before(function (done) {
       createNode('/ip4/0.0.0.0/tcp/0', {
-        datastore,
-        config: {
-          EXPERIMENTAL: {
-            dht: true
-          }
-        }
+        datastore
       }, (err, node) => {
         expect(err).to.not.exist()
         nodeA = node
@@ -124,8 +119,8 @@ describe('.dht', () => {
     before(function (done) {
       createNode('/ip4/0.0.0.0/tcp/0', {
         config: {
-          EXPERIMENTAL: {
-            dht: false
+          dht: {
+            enabled: false
           }
         }
       }, (err, node) => {

--- a/test/fsm.spec.js
+++ b/test/fsm.spec.js
@@ -13,7 +13,13 @@ describe('libp2p state machine (fsm)', () => {
   describe('starting and stopping', () => {
     let node
     beforeEach((done) => {
-      createNode([], (err, _node) => {
+      createNode([], {
+        config: {
+          dht: {
+            enabled: false
+          }
+        }
+      }, (err, _node) => {
         node = _node
         done(err)
       })

--- a/test/peer-routing.node.js
+++ b/test/peer-routing.node.js
@@ -24,13 +24,7 @@ describe('.peerRouting', () => {
 
     before('create the outer ring of connections', (done) => {
       const tasks = _times(5, () => (cb) => {
-        createNode('/ip4/0.0.0.0/tcp/0', {
-          config: {
-            EXPERIMENTAL: {
-              dht: true
-            }
-          }
-        }, (err, node) => {
+        createNode('/ip4/0.0.0.0/tcp/0', (err, node) => {
           expect(err).to.not.exist()
           node.start((err) => cb(err, node))
         })
@@ -112,6 +106,11 @@ describe('.peerRouting', () => {
           createNode('/ip4/0.0.0.0/tcp/0', {
             modules: {
               peerRouting: [ delegate ]
+            },
+            config: {
+              dht: {
+                enabled: false
+              }
             }
           }, (err, node) => {
             expect(err).to.not.exist()
@@ -213,11 +212,6 @@ describe('.peerRouting', () => {
           createNode('/ip4/0.0.0.0/tcp/0', {
             modules: {
               peerRouting: [ delegate ]
-            },
-            config: {
-              EXPERIMENTAL: {
-                dht: true
-              }
             }
           }, (err, node) => {
             expect(err).to.not.exist()
@@ -270,7 +264,13 @@ describe('.peerRouting', () => {
   describe('no routers', () => {
     let nodeA
     before((done) => {
-      createNode('/ip4/0.0.0.0/tcp/0', (err, node) => {
+      createNode('/ip4/0.0.0.0/tcp/0', {
+        config: {
+          dht: {
+            enabled: false
+          }
+        }
+      }, (err, node) => {
         expect(err).to.not.exist()
         nodeA = node
         done()

--- a/test/pnet.node.js
+++ b/test/pnet.node.js
@@ -9,6 +9,7 @@ const PeerId = require('peer-id')
 const waterfall = require('async/waterfall')
 const WS = require('libp2p-websockets')
 const defaultsDeep = require('@nodeutils/defaults-deep')
+const DHT = require('libp2p-kad-dht')
 
 const Libp2p = require('../src')
 
@@ -23,7 +24,8 @@ describe('private network', () => {
         config = {
           peerInfo,
           modules: {
-            transport: [ WS ]
+            transport: [ WS ],
+            dht: DHT
           }
         }
         cb()

--- a/test/stats.js
+++ b/test/stats.js
@@ -15,9 +15,6 @@ describe('libp2p', () => {
           mdns: {
             enabled: false
           }
-        },
-        EXPERIMENTAL: {
-          dht: true
         }
       }
     }, (err, node) => {

--- a/test/utils/bundle-browser.js
+++ b/test/utils/bundle-browser.js
@@ -80,10 +80,10 @@ class Node extends libp2p {
         },
         dht: {
           kBucketSize: 20,
-          enabledDiscovery: true
+          enabledDiscovery: true,
+          enabled: false
         },
         EXPERIMENTAL: {
-          dht: false,
           pubsub: false
         }
       }

--- a/test/utils/bundle-nodejs.js
+++ b/test/utils/bundle-nodejs.js
@@ -73,10 +73,10 @@ class Node extends libp2p {
         },
         dht: {
           kBucketSize: 20,
-          enabledDiscovery: true
+          enabledDiscovery: true,
+          enabled: true
         },
         EXPERIMENTAL: {
-          dht: false,
           pubsub: false
         }
       }


### PR DESCRIPTION
Enable dht by default for `node` in libp2p

Needed in the context of https://github.com/ipfs/js-ipfs/pull/856