### PR TITLE
fix: allow switch to be configured

### DIFF
--- a/src/config.js
+++ b/src/config.js
@@ -85,6 +85,7 @@ const configSchema = s({
 })
 
 const optionsSchema = s({
+  switch: 'object?',
   connectionManager: s('object', {
     minPeers: 25
   }),

--- a/test/config.spec.js
+++ b/test/config.spec.js
@@ -170,6 +170,33 @@ describe('configuration', () => {
     expect(validateConfig(options)).to.deep.equal(expected)
   })
 
+  it('should allow for configuring the switch', () => {
+    const options = {
+      peerInfo,
+      switch: {
+        blacklistTTL: 60e3,
+        blackListAttempts: 5,
+        maxParallelDials: 100,
+        maxColdCalls: 50,
+        dialTimeout: 30e3
+      },
+      modules: {
+        transport: [ WS ],
+        peerDiscovery: [ ]
+      }
+    }
+
+    expect(validateConfig(options)).to.deep.include({
+      switch: {
+        blacklistTTL: 60e3,
+        blackListAttempts: 5,
+        maxParallelDials: 100,
+        maxColdCalls: 50,
+        dialTimeout: 30e3
+      }
+    })
+  })
+
   it('should allow for delegated content and peer routing', () => {
     const peerRouter = new DelegatedPeerRouter()
     const contentRouter = new DelegatedContentRouter(peerInfo)


### PR DESCRIPTION
Attempting to configure the switch would throw a config validation error. This corrects that, so the switch can be configured.