### PR TITLE
chore: add error codes to dht and pubsub errors

### DIFF
--- a/src/dht.js
+++ b/src/dht.js
@@ -3,13 +3,13 @@
 const nextTick = require('async/nextTick')
 const errCode = require('err-code')
 
+const { messages, codes } = require('./errors')
+
 module.exports = (node) => {
   return {
     put: (key, value, callback) => {
       if (!node._dht) {
-        return nextTick(() => callback(
-          errCode(new Error('DHT is not available'), 'ERR_DHT_DISABLED')
-        ))
+        return nextTick(callback, errCode(new Error(messages.DHT_DISABLED), codes.DHT_DISABLED))
       }
 
       node._dht.put(key, value, callback)
@@ -21,9 +21,7 @@ module.exports = (node) => {
       }
 
       if (!node._dht) {
-        return nextTick(() => callback(
-          errCode(new Error('DHT is not available'), 'ERR_DHT_DISABLED')
-        ))
+        return nextTick(callback, errCode(new Error(messages.DHT_DISABLED), codes.DHT_DISABLED))
       }
 
       node._dht.get(key, options, callback)
@@ -35,9 +33,7 @@ module.exports = (node) => {
       }
 
       if (!node._dht) {
-        return nextTick(() => callback(
-          errCode(new Error('DHT is not available'), 'ERR_DHT_DISABLED')
-        ))
+        return nextTick(callback, errCode(new Error(messages.DHT_DISABLED), codes.DHT_DISABLED))
       }
 
       node._dht.getMany(key, nVals, options, callback)

--- a/src/dht.js
+++ b/src/dht.js
@@ -1,10 +1,15 @@
 'use strict'
 
+const nextTick = require('async/nextTick')
+const errCode = require('err-code')
+
 module.exports = (node) => {
   return {
     put: (key, value, callback) => {
       if (!node._dht) {
-        return callback(new Error('DHT is not available'))
+        return nextTick(() => callback(
+          errCode(new Error('DHT is not available'), 'ERR_DHT_DISABLED')
+        ))
       }
 
       node._dht.put(key, value, callback)
@@ -16,7 +21,9 @@ module.exports = (node) => {
       }
 
       if (!node._dht) {
-        return callback(new Error('DHT is not available'))
+        return nextTick(() => callback(
+          errCode(new Error('DHT is not available'), 'ERR_DHT_DISABLED')
+        ))
       }
 
       node._dht.get(key, options, callback)
@@ -28,7 +35,9 @@ module.exports = (node) => {
       }
 
       if (!node._dht) {
-        return callback(new Error('DHT is not available'))
+        return nextTick(() => callback(
+          errCode(new Error('DHT is not available'), 'ERR_DHT_DISABLED')
+        ))
       }
 
       node._dht.getMany(key, nVals, options, callback)

--- a/src/error-messages.js
+++ b/src/error-messages.js
@@ -1,3 +1,0 @@
-'use strict'
-
-exports.NOT_STARTED_YET = 'The libp2p node is not started yet'

--- a/src/errors.js
+++ b/src/errors.js
@@ -1,0 +1,11 @@
+'use strict'
+
+exports.messages = {
+  NOT_STARTED_YET: 'The libp2p node is not started yet',
+  DHT_DISABLED: 'DHT is not available'
+}
+
+exports.codes = {
+  DHT_DISABLED: 'ERR_DHT_DISABLED',
+  PUBSUB_NOT_STARTED: 'ERR_PUBSUB_NOT_STARTED'
+}

--- a/src/pubsub.js
+++ b/src/pubsub.js
@@ -1,7 +1,7 @@
 'use strict'
 
 const nextTick = require('async/nextTick')
-const NOT_STARTED_YET = require('./error-messages').NOT_STARTED_YET
+const { messages, codes } = require('./errors')
 const FloodSub = require('libp2p-floodsub')
 
 const errCode = require('err-code')
@@ -20,9 +20,7 @@ module.exports = (node) => {
       }
 
       if (!node.isStarted() && !floodSub.started) {
-        return nextTick(() => callback(
-          errCode(new Error(NOT_STARTED_YET), 'ERR_PUBSUB_NOT_STARTED')
-        ))
+        return nextTick(callback, errCode(new Error(messages.NOT_STARTED_YET), codes.PUBSUB_NOT_STARTED))
       }
 
       function subscribe (cb) {
@@ -39,9 +37,7 @@ module.exports = (node) => {
 
     unsubscribe: (topic, handler, callback) => {
       if (!node.isStarted() && !floodSub.started) {
-        return nextTick(() => callback(
-          errCode(new Error(NOT_STARTED_YET), 'ERR_PUBSUB_NOT_STARTED')
-        ))
+        return nextTick(callback, errCode(new Error(messages.NOT_STARTED_YET), codes.PUBSUB_NOT_STARTED))
       }
       if (!handler && !callback) {
         floodSub.removeAllListeners(topic)
@@ -60,15 +56,11 @@ module.exports = (node) => {
 
     publish: (topic, data, callback) => {
       if (!node.isStarted() && !floodSub.started) {
-        return nextTick(() => callback(
-          errCode(new Error(NOT_STARTED_YET), 'ERR_PUBSUB_NOT_STARTED')
-        ))
+        return nextTick(callback, errCode(new Error(messages.NOT_STARTED_YET), codes.PUBSUB_NOT_STARTED))
       }
 
       if (!Buffer.isBuffer(data)) {
-        return nextTick(() => callback(
-          errCode(new Error('data must be a Buffer'), 'ERR_DATA_IS_NOT_A_BUFFER')
-        ))
+        return nextTick(callback, errCode(new Error('data must be a Buffer'), 'ERR_DATA_IS_NOT_A_BUFFER'))
       }
 
       floodSub.publish(topic, data)
@@ -78,9 +70,7 @@ module.exports = (node) => {
 
     ls: (callback) => {
       if (!node.isStarted() && !floodSub.started) {
-        return nextTick(() => callback(
-          errCode(new Error(NOT_STARTED_YET), 'ERR_PUBSUB_NOT_STARTED')
-        ))
+        return nextTick(callback, errCode(new Error(messages.NOT_STARTED_YET), codes.PUBSUB_NOT_STARTED))
       }
 
       const subscriptions = Array.from(floodSub.subscriptions)
@@ -90,9 +80,7 @@ module.exports = (node) => {
 
     peers: (topic, callback) => {
       if (!node.isStarted() && !floodSub.started) {
-        return nextTick(() => callback(
-          errCode(new Error(NOT_STARTED_YET), 'ERR_PUBSUB_NOT_STARTED')
-        ))
+        return nextTick(callback, errCode(new Error(messages.NOT_STARTED_YET), codes.PUBSUB_NOT_STARTED))
       }
 
       if (typeof topic === 'function') {

--- a/src/pubsub.js
+++ b/src/pubsub.js
@@ -1,8 +1,10 @@
 'use strict'
 
-const setImmediate = require('async/setImmediate')
+const nextTick = require('async/nextTick')
 const NOT_STARTED_YET = require('./error-messages').NOT_STARTED_YET
 const FloodSub = require('libp2p-floodsub')
+
+const errCode = require('err-code')
 
 module.exports = (node) => {
   const floodSub = new FloodSub(node)
@@ -18,7 +20,9 @@ module.exports = (node) => {
       }
 
       if (!node.isStarted() && !floodSub.started) {
-        return setImmediate(() => callback(new Error(NOT_STARTED_YET)))
+        return nextTick(() => callback(
+          errCode(new Error(NOT_STARTED_YET), 'ERR_PUBSUB_NOT_STARTED')
+        ))
       }
 
       function subscribe (cb) {
@@ -27,7 +31,7 @@ module.exports = (node) => {
         }
 
         floodSub.on(topic, handler)
-        setImmediate(cb)
+        nextTick(cb)
       }
 
       subscribe(callback)
@@ -35,7 +39,9 @@ module.exports = (node) => {
 
     unsubscribe: (topic, handler, callback) => {
       if (!node.isStarted() && !floodSub.started) {
-        throw new Error(NOT_STARTED_YET)
+        return nextTick(() => callback(
+          errCode(new Error(NOT_STARTED_YET), 'ERR_PUBSUB_NOT_STARTED')
+        ))
       }
       if (!handler && !callback) {
         floodSub.removeAllListeners(topic)
@@ -48,37 +54,45 @@ module.exports = (node) => {
       }
 
       if (typeof callback === 'function') {
-        setImmediate(() => callback())
+        nextTick(() => callback())
       }
     },
 
     publish: (topic, data, callback) => {
       if (!node.isStarted() && !floodSub.started) {
-        return setImmediate(() => callback(new Error(NOT_STARTED_YET)))
+        return nextTick(() => callback(
+          errCode(new Error(NOT_STARTED_YET), 'ERR_PUBSUB_NOT_STARTED')
+        ))
       }
 
       if (!Buffer.isBuffer(data)) {
-        return setImmediate(() => callback(new Error('data must be a Buffer')))
+        return nextTick(() => callback(
+          errCode(new Error('data must be a Buffer'), 'ERR_DATA_IS_NOT_A_BUFFER')
+        ))
       }
 
       floodSub.publish(topic, data)
 
-      setImmediate(() => callback())
+      nextTick(() => callback())
     },
 
     ls: (callback) => {
       if (!node.isStarted() && !floodSub.started) {
-        return setImmediate(() => callback(new Error(NOT_STARTED_YET)))
+        return nextTick(() => callback(
+          errCode(new Error(NOT_STARTED_YET), 'ERR_PUBSUB_NOT_STARTED')
+        ))
       }
 
       const subscriptions = Array.from(floodSub.subscriptions)
 
-      setImmediate(() => callback(null, subscriptions))
+      nextTick(() => callback(null, subscriptions))
     },
 
     peers: (topic, callback) => {
       if (!node.isStarted() && !floodSub.started) {
-        return setImmediate(() => callback(new Error(NOT_STARTED_YET)))
+        return nextTick(() => callback(
+          errCode(new Error(NOT_STARTED_YET), 'ERR_PUBSUB_NOT_STARTED')
+        ))
       }
 
       if (typeof topic === 'function') {
@@ -90,7 +104,7 @@ module.exports = (node) => {
         .filter((peer) => topic ? peer.topics.has(topic) : true)
         .map((peer) => peer.info.id.toB58String())
 
-      setImmediate(() => callback(null, peers))
+      nextTick(() => callback(null, peers))
     },
 
     setMaxListeners (n) {

--- a/test/dht.node.js
+++ b/test/dht.node.js
@@ -140,6 +140,7 @@ describe('.dht', () => {
 
       nodeA.dht.put(key, value, (err) => {
         expect(err).to.exist()
+        expect(err.code).to.equal('ERR_DHT_DISABLED')
         done()
       })
     })
@@ -149,6 +150,7 @@ describe('.dht', () => {
 
       nodeA.dht.get(key, (err) => {
         expect(err).to.exist()
+        expect(err.code).to.equal('ERR_DHT_DISABLED')
         done()
       })
     })
@@ -158,6 +160,7 @@ describe('.dht', () => {
 
       nodeA.dht.getMany(key, 10, (err) => {
         expect(err).to.exist()
+        expect(err.code).to.equal('ERR_DHT_DISABLED')
         done()
       })
     })


### PR DESCRIPTION
Added error codes to the dht and pubsub errors, as well as replaced `setImmediate` by `nextTick`.

In the context of [ipfs/js-ipfs#1879](https://github.com/ipfs/js-ipfs/pull/1879)