### PR TITLE
fix: remove unneeded peerbook puts

### DIFF
--- a/.aegir.js
+++ b/.aegir.js
@@ -79,7 +79,7 @@ const after = (done) => {
 }
 
 module.exports = {
-  bundlesize: { maxSize: '215kB' },
+  bundlesize: { maxSize: '217kB' },
   hooks: {
     pre: before,
     post: after

--- a/package.json
+++ b/package.json
@@ -45,7 +45,7 @@
     "libp2p-connection-manager": "~0.0.2",
     "libp2p-floodsub": "~0.15.8",
     "libp2p-ping": "~0.8.5",
-    "libp2p-switch": "~0.42.1",
+    "libp2p-switch": "~0.42.7",
     "libp2p-websockets": "~0.12.2",
     "mafmt": "^6.0.7",
     "multiaddr": "^6.0.6",

--- a/src/index.js
+++ b/src/index.js
@@ -243,10 +243,7 @@ class Node extends EventEmitter {
     this._getPeerInfo(peer, (err, peerInfo) => {
       if (err) { return callback(err) }
 
-      this._switch.dial(peerInfo, protocol, (err, conn) => {
-        if (err) { return callback(err) }
-        callback(null, conn)
-      })
+      this._switch.dial(peerInfo, protocol, callback)
     })
   }
 
@@ -272,9 +269,7 @@ class Node extends EventEmitter {
     this._getPeerInfo(peer, (err, peerInfo) => {
       if (err) { return callback(err) }
 
-      this._switch.dialFSM(peerInfo, protocol, (err, connFSM) => {
-        callback(err, connFSM)
-      })
+      this._switch.dialFSM(peerInfo, protocol, callback)
     })
   }
 

--- a/src/index.js
+++ b/src/index.js
@@ -78,7 +78,6 @@ class Node extends EventEmitter {
       // reuse this muxed connection
       this._switch.on('peer-mux-established', (peerInfo) => {
         this.emit('peer:connect', peerInfo)
-        this.peerBook.put(peerInfo)
       })
 
       this._switch.on('peer-mux-closed', (peerInfo) => {
@@ -246,7 +245,6 @@ class Node extends EventEmitter {
 
       this._switch.dial(peerInfo, protocol, (err, conn) => {
         if (err) { return callback(err) }
-        this.peerBook.put(peerInfo)
         callback(null, conn)
       })
     })
@@ -275,9 +273,6 @@ class Node extends EventEmitter {
       if (err) { return callback(err) }
 
       this._switch.dialFSM(peerInfo, protocol, (err, connFSM) => {
-        if (!err) {
-          this.peerBook.put(peerInfo)
-        }
         callback(err, connFSM)
       })
     })

--- a/test/circuit-relay.node.js
+++ b/test/circuit-relay.node.js
@@ -114,10 +114,9 @@ describe('circuit relay', () => {
         nodeWS2 = node
         cb()
       }),
-      // set up node with TCP and listening on relay1
+      // set up node with TCP
       (cb) => setupNode([
-        '/ip4/0.0.0.0/tcp/0',
-        `/p2p/${relayNode1.peerInfo.id.toB58String()}/p2p-circuit`
+        '/ip4/0.0.0.0/tcp/0'
       ], {
         config: {
           relay: {
@@ -128,10 +127,9 @@ describe('circuit relay', () => {
         nodeTCP1 = node
         cb()
       }),
-      // set up node with TCP and listening on relay2 over TCP transport
+      // set up node with TCP
       (cb) => setupNode([
-        '/ip4/0.0.0.0/tcp/0',
-        `/ip4/0.0.0.0/tcp/0/p2p/${relayNode2.peerInfo.id.toB58String()}/p2p-circuit`
+        '/ip4/0.0.0.0/tcp/0'
       ], {
         config: {
           relay: {

--- a/test/peer-discovery.node.js
+++ b/test/peer-discovery.node.js
@@ -315,7 +315,7 @@ describe('peer discovery', () => {
         done()
       }
 
-      nodeA.on('peer:discovery', (peerInfo) => {s
+      nodeA.on('peer:discovery', (peerInfo) => {
         expectedPeers.delete(peerInfo.id.toB58String())
         if (expectedPeers.size === 0) {
           finish()

--- a/test/peer-discovery.node.js
+++ b/test/peer-discovery.node.js
@@ -389,11 +389,23 @@ describe('peer discovery', () => {
       }
     })
 
-    it('find a peer through another dht node', function (done) {
-      nodeA.once('peer:discovery', (peerInfo) => {
-        expect(nodeC.peerInfo.id.toB58String())
-          .to.eql(peerInfo.id.toB58String())
+    it('find peers through the dht', function (done) {
+      let expectedPeers = new Set([
+        nodeB.peerInfo.id.toB58String(),
+        nodeC.peerInfo.id.toB58String()
+      ])
+
+      function finish () {
+        nodeA.removeAllListeners('peer:discovery')
+        expect(expectedPeers.size).to.eql(0)
         done()
+      }
+
+      nodeA.on('peer:discovery', (peerInfo) => {
+        expectedPeers.delete(peerInfo.id.toB58String())
+        if (expectedPeers.size === 0) {
+          finish()
+        }
       })
 
       // Topology:


### PR DESCRIPTION
With https://github.com/libp2p/js-libp2p-kad-dht/pull/92 the dht test for peer discovery was out of date. I fixed it and updated the other tests to use lower intervals so we dont have to wait 10seconds for discovery to happen.

The circuit tests were also inaccurate so those were fixed.

Switch had a significant number of code added recently, so the bundle size threshold needed to be increased slightly.