### PR TITLE
test: add pull-mplex to test suite

### DIFF
--- a/package.json
+++ b/package.json
@@ -82,6 +82,7 @@
     "lodash.times": "^4.3.2",
     "nock": "^10.0.2",
     "pull-goodbye": "0.0.2",
+    "pull-mplex": "~0.1.0",
     "pull-serializer": "~0.3.2",
     "pull-stream": "^3.6.9",
     "sinon": "^7.1.1",

--- a/test/transports.browser.js
+++ b/test/transports.browser.js
@@ -7,7 +7,7 @@ chai.use(require('dirty-chai'))
 const expect = chai.expect
 const PeerInfo = require('peer-info')
 const PeerId = require('peer-id')
-const Mplex = require('libp2p-mplex')
+const Mplex = require('pull-mplex')
 const pull = require('pull-stream')
 const parallel = require('async/parallel')
 const goodbye = require('pull-goodbye')
@@ -57,7 +57,7 @@ describe('transports', () => {
             streamMuxer: [ Mplex ]
           }
         })
-        expect(b._modules.streamMuxer).to.eql([require('libp2p-mplex')])
+        expect(b._modules.streamMuxer).to.eql([require('pull-mplex')])
         done()
       })
     })

--- a/test/utils/bundle-browser.js
+++ b/test/utils/bundle-browser.js
@@ -6,6 +6,7 @@ const WebSocketStar = require('libp2p-websocket-star')
 const Bootstrap = require('libp2p-bootstrap')
 const SPDY = require('libp2p-spdy')
 const MPLEX = require('libp2p-mplex')
+const PULLMPLEX = require('pull-mplex')
 const KadDHT = require('libp2p-kad-dht')
 const SECIO = require('libp2p-secio')
 const defaultsDeep = require('@nodeutils/defaults-deep')
@@ -17,6 +18,7 @@ function mapMuxers (list) {
     switch (pref.trim().toLowerCase()) {
       case 'spdy': return SPDY
       case 'mplex': return MPLEX
+      case 'pullmplex': return PULLMPLEX
       default:
         throw new Error(pref + ' muxer not available')
     }
@@ -27,7 +29,7 @@ function getMuxers (options) {
   if (options) {
     return mapMuxers(options)
   } else {
-    return [MPLEX, SPDY]
+    return [PULLMPLEX, MPLEX, SPDY]
   }
 }
 

--- a/test/utils/bundle-nodejs.js
+++ b/test/utils/bundle-nodejs.js
@@ -7,6 +7,7 @@ const Bootstrap = require('libp2p-bootstrap')
 const SPDY = require('libp2p-spdy')
 const KadDHT = require('libp2p-kad-dht')
 const MPLEX = require('libp2p-mplex')
+const PULLMPLEX = require('pull-mplex')
 const SECIO = require('libp2p-secio')
 const defaultsDeep = require('@nodeutils/defaults-deep')
 const libp2p = require('../..')
@@ -17,6 +18,7 @@ function mapMuxers (list) {
     switch (pref.trim().toLowerCase()) {
       case 'spdy': return SPDY
       case 'mplex': return MPLEX
+      case 'pullmplex': return PULLMPLEX
       default:
         throw new Error(pref + ' muxer not available')
     }
@@ -30,7 +32,7 @@ function getMuxers (muxers) {
   } else if (muxers) {
     return mapMuxers(muxers)
   } else {
-    return [MPLEX, SPDY]
+    return [PULLMPLEX, MPLEX, SPDY]
   }
 }
 


### PR DESCRIPTION
This adds `pull-mplex` to the test suite, namely the stream muxing tests to verify interoperability. 