### PR TITLE
fix: make subscribe comply with ipfs interface

### DIFF
--- a/src/pubsub.js
+++ b/src/pubsub.js
@@ -13,10 +13,31 @@ module.exports = (node) => {
   node._floodSub = floodSub
 
   return {
-    subscribe: promisify((topic, options, handler, callback) => {
+    /**
+     * Subscribe the given handler to a pubsub topic
+     *
+     * @param {string} topic
+     * @param {function} handler The handler to subscribe
+     * @param {object|null} [options]
+     * @param {function} [callback] An optional callback
+     *
+     * @returns {Promise|void} A promise is returned if no callback is provided
+     *
+     * @example <caption>Subscribe a handler to a topic</caption>
+     *
+     * // `null` must be passed for options until subscribe is no longer using promisify
+     * const handler = (message) => { }
+     * await libp2p.subscribe(topic, handler, null)
+     *
+     * @example <caption>Use a callback instead of the Promise api</caption>
+     *
+     * // `options` may be passed or omitted when supplying a callback
+     * const handler = (message) => { }
+     * libp2p.subscribe(topic, handler, callback)
+     */
+    subscribe: promisify((topic, handler, options, callback) => {
       if (typeof options === 'function') {
-        callback = handler
-        handler = options
+        callback = options
         options = {}
       }
 

--- a/test/pubsub.node.js
+++ b/test/pubsub.node.js
@@ -72,7 +72,7 @@ describe('.pubsub', () => {
           cb(err)
         }),
         // subscribe on the first
-        (cb) => nodes[0].pubsub.subscribe('pubsub', handler, cb),
+        (cb) => nodes[0].pubsub.subscribe('pubsub', handler, null, cb),
         // Wait a moment before publishing
         (cb) => setTimeout(cb, 500),
         // publish on the second
@@ -110,7 +110,7 @@ describe('.pubsub', () => {
           cb(err)
         }),
         // subscribe on the first
-        (cb) => nodes[0].pubsub.subscribe('pubsub', handler, cb),
+        (cb) => nodes[0].pubsub.subscribe('pubsub', handler, {}, cb),
         // Wait a moment before publishing
         (cb) => setTimeout(cb, 500),
         // publish on the second


### PR DESCRIPTION
BREAKING CHANGE: The ipfs interface specified that options
should be provided after the handler, not before.
https://github.com/ipfs/interface-js-ipfs-core/blob/v0.109.0/SPEC/PUBSUB.md#pubsubsubscribe

This corrects the order of parameters. See the jsdocs examples
for subscribe to see how it should be used.

-----

Looking to include this breaking change update in the next libp2p minor release, since we're already making breaking changes to the pubsub api.