### PR TITLE
chore: update switch

### DIFF
--- a/package.json
+++ b/package.json
@@ -49,7 +49,7 @@
     "fsm-event": "^2.1.0",
     "libp2p-connection-manager": "^0.1.0",
     "libp2p-ping": "^0.8.5",
-    "libp2p-switch": "^0.42.12",
+    "libp2p-switch": "^0.43.0",
     "libp2p-websockets": "^0.12.2",
     "mafmt": "^6.0.7",
     "multiaddr": "^6.1.0",

--- a/test/config.spec.js
+++ b/test/config.spec.js
@@ -174,8 +174,8 @@ describe('configuration', () => {
     const options = {
       peerInfo,
       switch: {
-        blacklistTTL: 60e3,
-        blackListAttempts: 5,
+        denyTTL: 60e3,
+        denyAttempts: 5,
         maxParallelDials: 100,
         maxColdCalls: 50,
         dialTimeout: 30e3
@@ -188,8 +188,8 @@ describe('configuration', () => {
 
     expect(validateConfig(options)).to.deep.include({
       switch: {
-        blacklistTTL: 60e3,
-        blackListAttempts: 5,
+        denyTTL: 60e3,
+        denyAttempts: 5,
         maxParallelDials: 100,
         maxColdCalls: 50,
         dialTimeout: 30e3


### PR DESCRIPTION
BREAKING CHANGE: switch configuration has changed.
'blacklistTTL' is now 'denyTTL' and 'blackListAttempts' is now 'denyAttempts'


Aiming to include this in the 0.26 release along with the other breaking changes.