### PR TITLE
docs(fix): correct docs and example for pnet

### DIFF
--- a/README.md
+++ b/README.md
@@ -122,7 +122,7 @@ const MulticastDNS = require('libp2p-mdns')
 const DHT = require('libp2p-kad-dht')
 const GossipSub = require('libp2p-gossipsub')
 const defaultsDeep = require('@nodeutils/defaults-deep')
-const Protector = require('libp2p-pnet')
+const Protector = require('libp2p/src/pnet')
 const DelegatedPeerRouter = require('libp2p-delegated-peer-routing')
 const DelegatedContentRouter = require('libp2p-delegated-content-routing')
 
@@ -527,15 +527,15 @@ Libp2p provides support for connection protection, such as for private networks.
 #### Protectors
 
 Some available network protectors:
-* [libp2p-pnet](https://github.com/libp2p/js-libp2p-pnet)
+* [libp2p-pnet](https://github.com/libp2p/js-libp2p/tree/master/src/pnet)
 
 ## Development
 
 **Clone and install dependencies:**
 
 ```sh
-> git clone https://github.com/ipfs/js-ipfs.git
-> cd js-ipfs
+> git clone https://github.com/libp2p/js-libp2p.git
+> cd js-libp2p
 > npm install
 ```
 

--- a/examples/pnet-ipfs/index.js
+++ b/examples/pnet-ipfs/index.js
@@ -3,7 +3,7 @@
 
 const IPFS = require('ipfs')
 const assert = require('assert').strict
-const writeKey = require('libp2p-pnet').generate
+const { generate: writeKey } = require('libp2p/src/pnet')
 const path = require('path')
 const fs = require('fs')
 const privateLibp2pBundle = require('./libp2p-bundle')
@@ -117,7 +117,7 @@ const connectAndTalk = async () => {
   // Add some data to node 1
   let addedCID
   try {
-    addedCID = await node1.files.add(dataToAdd)
+    addedCID = await node1.add(dataToAdd)
   } catch (err) {
     return doStop(err)
   }
@@ -126,7 +126,7 @@ const connectAndTalk = async () => {
   // Retrieve the data from node 2
   let cattedData
   try {
-    cattedData = await node2.files.cat(addedCID[0].path)
+    cattedData = await node2.cat(addedCID[0].path)
   } catch (err) {
     return doStop(err)
   }

--- a/examples/pnet-ipfs/libp2p-bundle.js
+++ b/examples/pnet-ipfs/libp2p-bundle.js
@@ -5,7 +5,7 @@ const TCP = require('libp2p-tcp')
 const MPLEX = require('libp2p-mplex')
 const SECIO = require('libp2p-secio')
 const fs = require('fs')
-const Protector = require('libp2p-pnet')
+const Protector = require('libp2p/src/pnet')
 
 /**
  * Options for the libp2p bundle

--- a/examples/pnet-ipfs/package.json
+++ b/examples/pnet-ipfs/package.json
@@ -11,11 +11,10 @@
   "author": "",
   "license": "ISC",
   "dependencies": {
-    "ipfs": "~0.32.3",
-    "libp2p": "~0.23.1",
-    "libp2p-mplex": "~0.8.2",
-    "libp2p-pnet": "../../",
-    "libp2p-secio": "~0.10.0",
-    "libp2p-tcp": "~0.13.0"
+    "ipfs": "^0.38.0",
+    "libp2p": "^0.26.2",
+    "libp2p-mplex": "^0.8.5",
+    "libp2p-secio": "^0.11.1",
+    "libp2p-tcp": "^0.13.2"
   }
 }


### PR DESCRIPTION
This fixes the example and readme for private networks after the libp2p core module consolidation. The example also now works with the latest versions of ipfs and libp2p.