### PR TITLE
Instantiate transports with a reference to node

### DIFF
--- a/src/index.js
+++ b/src/index.js
@@ -345,7 +345,7 @@ class Node extends EventEmitter {
       let t
 
       if (typeof Transport === 'function') {
-        t = new Transport({libp2p: this})
+        t = new Transport({ libp2p: this })
       } else {
         t = Transport
       }

--- a/src/index.js
+++ b/src/index.js
@@ -345,7 +345,7 @@ class Node extends EventEmitter {
       let t
 
       if (typeof Transport === 'function') {
-        t = new Transport()
+        t = new Transport({libp2p: this})
       } else {
         t = Transport
       }


### PR DESCRIPTION
As discussed [here](https://github.com/libp2p/js-libp2p/issues/361#issuecomment-491229478), transports could benefit from having a reference to the libp2p node on creation (in case the transport depends on perior connections, e.g. webrtc, relay).

As far as I can tell, this change is backwards compatible.