### PR TITLE
fix: start and stop error callback

### DIFF
--- a/package.json
+++ b/package.json
@@ -54,6 +54,7 @@
     "libp2p-websockets": "~0.12.0",
     "mafmt": "^6.0.2",
     "multiaddr": "^6.0.2",
+    "once": "^1.4.0",
     "peer-book": "~0.9.0",
     "peer-id": "~0.12.0",
     "peer-info": "~0.15.0"

--- a/src/index.js
+++ b/src/index.js
@@ -6,6 +6,7 @@ const debug = require('debug')
 const log = debug('libp2p')
 log.error = debug('libp2p:error')
 const errCode = require('err-code')
+const once = require('once')
 
 const each = require('async/each')
 const series = require('async/series')
@@ -29,6 +30,35 @@ const notStarted = (action, state) => {
     new Error(`libp2p cannot ${action} when not started; state is ${state}`),
     'ERR_NODE_NOT_STARTED'
   )
+}
+
+/**
+ * Registers `handler` to each event in `events`. The `handler`
+ * will only be called for the first event fired, at which point
+ * the `handler` will be removed as a listener.
+ *
+ * Ensures `handler` is only called once.
+ *
+ * @example
+ * // will call `callback` when `start` or `error` is emitted by `this`
+ * eitherOnce(this, ['error', 'start'], callback)
+ *
+ * @private
+ * @param {EventEmitter} emitter The emitter to listen on
+ * @param {Array<string>} events The events to listen for
+ * @param {function(*)} handler The handler to call when an event is triggered
+ * @returns {void}
+ */
+function eitherOnce (emitter, events, handler) {
+  handler = once(handler)
+  events.forEach((e) => {
+    emitter.once(e, (...args) => {
+      events.forEach((ev) => {
+        emitter.removeListener(ev, handler)
+      })
+      handler.apply(emitter, args)
+    })
+  })
 }
 
 /**
@@ -194,7 +224,7 @@ class Node extends EventEmitter {
    * @returns {void}
    */
   start (callback = () => {}) {
-    this.once('start', callback)
+    eitherOnce(this, ['error', 'start'], callback)
     this.state('start')
   }
 

--- a/src/util/index.js
+++ b/src/util/index.js
@@ -1,0 +1,33 @@
+'use strict'
+const once = require('once')
+
+/**
+ * Registers `handler` to each event in `events`. The `handler`
+ * will only be called for the first event fired, at which point
+ * the `handler` will be removed as a listener.
+ *
+ * Ensures `handler` is only called once.
+ *
+ * @example
+ * // will call `callback` when `start` or `error` is emitted by `this`
+ * emitFirst(this, ['error', 'start'], callback)
+ *
+ * @private
+ * @param {EventEmitter} emitter The emitter to listen on
+ * @param {Array<string>} events The events to listen for
+ * @param {function(*)} handler The handler to call when an event is triggered
+ * @returns {void}
+ */
+function emitFirst (emitter, events, handler) {
+  handler = once(handler)
+  events.forEach((e) => {
+    emitter.once(e, (...args) => {
+      events.forEach((ev) => {
+        emitter.removeListener(ev, handler)
+      })
+      handler.apply(emitter, args)
+    })
+  })
+}
+
+module.exports.emitFirst = emitFirst

--- a/test/fsm.spec.js
+++ b/test/fsm.spec.js
@@ -66,7 +66,7 @@ describe('libp2p state machine (fsm)', () => {
           expect(err).to.eql(error).mark()
         })
         node.stop((err) => {
-          expect(err).to.not.exist().mark()
+          expect(err).to.eql(error).mark()
         })
       })
 

--- a/test/fsm.spec.js
+++ b/test/fsm.spec.js
@@ -20,6 +20,7 @@ describe('libp2p state machine (fsm)', () => {
     })
     afterEach(() => {
       node.removeAllListeners()
+      sinon.restore()
     })
     after((done) => {
       node.stop(done)
@@ -55,6 +56,23 @@ describe('libp2p state machine (fsm)', () => {
         // stop the stopped node
         node.stop()
       })
+      node.start()
+    })
+
+    it('should callback with an error when it occurs on stop', (done) => {
+      const error = new Error('some error starting')
+      node.once('start', () => {
+        node.once('error', (err) => {
+          expect(err).to.eql(error).mark()
+        })
+        node.stop((err) => {
+          expect(err).to.not.exist().mark()
+        })
+      })
+
+      expect(2).checks(done)
+
+      sinon.stub(node._switch, 'stop').callsArgWith(0, error)
       node.start()
     })
 
@@ -110,9 +128,11 @@ describe('libp2p state machine (fsm)', () => {
         throw new Error('should not start')
       })
 
-      expect(2).checks(done)
+      expect(3).checks(done)
 
-      node.start()
+      node.start((err) => {
+        expect(err).to.eql(error).mark()
+      })
     })
 
     it('should not dial when the node is stopped', (done) => {


### PR DESCRIPTION
This fixes an issue where, if an error occurred during starting or stopping the node, the callback would not be called. This was introduced during the recent change to state machine.

`start` and `stop` will now call `callback` as soon as either an error occurs, or their respective state is emitted, instead of only the latter.

ref: https://github.com/ipfs/js-ipfs/issues/1806#issuecomment-456109308