### PR TITLE
chore: disable dht discovery

### DIFF
--- a/src/config.js
+++ b/src/config.js
@@ -45,11 +45,11 @@ const optionsSchema = s(
         kBucketSize: 'number',
         enabled: 'boolean?',
         randomWalk: optional(s({
-          enabled: 'boolean?',
+          enabled: 'boolean?', // disabled waiting for https://github.com/libp2p/js-libp2p-kad-dht/issues/86
           queriesPerPeriod: 'number?',
           interval: 'number?',
           timeout: 'number?'
-        }, { enabled: true, queriesPerPeriod: 1, interval: 30000, timeout: 10000 })),
+        }, { enabled: false, queriesPerPeriod: 1, interval: 30000, timeout: 10000 })),
         validators: 'object?',
         selectors: 'object?'
       }, { enabled: true, kBucketSize: 20, enabledDiscovery: true }),

--- a/test/config.spec.js
+++ b/test/config.spec.js
@@ -97,7 +97,7 @@ describe('configuration', () => {
           kBucketSize: 20,
           enabled: true,
           randomWalk: {
-            enabled: true,
+            enabled: false,
             queriesPerPeriod: 1,
             interval: 30000,
             timeout: 10000
@@ -199,7 +199,7 @@ describe('configuration', () => {
           kBucketSize: 20,
           enabled: true,
           randomWalk: {
-            enabled: true,
+            enabled: false,
             queriesPerPeriod: 1,
             interval: 30000,
             timeout: 10000


### PR DESCRIPTION
Currently `js-ipfs` was having a bad time with CPU usage. 

In this context, we decided to go with a temporary change on `dht.put`, as well as disabling the `random-walk` discovery. We will benefit from discovery through the queries that we will be running for now. 

With this, we will get `js-libp2p` stable, as well as have the DHT available and have time to implement a proper solution to solve this issue.

More details about the problem and discussion of the solution:

- [libp2p/js-libp2p-kad-dht#86](https://github.com/libp2p/js-libp2p-kad-dht/issues/86)