### PR TITLE
PUBSUB: unsubscribe without handler reference

### DIFF
--- a/src/pubsub.js
+++ b/src/pubsub.js
@@ -8,27 +8,7 @@ module.exports = (node) => {
   const floodSub = new FloodSub(node)
 
   node._floodSub = floodSub
-  const _internalUnsubscribe = (input)=>{
-    let {topic,handler,callback} = input
 
-    if (!node.isStarted() && !floodSub.started) {
-      throw new Error(NOT_STARTED_YET)
-    }
-
-    if(handler){
-      floodSub.removeListener(topic, handler)
-    }else{
-      floodSub.removeAllListeners(topic)
-    }
-
-    if (floodSub.listenerCount(topic) === 0) {
-      floodSub.unsubscribe(topic)
-    }
-
-    if (typeof callback === 'function') {
-      setImmediate(() => callback())
-    }
-  }
   return {
     subscribe: (topic, options, handler, callback) => {
       if (typeof options === 'function') {
@@ -52,12 +32,26 @@ module.exports = (node) => {
 
       subscribe(callback)
     },
-    unsubscribeAll : (topic,callback)=>{
-      _internalUnsubscribe({topic : topic, callback: callback});
-    },
+
     unsubscribe: (topic, handler, callback) => {
-      _internalUnsubscribe({topic : topic, handler : handler, callback: callback});
+      if (!node.isStarted() && !floodSub.started) {
+        throw new Error(NOT_STARTED_YET)
+      }
+      if (!handler && !callback) {
+        floodSub.removeAllListeners(topic)
+      } else {
+        floodSub.removeListener(topic, handler)
+      }
+
+      if (floodSub.listenerCount(topic) === 0) {
+        floodSub.unsubscribe(topic)
+      }
+
+      if (typeof callback === 'function') {
+        setImmediate(() => callback())
+      }
     },
+
     publish: (topic, data, callback) => {
       if (!node.isStarted() && !floodSub.started) {
         return setImmediate(() => callback(new Error(NOT_STARTED_YET)))

--- a/test/pubsub.node.js
+++ b/test/pubsub.node.js
@@ -87,7 +87,7 @@ describe('.pubsub', () => {
         expect(err).to.not.exist().mark()
       })
     })
-    it('start two nodes and send one message, then unsubscribeAll', (done) => {
+    it('start two nodes and send one message, then unsubscribe without handler', (done) => {
       // Check the final series error, and the publish handler
       expect(3).checks(done)
 
@@ -113,12 +113,16 @@ describe('.pubsub', () => {
         // Wait a moment before unsubscribing
         (cb) => setTimeout(cb, 500),
         // unsubscribe on the first
-        (cb) => nodes[0].pubsub.unsubscribeAll('pubsub', cb),
+        (cb) => {
+          nodes[0].pubsub.unsubscribe('pubsub')
+          // Wait a moment to make sure the ubsubscribe-from-all worked
+          setTimeout(cb, 500)
+        },
         // Verify unsubscribed
         (cb) => {
-          nodes[0].pubsub.ls((err,topics)=>{
-            expect(topics.length).to.eql(0).mark();
-            cb(err);
+          nodes[0].pubsub.ls((err, topics) => {
+            expect(topics.length).to.eql(0).mark()
+            cb(err)
           })
         },
         // Stop both nodes

--- a/test/pubsub.node.js
+++ b/test/pubsub.node.js
@@ -87,6 +87,47 @@ describe('.pubsub', () => {
         expect(err).to.not.exist().mark()
       })
     })
+    it('start two nodes and send one message, then unsubscribeAll', (done) => {
+      // Check the final series error, and the publish handler
+      expect(3).checks(done)
+
+      let nodes
+      const data = Buffer.from('test')
+      const handler = (msg) => {
+        // verify the data is correct and mark the expect
+        expect(msg.data).to.eql(data).mark()
+      }
+
+      series([
+        // Start the nodes
+        (cb) => startTwo((err, _nodes) => {
+          nodes = _nodes
+          cb(err)
+        }),
+        // subscribe on the first
+        (cb) => nodes[0].pubsub.subscribe('pubsub', handler, cb),
+        // Wait a moment before publishing
+        (cb) => setTimeout(cb, 500),
+        // publish on the second
+        (cb) => nodes[1].pubsub.publish('pubsub', data, cb),
+        // Wait a moment before unsubscribing
+        (cb) => setTimeout(cb, 500),
+        // unsubscribe on the first
+        (cb) => nodes[0].pubsub.unsubscribeAll('pubsub', cb),
+        // Verify unsubscribed
+        (cb) => {
+          nodes[0].pubsub.ls((err,topics)=>{
+            expect(topics.length).to.eql(0).mark();
+            cb(err);
+          })
+        },
+        // Stop both nodes
+        (cb) => stopTwo(nodes, cb)
+      ], (err) => {
+        // Verify there was no error, and mark the expect
+        expect(err).to.not.exist().mark()
+      })
+    })
   })
 
   describe('.pubsub off', () => {


### PR DESCRIPTION
Hi :-)  
following up on an issue in [interface-js-ipfs-core](https://github.com/ipfs/interface-js-ipfs-core/issues/436) I'm creating this PR. 
Also created PR in [js-ipfs-http-client](https://github.com/ipfs/js-ipfs-http-client/pull/940) accordingly. 
This would help in cases like mine where my implementation is not able to support references to a handler function.
I will add the final url in the README to the method documentation once I merge the final PR `to interface-js-ipfs-core` since its pointing nowhere now. 

**Edit:** 

Opened a [PR](https://github.com/ipfs/interface-js-ipfs-core/pull/437) on `interface-js-ipfs-core`