### PR TITLE
fix: dht config

### DIFF
--- a/src/config.js
+++ b/src/config.js
@@ -48,27 +48,17 @@ const configSchema = s({
     enabled: true
   }),
   // DHT config
-  dht: s({
-    kBucketSize: 'number',
-    enabled: 'boolean?',
-    validators: 'object?',
-    selectors: 'object?',
-    randomWalk: optional(s({
-      enabled: 'boolean?',
-      queriesPerPeriod: 'number?',
-      interval: 'number?',
-      timeout: 'number?'
-    }, {
-      // random walk defaults
-      enabled: false, // disabled waiting for https://github.com/libp2p/js-libp2p-kad-dht/issues/86
-      queriesPerPeriod: 1,
-      interval: 30000,
-      timeout: 10000
-    }))
-  }, {
+  dht: s('object?', {
     // DHT defaults
     enabled: false,
-    kBucketSize: 20
+    kBucketSize: 20,
+    randomWalk: {
+      enabled: false, // disabled waiting for https://github.com/libp2p/js-libp2p-kad-dht/issues/86
+      queriesPerPeriod: 1,
+      interval: 300e3,
+      delay: 10e3,
+      timeout: 10e3
+    }
   }),
   // Experimental config
   EXPERIMENTAL: s({
@@ -77,11 +67,7 @@ const configSchema = s({
     // Experimental defaults
     pubsub: false
   })
-}, {
-  relay: {},
-  dht: {},
-  EXPERIMENTAL: {}
-})
+}, {})
 
 const optionsSchema = s({
   switch: 'object?',

--- a/src/config.js
+++ b/src/config.js
@@ -56,7 +56,6 @@ const configSchema = s({
       enabled: false, // disabled waiting for https://github.com/libp2p/js-libp2p-kad-dht/issues/86
       queriesPerPeriod: 1,
       interval: 300e3,
-      delay: 10e3,
       timeout: 10e3
     }
   }),

--- a/test/config.spec.js
+++ b/test/config.spec.js
@@ -92,7 +92,6 @@ describe('configuration', () => {
             enabled: false,
             queriesPerPeriod: 1,
             interval: 300000,
-            delay: 10000,
             timeout: 10000
           }
         },
@@ -155,7 +154,6 @@ describe('configuration', () => {
             enabled: false,
             queriesPerPeriod: 1,
             interval: 300000,
-            delay: 10000,
             timeout: 10000
           }
         },
@@ -309,7 +307,6 @@ describe('configuration', () => {
             enabled: false,
             queriesPerPeriod: 1,
             interval: 300000,
-            delay: 10000,
             timeout: 10000
           }
         }
@@ -324,7 +321,6 @@ describe('configuration', () => {
         enabled: false,
         queriesPerPeriod: 1,
         interval: 300000,
-        delay: 10000,
         timeout: 10000
       }
     }

--- a/test/config.spec.js
+++ b/test/config.spec.js
@@ -91,7 +91,8 @@ describe('configuration', () => {
           randomWalk: {
             enabled: false,
             queriesPerPeriod: 1,
-            interval: 30000,
+            interval: 300000,
+            delay: 10000,
             timeout: 10000
           }
         },
@@ -153,7 +154,8 @@ describe('configuration', () => {
           randomWalk: {
             enabled: false,
             queriesPerPeriod: 1,
-            interval: 30000,
+            interval: 300000,
+            delay: 10000,
             timeout: 10000
           }
         },
@@ -242,7 +244,7 @@ describe('configuration', () => {
     expect(() => validateConfig(options)).to.throw()
   })
 
-  it('should add defaults, validators and selectors for dht', () => {
+  it('should be able to add validators and selectors for dht', () => {
     const selectors = {}
     const validators = {}
 
@@ -283,19 +285,52 @@ describe('configuration', () => {
           }
         },
         dht: {
-          kBucketSize: 20,
-          enabled: false,
-          randomWalk: {
-            enabled: false,
-            queriesPerPeriod: 1,
-            interval: 30000,
-            timeout: 10000
-          },
           selectors,
           validators
         }
       }
     }
     expect(validateConfig(options)).to.deep.equal(expected)
+  })
+
+  it('should support new properties for the dht config', () => {
+    const options = {
+      peerInfo,
+      modules: {
+        transport: [WS],
+        dht: DHT
+      },
+      config: {
+        dht: {
+          kBucketSize: 20,
+          enabled: false,
+          myNewDHTConfigProperty: true,
+          randomWalk: {
+            enabled: false,
+            queriesPerPeriod: 1,
+            interval: 300000,
+            delay: 10000,
+            timeout: 10000
+          }
+        }
+      }
+    }
+
+    const expected = {
+      kBucketSize: 20,
+      enabled: false,
+      myNewDHTConfigProperty: true,
+      randomWalk: {
+        enabled: false,
+        queriesPerPeriod: 1,
+        interval: 300000,
+        delay: 10000,
+        timeout: 10000
+      }
+    }
+
+    const actual = validateConfig(options).config.dht
+
+    expect(actual).to.deep.equal(expected)
   })
 })


### PR DESCRIPTION
Right now the dht config is pretty restrictive. `superstruct` doesn't allow for non defined properties to exist. This makes it annoying to add new config options to the dht. For example, if a new option was added to the DHT, `myNewDHTConfigProperty`, and js-ipfs wanted to use that, libp2p would have to be updated to support that config option.

Modules should take care of their own config validation, not libp2p. Libp2p should really only be concerned with validating the things it needs to run.