### PR TITLE
fix: make the config less restrictive

### DIFF
--- a/package.json
+++ b/package.json
@@ -42,7 +42,6 @@
     "debug": "^4.1.0",
     "err-code": "^1.1.2",
     "fsm-event": "^2.1.0",
-    "kind-of": "^6.0.2",
     "libp2p-connection-manager": "~0.0.2",
     "libp2p-floodsub": "~0.15.7",
     "libp2p-ping": "~0.8.5",

--- a/src/config.js
+++ b/src/config.js
@@ -1,29 +1,17 @@
 'use strict'
 
 const { struct, superstruct } = require('superstruct')
-const kind = require('kind-of')
 const { optional, list } = struct
 
-const transports = ['tcp', 'utp', 'webrtcstar', 'webrtcdirect', 'websockets', 'websocketstar']
 // Define custom types
-const s = superstruct({
-  types: {
-    tcp: v => kind(v) === 'tcp',
-    utp: v => kind(v) === 'utp',
-    webrtcstar: v => kind(v) === 'webrtcstar',
-    webrtcdirect: v => kind(v) === 'webrtcdirect',
-    websockets: v => kind(v) === 'websockets',
-    websocketstar: v => kind(v) === 'websocketstar',
-    transport: value => {
-      const [error] = list([s.union([ ...transports, 'function' ])]).validate(value)
-      if (error) return error.message
-
-      return value.length > 0
-        ? true
-        : 'You need to provide at least one transport.'
-    }
-  }
-})
+const s = superstruct()
+const transport = s.union([
+  s.interface({
+    createListener: 'function',
+    dial: 'function'
+  }),
+  'function'
+])
 
 const optionsSchema = s(
   {
@@ -41,7 +29,7 @@ const optionsSchema = s(
       peerDiscovery: optional(list([s('object|function')])),
       peerRouting: optional(list(['object'])),
       streamMuxer: optional(list([s('object|function')])),
-      transport: 'transport'
+      transport: list([transport])
     }),
     config: s({
       peerDiscovery: 'object?',


### PR DESCRIPTION
Testing the 0.25 release candidate against js-ipfs, the test suite [errored](https://travis-ci.com/ipfs/js-ipfs/jobs/179820871) due to the config being too restrictive. I've simplified the config which has also allowed us to remove `kind-of`.