### PR TITLE
Fix ipfs cat in delegated routing example 

### DIFF
--- a/examples/delegated-routing/src/App.js
+++ b/examples/delegated-routing/src/App.js
@@ -44,7 +44,7 @@ class App extends Component {
       isLoading: this.state.isLoading + 1
     })
 
-    this.ipfs.files.cat(this.state.hash, (err, data) => {
+    this.ipfs.cat(this.state.hash, (err, data) => {
       if (err) console.log('Error', err)
 
       this.setState({


### PR DESCRIPTION
`ipfs.files.cat` is incorrect. the correct function is `ipfs.cat`