### PR TITLE
fix: pubsub default config

### DIFF
--- a/examples/libp2p-in-the-browser/1/package.json
+++ b/examples/libp2p-in-the-browser/1/package.json
@@ -19,6 +19,7 @@
     "detect-dom-ready": "^1.0.2",
     "libp2p": "../../../",
     "libp2p-bootstrap": "~0.9.7",
+    "libp2p-gossipsub": "~0.0.4",
     "libp2p-kad-dht": "^0.15.3",
     "libp2p-mplex": "~0.8.5",
     "libp2p-secio": "~0.11.1",

--- a/examples/libp2p-in-the-browser/1/src/browser-bundle.js
+++ b/examples/libp2p-in-the-browser/1/src/browser-bundle.js
@@ -8,6 +8,7 @@ const SPDY = require('libp2p-spdy')
 const SECIO = require('libp2p-secio')
 const Bootstrap = require('libp2p-bootstrap')
 const DHT = require('libp2p-kad-dht')
+const Gossipsub = require('libp2p-gossipsub')
 const libp2p = require('libp2p')
 
 // Find this list at: https://github.com/ipfs/js-ipfs/blob/master/src/core/runtime/config-browser.json
@@ -48,7 +49,8 @@ class Node extends libp2p {
           wsstar.discovery,
           Bootstrap
         ],
-        dht: DHT
+        dht: DHT,
+        pubsub: Gossipsub
       },
       config: {
         peerDiscovery: {
@@ -75,8 +77,8 @@ class Node extends libp2p {
         dht: {
           enabled: false
         },
-        EXPERIMENTAL: {
-          pubsub: false
+        pubsub: {
+          enabled: false
         }
       },
       connectionManager: {

--- a/examples/pubsub/1.js
+++ b/examples/pubsub/1.js
@@ -7,10 +7,10 @@ const Mplex = require('libp2p-mplex')
 const SECIO = require('libp2p-secio')
 const PeerInfo = require('peer-info')
 const MulticastDNS = require('libp2p-mdns')
+const Gossipsub = require('libp2p-gossipsub')
 const defaultsDeep = require('@nodeutils/defaults-deep')
 const waterfall = require('async/waterfall')
 const parallel = require('async/parallel')
-const series = require('async/series')
 
 class MyBundle extends libp2p {
   constructor (_options) {
@@ -19,7 +19,8 @@ class MyBundle extends libp2p {
         transport: [ TCP ],
         streamMuxer: [ Mplex ],
         connEncryption: [ SECIO ],
-        peerDiscovery: [ MulticastDNS ]
+        peerDiscovery: [ MulticastDNS ],
+        pubsub: Gossipsub
       },
       config: {
         peerDiscovery: {
@@ -27,9 +28,6 @@ class MyBundle extends libp2p {
             interval: 2000,
             enabled: true
           }
-        },
-        EXPERIMENTAL: {
-          pubsub: true
         }
       }
     }

--- a/src/config.js
+++ b/src/config.js
@@ -62,8 +62,8 @@ const configSchema = s({
   }),
   // Pubsub config
   pubsub: s('object?', {
-    // DHT defaults
-    enabled: false
+    // Pubsub defaults
+    enabled: true
   })
 }, {})
 

--- a/test/config.spec.js
+++ b/test/config.spec.js
@@ -83,7 +83,7 @@ describe('configuration', () => {
           autoDial: true
         },
         pubsub: {
-          enabled: false
+          enabled: true
         },
         dht: {
           kBucketSize: 20,
@@ -145,7 +145,7 @@ describe('configuration', () => {
           }
         },
         pubsub: {
-          enabled: false
+          enabled: true
         },
         dht: {
           kBucketSize: 20,
@@ -270,7 +270,7 @@ describe('configuration', () => {
       },
       config: {
         pubsub: {
-          enabled: false
+          enabled: true
         },
         peerDiscovery: {
           autoDial: true


### PR DESCRIPTION
* Also fixes examples for the latest release

The pubsub config was defaulting to `enabled=false`. This makes things a bit annoying since you now have to provide the desired pubsub module in configuration. If we provide the module we shouldn't need to enable it also, it should be enabled by default. If users for some reason want to provide the module but disable it, that should be the override behavior.