### PR TITLE
fix: dont override methods of created instance

### DIFF
--- a/src/index.js
+++ b/src/index.js
@@ -187,13 +187,6 @@ class Libp2p extends EventEmitter {
     })
 
     this._peerDiscovered = this._peerDiscovered.bind(this)
-
-    // promisify all instance methods
-    ;['start', 'stop', 'dial', 'dialProtocol', 'dialFSM', 'hangUp', 'ping'].forEach(method => {
-      this[method] = promisify(this[method], {
-        context: this
-      })
-    })
   }
 
   /**
@@ -556,6 +549,11 @@ class Libp2p extends EventEmitter {
     }, callback)
   }
 }
+
+// promisify all instance methods
+;['start', 'stop', 'dial', 'dialProtocol', 'dialFSM', 'hangUp', 'ping'].forEach(method => {
+  Libp2p[method] = promisify(Libp2p[method])
+})
 
 module.exports = Libp2p
 /**

--- a/src/index.js
+++ b/src/index.js
@@ -551,7 +551,7 @@ class Libp2p extends EventEmitter {
 }
 
 // promisify all instance methods
-;['start', 'stop', 'dial', 'dialProtocol', 'dialFSM', 'hangUp', 'ping'].forEach(method => {
+['start', 'stop', 'dial', 'dialProtocol', 'dialFSM', 'hangUp', 'ping'].forEach(method => {
   Libp2p[method] = promisify(Libp2p[method])
 })
 


### PR DESCRIPTION
Promisify was being run on the libp2p instance methods in the constructor. A side effect of this, is that if you extend libp2p the instance methods are modified. This can create problems for anyone extending libp2p. This corrects that problem by promisifying the class instead of individual instances.

Ref: https://github.com/libp2p/js-libp2p-daemon/pull/19#issuecomment-516868601