### PR TITLE
fix: disable dht by default #338

### DIFF
--- a/src/config.js
+++ b/src/config.js
@@ -29,7 +29,11 @@ const optionsSchema = s(
       peerDiscovery: optional(list([s('object|function')])),
       peerRouting: optional(list(['object'])),
       streamMuxer: optional(list([s('object|function')])),
-      transport: list([transport])
+      transport: s.intersection([[transport], s.interface({
+        length (v) {
+          return v > 0 ? true : 'ERROR_EMPTY'
+        }
+      })])
     }),
     config: s({
       peerDiscovery: 'object?',
@@ -52,7 +56,7 @@ const optionsSchema = s(
         }, { enabled: false, queriesPerPeriod: 1, interval: 30000, timeout: 10000 })),
         validators: 'object?',
         selectors: 'object?'
-      }, { enabled: true, kBucketSize: 20, enabledDiscovery: true }),
+      }, { enabled: false, kBucketSize: 20, enabledDiscovery: false }),
       EXPERIMENTAL: s({
         pubsub: 'boolean'
       }, { pubsub: false })

--- a/test/config.spec.js
+++ b/test/config.spec.js
@@ -55,7 +55,7 @@ describe('configuration', () => {
           transport: [ ]
         }
       })
-    }).to.throw()
+    }).to.throw('ERROR_EMPTY')
   })
 
   it('should add defaults to missing items', () => {
@@ -95,7 +95,7 @@ describe('configuration', () => {
         },
         dht: {
           kBucketSize: 20,
-          enabled: true,
+          enabled: false,
           randomWalk: {
             enabled: false,
             queriesPerPeriod: 1,
@@ -152,8 +152,8 @@ describe('configuration', () => {
         transport: [ WS ]
       },
       config: {
-        EXPERIMENTAL: {
-          dht: true
+        dht: {
+          enabled: true
         }
       }
     }
@@ -197,7 +197,7 @@ describe('configuration', () => {
         },
         dht: {
           kBucketSize: 20,
-          enabled: true,
+          enabled: false,
           randomWalk: {
             enabled: false,
             queriesPerPeriod: 1,


### PR DESCRIPTION
Turning the dht off by default exposed an issue where the modules.transport.length wasn't being properly validated. This also fixes that.


required by https://github.com/libp2p/js-libp2p/issues/338