### PR TITLE
feat: auto dial discovered peers

### DIFF
--- a/.aegir.js
+++ b/.aegir.js
@@ -79,7 +79,7 @@ const after = (done) => {
 }
 
 module.exports = {
-  bundlesize: { maxSize: '217kB' },
+  bundlesize: { maxSize: '218kB' },
   hooks: {
     pre: before,
     post: after

--- a/PEER_DISCOVERY.md
+++ b/PEER_DISCOVERY.md
@@ -1,0 +1,59 @@
+# Peer Discovery and Auto Dial
+
+**Synopsis**:
+* All peers discovered are emitted via `peer:discovery` so applications can take any desired action.
+* Libp2p defaults to automatically connecting to new peers, when under the [ConnectionManager](https://github.com/libp2p/js-libp2p-connection-manager) low watermark (minimum peers).
+  * Applications can disable this via the `peerDiscovery.autoDial` config property, and handle connections themselves.
+  * Applications who have not disabled this should **never** connect on peer discovery, unless performing a specific action.
+
+## Scenarios
+In any scenario, if a peer is discovered it should be added to the PeerBook. This ensures that
+even if we don't dial to a node when we discover it, we know about it in the event that it
+becomes known as a provider for something we need.
+
+### 1. Joining the network
+The node is new and needs to join the network. It currently has 0 peers.
+**Discovery Mechanisms**: [Ambient Discovery](#ambient-discovery)
+
+### Action to take
+Connect to discovered peers. This should have some degree of concurrency limiting. While the case should be low, if we immediately discover more peers than our high watermark we should avoid dialing them all.
+
+### 2. Connected to some
+The node is connected to other nodes. The current number of connections is less than the desired low watermark.
+**Discovery Mechanisms**: [Ambient Discovery](#ambient-discovery) and [Active Discovery](#active-discovery)
+
+### Action to take
+Connect to discovered peers. This should have some degree of concurrency limiting. The concurrency may need to be modified to reflect the current number of peers connected. The more peers we have, the lower the concurrency may need to be.
+
+### 3. Connected to enough
+**Discovery Mechanisms**: [Ambient Discovery](#ambient-discovery) and [Active Discovery](#active-discovery)
+
+### Action to take
+None. If we are connected to enough peers, the low watermark, we should not connect to discovered peers. As other peers discover us, they may connect to us based on their current scenario.
+
+For example, a long running node with adequate peers is on an MDNS network. A new peer joins the network and both become aware of each other. The new peer should be the peer that dials, as it has too few peers. The existing node has no reason to dial the new peer, but should keep a record of it in case it later becomes an important node due to its contents/capabilities.
+
+Avoiding dials above the low watermark also allows for a pool of connections to be reserved for application specific actions, such as connecting to a specific content provider via a DHT query to find that content (ipfs-bitswap).
+
+### 4. Connected to too many
+The node has more connections than it wants. The current number of connections is greater than the high watermark.
+
+[WIP Connection Manager v2 spec](https://github.com/libp2p/specs/pull/161)
+**Discovery Mechanisms**: [Ambient Discovery](#ambient-discovery) and [Active Discovery](#active-discovery)
+
+## Discovery Mechanisms
+Means of which a libp2p node discovers other peers.
+
+### Active Discovery
+Through active use of the libp2p network, a node may discovery peers.
+
+* Content/Peer routing (DHT, delegated, etc) provider and peer queries
+* DHT random walk
+* Rendezvous servers
+
+### Ambient Discovery
+Leveraging known addresses, or network discovery mechanisms, a node may discover peers outside of the bounds of the libp2p network.
+
+* Bootstrap
+* MDNS
+* proximity based (bluetooth, sound, etc)

--- a/PEER_DISCOVERY.md
+++ b/PEER_DISCOVERY.md
@@ -4,7 +4,7 @@
 * All peers discovered are emitted via `peer:discovery` so applications can take any desired action.
 * Libp2p defaults to automatically connecting to new peers, when under the [ConnectionManager](https://github.com/libp2p/js-libp2p-connection-manager) low watermark (minimum peers).
   * Applications can disable this via the `peerDiscovery.autoDial` config property, and handle connections themselves.
-  * Applications who have not disabled this should **never** connect on peer discovery, unless performing a specific action.
+  * Applications who have not disabled this should **never** connect on peer discovery. Applications should use the `peer:connect` event if they wish to take a specific action on new peers.
 
 ## Scenarios
 In any scenario, if a peer is discovered it should be added to the PeerBook. This ensures that even if we don't dial to a node when we discover it, we know about it in the event that it becomes known as a provider for something we need. The scenarios listed below detail what actions the auto dialer will take when peers are discovered.

--- a/PEER_DISCOVERY.md
+++ b/PEER_DISCOVERY.md
@@ -7,9 +7,7 @@
   * Applications who have not disabled this should **never** connect on peer discovery, unless performing a specific action.
 
 ## Scenarios
-In any scenario, if a peer is discovered it should be added to the PeerBook. This ensures that
-even if we don't dial to a node when we discover it, we know about it in the event that it
-becomes known as a provider for something we need.
+In any scenario, if a peer is discovered it should be added to the PeerBook. This ensures that even if we don't dial to a node when we discover it, we know about it in the event that it becomes known as a provider for something we need. The scenarios listed below detail what actions the auto dialer will take when peers are discovered.
 
 ### 1. Joining the network
 The node is new and needs to join the network. It currently has 0 peers.
@@ -40,6 +38,9 @@ The node has more connections than it wants. The current number of connections i
 
 [WIP Connection Manager v2 spec](https://github.com/libp2p/specs/pull/161)
 **Discovery Mechanisms**: [Ambient Discovery](#ambient-discovery) and [Active Discovery](#active-discovery)
+
+### Action to take
+None, the `ConnectionManager` will automatically prune connections.
 
 ## Discovery Mechanisms
 Means of which a libp2p node discovers other peers.

--- a/README.md
+++ b/README.md
@@ -159,6 +159,7 @@ class Node extends libp2p {
       // libp2p config options (typically found on a config.json)
       config: {                       // The config object is the part of the config that can go into a file, config.json.
         peerDiscovery: {
+          autoDial: true,             // Auto connect to discovered peers (limited by ConnectionManager minPeers)
           mdns: {                     // mdns options
             interval: 1000,           // ms
             enabled: true
@@ -303,6 +304,9 @@ Required keys in the `options` object:
 ##### `libp2p.on('peer:discovery', (peer) => {})`
 
 > Peer has been discovered.
+
+If `autoDial` is not set to false, applications should **not** attempt to connect to the peer
+unless they are performing a specific action. See [peer discovery and auto dial](./PEER_DISCOVERY.md) for more information.
 
 - `peer`: instance of [PeerInfo][]
 
@@ -506,18 +510,6 @@ Some available network protectors:
 
 # run just Browser tests (Chrome)
 > npm run test:browser
-```
-
-#### Run interop tests
-
-```sh
-N/A
-```
-
-#### Run benchmark tests
-
-```sh
-N/A
 ```
 
 ### Packages

--- a/README.md
+++ b/README.md
@@ -305,7 +305,7 @@ Required keys in the `options` object:
 
 > Peer has been discovered.
 
-If `autoDial` is not set to false, applications should **not** attempt to connect to the peer
+If `autoDial` is `true`, applications should **not** attempt to connect to the peer
 unless they are performing a specific action. See [peer discovery and auto dial](./PEER_DISCOVERY.md) for more information.
 
 - `peer`: instance of [PeerInfo][]

--- a/package.json
+++ b/package.json
@@ -45,7 +45,7 @@
     "libp2p-connection-manager": "~0.0.2",
     "libp2p-floodsub": "~0.15.8",
     "libp2p-ping": "~0.8.5",
-    "libp2p-switch": "~0.42.7",
+    "libp2p-switch": "github:libp2p/js-libp2p-switch#feat/priority-queue",
     "libp2p-websockets": "~0.12.2",
     "mafmt": "^6.0.7",
     "multiaddr": "^6.0.6",

--- a/package.json
+++ b/package.json
@@ -45,7 +45,7 @@
     "libp2p-connection-manager": "~0.0.2",
     "libp2p-floodsub": "~0.15.8",
     "libp2p-ping": "~0.8.5",
-    "libp2p-switch": "github:libp2p/js-libp2p-switch#feat/priority-queue",
+    "libp2p-switch": "~0.42.8",
     "libp2p-websockets": "~0.12.2",
     "mafmt": "^6.0.7",
     "multiaddr": "^6.0.6",

--- a/src/config.js
+++ b/src/config.js
@@ -15,7 +15,9 @@ const transport = s.union([
 
 const optionsSchema = s(
   {
-    connectionManager: 'object?',
+    connectionManager: s('object', {
+      minPeers: 25
+    }),
     datastore: 'object?',
     peerInfo: 'object',
     peerBook: 'object?',

--- a/src/config.js
+++ b/src/config.js
@@ -12,60 +12,88 @@ const transport = s.union([
   }),
   'function'
 ])
+const modulesSchema = s({
+  connEncryption: optional(list([s('object|function')])),
+  // this is hacky to simulate optional because interface doesnt work correctly with it
+  // change to optional when fixed upstream
+  connProtector: s.union(['undefined', s.interface({ protect: 'function' })]),
+  contentRouting: optional(list(['object'])),
+  dht: optional(s('null|function|object')),
+  peerDiscovery: optional(list([s('object|function')])),
+  peerRouting: optional(list(['object'])),
+  streamMuxer: optional(list([s('object|function')])),
+  transport: s.intersection([[transport], s.interface({
+    length (v) {
+      return v > 0 ? true : 'ERROR_EMPTY'
+    }
+  })])
+})
 
-const optionsSchema = s(
-  {
-    connectionManager: s('object', {
-      minPeers: 25
-    }),
-    datastore: 'object?',
-    peerInfo: 'object',
-    peerBook: 'object?',
-    modules: s({
-      connEncryption: optional(list([s('object|function')])),
-      // this is hacky to simulate optional because interface doesnt work correctly with it
-      // change to optional when fixed upstream
-      connProtector: s.union(['undefined', s.interface({ protect: 'function' })]),
-      contentRouting: optional(list(['object'])),
-      dht: optional(s('null|function|object')),
-      peerDiscovery: optional(list([s('object|function')])),
-      peerRouting: optional(list(['object'])),
-      streamMuxer: optional(list([s('object|function')])),
-      transport: s.intersection([[transport], s.interface({
-        length (v) {
-          return v > 0 ? true : 'ERROR_EMPTY'
-        }
-      })])
-    }),
-    config: s({
-      peerDiscovery: 'object?',
-      relay: s({
-        enabled: 'boolean',
-        hop: optional(s({
-          enabled: 'boolean',
-          active: 'boolean'
-        },
-        { enabled: false, active: false }))
-      }, { enabled: true, hop: {} }),
-      dht: s({
-        kBucketSize: 'number',
-        enabled: 'boolean?',
-        randomWalk: optional(s({
-          enabled: 'boolean?', // disabled waiting for https://github.com/libp2p/js-libp2p-kad-dht/issues/86
-          queriesPerPeriod: 'number?',
-          interval: 'number?',
-          timeout: 'number?'
-        }, { enabled: false, queriesPerPeriod: 1, interval: 30000, timeout: 10000 })),
-        validators: 'object?',
-        selectors: 'object?'
-      }, { enabled: false, kBucketSize: 20, enabledDiscovery: false }),
-      EXPERIMENTAL: s({
-        pubsub: 'boolean'
-      }, { pubsub: false })
-    }, { relay: {}, dht: {}, EXPERIMENTAL: {} })
-  },
-  { config: {}, modules: {} }
-)
+const configSchema = s({
+  peerDiscovery: s('object', {
+    autoDial: true
+  }),
+  relay: s({
+    enabled: 'boolean',
+    hop: optional(s({
+      enabled: 'boolean',
+      active: 'boolean'
+    }, {
+      // HOP defaults
+      enabled: false,
+      active: false
+    }))
+  }, {
+    // Relay defaults
+    enabled: true
+  }),
+  // DHT config
+  dht: s({
+    kBucketSize: 'number',
+    enabled: 'boolean?',
+    validators: 'object?',
+    selectors: 'object?',
+    randomWalk: optional(s({
+      enabled: 'boolean?',
+      queriesPerPeriod: 'number?',
+      interval: 'number?',
+      timeout: 'number?'
+    }, {
+      // random walk defaults
+      enabled: false, // disabled waiting for https://github.com/libp2p/js-libp2p-kad-dht/issues/86
+      queriesPerPeriod: 1,
+      interval: 30000,
+      timeout: 10000
+    }))
+  }, {
+    // DHT defaults
+    enabled: false,
+    kBucketSize: 20,
+    enabledDiscovery: false
+  }),
+  // Experimental config
+  EXPERIMENTAL: s({
+    pubsub: 'boolean'
+  }, {
+    // Experimental defaults
+    pubsub: false
+  })
+}, {
+  relay: {},
+  dht: {},
+  EXPERIMENTAL: {}
+})
+
+const optionsSchema = s({
+  connectionManager: s('object', {
+    minPeers: 25
+  }),
+  datastore: 'object?',
+  peerInfo: 'object',
+  peerBook: 'object?',
+  modules: modulesSchema,
+  config: configSchema
+})
 
 module.exports.validate = (opts) => {
   const [error, options] = optionsSchema.validate(opts)

--- a/src/config.js
+++ b/src/config.js
@@ -108,5 +108,9 @@ module.exports.validate = (opts) => {
     }
   }
 
+  if (options.config.peerDiscovery.autoDial === undefined) {
+    options.config.peerDiscovery.autoDial = true
+  }
+
   return options
 }

--- a/src/index.js
+++ b/src/index.js
@@ -442,23 +442,25 @@ class Node extends EventEmitter {
   }
 
   /**
-   * Handles discovered peers. If the peer is not known, it
-   * will be emitted to listeners. If auto dial is enabled for libp2p
+   * Handles discovered peers. Each discovered peer will be emitted via
+   * the `peer:discovery` event. If auto dial is enabled for libp2p
    * and the current connection count is under the low watermark, the
    * peer will be dialed.
+   *
+   * TODO: If `peerBook.put` becomes centralized, https://github.com/libp2p/js-libp2p/issues/345,
+   * it would be ideal if only new peers were emitted. Currently, with
+   * other modules adding peers to the `PeerBook` we have no way of knowing
+   * if a peer is new or not, so it has to be emitted.
    *
    * @private
    * @param {PeerInfo} peerInfo
    */
   _peerDiscovered (peerInfo) {
-    const havePeer = this.peerBook.has(peerInfo)
     peerInfo = this.peerBook.put(peerInfo)
 
     if (!this.isStarted()) return
 
-    if (!havePeer) {
-      this.emit('peer:discovery', peerInfo)
-    }
+    this.emit('peer:discovery', peerInfo)
     this._maybeConnect(peerInfo)
   }
 

--- a/src/index.js
+++ b/src/index.js
@@ -477,7 +477,7 @@ class Node extends EventEmitter {
       const minPeers = this._options.connectionManager.minPeers || 0
       if (minPeers > Object.keys(this._switch.connection.connections).length) {
         log('connecting to discovered peer', peerInfo)
-        this.dial(peerInfo, (err) => {
+        this._switch.dialer.connect(peerInfo, (err) => {
           log.error('could not connect to discovered peer', err)
         })
       }

--- a/src/index.js
+++ b/src/index.js
@@ -414,7 +414,10 @@ class Node extends EventEmitter {
         parallel(
           this._discovery.map((d) => {
             d.removeListener('peer', this._peerDiscovered)
-            return (_cb) => d.stop(() => { _cb() })
+            return (_cb) => d.stop((err) => {
+              log.error('an error occurred stopping the discovery service', err)
+              _cb()
+            })
           }),
           cb
         )
@@ -487,7 +490,7 @@ class Node extends EventEmitter {
       if (minPeers > Object.keys(this._switch.connection.connections).length) {
         log('connecting to discovered peer')
         this._switch.dialer.connect(peerInfo, (err) => {
-          log.error('could not connect to discovered peer', err)
+          err && log.error('could not connect to discovered peer', err)
         })
       }
     }

--- a/src/index.js
+++ b/src/index.js
@@ -25,11 +25,6 @@ const pubsub = require('./pubsub')
 const getPeerInfo = require('./get-peer-info')
 const validateConfig = require('./config').validate
 
-const DISCOVERY_STRATEGIES = {
-  ALL: 0, // All peers
-  LOW: 1 // When below the ConnectionManager watermark
-}
-
 const notStarted = (action, state) => {
   return errCode(
     new Error(`libp2p cannot ${action} when not started; state is ${state}`),
@@ -467,6 +462,13 @@ class Node extends EventEmitter {
     this._maybeConnect(peerInfo)
   }
 
+  /**
+   * Will dial to the given `peerInfo` if the current number of
+   * connected peers is less than the configured `ConnectionManager`
+   * minPeers.
+   * @private
+   * @param {PeerInfo} peerInfo
+   */
   _maybeConnect (peerInfo) {
     // If auto dialing is on, check if we should dial
     if (this._config.peerDiscovery.autoDial === true && !peerInfo.isConnected()) {

--- a/test/config.spec.js
+++ b/test/config.spec.js
@@ -138,6 +138,7 @@ describe('configuration', () => {
       },
       config: {
         peerDiscovery: {
+          autoDial: true,
           bootstrap: {
             interval: 1000,
             enabled: true

--- a/test/config.spec.js
+++ b/test/config.spec.js
@@ -58,6 +58,57 @@ describe('configuration', () => {
     }).to.throw('ERROR_EMPTY')
   })
 
+  it('should add defaults to config', () => {
+
+    const options = {
+      peerInfo,
+      modules: {
+        transport: [ WS ],
+        peerDiscovery: [ Bootstrap ],
+        dht: DHT
+      }
+    }
+
+    const expected = {
+      peerInfo,
+      connectionManager: {
+        minPeers: 25
+      },
+      modules: {
+        transport: [ WS ],
+        peerDiscovery: [ Bootstrap ],
+        dht: DHT
+      },
+      config: {
+        peerDiscovery: {
+          autoDial: true
+        },
+        EXPERIMENTAL: {
+          pubsub: false
+        },
+        dht: {
+          kBucketSize: 20,
+          enabled: false,
+          randomWalk: {
+            enabled: false,
+            queriesPerPeriod: 1,
+            interval: 30000,
+            timeout: 10000
+          }
+        },
+        relay: {
+          enabled: true,
+          hop: {
+            active: false,
+            enabled: false
+          }
+        }
+      }
+    }
+
+    expect(validateConfig(options)).to.deep.equal(expected)
+  })
+
   it('should add defaults to missing items', () => {
     const options = {
       peerInfo,
@@ -193,6 +244,9 @@ describe('configuration', () => {
       config: {
         EXPERIMENTAL: {
           pubsub: false
+        },
+        peerDiscovery: {
+          autoDial: true
         },
         relay: {
           enabled: true,

--- a/test/config.spec.js
+++ b/test/config.spec.js
@@ -78,6 +78,9 @@ describe('configuration', () => {
 
     const expected = {
       peerInfo,
+      connectionManager: {
+        minPeers: 25
+      },
       modules: {
         transport: [ WS ],
         peerDiscovery: [ Bootstrap ],
@@ -180,6 +183,9 @@ describe('configuration', () => {
     }
     const expected = {
       peerInfo,
+      connectionManager: {
+        minPeers: 25
+      },
       modules: {
         transport: [WS],
         dht: DHT

--- a/test/config.spec.js
+++ b/test/config.spec.js
@@ -59,7 +59,6 @@ describe('configuration', () => {
   })
 
   it('should add defaults to config', () => {
-
     const options = {
       peerInfo,
       modules: {

--- a/test/peer-discovery.node.js
+++ b/test/peer-discovery.node.js
@@ -78,6 +78,7 @@ describe('peer discovery', () => {
     it('should enable by default a module passed as an object', (done) => {
       const mockDiscovery = {
         on: sinon.stub(),
+        removeListener: sinon.stub(),
         start: sinon.stub().callsArg(0),
         stop: sinon.stub().callsArg(0)
       }
@@ -98,6 +99,7 @@ describe('peer discovery', () => {
     it('should enable by default a module passed as a function', (done) => {
       const mockDiscovery = {
         on: sinon.stub(),
+        removeListener: sinon.stub(),
         start: sinon.stub().callsArg(0),
         stop: sinon.stub().callsArg(0)
       }
@@ -120,6 +122,7 @@ describe('peer discovery', () => {
     it('should enable module by configutation', (done) => {
       const mockDiscovery = {
         on: sinon.stub(),
+        removeListener: sinon.stub(),
         start: sinon.stub().callsArg(0),
         stop: sinon.stub().callsArg(0),
         tag: 'mockDiscovery'
@@ -155,6 +158,7 @@ describe('peer discovery', () => {
     it('should disable module by configutation', (done) => {
       const mockDiscovery = {
         on: sinon.stub(),
+        removeListener: sinon.stub(),
         start: sinon.stub().callsArg(0),
         stop: sinon.stub().callsArg(0),
         tag: 'mockDiscovery'
@@ -190,6 +194,7 @@ describe('peer discovery', () => {
     it('should register module passed as function', (done) => {
       const mockDiscovery = {
         on: sinon.stub(),
+        removeListener: sinon.stub(),
         start: sinon.stub().callsArg(0),
         stop: sinon.stub().callsArg(0)
       }
@@ -227,6 +232,7 @@ describe('peer discovery', () => {
     it('should register module passed as object', (done) => {
       const mockDiscovery = {
         on: sinon.stub(),
+        removeListener: sinon.stub(),
         start: sinon.stub().callsArg(0),
         stop: sinon.stub().callsArg(0),
         tag: 'mockDiscovery'

--- a/test/peer-discovery.node.js
+++ b/test/peer-discovery.node.js
@@ -453,16 +453,19 @@ describe('peer discovery', () => {
       }
     })
 
-    it('should only dial when the peer count is below the low watermark', () => {
+    it('should only dial when the peer count is below the low watermark', (done) => {
       const bootstrap = nodeA._discovery[0]
-      sinon.spy(nodeA, 'dial')
+      sinon.stub(nodeA._switch.dialer, 'connect').callsFake((peerInfo) => {
+        nodeA._switch.connection.connections[peerInfo.id.toB58String()] = []
+      })
 
       bootstrap.emit('peer', nodeB.peerInfo)
       bootstrap.emit('peer', nodeC.peerInfo)
 
       // Only nodeB should get dialed
-      expect(nodeA.dial.callCount).to.eql(1)
-      expect(nodeA.dial.getCall(0).args[0]).to.eql(nodeB.peerInfo)
+      expect(nodeA._switch.dialer.connect.callCount).to.eql(1)
+      expect(nodeA._switch.dialer.connect.getCall(0).args[0]).to.eql(nodeB.peerInfo)
+      done()
     })
   })
 })

--- a/test/transports.browser.js
+++ b/test/transports.browser.js
@@ -413,14 +413,10 @@ describe('transports', () => {
     it('node1 hangUp node2', (done) => {
       node1.hangUp(peer2, (err) => {
         expect(err).to.not.exist()
-        setTimeout(check, 500)
-
-        function check () {
-          const peers = node1.peerBook.getAll()
-          expect(Object.keys(peers)).to.have.length(1)
-          expect(node1._switch.connection.getAll()).to.have.length(0)
-          done()
-        }
+        const peers = node1.peerBook.getAll()
+        expect(Object.keys(peers)).to.have.length(1)
+        expect(node1._switch.connection.getAll()).to.have.length(0)
+        done()
       })
     })
 

--- a/test/transports.browser.js
+++ b/test/transports.browser.js
@@ -4,6 +4,7 @@
 
 const chai = require('chai')
 chai.use(require('dirty-chai'))
+chai.use(require('chai-checkmark'))
 const expect = chai.expect
 const PeerInfo = require('peer-info')
 const PeerId = require('peer-id')
@@ -422,16 +423,10 @@ describe('transports', () => {
 
     it('create a third node and check that discovery works', function (done) {
       this.timeout(10 * 1000)
-
-      let counter = 0
-
-      function check () {
-        if (++counter === 3) {
-          expect(node1._switch.connection.getAll()).to.have.length(1)
-          expect(node2._switch.connection.getAll()).to.have.length(1)
-          done()
-        }
-      }
+      const expectedPeers = [
+        node1.peerInfo.id.toB58String(),
+        node2.peerInfo.id.toB58String()
+      ]
 
       PeerId.create((err, id3) => {
         expect(err).to.not.exist()
@@ -440,13 +435,18 @@ describe('transports', () => {
         const ma3 = '/ip4/127.0.0.1/tcp/14444/ws/p2p-websocket-star/p2p/' + id3.toB58String()
         peer3.multiaddrs.add(ma3)
 
-        node1.on('peer:discovery', (peerInfo) => node1.dial(peerInfo, check))
-        node2.on('peer:discovery', (peerInfo) => node2.dial(peerInfo, check))
+        // 2 connects and 1 start
+        expect(3).checks(done)
 
         const node3 = new Node({
           peerInfo: peer3
         })
-        node3.start(check)
+        node3.on('peer:connect', (peerInfo) => {
+          expect(expectedPeers).to.include(peerInfo.id.toB58String()).mark()
+        })
+        node3.start((err) => {
+          expect(err).to.not.exist().mark()
+        })
       })
     })
   })

--- a/test/transports.node.js
+++ b/test/transports.node.js
@@ -438,6 +438,7 @@ describe('transports', () => {
             },
             config: {
               peerDiscovery: {
+                autoDial: false,
                 [wstar.discovery.tag]: {
                   enabled: true
                 }
@@ -452,7 +453,13 @@ describe('transports', () => {
         },
         (cb) => createNode([
           '/ip4/0.0.0.0/tcp/0'
-        ], (err, node) => {
+        ], {
+          config: {
+            peerDiscovery: {
+              autoDial: false
+            }
+          }
+        }, (err, node) => {
           expect(err).to.not.exist()
           nodeTCP = node
           node.handle('/echo/1.0.0', echo)
@@ -460,7 +467,13 @@ describe('transports', () => {
         }),
         (cb) => createNode([
           '/ip4/127.0.0.1/tcp/25022/ws'
-        ], (err, node) => {
+        ], {
+          config: {
+            peerDiscovery: {
+              autoDial: false
+            }
+          }
+        }, (err, node) => {
           expect(err).to.not.exist()
           nodeWS = node
           node.handle('/echo/1.0.0', echo)
@@ -479,6 +492,7 @@ describe('transports', () => {
             },
             config: {
               peerDiscovery: {
+                autoDial: false,
                 [wstar.discovery.tag]: {
                   enabled: true
                 }

--- a/test/utils/bundle-browser.js
+++ b/test/utils/bundle-browser.js
@@ -61,6 +61,7 @@ class Node extends libp2p {
       },
       config: {
         peerDiscovery: {
+          autoDial: true,
           webRTCStar: {
             enabled: true
           },
@@ -69,7 +70,6 @@ class Node extends libp2p {
           },
           bootstrap: {
             interval: 10000,
-            strategy: libp2p.DISCOVERY_STRATEGIES.LOW,
             enabled: false,
             list: _options.boostrapList
           }

--- a/test/utils/bundle-browser.js
+++ b/test/utils/bundle-browser.js
@@ -61,7 +61,7 @@ class Node extends libp2p {
       },
       config: {
         peerDiscovery: {
-          autoDial: false,
+          autoDial: true,
           webRTCStar: {
             enabled: true
           },

--- a/test/utils/bundle-browser.js
+++ b/test/utils/bundle-browser.js
@@ -61,7 +61,7 @@ class Node extends libp2p {
       },
       config: {
         peerDiscovery: {
-          autoDial: true,
+          autoDial: false,
           webRTCStar: {
             enabled: true
           },

--- a/test/utils/bundle-browser.js
+++ b/test/utils/bundle-browser.js
@@ -69,6 +69,7 @@ class Node extends libp2p {
           },
           bootstrap: {
             interval: 10000,
+            strategy: libp2p.DISCOVERY_STRATEGIES.LOW,
             enabled: false,
             list: _options.boostrapList
           }

--- a/test/utils/bundle-nodejs.js
+++ b/test/utils/bundle-nodejs.js
@@ -56,13 +56,13 @@ class Node extends libp2p {
       },
       config: {
         peerDiscovery: {
+          autoDial: true,
           mdns: {
             interval: 10000,
             enabled: false
           },
           bootstrap: {
             interval: 10000,
-            strategy: libp2p.DISCOVERY_STRATEGIES.LOW,
             enabled: false,
             list: _options.bootstrapList
           }

--- a/test/utils/bundle-nodejs.js
+++ b/test/utils/bundle-nodejs.js
@@ -62,6 +62,7 @@ class Node extends libp2p {
           },
           bootstrap: {
             interval: 10000,
+            strategy: libp2p.DISCOVERY_STRATEGIES.LOW,
             enabled: false,
             list: _options.bootstrapList
           }


### PR DESCRIPTION
This PR leverages the strategies detailed at https://github.com/libp2p/js-libp2p/pull/349#issuecomment-480256157 to implement auto dial in libp2p. This should improve our ability to maintain an appropriate level of connections based on the min and max peers configured for the `ConnectionManager`. 

Applications leveraging libp2p should ensure they are not dialing discovered peers when using this update. Applications that do wish to handle all dialing can disable `autoDial` in the config.

Depends on https://github.com/libp2p/js-libp2p-switch/pull/325