### PR TITLE
test(fix): correct findProviders test for missing provider

### DIFF
--- a/package.json
+++ b/package.json
@@ -63,7 +63,7 @@
   },
   "devDependencies": {
     "@nodeutils/defaults-deep": "^1.1.0",
-    "aegir": "^19.0.3",
+    "aegir": "^20.0.0",
     "chai": "^4.2.0",
     "chai-checkmark": "^1.0.1",
     "cids": "^0.7.1",
@@ -74,7 +74,7 @@
     "libp2p-circuit": "^0.3.7",
     "libp2p-delegated-content-routing": "^0.2.2",
     "libp2p-delegated-peer-routing": "^0.2.2",
-    "libp2p-kad-dht": "^0.15.2",
+    "libp2p-kad-dht": "^0.15.3",
     "libp2p-mdns": "^0.12.3",
     "libp2p-mplex": "^0.8.4",
     "libp2p-secio": "^0.11.1",

--- a/src/index.js
+++ b/src/index.js
@@ -69,7 +69,7 @@ class Libp2p extends EventEmitter {
 
     // Attach stream multiplexers
     if (this._modules.streamMuxer) {
-      let muxers = this._modules.streamMuxer
+      const muxers = this._modules.streamMuxer
       muxers.forEach((muxer) => this._switch.connection.addStreamMuxer(muxer))
 
       // If muxer exists
@@ -99,7 +99,7 @@ class Libp2p extends EventEmitter {
 
     // Attach crypto channels
     if (this._modules.connEncryption) {
-      let cryptos = this._modules.connEncryption
+      const cryptos = this._modules.connEncryption
       cryptos.forEach((crypto) => {
         this._switch.connection.crypto(crypto.tag, crypto.encrypt)
       })

--- a/test/circuit-relay.node.js
+++ b/test/circuit-relay.node.js
@@ -16,7 +16,7 @@ const tryEcho = require('./utils/try-echo')
 const echo = require('./utils/echo')
 
 describe('circuit relay', () => {
-  let handlerSpies = []
+  const handlerSpies = []
   let relayNode1
   let relayNode2
   let nodeWS1

--- a/test/config.spec.js
+++ b/test/config.spec.js
@@ -33,7 +33,7 @@ describe('configuration', () => {
     expect(() => {
       validateConfig({
         modules: {
-          transport: [ WS ]
+          transport: [WS]
         }
       })
     }).to.throw()
@@ -52,7 +52,7 @@ describe('configuration', () => {
       validateConfig({
         peerInfo,
         modules: {
-          transport: [ ]
+          transport: []
         }
       })
     }).to.throw('ERROR_EMPTY')
@@ -62,8 +62,8 @@ describe('configuration', () => {
     const options = {
       peerInfo,
       modules: {
-        transport: [ WS ],
-        peerDiscovery: [ Bootstrap ],
+        transport: [WS],
+        peerDiscovery: [Bootstrap],
         dht: DHT
       }
     }
@@ -74,8 +74,8 @@ describe('configuration', () => {
         minPeers: 25
       },
       modules: {
-        transport: [ WS ],
-        peerDiscovery: [ Bootstrap ],
+        transport: [WS],
+        peerDiscovery: [Bootstrap],
         dht: DHT
       },
       config: {
@@ -112,8 +112,8 @@ describe('configuration', () => {
     const options = {
       peerInfo,
       modules: {
-        transport: [ WS ],
-        peerDiscovery: [ Bootstrap ],
+        transport: [WS],
+        peerDiscovery: [Bootstrap],
         dht: DHT
       },
       config: {
@@ -132,8 +132,8 @@ describe('configuration', () => {
         minPeers: 25
       },
       modules: {
-        transport: [ WS ],
-        peerDiscovery: [ Bootstrap ],
+        transport: [WS],
+        peerDiscovery: [Bootstrap],
         dht: DHT
       },
       config: {
@@ -181,8 +181,8 @@ describe('configuration', () => {
         dialTimeout: 30e3
       },
       modules: {
-        transport: [ WS ],
-        peerDiscovery: [ ]
+        transport: [WS],
+        peerDiscovery: []
       }
     }
 
@@ -204,10 +204,10 @@ describe('configuration', () => {
     const options = {
       peerInfo,
       modules: {
-        transport: [ WS ],
-        peerDiscovery: [ Bootstrap ],
-        peerRouting: [ peerRouter ],
-        contentRouting: [ contentRouter ],
+        transport: [WS],
+        peerDiscovery: [Bootstrap],
+        peerRouting: [peerRouter],
+        contentRouting: [contentRouter],
         dht: DHT
       },
       config: {
@@ -221,8 +221,8 @@ describe('configuration', () => {
     }
 
     expect(validateConfig(options).modules).to.deep.include({
-      peerRouting: [ peerRouter ],
-      contentRouting: [ contentRouter ]
+      peerRouting: [peerRouter],
+      contentRouting: [contentRouter]
     })
   })
 
@@ -230,7 +230,7 @@ describe('configuration', () => {
     const options = {
       peerInfo,
       modules: {
-        transport: [ WS ]
+        transport: [WS]
       },
       config: {
         dht: {

--- a/test/content-routing.node.js
+++ b/test/content-routing.node.js
@@ -121,8 +121,9 @@ describe('.contentRouting', () => {
         const cid = new CID('QmTp9VkYvnHyrqKQuFPiuZkiX9gPcqj6x5LJ1rmWuSnnnn')
 
         nodeE.contentRouting.findProviders(cid, { maxTimeout: 5000 }, (err, providers) => {
-          expect(err).to.not.exist()
-          expect(providers).to.have.length(0)
+          expect(err).to.exist()
+          expect(err.code).to.eql('ERR_NOT_FOUND')
+          expect(providers).to.not.exist()
           done()
         })
       })

--- a/test/content-routing.node.js
+++ b/test/content-routing.node.js
@@ -151,7 +151,7 @@ describe('.contentRouting', () => {
           nodeA = new Node({
             peerInfo,
             modules: {
-              contentRouting: [ delegate ]
+              contentRouting: [delegate]
             },
             config: {
               dht: {
@@ -301,7 +301,7 @@ describe('.contentRouting', () => {
           nodeA = new Node({
             peerInfo,
             modules: {
-              contentRouting: [ delegate ]
+              contentRouting: [delegate]
             },
             config: {
               relay: {

--- a/test/create.spec.js
+++ b/test/create.spec.js
@@ -29,10 +29,10 @@ describe('libp2p creation', () => {
     }, (err, node) => {
       expect(err).to.not.exist()
 
-      let sw = node._switch
-      let cm = node.connectionManager
-      let dht = node._dht
-      let pub = node._floodSub
+      const sw = node._switch
+      const cm = node.connectionManager
+      const dht = node._dht
+      const pub = node._floodSub
 
       sinon.spy(sw, 'start')
       sinon.spy(cm, 'start')
@@ -113,7 +113,7 @@ describe('libp2p creation', () => {
     this.timeout(10e3)
     createLibp2p({
       modules: {
-        transport: [ WS ]
+        transport: [WS]
       }
     }, (err, libp2p) => {
       expect(err).to.not.exist()
@@ -130,7 +130,7 @@ describe('libp2p creation', () => {
       createLibp2p({
         peerInfo,
         modules: {
-          transport: [ WS ]
+          transport: [WS]
         }
       }, (err, libp2p) => {
         expect(err).to.not.exist()

--- a/test/fsm.spec.js
+++ b/test/fsm.spec.js
@@ -99,7 +99,7 @@ describe('libp2p state machine (fsm)', () => {
     })
 
     it('should error on start with no transports', (done) => {
-      let transports = node._modules.transport
+      const transports = node._modules.transport
       node._modules.transport = null
 
       node.on('stop', () => {

--- a/test/peer-discovery.node.js
+++ b/test/peer-discovery.node.js
@@ -72,7 +72,7 @@ describe('peer discovery', () => {
         stop: sinon.stub().callsArg(0)
       }
 
-      const options = { modules: { peerDiscovery: [ mockDiscovery ] } }
+      const options = { modules: { peerDiscovery: [mockDiscovery] } }
 
       createNode(['/ip4/0.0.0.0/tcp/0'], options, (err, node) => {
         expect(err).to.not.exist()
@@ -95,7 +95,7 @@ describe('peer discovery', () => {
 
       const MockDiscovery = sinon.stub().returns(mockDiscovery)
 
-      const options = { modules: { peerDiscovery: [ MockDiscovery ] } }
+      const options = { modules: { peerDiscovery: [MockDiscovery] } }
 
       createNode(['/ip4/0.0.0.0/tcp/0'], options, (err, node) => {
         expect(err).to.not.exist()
@@ -120,7 +120,7 @@ describe('peer discovery', () => {
       const enabled = sinon.stub().returns(true)
 
       const options = {
-        modules: { peerDiscovery: [ mockDiscovery ] },
+        modules: { peerDiscovery: [mockDiscovery] },
         config: {
           peerDiscovery: {
             mockDiscovery: {
@@ -156,7 +156,7 @@ describe('peer discovery', () => {
       const disabled = sinon.stub().returns(false)
 
       const options = {
-        modules: { peerDiscovery: [ mockDiscovery ] },
+        modules: { peerDiscovery: [mockDiscovery] },
         config: {
           peerDiscovery: {
             mockDiscovery: {
@@ -192,7 +192,7 @@ describe('peer discovery', () => {
       MockDiscovery.tag = 'mockDiscovery'
 
       const options = {
-        modules: { peerDiscovery: [ MockDiscovery ] },
+        modules: { peerDiscovery: [MockDiscovery] },
         config: {
           peerDiscovery: {
             mockDiscovery: {
@@ -228,7 +228,7 @@ describe('peer discovery', () => {
       }
 
       const options = {
-        modules: { peerDiscovery: [ mockDiscovery ] },
+        modules: { peerDiscovery: [mockDiscovery] },
         config: {
           peerDiscovery: {
             mockDiscovery: { enabled: true }
@@ -294,7 +294,7 @@ describe('peer discovery', () => {
     })
 
     it('find peers', function (done) {
-      let expectedPeers = new Set([
+      const expectedPeers = new Set([
         nodeB.peerInfo.id.toB58String(),
         nodeC.peerInfo.id.toB58String()
       ])
@@ -332,7 +332,7 @@ describe('peer discovery', () => {
 
     it('find peers', function (done) {
       this.timeout(20e3)
-      let expectedPeers = new Set([
+      const expectedPeers = new Set([
         nodeB.peerInfo.id.toB58String(),
         nodeC.peerInfo.id.toB58String()
       ])
@@ -374,7 +374,7 @@ describe('peer discovery', () => {
     })
 
     it('find peers', function (done) {
-      let expectedPeers = new Set([
+      const expectedPeers = new Set([
         nodeB.peerInfo.id.toB58String(),
         nodeC.peerInfo.id.toB58String()
       ])
@@ -421,7 +421,7 @@ describe('peer discovery', () => {
     })
 
     it('find peers through the dht', function (done) {
-      let expectedPeers = new Set([
+      const expectedPeers = new Set([
         nodeB.peerInfo.id.toB58String(),
         nodeC.peerInfo.id.toB58String()
       ])

--- a/test/peer-routing.node.js
+++ b/test/peer-routing.node.js
@@ -105,7 +105,7 @@ describe('.peerRouting', () => {
           })
           createNode('/ip4/0.0.0.0/tcp/0', {
             modules: {
-              peerRouting: [ delegate ]
+              peerRouting: [delegate]
             },
             config: {
               dht: {
@@ -211,7 +211,7 @@ describe('.peerRouting', () => {
           })
           createNode('/ip4/0.0.0.0/tcp/0', {
             modules: {
-              peerRouting: [ delegate ]
+              peerRouting: [delegate]
             }
           }, (err, node) => {
             expect(err).to.not.exist()

--- a/test/pnet.node.js
+++ b/test/pnet.node.js
@@ -24,7 +24,7 @@ describe('private network', () => {
         config = {
           peerInfo,
           modules: {
-            transport: [ WS ],
+            transport: [WS],
             dht: DHT
           }
         }
@@ -50,14 +50,14 @@ describe('private network', () => {
 
     it('should create a libp2p node with a provided protector', () => {
       let node
-      let protector = {
+      const protector = {
         psk: '123',
         tag: '/psk/1.0.0',
         protect: () => { }
       }
 
       expect(() => {
-        let options = defaultsDeep(config, {
+        const options = defaultsDeep(config, {
           modules: {
             connProtector: protector
           }
@@ -71,7 +71,7 @@ describe('private network', () => {
 
     it('should throw an error if the protector does not have a protect method', () => {
       expect(() => {
-        let options = defaultsDeep(config, {
+        const options = defaultsDeep(config, {
           modules: {
             connProtector: { }
           }

--- a/test/stream-muxing.node.js
+++ b/test/stream-muxing.node.js
@@ -36,7 +36,7 @@ describe('stream muxing', () => {
       parallel([
         (cb) => createNode('/ip4/0.0.0.0/tcp/0', {
           modules: {
-            streamMuxer: [ SPDY ]
+            streamMuxer: [SPDY]
           }
         }, (err, node) => {
           expect(err).to.not.exist()
@@ -46,7 +46,7 @@ describe('stream muxing', () => {
         }),
         (cb) => createNode('/ip4/0.0.0.0/tcp/0', {
           modules: {
-            streamMuxer: [ SPDY ]
+            streamMuxer: [SPDY]
           }
         }, (err, node) => {
           expect(err).to.not.exist()
@@ -72,7 +72,7 @@ describe('stream muxing', () => {
       parallel([
         (cb) => createNode('/ip4/0.0.0.0/tcp/0', {
           modules: {
-            streamMuxer: [ Mplex ]
+            streamMuxer: [Mplex]
           }
         }, (err, node) => {
           expect(err).to.not.exist()
@@ -82,7 +82,7 @@ describe('stream muxing', () => {
         }),
         (cb) => createNode('/ip4/0.0.0.0/tcp/0', {
           modules: {
-            streamMuxer: [ Mplex ]
+            streamMuxer: [Mplex]
           }
         }, (err, node) => {
           expect(err).to.not.exist()
@@ -108,7 +108,7 @@ describe('stream muxing', () => {
       parallel([
         (cb) => createNode('/ip4/0.0.0.0/tcp/0', {
           modules: {
-            streamMuxer: [ pMplex ]
+            streamMuxer: [pMplex]
           }
         }, (err, node) => {
           expect(err).to.not.exist()
@@ -118,7 +118,7 @@ describe('stream muxing', () => {
         }),
         (cb) => createNode('/ip4/0.0.0.0/tcp/0', {
           modules: {
-            streamMuxer: [ pMplex ]
+            streamMuxer: [pMplex]
           }
         }, (err, node) => {
           expect(err).to.not.exist()
@@ -146,7 +146,7 @@ describe('stream muxing', () => {
       parallel([
         (cb) => createNode('/ip4/0.0.0.0/tcp/0', {
           modules: {
-            streamMuxer: [ Mplex ]
+            streamMuxer: [Mplex]
           }
         }, (err, node) => {
           expect(err).to.not.exist()
@@ -156,7 +156,7 @@ describe('stream muxing', () => {
         }),
         (cb) => createNode('/ip4/0.0.0.0/tcp/0', {
           modules: {
-            streamMuxer: [ SPDY, Mplex ]
+            streamMuxer: [SPDY, Mplex]
           }
         }, (err, node) => {
           expect(err).to.not.exist()
@@ -184,7 +184,7 @@ describe('stream muxing', () => {
       parallel([
         (cb) => createNode('/ip4/0.0.0.0/tcp/0', {
           modules: {
-            streamMuxer: [ Mplex ]
+            streamMuxer: [Mplex]
           }
         }, (err, node) => {
           expect(err).to.not.exist()
@@ -194,7 +194,7 @@ describe('stream muxing', () => {
         }),
         (cb) => createNode('/ip4/0.0.0.0/tcp/0', {
           modules: {
-            streamMuxer: [ pMplex ]
+            streamMuxer: [pMplex]
           }
         }, (err, node) => {
           expect(err).to.not.exist()
@@ -222,7 +222,7 @@ describe('stream muxing', () => {
       parallel([
         (cb) => createNode('/ip4/0.0.0.0/tcp/0', {
           modules: {
-            streamMuxer: [ SPDY, Mplex ]
+            streamMuxer: [SPDY, Mplex]
           }
         }, (err, node) => {
           expect(err).to.not.exist()
@@ -232,7 +232,7 @@ describe('stream muxing', () => {
         }),
         (cb) => createNode('/ip4/0.0.0.0/tcp/0', {
           modules: {
-            streamMuxer: [ Mplex, SPDY ]
+            streamMuxer: [Mplex, SPDY]
           }
         }, (err, node) => {
           expect(err).to.not.exist()
@@ -260,7 +260,7 @@ describe('stream muxing', () => {
       parallel([
         (cb) => createNode('/ip4/0.0.0.0/tcp/0', {
           modules: {
-            streamMuxer: [ SPDY, pMplex ]
+            streamMuxer: [SPDY, pMplex]
           }
         }, (err, node) => {
           expect(err).to.not.exist()
@@ -270,7 +270,7 @@ describe('stream muxing', () => {
         }),
         (cb) => createNode('/ip4/0.0.0.0/tcp/0', {
           modules: {
-            streamMuxer: [ pMplex, SPDY ]
+            streamMuxer: [pMplex, SPDY]
           }
         }, (err, node) => {
           expect(err).to.not.exist()
@@ -298,7 +298,7 @@ describe('stream muxing', () => {
       parallel([
         (cb) => createNode('/ip4/0.0.0.0/tcp/0', {
           modules: {
-            streamMuxer: [ SPDY ]
+            streamMuxer: [SPDY]
           }
         }, (err, node) => {
           expect(err).to.not.exist()
@@ -308,7 +308,7 @@ describe('stream muxing', () => {
         }),
         (cb) => createNode('/ip4/0.0.0.0/tcp/0', {
           modules: {
-            streamMuxer: [ Mplex ]
+            streamMuxer: [Mplex]
           }
         }, (err, node) => {
           expect(err).to.not.exist()

--- a/test/transports.browser.js
+++ b/test/transports.browser.js
@@ -55,7 +55,7 @@ describe('transports', () => {
         const b = new Node({
           peerInfo: peerInfo,
           modules: {
-            streamMuxer: [ Mplex ]
+            streamMuxer: [Mplex]
           }
         })
         expect(b._modules.streamMuxer).to.eql([require('pull-mplex')])


### PR DESCRIPTION
https://github.com/libp2p/js-libp2p-kad-dht/pull/137 fixed a bug with how providers were being returned. 

This corrects a test for findProviders to return an error when no providers can be found, rather than just the empty array.

* updates Aegir and fixes linting