### PR TITLE
Fix pubsub promisify

### DIFF
--- a/package.json
+++ b/package.json
@@ -81,6 +81,7 @@
     "chai": "^4.2.0",
     "chai-checkmark": "^1.0.1",
     "cids": "^0.7.1",
+    "delay": "^4.3.0",
     "dirty-chai": "^2.0.1",
     "electron-webrtc": "^0.3.0",
     "interface-datastore": "^0.6.0",

--- a/src/circuit/circuit/dialer.js
+++ b/src/circuit/circuit/dialer.js
@@ -153,7 +153,7 @@ class Dialer {
       const relays = Array.from(this.relayPeers.values())
       const next = (nextRelay) => {
         if (!nextRelay) {
-          const err = `no relay peers were found or all relays failed to dial`
+          const err = 'no relay peers were found or all relays failed to dial'
           log.err(err)
           return cb(err)
         }
@@ -235,7 +235,7 @@ class Dialer {
         }
         const message = proto.CircuitRelay.decode(msg)
         if (message.type !== proto.CircuitRelay.Type.STATUS) {
-          return callback(new Error(`Got invalid message type - ` +
+          return callback(new Error('Got invalid message type - ' +
             `expected ${proto.CircuitRelay.Type.STATUS} got ${message.type}`))
         }
 

--- a/src/circuit/circuit/hop.js
+++ b/src/circuit/circuit/hop.js
@@ -203,7 +203,7 @@ class Hop extends EE {
 
           const message = proto.decode(msg)
           if (message.code !== proto.Status.SUCCESS) {
-            return callback(new Error(`Unable to create circuit!`))
+            return callback(new Error('Unable to create circuit!'))
           }
 
           return callback(null, msg)

--- a/src/circuit/circuit/stream-handler.js
+++ b/src/circuit/circuit/stream-handler.js
@@ -49,7 +49,7 @@ class StreamHandler {
    */
   read (cb) {
     if (!this.isValid()) {
-      return cb(new Error(`handler is not in a valid state`))
+      return cb(new Error('handler is not in a valid state'))
     }
 
     lp.decodeFromReader(
@@ -77,7 +77,7 @@ class StreamHandler {
     cb = cb || (() => {})
 
     if (!this.isValid()) {
-      return cb(new Error(`handler is not in a valid state`))
+      return cb(new Error('handler is not in a valid state'))
     }
 
     pull(

--- a/src/circuit/listener.js
+++ b/src/circuit/listener.js
@@ -132,10 +132,10 @@ module.exports = (swarm, options, connHandler) => {
       if (!mafmt.Circuit.matches(addr)) {
         if (addr.getPeerId()) {
           // by default we're reachable over any relay
-          listenAddrs.push(multiaddr(`/p2p-circuit`).encapsulate(addr))
+          listenAddrs.push(multiaddr('/p2p-circuit').encapsulate(addr))
         } else {
           const ma = `${addr}/ipfs/${swarm._peerInfo.id.toB58String()}`
-          listenAddrs.push(multiaddr(`/p2p-circuit`).encapsulate(ma))
+          listenAddrs.push(multiaddr('/p2p-circuit').encapsulate(ma))
         }
       } else {
         listenAddrs.push(addr.encapsulate(`/ipfs/${swarm._peerInfo.id.toB58String()}`))

--- a/src/switch/connection/handler.js
+++ b/src/switch/connection/handler.js
@@ -5,7 +5,7 @@ const IncomingConnection = require('./incoming')
 const observeConn = require('../observe-connection')
 
 function listener (_switch) {
-  const log = debug(`libp2p:switch:listener`)
+  const log = debug('libp2p:switch:listener')
 
   /**
    * Takes a transport key and returns a connection handler function

--- a/src/switch/protocol-muxer.js
+++ b/src/switch/protocol-muxer.js
@@ -41,7 +41,7 @@ module.exports = function protocolMuxer (protocols, observer) {
 
     ms.handle(parentConn, (err) => {
       if (err) {
-        log.error(`multistream handshake failed`, err)
+        log.error('multistream handshake failed', err)
       }
     })
   }

--- a/test/circuit/dialer.spec.js
+++ b/test/circuit/dialer.spec.js
@@ -24,7 +24,7 @@ const dirtyChai = require('dirty-chai')
 const expect = chai.expect
 chai.use(dirtyChai)
 
-describe(`dialer tests`, function () {
+describe('dialer tests', function () {
   let dialer
 
   beforeEach(() => {
@@ -35,7 +35,7 @@ describe(`dialer tests`, function () {
     sinon.restore()
   })
 
-  describe(`.dial`, function () {
+  describe('.dial', function () {
     beforeEach(function () {
       dialer.relayPeers = new Map()
       dialer.relayPeers.set(nodes.node2.id, new Connection())
@@ -43,14 +43,14 @@ describe(`dialer tests`, function () {
       dialer.dial.callThrough()
     })
 
-    it(`fail on non circuit addr`, function () {
+    it('fail on non circuit addr', function () {
       const dstMa = multiaddr(`/ipfs/${nodes.node4.id}`)
       expect(() => dialer.dial(dstMa, (err) => {
         err.to.match(/invalid circuit address/)
       }))
     })
 
-    it(`dial a peer`, function (done) {
+    it('dial a peer', function (done) {
       const dstMa = multiaddr(`/p2p-circuit/ipfs/${nodes.node3.id}`)
       dialer._dialPeer.callsFake(function (dstMa, relay, callback) {
         return callback(null, dialer.relayPeers.get(nodes.node3.id))
@@ -63,7 +63,7 @@ describe(`dialer tests`, function () {
       })
     })
 
-    it(`dial a peer over the specified relay`, function (done) {
+    it('dial a peer over the specified relay', function (done) {
       const dstMa = multiaddr(`/ipfs/${nodes.node3.id}/p2p-circuit/ipfs/${nodes.node4.id}`)
       dialer._dialPeer.callsFake(function (dstMa, relay, callback) {
         expect(relay.toString()).to.equal(`/ipfs/${nodes.node3.id}`)
@@ -78,7 +78,7 @@ describe(`dialer tests`, function () {
     })
   })
 
-  describe(`.canHop`, function () {
+  describe('.canHop', function () {
     let fromConn = null
     const peer = new PeerInfo(PeerId.createFromB58String('QmQWqGdndSpAkxfk8iyiJyz3XXGkrDNujvc8vEst3baubA'))
 
@@ -94,7 +94,7 @@ describe(`dialer tests`, function () {
       dialer._dialRelayHelper.callThrough()
     })
 
-    it(`should handle successful CAN_HOP`, (done) => {
+    it('should handle successful CAN_HOP', (done) => {
       dialer._dialRelay.callsFake((_, cb) => {
         pull(
           values([{
@@ -114,7 +114,7 @@ describe(`dialer tests`, function () {
       })
     })
 
-    it(`should handle failed CAN_HOP`, function (done) {
+    it('should handle failed CAN_HOP', function (done) {
       dialer._dialRelay.callsFake((_, cb) => {
         pull(
           values([{
@@ -135,7 +135,7 @@ describe(`dialer tests`, function () {
     })
   })
 
-  describe(`._dialPeer`, function () {
+  describe('._dialPeer', function () {
     beforeEach(function () {
       dialer.relayPeers = new Map()
       dialer.relayPeers.set(nodes.node1.id, new Connection())
@@ -144,14 +144,14 @@ describe(`dialer tests`, function () {
       dialer._dialPeer.callThrough()
     })
 
-    it(`should dial a peer over any relay`, function (done) {
+    it('should dial a peer over any relay', function (done) {
       const dstMa = multiaddr(`/ipfs/${nodes.node4.id}`)
       dialer._negotiateRelay.callsFake(function (conn, dstMa, callback) {
         if (conn === dialer.relayPeers.get(nodes.node3.id)) {
           return callback(null, dialer.relayPeers.get(nodes.node3.id))
         }
 
-        callback(new Error(`error`))
+        callback(new Error('error'))
       })
 
       dialer._dialPeer(dstMa, (err, conn) => {
@@ -162,22 +162,22 @@ describe(`dialer tests`, function () {
       })
     })
 
-    it(`should fail dialing a peer over any relay`, function (done) {
+    it('should fail dialing a peer over any relay', function (done) {
       const dstMa = multiaddr(`/ipfs/${nodes.node4.id}`)
       dialer._negotiateRelay.callsFake(function (conn, dstMa, callback) {
-        callback(new Error(`error`))
+        callback(new Error('error'))
       })
 
       dialer._dialPeer(dstMa, (err, conn) => {
         expect(conn).to.be.undefined()
         expect(err).to.not.be.null()
-        expect(err).to.equal(`no relay peers were found or all relays failed to dial`)
+        expect(err).to.equal('no relay peers were found or all relays failed to dial')
         done()
       })
     })
   })
 
-  describe(`._negotiateRelay`, function () {
+  describe('._negotiateRelay', function () {
     const dstMa = multiaddr(`/ipfs/${nodes.node4.id}`)
 
     let conn = null
@@ -188,7 +188,7 @@ describe(`dialer tests`, function () {
       PeerId.createFromJSON(nodes.node4, (_, peerId) => {
         PeerInfo.create(peerId, (err, peerInfo) => {
           peer = peerInfo
-          peer.multiaddrs.add(`/p2p-circuit/ipfs/QmSswe1dCFRepmhjAMR5VfHeokGLcvVggkuDJm7RMfJSrE`)
+          peer.multiaddrs.add('/p2p-circuit/ipfs/QmSswe1dCFRepmhjAMR5VfHeokGLcvVggkuDJm7RMfJSrE')
           done(err)
         })
       })
@@ -202,12 +202,12 @@ describe(`dialer tests`, function () {
       dialer.relayConns = new Map()
       dialer._negotiateRelay.callThrough()
       dialer._dialRelayHelper.callThrough()
-      peer = new PeerInfo(PeerId.createFromB58String(`QmSswe1dCFRepmhjAMR5VfHeokGLcvVggkuDJm7RMfJSrE`))
+      peer = new PeerInfo(PeerId.createFromB58String('QmSswe1dCFRepmhjAMR5VfHeokGLcvVggkuDJm7RMfJSrE'))
       p = pair()
       conn = new Connection(p[1])
     })
 
-    it(`should write the correct dst addr`, function (done) {
+    it('should write the correct dst addr', function (done) {
       dialer._dialRelay.callsFake((_, cb) => {
         pull(
           p[0],
@@ -228,7 +228,7 @@ describe(`dialer tests`, function () {
       dialer._negotiateRelay(peer, dstMa, done)
     })
 
-    it(`should negotiate relay`, function (done) {
+    it('should negotiate relay', function (done) {
       dialer._dialRelay.callsFake((_, cb) => {
         pull(
           p[0],
@@ -253,7 +253,7 @@ describe(`dialer tests`, function () {
       })
     })
 
-    it(`should fail with an invalid peer id`, function (done) {
+    it('should fail with an invalid peer id', function (done) {
       const dstMa = multiaddr('/ip4/127.0.0.1/tcp/4001')
       dialer._dialRelay.callsFake((_, cb) => {
         pull(
@@ -279,7 +279,7 @@ describe(`dialer tests`, function () {
       })
     })
 
-    it(`should handle failed relay negotiation`, function (done) {
+    it('should handle failed relay negotiation', function (done) {
       dialer._dialRelay.callsFake((_, cb) => {
         cb(null, conn)
         pull(
@@ -295,7 +295,7 @@ describe(`dialer tests`, function () {
       dialer._negotiateRelay(peer, dstMa, (err, conn) => {
         expect(err).to.not.be.null()
         expect(err).to.be.an.instanceOf(Error)
-        expect(err.message).to.be.equal(`Got 400 error code trying to dial over relay`)
+        expect(err.message).to.be.equal('Got 400 error code trying to dial over relay')
         done()
       })
     })

--- a/test/circuit/hop.spec.js
+++ b/test/circuit/hop.spec.js
@@ -24,7 +24,7 @@ const expect = chai.expect
 chai.use(dirtyChai)
 
 describe('relay', () => {
-  describe(`.handle`, () => {
+  describe('.handle', () => {
     let relay
     let swarm
     let fromConn
@@ -40,11 +40,11 @@ describe('relay', () => {
 
       const peers = {
         QmSswe1dCFRepmhjAMR5VfHeokGLcvVggkuDJm7RMfJSrE:
-          new PeerInfo(PeerId.createFromB58String(`QmSswe1dCFRepmhjAMR5VfHeokGLcvVggkuDJm7RMfJSrE`)),
+          new PeerInfo(PeerId.createFromB58String('QmSswe1dCFRepmhjAMR5VfHeokGLcvVggkuDJm7RMfJSrE')),
         QmQWqGdndSpAkxfk8iyiJyz3XXGkrDNujvc8vEst3baubA:
-          new PeerInfo(PeerId.createFromB58String(`QmQWqGdndSpAkxfk8iyiJyz3XXGkrDNujvc8vEst3baubA`)),
+          new PeerInfo(PeerId.createFromB58String('QmQWqGdndSpAkxfk8iyiJyz3XXGkrDNujvc8vEst3baubA')),
         QmQvM2mpqkjyXWbTHSUidUAWN26GgdMphTh9iGDdjgVXCy:
-          new PeerInfo(PeerId.createFromB58String(`QmQvM2mpqkjyXWbTHSUidUAWN26GgdMphTh9iGDdjgVXCy`))
+          new PeerInfo(PeerId.createFromB58String('QmQvM2mpqkjyXWbTHSUidUAWN26GgdMphTh9iGDdjgVXCy'))
       }
 
       Object.keys(peers).forEach((key) => { peers[key]._connectedMultiaddr = true }) // make it truthy
@@ -86,16 +86,16 @@ describe('relay', () => {
       relay._circuit.reset()
     })
 
-    it(`should handle a valid circuit request`, (done) => {
+    it('should handle a valid circuit request', (done) => {
       const relayMsg = {
         type: proto.CircuitRelay.Type.HOP,
         srcPeer: {
-          id: PeerId.createFromB58String(`QmSswe1dCFRepmhjAMR5VfHeokGLcvVggkuDJm7RMfJSrE`).id,
-          addrs: [multiaddr(`/ipfs/QmSswe1dCFRepmhjAMR5VfHeokGLcvVggkuDJm7RMfJSrE`).buffer]
+          id: PeerId.createFromB58String('QmSswe1dCFRepmhjAMR5VfHeokGLcvVggkuDJm7RMfJSrE').id,
+          addrs: [multiaddr('/ipfs/QmSswe1dCFRepmhjAMR5VfHeokGLcvVggkuDJm7RMfJSrE').buffer]
         },
         dstPeer: {
-          id: PeerId.createFromB58String(`QmQWqGdndSpAkxfk8iyiJyz3XXGkrDNujvc8vEst3baubA`).id,
-          addrs: [multiaddr(`/ipfs/QmQWqGdndSpAkxfk8iyiJyz3XXGkrDNujvc8vEst3baubA`).buffer]
+          id: PeerId.createFromB58String('QmQWqGdndSpAkxfk8iyiJyz3XXGkrDNujvc8vEst3baubA').id,
+          addrs: [multiaddr('/ipfs/QmQWqGdndSpAkxfk8iyiJyz3XXGkrDNujvc8vEst3baubA').buffer]
         }
       }
 
@@ -107,16 +107,16 @@ describe('relay', () => {
       relay.handle(relayMsg, new StreamHandler(fromConn))
     })
 
-    it(`should handle a request to passive circuit`, (done) => {
+    it('should handle a request to passive circuit', (done) => {
       const relayMsg = {
         type: proto.CircuitRelay.Type.HOP,
         srcPeer: {
-          id: PeerId.createFromB58String(`QmQWqGdndSpAkxfk8iyiJyz3XXGkrDNujvc8vEst3baubA`).id,
-          addrs: [multiaddr(`/ipfs/QmQWqGdndSpAkxfk8iyiJyz3XXGkrDNujvc8vEst3baubA`).buffer]
+          id: PeerId.createFromB58String('QmQWqGdndSpAkxfk8iyiJyz3XXGkrDNujvc8vEst3baubA').id,
+          addrs: [multiaddr('/ipfs/QmQWqGdndSpAkxfk8iyiJyz3XXGkrDNujvc8vEst3baubA').buffer]
         },
         dstPeer: {
-          id: PeerId.createFromB58String(`QmYJjAri5soV8RbeQcHaYYcTAYTET17QTvcoFMyKvRDTXe`).id,
-          addrs: [multiaddr(`/ipfs/QmYJjAri5soV8RbeQcHaYYcTAYTET17QTvcoFMyKvRDTXe`).buffer]
+          id: PeerId.createFromB58String('QmYJjAri5soV8RbeQcHaYYcTAYTET17QTvcoFMyKvRDTXe').id,
+          addrs: [multiaddr('/ipfs/QmYJjAri5soV8RbeQcHaYYcTAYTET17QTvcoFMyKvRDTXe').buffer]
         }
       }
 
@@ -135,16 +135,16 @@ describe('relay', () => {
       relay.handle(relayMsg, new StreamHandler(fromConn))
     })
 
-    it(`should handle a request to active circuit`, (done) => {
+    it('should handle a request to active circuit', (done) => {
       const relayMsg = {
         type: proto.CircuitRelay.Type.HOP,
         srcPeer: {
-          id: PeerId.createFromB58String(`QmQWqGdndSpAkxfk8iyiJyz3XXGkrDNujvc8vEst3baubA`).id,
-          addrs: [multiaddr(`/ipfs/QmQWqGdndSpAkxfk8iyiJyz3XXGkrDNujvc8vEst3baubA`).buffer]
+          id: PeerId.createFromB58String('QmQWqGdndSpAkxfk8iyiJyz3XXGkrDNujvc8vEst3baubA').id,
+          addrs: [multiaddr('/ipfs/QmQWqGdndSpAkxfk8iyiJyz3XXGkrDNujvc8vEst3baubA').buffer]
         },
         dstPeer: {
-          id: PeerId.createFromB58String(`QmYJjAri5soV8RbeQcHaYYcTAYTET17QTvcoFMyKvRDTXe`).id,
-          addrs: [multiaddr(`/ipfs/QmYJjAri5soV8RbeQcHaYYcTAYTET17QTvcoFMyKvRDTXe`).buffer]
+          id: PeerId.createFromB58String('QmYJjAri5soV8RbeQcHaYYcTAYTET17QTvcoFMyKvRDTXe').id,
+          addrs: [multiaddr('/ipfs/QmYJjAri5soV8RbeQcHaYYcTAYTET17QTvcoFMyKvRDTXe').buffer]
         }
       }
 
@@ -161,16 +161,16 @@ describe('relay', () => {
       relay.handle(relayMsg, new StreamHandler(fromConn))
     })
 
-    it(`not dial to self`, (done) => {
+    it('not dial to self', (done) => {
       const relayMsg = {
         type: proto.CircuitRelay.Type.HOP,
         srcPeer: {
-          id: PeerId.createFromB58String(`QmSswe1dCFRepmhjAMR5VfHeokGLcvVggkuDJm7RMfJSrE`).id,
-          addrs: [multiaddr(`/ipfs/QmSswe1dCFRepmhjAMR5VfHeokGLcvVggkuDJm7RMfJSrE`).buffer]
+          id: PeerId.createFromB58String('QmSswe1dCFRepmhjAMR5VfHeokGLcvVggkuDJm7RMfJSrE').id,
+          addrs: [multiaddr('/ipfs/QmSswe1dCFRepmhjAMR5VfHeokGLcvVggkuDJm7RMfJSrE').buffer]
         },
         dstPeer: {
-          id: PeerId.createFromB58String(`QmSswe1dCFRepmhjAMR5VfHeokGLcvVggkuDJm7RMfJSrE`).id,
-          addrs: [multiaddr(`/ipfs/QmSswe1dCFRepmhjAMR5VfHeokGLcvVggkuDJm7RMfJSrE`).buffer]
+          id: PeerId.createFromB58String('QmSswe1dCFRepmhjAMR5VfHeokGLcvVggkuDJm7RMfJSrE').id,
+          addrs: [multiaddr('/ipfs/QmSswe1dCFRepmhjAMR5VfHeokGLcvVggkuDJm7RMfJSrE').buffer]
         }
       }
 
@@ -188,16 +188,16 @@ describe('relay', () => {
       relay.handle(relayMsg, new StreamHandler(fromConn))
     })
 
-    it(`fail on invalid src address`, (done) => {
+    it('fail on invalid src address', (done) => {
       const relayMsg = {
         type: proto.CircuitRelay.Type.HOP,
         srcPeer: {
-          id: `sdfkjsdnfkjdsb`,
-          addrs: [`sdfkjsdnfkjdsb`]
+          id: 'sdfkjsdnfkjdsb',
+          addrs: ['sdfkjsdnfkjdsb']
         },
         dstPeer: {
-          id: PeerId.createFromB58String(`QmQWqGdndSpAkxfk8iyiJyz3XXGkrDNujvc8vEst3baubA`).id,
-          addrs: [multiaddr(`/ipfs/QmQWqGdndSpAkxfk8iyiJyz3XXGkrDNujvc8vEst3baubA`).buffer]
+          id: PeerId.createFromB58String('QmQWqGdndSpAkxfk8iyiJyz3XXGkrDNujvc8vEst3baubA').id,
+          addrs: [multiaddr('/ipfs/QmQWqGdndSpAkxfk8iyiJyz3XXGkrDNujvc8vEst3baubA').buffer]
         }
       }
 
@@ -215,16 +215,16 @@ describe('relay', () => {
       relay.handle(relayMsg, new StreamHandler(fromConn))
     })
 
-    it(`fail on invalid dst address`, (done) => {
+    it('fail on invalid dst address', (done) => {
       const relayMsg = {
         type: proto.CircuitRelay.Type.HOP,
         srcPeer: {
-          id: PeerId.createFromB58String(`QmQWqGdndSpAkxfk8iyiJyz3XXGkrDNujvc8vEst3baubA`).id,
-          addrs: [multiaddr(`/ipfs/QmQWqGdndSpAkxfk8iyiJyz3XXGkrDNujvc8vEst3baubA`).buffer]
+          id: PeerId.createFromB58String('QmQWqGdndSpAkxfk8iyiJyz3XXGkrDNujvc8vEst3baubA').id,
+          addrs: [multiaddr('/ipfs/QmQWqGdndSpAkxfk8iyiJyz3XXGkrDNujvc8vEst3baubA').buffer]
         },
         dstPeer: {
-          id: PeerId.createFromB58String(`QmSswe1dCFRepmhjAMR5VfHeokGLcvVggkuDJm7RMfJSrE`).id,
-          addrs: [`sdfkjsdnfkjdsb`]
+          id: PeerId.createFromB58String('QmSswe1dCFRepmhjAMR5VfHeokGLcvVggkuDJm7RMfJSrE').id,
+          addrs: ['sdfkjsdnfkjdsb']
         }
       }
 
@@ -243,7 +243,7 @@ describe('relay', () => {
     })
   })
 
-  describe(`._circuit`, () => {
+  describe('._circuit', () => {
     let relay
     let swarm
     let srcConn
@@ -265,11 +265,11 @@ describe('relay', () => {
 
       const peers = {
         QmSswe1dCFRepmhjAMR5VfHeokGLcvVggkuDJm7RMfJSrE:
-          new PeerInfo(PeerId.createFromB58String(`QmSswe1dCFRepmhjAMR5VfHeokGLcvVggkuDJm7RMfJSrE`)),
+          new PeerInfo(PeerId.createFromB58String('QmSswe1dCFRepmhjAMR5VfHeokGLcvVggkuDJm7RMfJSrE')),
         QmQWqGdndSpAkxfk8iyiJyz3XXGkrDNujvc8vEst3baubA:
-          new PeerInfo(PeerId.createFromB58String(`QmQWqGdndSpAkxfk8iyiJyz3XXGkrDNujvc8vEst3baubA`)),
+          new PeerInfo(PeerId.createFromB58String('QmQWqGdndSpAkxfk8iyiJyz3XXGkrDNujvc8vEst3baubA')),
         QmQvM2mpqkjyXWbTHSUidUAWN26GgdMphTh9iGDdjgVXCy:
-          new PeerInfo(PeerId.createFromB58String(`QmQvM2mpqkjyXWbTHSUidUAWN26GgdMphTh9iGDdjgVXCy`))
+          new PeerInfo(PeerId.createFromB58String('QmQvM2mpqkjyXWbTHSUidUAWN26GgdMphTh9iGDdjgVXCy'))
       }
 
       Object.keys(peers).forEach((key) => { peers[key]._connectedMultiaddr = true }) // make it truthy
@@ -314,12 +314,12 @@ describe('relay', () => {
       const msg = {
         type: proto.CircuitRelay.Type.STOP,
         srcPeer: {
-          id: Buffer.from(`QmQWqGdndSpAkxfk8iyiJyz3XXGkrDNujvc8vEst3baubA`),
-          addrs: [Buffer.from(`dsfsdfsdf`)]
+          id: Buffer.from('QmQWqGdndSpAkxfk8iyiJyz3XXGkrDNujvc8vEst3baubA'),
+          addrs: [Buffer.from('dsfsdfsdf')]
         },
         dstPeer: {
-          id: Buffer.from(`QmSswe1dCFRepmhjAMR5VfHeokGLcvVggkuDJm7RMfJSrE`),
-          addrs: [Buffer.from(`sdflksdfndsklfnlkdf`)]
+          id: Buffer.from('QmSswe1dCFRepmhjAMR5VfHeokGLcvVggkuDJm7RMfJSrE'),
+          addrs: [Buffer.from('sdflksdfndsklfnlkdf')]
         }
       }
 
@@ -396,12 +396,12 @@ describe('relay', () => {
       const msg = {
         type: proto.CircuitRelay.Type.STOP,
         srcPeer: {
-          id: Buffer.from(`QmQWqGdndSpAkxfk8iyiJyz3XXGkrDNujvc8vEst3baubA`),
-          addrs: [Buffer.from(`dsfsdfsdf`)]
+          id: Buffer.from('QmQWqGdndSpAkxfk8iyiJyz3XXGkrDNujvc8vEst3baubA'),
+          addrs: [Buffer.from('dsfsdfsdf')]
         },
         dstPeer: {
-          id: Buffer.from(`QmSswe1dCFRepmhjAMR5VfHeokGLcvVggkuDJm7RMfJSrE`),
-          addrs: [Buffer.from(`sdflksdfndsklfnlkdf`)]
+          id: Buffer.from('QmSswe1dCFRepmhjAMR5VfHeokGLcvVggkuDJm7RMfJSrE'),
+          addrs: [Buffer.from('sdflksdfndsklfnlkdf')]
         }
       }
 

--- a/test/circuit/listener.spec.js
+++ b/test/circuit/listener.spec.js
@@ -23,7 +23,7 @@ chai.use(dirtyChai)
 const sinon = require('sinon')
 
 describe('listener', function () {
-  describe(`listen`, function () {
+  describe('listen', function () {
     let swarm = null
     let handlerSpy = null
     let listener = null
@@ -63,18 +63,18 @@ describe('listener', function () {
       listener = null
     })
 
-    it(`should handle HOP`, function (done) {
+    it('should handle HOP', function (done) {
       handlerSpy(multicodec.relay, conn)
 
       const relayMsg = {
         type: proto.CircuitRelay.Type.HOP,
         srcPeer: {
-          id: `QmSswe1dCFRepmhjAMR5VfHeokGLcvVggkuDJm7RMfJSrE`,
-          addrs: [`/ipfs/QmSswe1dCFRepmhjAMR5VfHeokGLcvVggkuDJm7RMfJSrE`]
+          id: 'QmSswe1dCFRepmhjAMR5VfHeokGLcvVggkuDJm7RMfJSrE',
+          addrs: ['/ipfs/QmSswe1dCFRepmhjAMR5VfHeokGLcvVggkuDJm7RMfJSrE']
         },
         dstPeer: {
-          id: `QmQvM2mpqkjyXWbTHSUidUAWN26GgdMphTh9iGDdjgVXCy`,
-          addrs: [`/ipfs/QmQvM2mpqkjyXWbTHSUidUAWN26GgdMphTh9iGDdjgVXCy`]
+          id: 'QmQvM2mpqkjyXWbTHSUidUAWN26GgdMphTh9iGDdjgVXCy',
+          addrs: ['/ipfs/QmQvM2mpqkjyXWbTHSUidUAWN26GgdMphTh9iGDdjgVXCy']
         }
       }
 
@@ -100,18 +100,18 @@ describe('listener', function () {
       )
     })
 
-    it(`should handle STOP`, function (done) {
+    it('should handle STOP', function (done) {
       handlerSpy(multicodec.relay, conn)
 
       const relayMsg = {
         type: proto.CircuitRelay.Type.STOP,
         srcPeer: {
-          id: `QmSswe1dCFRepmhjAMR5VfHeokGLcvVggkuDJm7RMfJSrE`,
-          addrs: [`/ipfs/QmSswe1dCFRepmhjAMR5VfHeokGLcvVggkuDJm7RMfJSrE`]
+          id: 'QmSswe1dCFRepmhjAMR5VfHeokGLcvVggkuDJm7RMfJSrE',
+          addrs: ['/ipfs/QmSswe1dCFRepmhjAMR5VfHeokGLcvVggkuDJm7RMfJSrE']
         },
         dstPeer: {
-          id: `QmQvM2mpqkjyXWbTHSUidUAWN26GgdMphTh9iGDdjgVXCy`,
-          addrs: [`/ipfs/QmQvM2mpqkjyXWbTHSUidUAWN26GgdMphTh9iGDdjgVXCy`]
+          id: 'QmQvM2mpqkjyXWbTHSUidUAWN26GgdMphTh9iGDdjgVXCy',
+          addrs: ['/ipfs/QmQvM2mpqkjyXWbTHSUidUAWN26GgdMphTh9iGDdjgVXCy']
         }
       }
 
@@ -137,18 +137,18 @@ describe('listener', function () {
       )
     })
 
-    it(`should emit 'connection'`, function (done) {
+    it('should emit \'connection\'', function (done) {
       handlerSpy(multicodec.relay, conn)
 
       const relayMsg = {
         type: proto.CircuitRelay.Type.STOP,
         srcPeer: {
-          id: `QmSswe1dCFRepmhjAMR5VfHeokGLcvVggkuDJm7RMfJSrE`,
-          addrs: [`/ipfs/QmSswe1dCFRepmhjAMR5VfHeokGLcvVggkuDJm7RMfJSrE`]
+          id: 'QmSswe1dCFRepmhjAMR5VfHeokGLcvVggkuDJm7RMfJSrE',
+          addrs: ['/ipfs/QmSswe1dCFRepmhjAMR5VfHeokGLcvVggkuDJm7RMfJSrE']
         },
         dstPeer: {
-          id: `QmQvM2mpqkjyXWbTHSUidUAWN26GgdMphTh9iGDdjgVXCy`,
-          addrs: [`/ipfs/QmQvM2mpqkjyXWbTHSUidUAWN26GgdMphTh9iGDdjgVXCy`]
+          id: 'QmQvM2mpqkjyXWbTHSUidUAWN26GgdMphTh9iGDdjgVXCy',
+          addrs: ['/ipfs/QmQvM2mpqkjyXWbTHSUidUAWN26GgdMphTh9iGDdjgVXCy']
         }
       }
 
@@ -172,18 +172,18 @@ describe('listener', function () {
       )
     })
 
-    it(`should handle CAN_HOP`, function (done) {
+    it('should handle CAN_HOP', function (done) {
       handlerSpy(multicodec.relay, conn)
 
       const relayMsg = {
         type: proto.CircuitRelay.Type.CAN_HOP,
         srcPeer: {
-          id: `QmSswe1dCFRepmhjAMR5VfHeokGLcvVggkuDJm7RMfJSrE`,
-          addrs: [`/ipfs/QmSswe1dCFRepmhjAMR5VfHeokGLcvVggkuDJm7RMfJSrE`]
+          id: 'QmSswe1dCFRepmhjAMR5VfHeokGLcvVggkuDJm7RMfJSrE',
+          addrs: ['/ipfs/QmSswe1dCFRepmhjAMR5VfHeokGLcvVggkuDJm7RMfJSrE']
         },
         dstPeer: {
-          id: `QmQvM2mpqkjyXWbTHSUidUAWN26GgdMphTh9iGDdjgVXCy`,
-          addrs: [`/ipfs/QmQvM2mpqkjyXWbTHSUidUAWN26GgdMphTh9iGDdjgVXCy`]
+          id: 'QmQvM2mpqkjyXWbTHSUidUAWN26GgdMphTh9iGDdjgVXCy',
+          addrs: ['/ipfs/QmQvM2mpqkjyXWbTHSUidUAWN26GgdMphTh9iGDdjgVXCy']
         }
       }
 
@@ -209,18 +209,18 @@ describe('listener', function () {
       )
     })
 
-    it(`should handle invalid message correctly`, function (done) {
+    it('should handle invalid message correctly', function (done) {
       handlerSpy(multicodec.relay, conn)
 
       const relayMsg = {
         type: 100000,
         srcPeer: {
-          id: Buffer.from(`QmSswe1dCFRepmhjAMR5VfHeokGLcvVggkuDJm7RMfJSrE`),
-          addrs: [multiaddr(`/ipfs/QmSswe1dCFRepmhjAMR5VfHeokGLcvVggkuDJm7RMfJSrE`).buffer]
+          id: Buffer.from('QmSswe1dCFRepmhjAMR5VfHeokGLcvVggkuDJm7RMfJSrE'),
+          addrs: [multiaddr('/ipfs/QmSswe1dCFRepmhjAMR5VfHeokGLcvVggkuDJm7RMfJSrE').buffer]
         },
         dstPeer: {
-          id: Buffer.from(`QmQvM2mpqkjyXWbTHSUidUAWN26GgdMphTh9iGDdjgVXCy`),
-          addrs: [multiaddr(`/ipfs/QmQvM2mpqkjyXWbTHSUidUAWN26GgdMphTh9iGDdjgVXCy`).buffer]
+          id: Buffer.from('QmQvM2mpqkjyXWbTHSUidUAWN26GgdMphTh9iGDdjgVXCy'),
+          addrs: [multiaddr('/ipfs/QmQvM2mpqkjyXWbTHSUidUAWN26GgdMphTh9iGDdjgVXCy').buffer]
         }
       }
 
@@ -241,7 +241,7 @@ describe('listener', function () {
     })
   })
 
-  describe(`getAddrs`, function () {
+  describe('getAddrs', function () {
     let swarm = null
     let listener = null
     let peerInfo = null
@@ -266,26 +266,26 @@ describe('listener', function () {
       peerInfo = null
     })
 
-    it(`should return correct addrs`, function () {
-      peerInfo.multiaddrs.add(`/ip4/0.0.0.0/tcp/4002`)
-      peerInfo.multiaddrs.add(`/ip4/127.0.0.1/tcp/4003/ws`)
+    it('should return correct addrs', function () {
+      peerInfo.multiaddrs.add('/ip4/0.0.0.0/tcp/4002')
+      peerInfo.multiaddrs.add('/ip4/127.0.0.1/tcp/4003/ws')
 
       listener.getAddrs((err, addrs) => {
         expect(err).to.not.exist()
         expect(addrs).to.deep.equal([
-          multiaddr(`/p2p-circuit/ip4/0.0.0.0/tcp/4002/ipfs/QmQvM2mpqkjyXWbTHSUidUAWN26GgdMphTh9iGDdjgVXCy`),
-          multiaddr(`/p2p-circuit/ip4/127.0.0.1/tcp/4003/ws/ipfs/QmQvM2mpqkjyXWbTHSUidUAWN26GgdMphTh9iGDdjgVXCy`)])
+          multiaddr('/p2p-circuit/ip4/0.0.0.0/tcp/4002/ipfs/QmQvM2mpqkjyXWbTHSUidUAWN26GgdMphTh9iGDdjgVXCy'),
+          multiaddr('/p2p-circuit/ip4/127.0.0.1/tcp/4003/ws/ipfs/QmQvM2mpqkjyXWbTHSUidUAWN26GgdMphTh9iGDdjgVXCy')])
       })
     })
 
-    it(`don't return default addrs in an explicit p2p-circuit addres`, function () {
-      peerInfo.multiaddrs.add(`/ip4/127.0.0.1/tcp/4003/ws`)
-      peerInfo.multiaddrs.add(`/p2p-circuit/ip4/0.0.0.0/tcp/4002`)
+    it('don\'t return default addrs in an explicit p2p-circuit addres', function () {
+      peerInfo.multiaddrs.add('/ip4/127.0.0.1/tcp/4003/ws')
+      peerInfo.multiaddrs.add('/p2p-circuit/ip4/0.0.0.0/tcp/4002')
       listener.getAddrs((err, addrs) => {
         expect(err).to.not.exist()
         expect(addrs[0]
           .toString())
-          .to.equal(`/p2p-circuit/ip4/0.0.0.0/tcp/4002/ipfs/QmQvM2mpqkjyXWbTHSUidUAWN26GgdMphTh9iGDdjgVXCy`)
+          .to.equal('/p2p-circuit/ip4/0.0.0.0/tcp/4002/ipfs/QmQvM2mpqkjyXWbTHSUidUAWN26GgdMphTh9iGDdjgVXCy')
       })
     })
   })

--- a/test/circuit/proto.spec.js
+++ b/test/circuit/proto.spec.js
@@ -39,12 +39,12 @@ describe('protocol', function () {
     message = proto.CircuitRelay.decode(buff)
   })
 
-  it(`should source and dest`, () => {
+  it('should source and dest', () => {
     expect(message.srcPeer).to.deep.equal(msgObject.srcPeer)
     expect(message.dstPeer).to.deep.equal(msgObject.dstPeer)
   })
 
-  it(`should encode message`, () => {
+  it('should encode message', () => {
     expect(message.message).to.deep.equal(msgObject.message)
   })
 })

--- a/test/circuit/stop.spec.js
+++ b/test/circuit/stop.spec.js
@@ -17,7 +17,7 @@ const expect = chai.expect
 chai.use(dirtyChai)
 
 describe('stop', function () {
-  describe(`handle relayed connections`, function () {
+  describe('handle relayed connections', function () {
     let stopHandler
 
     let swarm
@@ -48,16 +48,16 @@ describe('stop', function () {
       ], done)
     })
 
-    it(`handle request with a valid multiaddr`, function (done) {
+    it('handle request with a valid multiaddr', function (done) {
       stopHandler.handle({
         type: proto.CircuitRelay.Type.STOP,
         srcPeer: {
-          id: `QmSswe1dCFRepmhjAMR5VfHeokGLcvVggkuDJm7RMfJSrE`,
-          addrs: [`/ipfs/QmSswe1dCFRepmhjAMR5VfHeokGLcvVggkuDJm7RMfJSrE`]
+          id: 'QmSswe1dCFRepmhjAMR5VfHeokGLcvVggkuDJm7RMfJSrE',
+          addrs: ['/ipfs/QmSswe1dCFRepmhjAMR5VfHeokGLcvVggkuDJm7RMfJSrE']
         },
         dstPeer: {
-          id: `QmQvM2mpqkjyXWbTHSUidUAWN26GgdMphTh9iGDdjgVXCy`,
-          addrs: [`/ipfs/QmQvM2mpqkjyXWbTHSUidUAWN26GgdMphTh9iGDdjgVXCy`]
+          id: 'QmQvM2mpqkjyXWbTHSUidUAWN26GgdMphTh9iGDdjgVXCy',
+          addrs: ['/ipfs/QmQvM2mpqkjyXWbTHSUidUAWN26GgdMphTh9iGDdjgVXCy']
         }
       }, new StreamHandler(conn), (conn) => { // multistream handler doesn't expect errors...
         expect(conn).to.be.instanceOf(Connection)
@@ -65,16 +65,16 @@ describe('stop', function () {
       })
     })
 
-    it(`handle request with invalid multiaddr`, function (done) {
+    it('handle request with invalid multiaddr', function (done) {
       stopHandler.handle({
         type: proto.CircuitRelay.Type.STOP,
         srcPeer: {
-          id: `QmSswe1dCFRepmhjAMR5VfHeokGLcvVggkuDJm7RMfJSrE`,
-          addrs: [`dsfsdfsdf`]
+          id: 'QmSswe1dCFRepmhjAMR5VfHeokGLcvVggkuDJm7RMfJSrE',
+          addrs: ['dsfsdfsdf']
         },
         dstPeer: {
-          id: `QmQvM2mpqkjyXWbTHSUidUAWN26GgdMphTh9iGDdjgVXCy`,
-          addrs: [`sdflksdfndsklfnlkdf`]
+          id: 'QmQvM2mpqkjyXWbTHSUidUAWN26GgdMphTh9iGDdjgVXCy',
+          addrs: ['sdflksdfndsklfnlkdf']
         }
       }, new StreamHandler(conn), (conn) => {
         expect(conn).to.not.exist()

--- a/test/peer-routing.node.js
+++ b/test/peer-routing.node.js
@@ -163,7 +163,7 @@ describe('.peerRouting', () => {
           timeout: '30000ms',
           'stream-channels': true
         })
-        .reply(200, `{"Extra":"","ID":"some other id","Responses":null,"Type":6}\n{"Extra":"","ID":"yet another id","Responses":null,"Type":0}\n{"Extra":"routing:not found","ID":"","Responses":null,"Type":3}\n`, [
+        .reply(200, '{"Extra":"","ID":"some other id","Responses":null,"Type":6}\n{"Extra":"","ID":"yet another id","Responses":null,"Type":0}\n{"Extra":"routing:not found","ID":"","Responses":null,"Type":3}\n', [
           'Content-Type', 'application/json',
           'X-Chunked-Output', '1'
         ])

--- a/test/switch/dialSelf.spec.js
+++ b/test/switch/dialSelf.spec.js
@@ -37,7 +37,7 @@ class MockTransport extends EventEmitter {
   }
 }
 
-describe(`dial self`, () => {
+describe('dial self', () => {
   let swarmA
   let peerInfos
 

--- a/test/switch/transport-manager.spec.js
+++ b/test/switch/transport-manager.spec.js
@@ -93,7 +93,7 @@ describe('Transport Manager', () => {
       ].map(a => Multiaddr(a))
 
       const ourAddrs = [
-        `/ip4/127.0.0.1/tcp/4002`,
+        '/ip4/127.0.0.1/tcp/4002',
         `/ip4/192.168.0.3/tcp/4002/ipfs/${peerInfo.id.toB58String()}`
       ]
 
@@ -126,12 +126,12 @@ describe('Transport Manager', () => {
       const peerId = peerInfo.id.toB58String()
       const queryAddrs = [
         `/p2p-circuit/ipfs/${peerId}`,
-        `/p2p-circuit/ip4/127.0.0.1/tcp/4002`,
-        `/p2p-circuit/ip4/192.168.0.3/tcp/4002`,
+        '/p2p-circuit/ip4/127.0.0.1/tcp/4002',
+        '/p2p-circuit/ip4/192.168.0.3/tcp/4002',
         `/p2p-circuit/ip4/127.0.0.1/tcp/4002/ipfs/${peerId}`,
         `/p2p-circuit/ip4/192.168.0.3/tcp/4002/ipfs/${peerId}`,
-        `/p2p-circuit/ip4/127.0.0.1/tcp/4002/ipfs/QmebzNV1kSzLfaYpSZdShuiABNUxoKT1vJmCdxM2iWsM2j`,
-        `/p2p-circuit/ip4/192.168.0.3/tcp/4002/ipfs/QmebzNV1kSzLfaYpSZdShuiABNUxoKT1vJmCdxM2iWsM2j`,
+        '/p2p-circuit/ip4/127.0.0.1/tcp/4002/ipfs/QmebzNV1kSzLfaYpSZdShuiABNUxoKT1vJmCdxM2iWsM2j',
+        '/p2p-circuit/ip4/192.168.0.3/tcp/4002/ipfs/QmebzNV1kSzLfaYpSZdShuiABNUxoKT1vJmCdxM2iWsM2j',
         `/p2p-webrtc-star/ipfs/${peerId}`,
         `/p2p-websocket-star/ipfs/${peerId}`,
         `/p2p-stardust/ipfs/${peerId}`,
@@ -139,7 +139,7 @@ describe('Transport Manager', () => {
       ].map(a => Multiaddr(a))
 
       const ourAddrs = [
-        `/ip4/127.0.0.1/tcp/4002`,
+        '/ip4/127.0.0.1/tcp/4002',
         `/ip4/192.168.0.3/tcp/4002/ipfs/${peerInfo.id.toB58String()}`
       ]
 


### PR DESCRIPTION
We can't use promisify to wrap the pubsub subscribe/unsubscribe functions because it thinks the handler is the callback.

Also fixes up all the linting issues flagged by the stealth upgrade of `standard` that [went out](https://github.com/ipfs/aegir/commit/8500e2f878e04cfe7373bf6986aa66286a67cc4e#r35123512) with `aegir@20.2.0`