### PR TITLE
Change from ipfs to p2p protocol

### DIFF
--- a/examples/chat/src/dialer.js
+++ b/examples/chat/src/dialer.js
@@ -46,7 +46,7 @@ async.parallel([
     console.log('Dialer ready, listening on:')
 
     peerListener.multiaddrs.forEach((ma) => {
-      console.log(ma.toString() + '/ipfs/' + idListener.toB58String())
+      console.log(ma.toString() + '/p2p/' + idListener.toB58String())
     })
 
     nodeDialer.dialProtocol(peerListener, '/chat/1.0.0', (err, conn) => {

--- a/examples/chat/src/listener.js
+++ b/examples/chat/src/listener.js
@@ -50,7 +50,7 @@ PeerId.createFromJSON(require('./peer-id-listener'), (err, idListener) => {
 
     console.log('Listener ready, listening on:')
     peerListener.multiaddrs.forEach((ma) => {
-      console.log(ma.toString() + '/ipfs/' + idListener.toB58String())
+      console.log(ma.toString() + '/p2p/' + idListener.toB58String())
     })
   })
 })

--- a/examples/delegated-routing/src/App.js
+++ b/examples/delegated-routing/src/App.js
@@ -7,7 +7,7 @@ const Ipfs = require('ipfs')
 const libp2pBundle = require('./libp2p-bundle')
 // require('./App.css')
 
-const BootstrapNode = '/ip4/127.0.0.1/tcp/8081/ws/ipfs/QmdoG8DpzYUZMVP5dGmgmigZwR1RE8Cf6SxMPg1SBXJAQ8'
+const BootstrapNode = '/ip4/127.0.0.1/tcp/8081/ws/p2p/QmdoG8DpzYUZMVP5dGmgmigZwR1RE8Cf6SxMPg1SBXJAQ8'
 
 class App extends Component {
   constructor (props) {

--- a/examples/discovery-mechanisms/1.js
+++ b/examples/discovery-mechanisms/1.js
@@ -12,15 +12,15 @@ const defaultsDeep = require('@nodeutils/defaults-deep')
 
 // Find this list at: https://github.com/ipfs/js-ipfs/blob/master/src/core/runtime/config-nodejs.json
 const bootstrapers = [
-  '/ip4/104.131.131.82/tcp/4001/ipfs/QmaCpDMGvV2BGHeYERUEnRQAwe3N8SzbUtfsmvsqQLuvuJ',
-  '/ip4/104.236.176.52/tcp/4001/ipfs/QmSoLnSGccFuZQJzRadHn95W2CrSFmZuTdDWP8HXaHca9z',
-  '/ip4/104.236.179.241/tcp/4001/ipfs/QmSoLPppuBtQSGwKDZT2M73ULpjvfd3aZ6ha4oFGL1KrGM',
-  '/ip4/162.243.248.213/tcp/4001/ipfs/QmSoLueR4xBeUbY9WZ9xGUUxunbKWcrNFTDAadQJmocnWm',
-  '/ip4/128.199.219.111/tcp/4001/ipfs/QmSoLSafTMBsPKadTEgaXctDQVcqN88CNLHXMkTNwMKPnu',
-  '/ip4/104.236.76.40/tcp/4001/ipfs/QmSoLV4Bbm51jM9C4gDYZQ9Cy3U6aXMJDAbzgu2fzaDs64',
-  '/ip4/178.62.158.247/tcp/4001/ipfs/QmSoLer265NRgSp2LA3dPaeykiS1J6DifTC88f5uVQKNAd',
-  '/ip4/178.62.61.185/tcp/4001/ipfs/QmSoLMeWqB7YGVLJN3pNLQpmmEk35v6wYtsMGLzSr5QBU3',
-  '/ip4/104.236.151.122/tcp/4001/ipfs/QmSoLju6m7xTh3DuokvT3886QRYqxAzb1kShaanJgW36yx'
+  '/ip4/104.131.131.82/tcp/4001/p2p/QmaCpDMGvV2BGHeYERUEnRQAwe3N8SzbUtfsmvsqQLuvuJ',
+  '/ip4/104.236.176.52/tcp/4001/p2p/QmSoLnSGccFuZQJzRadHn95W2CrSFmZuTdDWP8HXaHca9z',
+  '/ip4/104.236.179.241/tcp/4001/p2p/QmSoLPppuBtQSGwKDZT2M73ULpjvfd3aZ6ha4oFGL1KrGM',
+  '/ip4/162.243.248.213/tcp/4001/p2p/QmSoLueR4xBeUbY9WZ9xGUUxunbKWcrNFTDAadQJmocnWm',
+  '/ip4/128.199.219.111/tcp/4001/p2p/QmSoLSafTMBsPKadTEgaXctDQVcqN88CNLHXMkTNwMKPnu',
+  '/ip4/104.236.76.40/tcp/4001/p2p/QmSoLV4Bbm51jM9C4gDYZQ9Cy3U6aXMJDAbzgu2fzaDs64',
+  '/ip4/178.62.158.247/tcp/4001/p2p/QmSoLer265NRgSp2LA3dPaeykiS1J6DifTC88f5uVQKNAd',
+  '/ip4/178.62.61.185/tcp/4001/p2p/QmSoLMeWqB7YGVLJN3pNLQpmmEk35v6wYtsMGLzSr5QBU3',
+  '/ip4/104.236.151.122/tcp/4001/p2p/QmSoLju6m7xTh3DuokvT3886QRYqxAzb1kShaanJgW36yx'
 ]
 
 class MyBundle extends libp2p {

--- a/examples/discovery-mechanisms/README.md
+++ b/examples/discovery-mechanisms/README.md
@@ -43,15 +43,15 @@ In this bundle, we use a `bootstrappers` array listing peers to connect _on boot
 
 ```JavaScript
 const bootstrapers = [
-  '/ip4/104.131.131.82/tcp/4001/ipfs/QmaCpDMGvV2BGHeYERUEnRQAwe3N8SzbUtfsmvsqQLuvuJ',
-  '/ip4/104.236.176.52/tcp/4001/ipfs/QmSoLnSGccFuZQJzRadHn95W2CrSFmZuTdDWP8HXaHca9z',
-  '/ip4/104.236.179.241/tcp/4001/ipfs/QmSoLPppuBtQSGwKDZT2M73ULpjvfd3aZ6ha4oFGL1KrGM',
-  '/ip4/162.243.248.213/tcp/4001/ipfs/QmSoLueR4xBeUbY9WZ9xGUUxunbKWcrNFTDAadQJmocnWm',
-  '/ip4/128.199.219.111/tcp/4001/ipfs/QmSoLSafTMBsPKadTEgaXctDQVcqN88CNLHXMkTNwMKPnu',
-  '/ip4/104.236.76.40/tcp/4001/ipfs/QmSoLV4Bbm51jM9C4gDYZQ9Cy3U6aXMJDAbzgu2fzaDs64',
-  '/ip4/178.62.158.247/tcp/4001/ipfs/QmSoLer265NRgSp2LA3dPaeykiS1J6DifTC88f5uVQKNAd',
-  '/ip4/178.62.61.185/tcp/4001/ipfs/QmSoLMeWqB7YGVLJN3pNLQpmmEk35v6wYtsMGLzSr5QBU3',
-  '/ip4/104.236.151.122/tcp/4001/ipfs/QmSoLju6m7xTh3DuokvT3886QRYqxAzb1kShaanJgW36yx'
+  '/ip4/104.131.131.82/tcp/4001/p2p/QmaCpDMGvV2BGHeYERUEnRQAwe3N8SzbUtfsmvsqQLuvuJ',
+  '/ip4/104.236.176.52/tcp/4001/p2p/QmSoLnSGccFuZQJzRadHn95W2CrSFmZuTdDWP8HXaHca9z',
+  '/ip4/104.236.179.241/tcp/4001/p2p/QmSoLPppuBtQSGwKDZT2M73ULpjvfd3aZ6ha4oFGL1KrGM',
+  '/ip4/162.243.248.213/tcp/4001/p2p/QmSoLueR4xBeUbY9WZ9xGUUxunbKWcrNFTDAadQJmocnWm',
+  '/ip4/128.199.219.111/tcp/4001/p2p/QmSoLSafTMBsPKadTEgaXctDQVcqN88CNLHXMkTNwMKPnu',
+  '/ip4/104.236.76.40/tcp/4001/p2p/QmSoLV4Bbm51jM9C4gDYZQ9Cy3U6aXMJDAbzgu2fzaDs64',
+  '/ip4/178.62.158.247/tcp/4001/p2p/QmSoLer265NRgSp2LA3dPaeykiS1J6DifTC88f5uVQKNAd',
+  '/ip4/178.62.61.185/tcp/4001/p2p/QmSoLMeWqB7YGVLJN3pNLQpmmEk35v6wYtsMGLzSr5QBU3',
+  '/ip4/104.236.151.122/tcp/4001/p2p/QmSoLju6m7xTh3DuokvT3886QRYqxAzb1kShaanJgW36yx'
 ]
 ```
 

--- a/examples/echo/src/dialer.js
+++ b/examples/echo/src/dialer.js
@@ -28,7 +28,7 @@ async.parallel([
   // Peer to Dial
   const listenerPeerInfo = new PeerInfo(ids[1])
   const listenerId = ids[1]
-  const listenerMultiaddr = '/ip4/127.0.0.1/tcp/10333/ipfs/' +
+  const listenerMultiaddr = '/ip4/127.0.0.1/tcp/10333/p2p/' +
       listenerId.toB58String()
   listenerPeerInfo.multiaddrs.add(listenerMultiaddr)
 
@@ -37,7 +37,7 @@ async.parallel([
 
     console.log('Dialer ready, listening on:')
     dialerPeerInfo.multiaddrs.forEach((ma) => console.log(ma.toString() +
-          '/ipfs/' + dialerId.toB58String()))
+          '/p2p/' + dialerId.toB58String()))
 
     console.log('Dialing to peer:', listenerMultiaddr.toString())
     dialerNode.dialProtocol(listenerPeerInfo, '/echo/1.0.0', (err, conn) => {

--- a/examples/echo/src/listener.js
+++ b/examples/echo/src/listener.js
@@ -41,6 +41,6 @@ series([
 
   console.log('Listener ready, listening on:')
   listenerNode.peerInfo.multiaddrs.forEach((ma) => {
-    console.log(ma.toString() + '/ipfs/' + listenerId.toB58String())
+    console.log(ma.toString() + '/p2p/' + listenerId.toB58String())
   })
 })

--- a/examples/libp2p-in-the-browser/1/package.json
+++ b/examples/libp2p-in-the-browser/1/package.json
@@ -23,7 +23,7 @@
     "libp2p-spdy": "~0.12.1",
     "libp2p-webrtc-star": "~0.15.3",
     "libp2p-websocket-star": "~0.8.1",
-    "libp2p-websockets": "^0.12.0",
+    "libp2p-websockets": "~0.12.0",
     "peer-info": "~0.15.1"
   }
 }

--- a/examples/libp2p-in-the-browser/1/package.json
+++ b/examples/libp2p-in-the-browser/1/package.json
@@ -23,7 +23,7 @@
     "libp2p-spdy": "~0.12.1",
     "libp2p-webrtc-star": "~0.15.3",
     "libp2p-websocket-star": "~0.8.1",
-    "libp2p-websockets": "~0.12.0",
-    "peer-info": "~0.14.1"
+    "libp2p-websockets": "^0.12.0",
+    "peer-info": "~0.15.1"
   }
 }

--- a/examples/libp2p-in-the-browser/1/src/browser-bundle.js
+++ b/examples/libp2p-in-the-browser/1/src/browser-bundle.js
@@ -12,16 +12,16 @@ const libp2p = require('../../../../')
 
 // Find this list at: https://github.com/ipfs/js-ipfs/blob/master/src/core/runtime/config-browser.json
 const bootstrapList = [
-  '/dns4/ams-1.bootstrap.libp2p.io/tcp/443/wss/ipfs/QmSoLer265NRgSp2LA3dPaeykiS1J6DifTC88f5uVQKNAd',
-  '/dns4/sfo-1.bootstrap.libp2p.io/tcp/443/wss/ipfs/QmSoLju6m7xTh3DuokvT3886QRYqxAzb1kShaanJgW36yx',
-  '/dns4/lon-1.bootstrap.libp2p.io/tcp/443/wss/ipfs/QmSoLMeWqB7YGVLJN3pNLQpmmEk35v6wYtsMGLzSr5QBU3',
-  '/dns4/sfo-2.bootstrap.libp2p.io/tcp/443/wss/ipfs/QmSoLnSGccFuZQJzRadHn95W2CrSFmZuTdDWP8HXaHca9z',
-  '/dns4/sfo-3.bootstrap.libp2p.io/tcp/443/wss/ipfs/QmSoLPppuBtQSGwKDZT2M73ULpjvfd3aZ6ha4oFGL1KrGM',
-  '/dns4/sgp-1.bootstrap.libp2p.io/tcp/443/wss/ipfs/QmSoLSafTMBsPKadTEgaXctDQVcqN88CNLHXMkTNwMKPnu',
-  '/dns4/nyc-1.bootstrap.libp2p.io/tcp/443/wss/ipfs/QmSoLueR4xBeUbY9WZ9xGUUxunbKWcrNFTDAadQJmocnWm',
-  '/dns4/nyc-2.bootstrap.libp2p.io/tcp/443/wss/ipfs/QmSoLV4Bbm51jM9C4gDYZQ9Cy3U6aXMJDAbzgu2fzaDs64',
-  '/dns4/node0.preload.ipfs.io/tcp/443/wss/ipfs/QmZMxNdpMkewiVZLMRxaNxUeZpDUb34pWjZ1kZvsd16Zic',
-  '/dns4/node0.preload.ipfs.io/tcp/443/wss/ipfs/Qmbut9Ywz9YEDrz8ySBSgWyJk41Uvm2QJPhwDJzJyGFsD6'
+  '/dns4/ams-1.bootstrap.libp2p.io/tcp/443/wss/p2p/QmSoLer265NRgSp2LA3dPaeykiS1J6DifTC88f5uVQKNAd',
+  '/dns4/sfo-1.bootstrap.libp2p.io/tcp/443/wss/p2p/QmSoLju6m7xTh3DuokvT3886QRYqxAzb1kShaanJgW36yx',
+  '/dns4/lon-1.bootstrap.libp2p.io/tcp/443/wss/p2p/QmSoLMeWqB7YGVLJN3pNLQpmmEk35v6wYtsMGLzSr5QBU3',
+  '/dns4/sfo-2.bootstrap.libp2p.io/tcp/443/wss/p2p/QmSoLnSGccFuZQJzRadHn95W2CrSFmZuTdDWP8HXaHca9z',
+  '/dns4/sfo-3.bootstrap.libp2p.io/tcp/443/wss/p2p/QmSoLPppuBtQSGwKDZT2M73ULpjvfd3aZ6ha4oFGL1KrGM',
+  '/dns4/sgp-1.bootstrap.libp2p.io/tcp/443/wss/p2p/QmSoLSafTMBsPKadTEgaXctDQVcqN88CNLHXMkTNwMKPnu',
+  '/dns4/nyc-1.bootstrap.libp2p.io/tcp/443/wss/p2p/QmSoLueR4xBeUbY9WZ9xGUUxunbKWcrNFTDAadQJmocnWm',
+  '/dns4/nyc-2.bootstrap.libp2p.io/tcp/443/wss/p2p/QmSoLV4Bbm51jM9C4gDYZQ9Cy3U6aXMJDAbzgu2fzaDs64',
+  '/dns4/node0.preload.ipfs.io/tcp/443/wss/p2p/QmZMxNdpMkewiVZLMRxaNxUeZpDUb34pWjZ1kZvsd16Zic',
+  '/dns4/node0.preload.ipfs.io/tcp/443/wss/p2p/Qmbut9Ywz9YEDrz8ySBSgWyJk41Uvm2QJPhwDJzJyGFsD6'
 ]
 
 class Node extends libp2p {

--- a/examples/libp2p-in-the-browser/1/src/create-node.js
+++ b/examples/libp2p-in-the-browser/1/src/create-node.js
@@ -10,7 +10,7 @@ function createNode (callback) {
     }
 
     const peerIdStr = peerInfo.id.toB58String()
-    const ma = `/dns4/star-signal.cloud.ipfs.team/tcp/443/wss/p2p-webrtc-star/ipfs/${peerIdStr}`
+    const ma = `/dns4/star-signal.cloud.ipfs.team/tcp/443/wss/p2p-webrtc-star/p2p/${peerIdStr}`
 
     peerInfo.multiaddrs.add(ma)
 

--- a/examples/peer-and-content-routing/README.md
+++ b/examples/peer-and-content-routing/README.md
@@ -69,8 +69,8 @@ You should see the output being something like:
 ```Bash
 > node 1.js
 Found it, multiaddrs are:
-/ip4/127.0.0.1/tcp/63617/ipfs/QmWrFXvZr9S4iDqycyoyc2zDdrT1jg9wpdenUTdd1LTar6
-/ip4/192.168.86.41/tcp/63617/ipfs/QmWrFXvZr9S4iDqycyoyc2zDdrT1jg9wpdenUTdd1LTar6
+/ip4/127.0.0.1/tcp/63617/p2p/QmWrFXvZr9S4iDqycyoyc2zDdrT1jg9wpdenUTdd1LTar6
+/ip4/192.168.86.41/tcp/63617/p2p/QmWrFXvZr9S4iDqycyoyc2zDdrT1jg9wpdenUTdd1LTar6
 ```
 
 You have successfully used Peer Routing to find a peer that you were not directly connected. Now all you have to do is to dial to the multiaddrs you discovered.

--- a/examples/protocol-and-stream-muxing/README.md
+++ b/examples/protocol-and-stream-muxing/README.md
@@ -169,7 +169,7 @@ You can see this working on example [3.js](./3.js). The result should look like 
 > node 3.js
 from 1 to 2
 Addresses by which both peers are connected
-node 1 to node 2: /ip4/127.0.0.1/tcp/50629/ipfs/QmZwMKTo6wG4Te9A6M2eJnWDpR8uhsGed4YRegnV5DcKiv
-node 2 to node 1: /ip4/127.0.0.1/tcp/50630/ipfs/QmRgormJQeDyXhDKma11eUtksoh8vWmeBoxghVt4meauW9
+node 1 to node 2: /ip4/127.0.0.1/tcp/50629/p2p/QmZwMKTo6wG4Te9A6M2eJnWDpR8uhsGed4YRegnV5DcKiv
+node 2 to node 1: /ip4/127.0.0.1/tcp/50630/p2p/QmRgormJQeDyXhDKma11eUtksoh8vWmeBoxghVt4meauW9
 from 2 to 1
 ```

--- a/examples/transports/README.md
+++ b/examples/transports/README.md
@@ -88,8 +88,8 @@ Running this should result in something like:
 > node 1.js
 node has started (true/false): true
 listening on:
-/ip4/127.0.0.1/tcp/61329/ipfs/QmW2cKTakTYqbQkUzBTEGXgWYFj1YEPeUndE1YWs6CBzDQ
-/ip4/192.168.2.156/tcp/61329/ipfs/QmW2cKTakTYqbQkUzBTEGXgWYFj1YEPeUndE1YWs6CBzDQ
+/ip4/127.0.0.1/tcp/61329/p2p/QmW2cKTakTYqbQkUzBTEGXgWYFj1YEPeUndE1YWs6CBzDQ
+/ip4/192.168.2.156/tcp/61329/p2p/QmW2cKTakTYqbQkUzBTEGXgWYFj1YEPeUndE1YWs6CBzDQ
 ```
 
 That `QmW2cKTakTYqbQkUzBTEGXgWYFj1YEPeUndE1YWs6CBzDQ` is the PeerId that was created during the PeerInfo generation.
@@ -175,11 +175,11 @@ The result should be look like:
 ```bash
 > node 2.js
 node 1 is listening on:
-/ip4/127.0.0.1/tcp/62279/ipfs/QmeM4wNWv1uci7UJjUXZYfvcy9uqAbw7G9icuxdqy88Mj9
-/ip4/192.168.2.156/tcp/62279/ipfs/QmeM4wNWv1uci7UJjUXZYfvcy9uqAbw7G9icuxdqy88Mj9
+/ip4/127.0.0.1/tcp/62279/p2p/QmeM4wNWv1uci7UJjUXZYfvcy9uqAbw7G9icuxdqy88Mj9
+/ip4/192.168.2.156/tcp/62279/p2p/QmeM4wNWv1uci7UJjUXZYfvcy9uqAbw7G9icuxdqy88Mj9
 node 2 is listening on:
-/ip4/127.0.0.1/tcp/62278/ipfs/QmWp58xJgzbouNJcyiNNTpZuqQCJU8jf6ixc7TZT9xEZhV
-/ip4/192.168.2.156/tcp/62278/ipfs/QmWp58xJgzbouNJcyiNNTpZuqQCJU8jf6ixc7TZT9xEZhV
+/ip4/127.0.0.1/tcp/62278/p2p/QmWp58xJgzbouNJcyiNNTpZuqQCJU8jf6ixc7TZT9xEZhV
+/ip4/192.168.2.156/tcp/62278/p2p/QmWp58xJgzbouNJcyiNNTpZuqQCJU8jf6ixc7TZT9xEZhV
 Hello p2p world!
 ```
 
@@ -304,14 +304,14 @@ If everything was set correctly, you now should see the following after you run 
 ```Bash
 > node 3.js
 node 1 is listening on:
-/ip4/127.0.0.1/tcp/62620/ipfs/QmWpWmcVJkF6EpmAaVDauku8g1uFGuxPsGP35XZp9GYEqs
-/ip4/192.168.2.156/tcp/62620/ipfs/QmWpWmcVJkF6EpmAaVDauku8g1uFGuxPsGP35XZp9GYEqs
+/ip4/127.0.0.1/tcp/62620/p2p/QmWpWmcVJkF6EpmAaVDauku8g1uFGuxPsGP35XZp9GYEqs
+/ip4/192.168.2.156/tcp/62620/p2p/QmWpWmcVJkF6EpmAaVDauku8g1uFGuxPsGP35XZp9GYEqs
 node 2 is listening on:
-/ip4/127.0.0.1/tcp/10000/ws/ipfs/QmWAQtWdzWXibgfyc7WRHhhv6MdqVKzXvyfSTnN2aAvixX
-/ip4/127.0.0.1/tcp/62619/ipfs/QmWAQtWdzWXibgfyc7WRHhhv6MdqVKzXvyfSTnN2aAvixX
-/ip4/192.168.2.156/tcp/62619/ipfs/QmWAQtWdzWXibgfyc7WRHhhv6MdqVKzXvyfSTnN2aAvixX
+/ip4/127.0.0.1/tcp/10000/ws/p2p/QmWAQtWdzWXibgfyc7WRHhhv6MdqVKzXvyfSTnN2aAvixX
+/ip4/127.0.0.1/tcp/62619/p2p/QmWAQtWdzWXibgfyc7WRHhhv6MdqVKzXvyfSTnN2aAvixX
+/ip4/192.168.2.156/tcp/62619/p2p/QmWAQtWdzWXibgfyc7WRHhhv6MdqVKzXvyfSTnN2aAvixX
 node 3 is listening on:
-/ip4/127.0.0.1/tcp/20000/ws/ipfs/QmVq1PWh3VSDYdFqYMtqp4YQyXcrH27N7968tGdM1VQPj1
+/ip4/127.0.0.1/tcp/20000/ws/p2p/QmVq1PWh3VSDYdFqYMtqp4YQyXcrH27N7968tGdM1VQPj1
 node 3 failed to dial to node 1 with: No available transport to dial to
 node 1 dialed to node 2 successfully
 node 2 dialed to node 3 successfully

--- a/pdd/pdd-the-ipfs-bundle--story-1--peer-a.js
+++ b/pdd/pdd-the-ipfs-bundle--story-1--peer-a.js
@@ -59,7 +59,7 @@ test('story 1 - peerA', (t) => {
     t.ifErr(err, 'created Node successfully')
     t.ok(node.isStarted(), 'PeerA is Running')
 
-    const peerBAddr = `/ip4/127.0.0.1/tcp/10001/ipfs/${PeerB.id}`
+    const peerBAddr = `/ip4/127.0.0.1/tcp/10001/p2p/${PeerB.id}`
 
     node.handle('/time/1.0.0', (protocol, conn) => {
       pull(

--- a/pdd/pdd-the-ipfs-bundle--story-1--peer-b.js
+++ b/pdd/pdd-the-ipfs-bundle--story-1--peer-b.js
@@ -59,7 +59,7 @@ test('story 1 - peerA', (t) => {
     t.ifErr(err, 'created Node successfully')
     t.ok(node.isStarted(), 'PeerB is Running')
 
-    const peerAAddr = `/ip4/127.0.0.1/tcp/10000/ipfs/${PeerA.id}`
+    const peerAAddr = `/ip4/127.0.0.1/tcp/10000/p2p/${PeerA.id}`
 
     node.handle('/echo/1.0.0', (protocol, conn) => {
       pull(

--- a/pdd/pdd-transport--story-1--peer-a.js
+++ b/pdd/pdd-transport--story-1--peer-a.js
@@ -33,7 +33,7 @@ test('story 1 - peerA', (t) => {
     t.ifErr(err, 'created Node')
     t.ok(node.isStarted(), 'PeerA is running')
 
-    const PeerBAddr = `/ip4/127.0.0.1/tcp/10001/ipfs/${PeerB.id}`
+    const PeerBAddr = `/ip4/127.0.0.1/tcp/10001/p2p/${PeerB.id}`
 
     node.dial(PeerBAddr, '/echo/1.0.0', (err, conn) => {
       t.ifErr(err, 'dial successful')

--- a/pdd/pdd-transport--story-2--peer-a.js
+++ b/pdd/pdd-transport--story-2--peer-a.js
@@ -33,7 +33,7 @@ test('story 2 - peerA', (t) => {
     t.ifErr(err, 'created Node')
     t.ok(node.isStarted(), 'PeerA is running')
 
-    const PeerBAddr = `/ip4/127.0.0.1/tcp/10001/ws/ipfs/${PeerB.id}`
+    const PeerBAddr = `/ip4/127.0.0.1/tcp/10001/p2p/${PeerB.id}`
 
     node.dial(PeerBAddr, '/echo/1.0.0', (err, conn) => {
       t.ifErr(err, 'dial successful')

--- a/pdd/pdd-transport--story-3--peer-a.js
+++ b/pdd/pdd-transport--story-3--peer-a.js
@@ -32,7 +32,7 @@ test('story 3 - peerA', (t) => {
     t.ifErr(err, 'created Node')
     t.ok(node.isStarted(), 'PeerA is running')
 
-    const PeerBAddr = `/ip4/127.0.0.1/tcp/10001/ws/ipfs/${PeerB.id}`
+    const PeerBAddr = `/ip4/127.0.0.1/tcp/10001/ws/p2p/${PeerB.id}`
 
     setTimeout(() => node.dial(PeerBAddr, '/echo/1.0.0', (err, conn) => {
       t.ok(err, 'dial failed')

--- a/pdd/pdd-transport--story-3--peer-b.js
+++ b/pdd/pdd-transport--story-3--peer-b.js
@@ -32,7 +32,7 @@ test('story 3 - peerB', (t) => {
     t.ifErr(err, 'created Node')
     t.ok(node.isStarted(), 'PeerA is running')
 
-    const PeerAAddr = `/ip4/127.0.0.1/tcp/10000/ws/ipfs/${PeerA.id}`
+    const PeerAAddr = `/ip4/127.0.0.1/tcp/10000/ws/p2p/${PeerA.id}`
 
     setTimeout(() => node.dial(PeerAAddr, '/echo/1.0.0', (err, conn) => {
       t.ok(err, 'dial failed')

--- a/src/index.js
+++ b/src/index.js
@@ -330,7 +330,7 @@ class Node extends EventEmitter {
     this.peerInfo.multiaddrs.toArray().forEach((ma) => {
       if (!ma.getPeerId()) {
         maOld.push(ma)
-        maNew.push(ma.encapsulate('/ipfs/' + this.peerInfo.id.toB58String()))
+        maNew.push(ma.encapsulate('/p2p/' + this.peerInfo.id.toB58String()))
       }
     })
     this.peerInfo.multiaddrs.replace(maOld, maNew)

--- a/test/circuit-relay.node.js
+++ b/test/circuit-relay.node.js
@@ -195,7 +195,7 @@ describe('circuit relay', () => {
 
         tryEcho(conn, () => {
           const addr = multiaddr(handlerSpies[0].args[2][0].dstPeer.addrs[0]).toString()
-          expect(addr).to.equal(`/p2p/${nodeTCP1.peerInfo.id.toB58String()}`)
+          expect(addr).to.equal(`/ipfs/${nodeTCP1.peerInfo.id.toB58String()}`)
           done()
         })
       })
@@ -208,7 +208,7 @@ describe('circuit relay', () => {
 
         tryEcho(conn, () => {
           const addr = multiaddr(handlerSpies[1].args[2][0].dstPeer.addrs[0]).toString()
-          expect(addr).to.equal(`/p2p/${nodeTCP2.peerInfo.id.toB58String()}`)
+          expect(addr).to.equal(`/ipfs/${nodeTCP2.peerInfo.id.toB58String()}`)
           done()
         })
       })

--- a/test/circuit-relay.node.js
+++ b/test/circuit-relay.node.js
@@ -117,7 +117,7 @@ describe('circuit relay', () => {
       // set up node with TCP and listening on relay1
       (cb) => setupNode([
         '/ip4/0.0.0.0/tcp/0',
-        `/ipfs/${relayNode1.peerInfo.id.toB58String()}/p2p-circuit`
+        `/p2p/${relayNode1.peerInfo.id.toB58String()}/p2p-circuit`
       ], {
         config: {
           relay: {
@@ -131,7 +131,7 @@ describe('circuit relay', () => {
       // set up node with TCP and listening on relay2 over TCP transport
       (cb) => setupNode([
         '/ip4/0.0.0.0/tcp/0',
-        `/ip4/0.0.0.0/tcp/0/ipfs/${relayNode2.peerInfo.id.toB58String()}/p2p-circuit`
+        `/ip4/0.0.0.0/tcp/0/p2p/${relayNode2.peerInfo.id.toB58String()}/p2p-circuit`
       ], {
         config: {
           relay: {
@@ -195,7 +195,7 @@ describe('circuit relay', () => {
 
         tryEcho(conn, () => {
           const addr = multiaddr(handlerSpies[0].args[2][0].dstPeer.addrs[0]).toString()
-          expect(addr).to.equal(`/ipfs/${nodeTCP1.peerInfo.id.toB58String()}`)
+          expect(addr).to.equal(`/p2p/${nodeTCP1.peerInfo.id.toB58String()}`)
           done()
         })
       })
@@ -208,7 +208,7 @@ describe('circuit relay', () => {
 
         tryEcho(conn, () => {
           const addr = multiaddr(handlerSpies[1].args[2][0].dstPeer.addrs[0]).toString()
-          expect(addr).to.equal(`/ipfs/${nodeTCP2.peerInfo.id.toB58String()}`)
+          expect(addr).to.equal(`/p2p/${nodeTCP2.peerInfo.id.toB58String()}`)
           done()
         })
       })

--- a/test/content-routing.node.js
+++ b/test/content-routing.node.js
@@ -191,7 +191,7 @@ describe('.contentRouting', () => {
           // mock the swarm connect
           .post('/api/v0/swarm/connect')
           .query({
-            arg: `/ip4/0.0.0.0/tcp/60194/p2p-circuit/ipfs/${nodeA.peerInfo.id.toB58String()}`,
+            arg: `/ip4/0.0.0.0/tcp/60194/p2p-circuit/p2p/${nodeA.peerInfo.id.toB58String()}`,
             'stream-channels': true
           })
           .reply(200, {
@@ -222,7 +222,7 @@ describe('.contentRouting', () => {
           // mock the swarm connect
           .post('/api/v0/swarm/connect')
           .query({
-            arg: `/ip4/0.0.0.0/tcp/60194/p2p-circuit/ipfs/${nodeA.peerInfo.id.toB58String()}`,
+            arg: `/ip4/0.0.0.0/tcp/60194/p2p-circuit/p2p/${nodeA.peerInfo.id.toB58String()}`,
             'stream-channels': true
           })
           .reply(502, 'Bad Gateway', ['Content-Type', 'application/json'])

--- a/test/content-routing.node.js
+++ b/test/content-routing.node.js
@@ -191,7 +191,7 @@ describe('.contentRouting', () => {
           // mock the swarm connect
           .post('/api/v0/swarm/connect')
           .query({
-            arg: `/ip4/0.0.0.0/tcp/60194/p2p-circuit/p2p/${nodeA.peerInfo.id.toB58String()}`,
+            arg: `/ip4/0.0.0.0/tcp/60194/p2p-circuit/ipfs/${nodeA.peerInfo.id.toB58String()}`,
             'stream-channels': true
           })
           .reply(200, {
@@ -222,7 +222,7 @@ describe('.contentRouting', () => {
           // mock the swarm connect
           .post('/api/v0/swarm/connect')
           .query({
-            arg: `/ip4/0.0.0.0/tcp/60194/p2p-circuit/p2p/${nodeA.peerInfo.id.toB58String()}`,
+            arg: `/ip4/0.0.0.0/tcp/60194/p2p-circuit/ipfs/${nodeA.peerInfo.id.toB58String()}`,
             'stream-channels': true
           })
           .reply(502, 'Bad Gateway', ['Content-Type', 'application/json'])

--- a/test/transports.browser.js
+++ b/test/transports.browser.js
@@ -21,7 +21,7 @@ const jsonPeerId = require('./fixtures/test-peer.json')
 describe('transports', () => {
   describe('websockets', () => {
     let peerB
-    let peerBMultiaddr = '/ip4/127.0.0.1/tcp/9200/ws/ipfs/' + jsonPeerId.id
+    let peerBMultiaddr = '/ip4/127.0.0.1/tcp/9200/ws/p2p/' + jsonPeerId.id
     let nodeA
 
     before((done) => {
@@ -256,11 +256,11 @@ describe('transports', () => {
         expect(err).to.not.exist()
 
         peer1 = new PeerInfo(ids[0])
-        const ma1 = '/ip4/127.0.0.1/tcp/15555/ws/p2p-webrtc-star/ipfs/' + ids[0].toB58String()
+        const ma1 = '/ip4/127.0.0.1/tcp/15555/ws/p2p-webrtc-star/p2p/' + ids[0].toB58String()
         peer1.multiaddrs.add(ma1)
 
         peer2 = new PeerInfo(ids[1])
-        const ma2 = '/ip4/127.0.0.1/tcp/15555/ws/p2p-webrtc-star/ipfs/' + ids[1].toB58String()
+        const ma2 = '/ip4/127.0.0.1/tcp/15555/ws/p2p-webrtc-star/p2p/' + ids[1].toB58String()
         peer2.multiaddrs.add(ma2)
 
         done()
@@ -333,7 +333,7 @@ describe('transports', () => {
         }
 
         const peer3 = new PeerInfo(id3)
-        const ma3 = '/ip4/127.0.0.1/tcp/15555/ws/p2p-webrtc-star/ipfs/' + b58Id
+        const ma3 = '/ip4/127.0.0.1/tcp/15555/ws/p2p-webrtc-star/p2p/' + b58Id
         peer3.multiaddrs.add(ma3)
 
         node1.on('peer:discovery', (peerInfo) => node1.dial(peerInfo, check))
@@ -441,7 +441,7 @@ describe('transports', () => {
         expect(err).to.not.exist()
 
         const peer3 = new PeerInfo(id3)
-        const ma3 = '/ip4/127.0.0.1/tcp/14444/ws/p2p-websocket-star/ipfs/' + id3.toB58String()
+        const ma3 = '/ip4/127.0.0.1/tcp/14444/ws/p2p-websocket-star/p2p/' + id3.toB58String()
         peer3.multiaddrs.add(ma3)
 
         node1.on('peer:discovery', (peerInfo) => node1.dial(peerInfo, check))

--- a/test/turbolence.node.js
+++ b/test/turbolence.node.js
@@ -48,7 +48,7 @@ describe('Turbolence tests', () => {
 
   it('connect nodeA to that node', (done) => {
     const spawnedId = require('./test-data/test-id.json')
-    const maddr = multiaddr('/ip4/127.0.0.1/tcp/12345/ipfs/' + spawnedId.id)
+    const maddr = multiaddr('/ip4/127.0.0.1/tcp/12345/p2p/' + spawnedId.id)
 
     nodeA.dial(maddr, '/echo/1.0.0', (err, conn) => {
       expect(err).to.not.exist()


### PR DESCRIPTION
https://github.com/multiformats/js-multiaddr/pull/76 changed the default protocol from ipfs to p2p.

js-multiaddr is a transitive dependency of peer-info, so in order to get this change, we had to bump the version of peer-info.