### PR TITLE
docs: fix incorrect references for enabling dht discovery

### DIFF
--- a/README.md
+++ b/README.md
@@ -181,7 +181,11 @@ class Node extends libp2p {
         dht: {
           kBucketSize: 20,
           enabled: true,
-          enabledDiscovery: true      // Allows to disable discovery (enabled by default)
+          randomWalk: {
+            enabled: true,      // Allows to disable discovery (enabled by default)
+            interval: 300e3,
+            timeout: 10e3
+          }
         },
         // Enable/Disable Experimental features
         EXPERIMENTAL: {               // Experimental features ("behind a flag")

--- a/src/config.js
+++ b/src/config.js
@@ -68,8 +68,7 @@ const configSchema = s({
   }, {
     // DHT defaults
     enabled: false,
-    kBucketSize: 20,
-    enabledDiscovery: false
+    kBucketSize: 20
   }),
   // Experimental config
   EXPERIMENTAL: s({


### PR DESCRIPTION
dht config option `enabledDiscovery` is no longer an option and instead discovery is configured via `randomWalk`.

This PR removes the bad references. I did a repo search to make sure there were no more instances of `enabledDiscovery`