### PR TITLE
chore: update required libp2p-crypto version

### DIFF
--- a/package.json
+++ b/package.json
@@ -53,7 +53,7 @@
     "hashlru": "^2.3.0",
     "interface-connection": "~0.3.3",
     "latency-monitor": "~0.2.1",
-    "libp2p-crypto": "~0.16.1",
+    "libp2p-crypto": "^0.16.2",
     "libp2p-websockets": "^0.12.2",
     "mafmt": "^6.0.7",
     "merge-options": "^1.0.1",


### PR DESCRIPTION
So as to only pull in libp2p-crypto version with updated `node-forge` dep