### PR TITLE
chore: promisify pubsub start and stop

### DIFF
--- a/src/pubsub.js
+++ b/src/pubsub.js
@@ -143,8 +143,8 @@ module.exports = (node, Pubsub) => {
       return pubsub.setMaxListeners(n)
     },
 
-    start: (cb) => pubsub.start(cb),
+    start: promisify((cb) => pubsub.start(cb)),
 
-    stop: (cb) => pubsub.stop(cb)
+    stop: promisify((cb) => pubsub.stop(cb))
   }
 }


### PR DESCRIPTION
With #381 and #365 , the gossipsub PR got in after and we did not promisify `start` and `stop`. This PR solves that