### PR TITLE
fix: reject rather than throw in get peer info

### DIFF
--- a/src/get-peer-info.js
+++ b/src/get-peer-info.js
@@ -56,10 +56,10 @@ function getPeerInfoRemote (peer, libp2p) {
   try {
     peerInfo = getPeerInfo(peer, libp2p.peerBook)
   } catch (err) {
-    throw errCode(
+    return Promise.reject(errCode(
       new Error(`${peer} is not a valid peer type`),
       'ERR_INVALID_PEER_TYPE'
-    )
+    ))
   }
 
   // If we don't have an address for the peer, attempt to find it

--- a/test/get-peer-info.spec.js
+++ b/test/get-peer-info.spec.js
@@ -123,5 +123,12 @@ describe('Get Peer Info', () => {
 
       expect(error.code).to.eql('ERR_INVALID_PEER_TYPE')
     })
+
+    it('should callback with error for invalid non-peer multiaddr (promise)', () => {
+      return getPeerInfoRemote(undefined)
+        .then(expect.fail, (err) => {
+          expect(err.code).to.eql('ERR_INVALID_PEER_TYPE')
+        })
+    })
   })
 })


### PR DESCRIPTION
The get peer info util consolidation from #400 exposed an issue
with how bad values are being handled. Throwing the error can cause
issues when promises are being used. Rejecting resolves this.
I added a test case to validate the change.