### PR TITLE
fix: performance bottleneck in stat.js

### DIFF
--- a/src/switch/stats/stat.js
+++ b/src/switch/stats/stat.js
@@ -139,10 +139,10 @@ class Stats extends EventEmitter {
     this._timeout = null
     if (this._queue.length) {
       let last
-      while (this._queue.length) {
-        const op = last = this._queue.shift()
-        this._applyOp(op)
+      for (last of this._queue) {
+        this._applyOp(last)
       }
+      this._queue = []
 
       this._updateFrequency(last[2]) // contains timestamp of last op
 


### PR DESCRIPTION
Array.shift seems to be very slow, perhaps linear, on some engines, resulting in  _update consuming a lot of CPU.

I transferred a large payload of 2.4GB between two machines running Node 12 on a local network and attached a Chrome profiler which showed a hotspot on the target machine of about 15s in this single line of code (the shift operation). The total transfer time was about 45s.

The CPU consumption was so high that the target machine was not able to consume the stream as new data was received, resulting in the TCP window filling up and causing network congestion. This was at speeds around 60MB/s on a high end MBP.

After this change, the time for the loop was down to about 1s. This might sound like a big improvement but 1s is still a lot for stats that are not important to all clients; perhaps consider allowing an option for turning stats off completely.