### PR TITLE
feat: sign pubsub messages

### DIFF
--- a/package.json
+++ b/package.json
@@ -43,7 +43,7 @@
     "err-code": "^1.1.2",
     "fsm-event": "^2.1.0",
     "libp2p-connection-manager": "~0.1.0",
-    "libp2p-floodsub": "~0.15.8",
+    "libp2p-floodsub": "libp2p/js-libp2p-floodsub#feat/signing",
     "libp2p-ping": "~0.8.5",
     "libp2p-switch": "~0.42.9",
     "libp2p-websockets": "~0.12.2",

--- a/package.json
+++ b/package.json
@@ -43,7 +43,7 @@
     "err-code": "^1.1.2",
     "fsm-event": "^2.1.0",
     "libp2p-connection-manager": "~0.1.0",
-    "libp2p-floodsub": "libp2p/js-libp2p-floodsub#feat/signing",
+    "libp2p-floodsub": "~0.16.0",
     "libp2p-ping": "~0.8.5",
     "libp2p-switch": "~0.42.9",
     "libp2p-websockets": "~0.12.2",

--- a/src/pubsub.js
+++ b/src/pubsub.js
@@ -63,9 +63,7 @@ module.exports = (node) => {
         return nextTick(callback, errCode(new Error('data must be a Buffer'), 'ERR_DATA_IS_NOT_A_BUFFER'))
       }
 
-      floodSub.publish(topic, data)
-
-      nextTick(() => callback())
+      floodSub.publish(topic, data, callback)
     },
 
     ls: (callback) => {

--- a/test/peer-discovery.node.js
+++ b/test/peer-discovery.node.js
@@ -423,6 +423,7 @@ describe('peer discovery', () => {
           randomWalk: {
             enabled: true,
             queriesPerPeriod: 1,
+            delay: 100,
             interval: 200, // start the query sooner
             timeout: 3000
           }


### PR DESCRIPTION
This upgrades floodsub so that all messages published are signed

Requires https://github.com/libp2p/js-libp2p-floodsub/pull/78

I ran libp2p/interop against this branch to verify it's passing, https://github.com/libp2p/interop/runs/119819194