### PR TITLE
test: add circuit browser test

### DIFF
--- a/.aegir.js
+++ b/.aegir.js
@@ -1,15 +1,16 @@
 'use strict'
 
-const PeerInfo = require('peer-info')
-const PeerId = require('peer-id')
 const pull = require('pull-stream')
 const parallel = require('async/parallel')
-
 const WebSocketStarRendezvous = require('libp2p-websocket-star-rendezvous')
 const sigServer = require('libp2p-webrtc-star/src/sig-server')
 
-const rawPeer = require('./test/fixtures/test-peer.json')
 const Node = require('./test/utils/bundle-nodejs.js')
+const {
+  getPeerRelay,
+  WRTC_RENDEZVOUS_MULTIADDR,
+  WS_RENDEZVOUS_MULTIADDR
+} = require('./test/utils/constants')
 
 let wrtcRendezvous
 let wsRendezvous
@@ -19,7 +20,7 @@ const before = (done) => {
   parallel([
     (cb) => {
       sigServer.start({
-        port: 15555
+        port: WRTC_RENDEZVOUS_MULTIADDR.nodeAddress().port
         // cryptoChallenge: true TODO: needs https://github.com/libp2p/js-libp2p-webrtc-star/issues/128
       }, (err, server) => {
         if (err) {
@@ -31,7 +32,7 @@ const before = (done) => {
     },
     (cb) => {
       WebSocketStarRendezvous.start({
-        port: 14444,
+        port: WS_RENDEZVOUS_MULTIADDR.nodeAddress().port,
         refreshPeerListIntervalMS: 1000,
         strictMultiaddr: false,
         cryptoChallenge: true
@@ -44,17 +45,24 @@ const before = (done) => {
       })
     },
     (cb) => {
-      PeerId.createFromJSON(rawPeer, (err, peerId) => {
+      getPeerRelay((err, peerInfo) => {
         if (err) {
           return done(err)
         }
-        const peer = new PeerInfo(peerId)
-
-        peer.multiaddrs.add('/ip4/127.0.0.1/tcp/9200/ws')
 
         node = new Node({
-          peerInfo: peer
+          peerInfo,
+          config: {
+            relay: {
+              enabled: true,
+              hop: {
+                enabled: true,
+                active: true
+              }
+            }
+          }
         })
+
         node.handle('/echo/1.0.0', (protocol, conn) => pull(conn, conn))
         node.start(cb)
       })

--- a/test/browser.js
+++ b/test/browser.js
@@ -1,3 +1,4 @@
 'use strict'
 
+require('./circuit-relay.browser')
 require('./transports.browser')

--- a/test/circuit-relay.browser.js
+++ b/test/circuit-relay.browser.js
@@ -1,0 +1,98 @@
+/* eslint-env mocha */
+'use strict'
+
+const chai = require('chai')
+chai.use(require('dirty-chai'))
+const expect = chai.expect
+
+const createNode = require('./utils/create-node')
+const tryEcho = require('./utils/try-echo')
+const echo = require('./utils/echo')
+
+const {
+  getPeerRelay
+} = require('./utils/constants')
+
+function setupNodeWithRelay (addrs, options = {}) {
+  options = {
+    config: {
+      relay: {
+        enabled: true
+      },
+      ...options.config
+    },
+    ...options
+  }
+
+  return new Promise((resolve) => {
+    createNode(addrs, options, (err, node) => {
+      expect(err).to.not.exist()
+
+      node.handle(echo.multicodec, echo)
+      node.start((err) => {
+        expect(err).to.not.exist()
+        resolve(node)
+      })
+    })
+  })
+}
+
+describe('circuit relay', () => {
+  let browserNode1
+  let browserNode2
+  let peerRelay
+
+  before('get peer relay', async () => {
+    peerRelay = await new Promise(resolve => {
+      getPeerRelay((err, peer) => {
+        expect(err).to.not.exist()
+        resolve(peer)
+      })
+    })
+  })
+
+  before('create the browser nodes', async () => {
+    [browserNode1, browserNode2] = await Promise.all([
+      setupNodeWithRelay([]),
+      setupNodeWithRelay([])
+    ])
+  })
+
+  before('connect to the relay node', async () => {
+    await Promise.all(
+      [browserNode1, browserNode2].map((node) => {
+        return new Promise(resolve => {
+          node.dialProtocol(peerRelay, (err) => {
+            expect(err).to.not.exist()
+            resolve()
+          })
+        })
+      })
+    )
+  })
+
+  before('give time for HOP support to be determined', async () => {
+    await new Promise(resolve => {
+      setTimeout(resolve, 1e3)
+    })
+  })
+
+  after(async () => {
+    await Promise.all(
+      [browserNode1, browserNode2].map((node) => {
+        return new Promise((resolve) => {
+          node.stop(resolve)
+        })
+      })
+    )
+  })
+
+  it('should be able to echo over relay', (done) => {
+    browserNode1.dialProtocol(browserNode2.peerInfo, echo.multicodec, (err, conn) => {
+      expect(err).to.not.exist()
+      expect(conn).to.exist()
+
+      tryEcho(conn, done)
+    })
+  })
+})

--- a/test/transports.browser.js
+++ b/test/transports.browser.js
@@ -16,19 +16,19 @@ const wrtcSupport = self.RTCPeerConnection && ('createDataChannel' in self.RTCPe
 const tryEcho = require('./utils/try-echo')
 
 const Node = require('./utils/bundle-browser')
-const jsonPeerId = require('./fixtures/test-peer.json')
+const { getPeerRelay } = require('./utils/constants')
 
 describe('transports', () => {
   describe('websockets', () => {
     let peerB
-    let peerBMultiaddr = '/ip4/127.0.0.1/tcp/9200/ws/p2p/' + jsonPeerId.id
+    let peerBMultiaddr
     let nodeA
 
     before((done) => {
-      PeerId.createFromPrivKey(jsonPeerId.privKey, (err, id) => {
+      getPeerRelay((err, peerInfo) => {
         expect(err).to.not.exist()
-
-        peerB = new PeerInfo(id)
+        peerB = new PeerInfo(peerInfo.id)
+        peerBMultiaddr = `/ip4/127.0.0.1/tcp/9200/ws/p2p/${peerInfo.id.toB58String()}`
         peerB.multiaddrs.add(peerBMultiaddr)
         done()
       })

--- a/test/utils/constants.js
+++ b/test/utils/constants.js
@@ -1,0 +1,40 @@
+'use strict'
+
+const PeerId = require('peer-id')
+const PeerInfo = require('peer-info')
+const nextTick = require('async/nextTick')
+const peerJSON = require('../fixtures/test-peer')
+const multiaddr = require('multiaddr')
+
+let peerRelay = null
+
+/**
+ * Creates a `PeerInfo` that can be used across testing. Once the
+ * relay `PeerInfo` has been requested, it will be reused for each
+ * additional request.
+ *
+ * This is currently being used to create a relay on test bootstrapping
+ * so that it can be used by browser nodes during their test suite. This
+ * is necessary for running a TCP node during browser tests.
+ * @private
+ * @param {function(error, PeerInfo)} callback
+ * @returns {void}
+ */
+module.exports.getPeerRelay = (callback) => {
+  if (peerRelay) return nextTick(callback, null, peerRelay)
+
+  PeerId.createFromJSON(peerJSON, (err, peerId) => {
+    if (err) {
+      return callback(err)
+    }
+    peerRelay = new PeerInfo(peerId)
+
+    peerRelay.multiaddrs.add('/ip4/127.0.0.1/tcp/9200/ws')
+    peerRelay.multiaddrs.add('/ip4/127.0.0.1/tcp/9245')
+
+    callback(null, peerRelay)
+  })
+}
+
+module.exports.WS_RENDEZVOUS_MULTIADDR = multiaddr('/ip4/127.0.0.1/tcp/14444/wss')
+module.exports.WRTC_RENDEZVOUS_MULTIADDR = multiaddr('/ip4/127.0.0.1/tcp/15555/wss')

--- a/test/utils/echo.js
+++ b/test/utils/echo.js
@@ -8,3 +8,4 @@ function echo (protocol, conn) {
 }
 
 module.exports = echo
+module.exports.multicodec = '/echo/1.0.0'


### PR DESCRIPTION
Browser tests weren't being run for circuit relay. This adds a basic echo test for two browser nodes over a nodejs node to give us better visibility to potential issues.