### PR TITLE
docs: async migration

### DIFF
--- a/README.md
+++ b/README.md
@@ -94,6 +94,8 @@ npm install --save libp2p
 
 ## Usage
 
+**IMPORTANT NOTE**: We are currently on the way of migrating all our `libp2p` modules to use `async await` and `async iterators`, instead of callbacks and `pull-streams`. As a consequence, when you start a new libp2p project, we must check which versions of the modules you should use. For now, it is required to use the modules using callbacks with `libp2p`, while we are working on getting the remaining modules ready for a full migration. For more details, you can have a look at [libp2p/js-libp2p#266](https://github.com/libp2p/js-libp2p/issues/266).
+
 ### [Tutorials and Examples](/examples)
 
 You can find multiple examples on the [examples folder](/examples) that will guide you through using libp2p for several scenarios.


### PR DESCRIPTION
In the context of `js-libp2p` being a skeleton project, when a new user tries to use this there is a probability of hitting problems, as a consequence of the on going efforts to migrate the codebase to `async`. For instance, if we try to install `libp2p-bootstrap` to use in the bundle, it will use the newest version by default, which is already migrated, taking problems to `js-libp2p`, which still expects callbacks.

This PR adds a note to new users in the README