### PR TITLE
feat: add createLibp2p to generate a PeerInfo instance

### DIFF
--- a/src/index.js
+++ b/src/index.js
@@ -10,8 +10,10 @@ const errCode = require('err-code')
 const each = require('async/each')
 const series = require('async/series')
 const parallel = require('async/parallel')
+const nextTick = require('async/nextTick')
 
 const PeerBook = require('peer-book')
+const PeerInfo = require('peer-info')
 const Switch = require('libp2p-switch')
 const Ping = require('libp2p-ping')
 const WebSockets = require('libp2p-websockets')
@@ -34,14 +36,14 @@ const notStarted = (action, state) => {
 }
 
 /**
- * @fires Node#error Emitted when an error occurs
- * @fires Node#peer:connect Emitted when a peer is connected to this node
- * @fires Node#peer:disconnect Emitted when a peer disconnects from this node
- * @fires Node#peer:discovery Emitted when a peer is discovered
- * @fires Node#start Emitted when the node and its services has started
- * @fires Node#stop Emitted when the node and its services has stopped
+ * @fires Libp2p#error Emitted when an error occurs
+ * @fires Libp2p#peer:connect Emitted when a peer is connected to this node
+ * @fires Libp2p#peer:disconnect Emitted when a peer disconnects from this node
+ * @fires Libp2p#peer:discovery Emitted when a peer is discovered
+ * @fires Libp2p#start Emitted when the node and its services has started
+ * @fires Libp2p#stop Emitted when the node and its services has stopped
  */
-class Node extends EventEmitter {
+class Libp2p extends EventEmitter {
   constructor (_options) {
     super()
     // validateConfig will ensure the config is correct,
@@ -547,4 +549,21 @@ class Node extends EventEmitter {
   }
 }
 
-module.exports = Node
+module.exports = Libp2p
+/**
+ * Like `new Libp2p(options)` except it will create a `PeerInfo`
+ * instance if one is not provided in options.
+ * @param {object} options Libp2p configuration options
+ * @param {function(Error, Libp2p)} callback
+ * @returns {void}
+ */
+module.exports.createLibp2p = (options, callback) => {
+  if (options.peerInfo) {
+    return nextTick(callback, null, new Libp2p(options))
+  }
+  PeerInfo.create((err, peerInfo) => {
+    if (err) return callback(err)
+    options.peerInfo = peerInfo
+    callback(null, new Libp2p(options))
+  })
+}

--- a/test/create.spec.js
+++ b/test/create.spec.js
@@ -7,8 +7,15 @@ const expect = chai.expect
 const series = require('async/series')
 const createNode = require('./utils/create-node')
 const sinon = require('sinon')
+const { createLibp2p } = require('../src')
+const WS = require('libp2p-websockets')
+const PeerInfo = require('peer-info')
 
 describe('libp2p creation', () => {
+  afterEach(() => {
+    sinon.restore()
+  })
+
   it('should be able to start and stop successfully', (done) => {
     createNode([], {
       config: {
@@ -99,6 +106,36 @@ describe('libp2p creation', () => {
         done()
       })
       node._switch.emit('error', error)
+    })
+  })
+
+  it('createLibp2p should create a peerInfo instance', (done) => {
+    createLibp2p({
+      modules: {
+        transport: [ WS ]
+      }
+    }, (err, libp2p) => {
+      expect(err).to.not.exist()
+      expect(libp2p).to.exist()
+      done()
+    })
+  })
+
+  it('createLibp2p should allow for a provided peerInfo instance', (done) => {
+    PeerInfo.create((err, peerInfo) => {
+      expect(err).to.not.exist()
+      sinon.spy(PeerInfo, 'create')
+      createLibp2p({
+        peerInfo,
+        modules: {
+          transport: [ WS ]
+        }
+      }, (err, libp2p) => {
+        expect(err).to.not.exist()
+        expect(libp2p).to.exist()
+        expect(PeerInfo.create.callCount).to.eql(0)
+        done()
+      })
     })
   })
 })


### PR DESCRIPTION
`createLibp2p` is a new exported helper function that allows users to create a libp2p instance without worrying about creating a PeerInfo instance first.

Now instead of needing to do this:
```js
const PeerInfo = require('peer-info')
const Libp2p = require('libp2p')
PeerInfo.create((err, peerInfo) => {
  const libp2p = new Libp2p({
    ...options,
    peerInfo
  }) 
  // Use libp2p
})
```

you can just do:
```js
const { createLibp2p } = require('libp2p')
createLibp2p(options, (err, libp2p) => {
    // Use libp2p
}) 
```

While the code change is not significant, it removes the need to know about `PeerInfo` creation prior to creating a libp2p instance. This should hopefully help reduce the barrier to entry by a small degree.

I also changed `Node` to `Libp2p` because the naming is unnecessarily confusing and nondescript.