### PR TITLE
chore: update keywords and description

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,7 +1,7 @@
 {
   "name": "libp2p",
   "version": "0.25.4",
-  "description": "JavaScript base class for libp2p bundles",
+  "description": "JavaScript implementation of libp2p, a modular peer to peer network stack",
   "leadMaintainer": "Jacob Heun <jacobheun@gmail.com>",
   "main": "src/index.js",
   "files": [
@@ -23,19 +23,24 @@
     "url": "https://github.com/libp2p/js-libp2p.git"
   },
   "keywords": [
+    "libp2p",
+    "network",
+    "p2p",
+    "peer",
+    "peer-to-peer",
     "IPFS"
   ],
-  "engines": {
-    "node": ">=6.0.0",
-    "npm": ">=3.0.0"
-  },
-  "license": "MIT",
   "bugs": {
     "url": "https://github.com/libp2p/js-libp2p/issues"
   },
-  "homepage": "https://github.com/libp2p/js-libp2p",
+  "homepage": "https://libp2p.io",
+  "license": "MIT",
   "browser": {
     "./test/utils/bundle-nodejs": "./test/utils/bundle-browser"
+  },
+  "engines": {
+    "node": ">=10.0.0",
+    "npm": ">=6.0.0"
   },
   "dependencies": {
     "async": "^2.6.2",

--- a/test/create.spec.js
+++ b/test/create.spec.js
@@ -109,7 +109,8 @@ describe('libp2p creation', () => {
     })
   })
 
-  it('createLibp2p should create a peerInfo instance', (done) => {
+  it('createLibp2p should create a peerInfo instance', function (done) {
+    this.timeout(10e3)
     createLibp2p({
       modules: {
         transport: [ WS ]
@@ -121,7 +122,8 @@ describe('libp2p creation', () => {
     })
   })
 
-  it('createLibp2p should allow for a provided peerInfo instance', (done) => {
+  it('createLibp2p should allow for a provided peerInfo instance', function (done) {
+    this.timeout(10e3)
     PeerInfo.create((err, peerInfo) => {
       expect(err).to.not.exist()
       sinon.spy(PeerInfo, 'create')


### PR DESCRIPTION
I noticed the only keyword being used in package.json was IPFS, so I added some more libp2p specific keywords and also updated the description. The homepage also now points to libp2p.io.

I also reordered a couple other fields in package.json to group them a bit better.