### PR TITLE
fix: config validation

### DIFF
--- a/src/config.js
+++ b/src/config.js
@@ -4,29 +4,33 @@ const { struct, superstruct } = require('superstruct')
 const { optional, list } = struct
 
 // Define custom types
-const s = superstruct()
-const transport = s.union([
-  s.interface({
-    createListener: 'function',
-    dial: 'function'
-  }),
-  'function'
-])
+const s = superstruct({
+  types: {
+    transport: value => {
+      if (value.length === 0) return 'ERROR_EMPTY'
+      value.forEach(i => {
+        if (!i.dial) return 'ERR_NOT_A_TRANSPORT'
+      })
+      return true
+    },
+    protector: value => {
+      if (!value.protect) return 'ERR_NOT_A_PROTECTOR'
+      return true
+    }
+  }
+})
+
 const modulesSchema = s({
   connEncryption: optional(list([s('object|function')])),
   // this is hacky to simulate optional because interface doesnt work correctly with it
   // change to optional when fixed upstream
-  connProtector: s.union(['undefined', s.interface({ protect: 'function' })]),
+  connProtector: s('undefined|protector'),
   contentRouting: optional(list(['object'])),
   dht: optional(s('null|function|object')),
   peerDiscovery: optional(list([s('object|function')])),
   peerRouting: optional(list(['object'])),
   streamMuxer: optional(list([s('object|function')])),
-  transport: s.intersection([[transport], s.interface({
-    length (v) {
-      return v > 0 ? true : 'ERROR_EMPTY'
-    }
-  })])
+  transport: 'transport'
 })
 
 const configSchema = s({

--- a/test/content-routing.node.js
+++ b/test/content-routing.node.js
@@ -121,8 +121,9 @@ describe('.contentRouting', () => {
         const cid = new CID('QmTp9VkYvnHyrqKQuFPiuZkiX9gPcqj6x5LJ1rmWuSnnnn')
 
         nodeE.contentRouting.findProviders(cid, { maxTimeout: 5000 }, (err, providers) => {
-          expect(err).to.not.exist()
-          expect(providers).to.have.length(0)
+          expect(err).to.exist()
+          expect(err.code).to.eql('ERR_NOT_FOUND')
+          expect(providers).to.not.exist()
           done()
         })
       })
@@ -185,19 +186,10 @@ describe('.contentRouting', () => {
       it('should be able to register as a provider', (done) => {
         const cid = new CID('QmU621oD8AhHw6t25vVyfYKmL9VV3PTgc52FngEhTGACFB')
         const mockApi = nock('http://0.0.0.0:60197')
-          // mock the swarm connect
-          .post('/api/v0/swarm/connect')
-          .query({
-            arg: `/ip4/0.0.0.0/tcp/60194/p2p-circuit/ipfs/${nodeA.peerInfo.id.toB58String()}`,
-            'stream-channels': true
-          })
-          .reply(200, {
-            Strings: [`connect ${nodeA.peerInfo.id.toB58String()} success`]
-          }, ['Content-Type', 'application/json'])
           // mock the refs call
           .post('/api/v0/refs')
           .query({
-            recursive: true,
+            recursive: false,
             arg: cid.toBaseEncodedString(),
             'stream-channels': true
           })
@@ -216,10 +208,11 @@ describe('.contentRouting', () => {
       it('should handle errors when registering as a provider', (done) => {
         const cid = new CID('QmU621oD8AhHw6t25vVyfYKmL9VV3PTgc52FngEhTGACFB')
         const mockApi = nock('http://0.0.0.0:60197')
-          // mock the swarm connect
-          .post('/api/v0/swarm/connect')
+          // mock the refs call
+          .post('/api/v0/refs')
           .query({
-            arg: `/ip4/0.0.0.0/tcp/60194/p2p-circuit/ipfs/${nodeA.peerInfo.id.toB58String()}`,
+            recursive: false,
+            arg: cid.toBaseEncodedString(),
             'stream-channels': true
           })
           .reply(502, 'Bad Gateway', ['Content-Type', 'application/json'])


### PR DESCRIPTION
This applies to the 0.25.x line. I will also create a PR to apply this to the 0.26 line

* Avoids using the superstruct `interface` method, as their recent release of 0.6.2 breaks how we're doing validation. The config is now a bit looser with how it's checking things now. We will migrate away from superstruct in a future PR, https://github.com/libp2p/js-libp2p/issues/406.
* Test updates for content routing were back ported from 0.26 as tests break in 0.25 with their latest releases.
