### PR TITLE
refactor: core async

### DIFF
--- a/src/get-peer-info.js
+++ b/src/get-peer-info.js
@@ -56,10 +56,7 @@ function getPeerInfoRemote (peer, libp2p) {
   try {
     peerInfo = getPeerInfo(peer, libp2p.peerStore)
   } catch (err) {
-    return Promise.reject(errCode(
-      new Error(`${peer} is not a valid peer type`),
-      'ERR_INVALID_PEER_TYPE'
-    ))
+    throw errCode(err, 'ERR_INVALID_PEER_TYPE')
   }
 
   // If we don't have an address for the peer, attempt to find it
@@ -67,7 +64,7 @@ function getPeerInfoRemote (peer, libp2p) {
     return libp2p.peerRouting.findPeer(peerInfo.id)
   }
 
-  return Promise.resolve(peerInfo)
+  return peerInfo
 }
 
 module.exports = {

--- a/src/index.js
+++ b/src/index.js
@@ -256,7 +256,7 @@ class Libp2p extends EventEmitter {
    * @param {PeerId} peer The PeerId to close connections to
    * @returns {Promise<void>}
    */
-  async hangUp (peer) {
+  hangUp (peer) {
     return Promise.all(
       this.registrar.connections.get(peer.toB58String()).map(connection => {
         return connection.close()
@@ -374,6 +374,7 @@ class Libp2p extends EventEmitter {
    * Initializes and starts peer discovery services
    *
    * @private
+   * @returns {Promise<void>}
    */
   _setupPeerDiscovery () {
     for (const DiscoveryService of this._modules.peerDiscovery) {

--- a/src/index.js
+++ b/src/index.js
@@ -157,7 +157,7 @@ class Libp2p extends EventEmitter {
   }
 
   /**
-   * Starts the libp2p node and all subsystems
+   * Starts the libp2p node and all its subsystems
    *
    * @returns {Promise<void>}
    */

--- a/src/index.js
+++ b/src/index.js
@@ -251,18 +251,17 @@ class Libp2p extends EventEmitter {
   }
 
   /**
-   * Disconnects from the given peer
+   * Disconnects all connections to the given `peer`
    *
-   * @param {PeerInfo|PeerId|Multiaddr|string} peer
+   * @param {PeerId} peer The PeerId to close connections to
    * @returns {Promise<void>}
    */
   async hangUp (peer) {
-    const peerInfo = await getPeerInfoRemote(peer)
-    return Promise.all([
-      this.connections.get(peerInfo.id.toB58String()).map(connection => {
+    return Promise.all(
+      this.registrar.connections.get(peer.toB58String()).map(connection => {
         return connection.close()
       })
-    ])
+    )
   }
 
   // TODO: Update ping
@@ -273,7 +272,7 @@ class Libp2p extends EventEmitter {
   //  * @returns {Promise<Ping>}
   //  */
   // ping (peer) {
-  //   const peerInfo = await getPeerInfoRemote(peer)
+  //   const peerInfo = await getPeerInfoRemote(peer, this)
   //   return new Ping(this._switch, peerInfo)
   // }
 

--- a/src/util/index.js
+++ b/src/util/index.js
@@ -1,34 +1,4 @@
 'use strict'
-const once = require('once')
-
-/**
- * Registers `handler` to each event in `events`. The `handler`
- * will only be called for the first event fired, at which point
- * the `handler` will be removed as a listener.
- *
- * Ensures `handler` is only called once.
- *
- * @example
- * // will call `callback` when `start` or `error` is emitted by `this`
- * emitFirst(this, ['error', 'start'], callback)
- *
- * @private
- * @param {EventEmitter} emitter The emitter to listen on
- * @param {Array<string>} events The events to listen for
- * @param {function(*)} handler The handler to call when an event is triggered
- * @returns {void}
- */
-function emitFirst (emitter, events, handler) {
-  handler = once(handler)
-  events.forEach((e) => {
-    emitter.once(e, (...args) => {
-      events.forEach((ev) => {
-        emitter.removeListener(ev, handler)
-      })
-      handler.apply(emitter, args)
-    })
-  })
-}
 
 /**
  * Converts BufferList messages to Buffers
@@ -43,5 +13,4 @@ function toBuffer (source) {
   })()
 }
 
-module.exports.emitFirst = emitFirst
 module.exports.toBuffer = toBuffer

--- a/test/dialing/direct.node.js
+++ b/test/dialing/direct.node.js
@@ -231,6 +231,23 @@ describe('Dialing (direct, TCP)', () => {
       expect(libp2p.dialer.connectToMultiaddr.callCount).to.equal(1)
     })
 
+    it('should be able to use hangup to close connections', async () => {
+      libp2p = new Libp2p({
+        peerInfo,
+        modules: {
+          transport: [Transport],
+          streamMuxer: [Muxer],
+          connEncryption: [Crypto]
+        }
+      })
+
+      const connection = await libp2p.dial(remoteAddr)
+      expect(connection).to.exist()
+      expect(connection.stat.timeline.close).to.not.exist()
+      await libp2p.hangUp(connection.remotePeer)
+      expect(connection.stat.timeline.close).to.exist()
+    })
+
     it('should use the protectors when provided for connecting', async () => {
       const protector = new Protector(swarmKeyBuffer)
       libp2p = new Libp2p({

--- a/test/dialing/direct.spec.js
+++ b/test/dialing/direct.spec.js
@@ -210,7 +210,7 @@ describe('Dialing (direct, WebSockets)', () => {
 
       sinon.spy(libp2p.dialer, 'connectToMultiaddr')
 
-      const connection = await libp2p.dialer.connectToMultiaddr(remoteAddr)
+      const connection = await libp2p.dial(remoteAddr)
       expect(connection).to.exist()
       const { stream, protocol } = await connection.newStream('/echo/1.0.0')
       expect(stream).to.exist()
@@ -240,6 +240,23 @@ describe('Dialing (direct, WebSockets)', () => {
       await libp2p.dialer.identifyService.identify.firstCall.returnValue
 
       expect(libp2p.peerStore.update.callCount).to.equal(1)
+    })
+
+    it('should be able to use hangup to close connections', async () => {
+      libp2p = new Libp2p({
+        peerInfo,
+        modules: {
+          transport: [Transport],
+          streamMuxer: [Muxer],
+          connEncryption: [Crypto]
+        }
+      })
+
+      const connection = await libp2p.dial(remoteAddr)
+      expect(connection).to.exist()
+      expect(connection.stat.timeline.close).to.not.exist()
+      await libp2p.hangUp(connection.remotePeer)
+      expect(connection.stat.timeline.close).to.exist()
     })
   })
 })

--- a/test/peer-discovery/index.spec.js
+++ b/test/peer-discovery/index.spec.js
@@ -9,7 +9,7 @@ const defer = require('p-defer')
 
 const Libp2p = require('../../src')
 const baseOptions = require('../utils/base-options.browser')
-const { createPeerInfo } = require('../utils/creators/peer')
+const { createPeerInfoFromFixture } = require('../utils/creators/peer')
 
 describe('peer discovery', () => {
   let peerInfo
@@ -17,7 +17,7 @@ describe('peer discovery', () => {
   let libp2p
 
   before(async () => {
-    [peerInfo, remotePeerInfo] = await createPeerInfo(2)
+    [peerInfo, remotePeerInfo] = await createPeerInfoFromFixture(2)
   })
 
   afterEach(async () => {

--- a/test/peer-discovery/index.spec.js
+++ b/test/peer-discovery/index.spec.js
@@ -11,7 +11,6 @@ const Libp2p = require('../../src')
 const baseOptions = require('../utils/base-options.browser')
 const { createPeerInfo } = require('../utils/creators/peer')
 
-
 describe('peer discovery', () => {
   let peerInfo
   let remotePeerInfo
@@ -22,7 +21,7 @@ describe('peer discovery', () => {
   })
 
   afterEach(async () => {
-    libp2p && libp2p.stop()
+    libp2p && await libp2p.stop()
   })
 
   it('should dial know peers on startup', async () => {

--- a/test/peer-discovery/index.spec.js
+++ b/test/peer-discovery/index.spec.js
@@ -1,0 +1,46 @@
+'use strict'
+/* eslint-env mocha */
+
+const chai = require('chai')
+chai.use(require('dirty-chai'))
+const { expect } = chai
+const sinon = require('sinon')
+const defer = require('p-defer')
+
+const Libp2p = require('../../src')
+const baseOptions = require('../utils/base-options.browser')
+const { createPeerInfo } = require('../utils/creators/peer')
+
+
+describe('peer discovery', () => {
+  let peerInfo
+  let remotePeerInfo
+  let libp2p
+
+  before(async () => {
+    [peerInfo, remotePeerInfo] = await createPeerInfo(2)
+  })
+
+  afterEach(async () => {
+    libp2p && libp2p.stop()
+  })
+
+  it('should dial know peers on startup', async () => {
+    libp2p = new Libp2p({
+      ...baseOptions,
+      peerInfo
+    })
+    libp2p.peerStore.add(remotePeerInfo)
+    const deferred = defer()
+    sinon.stub(libp2p.dialer, 'connectToPeer').callsFake((remotePeerInfo) => {
+      expect(remotePeerInfo).to.equal(remotePeerInfo)
+      deferred.resolve()
+    })
+    const spy = sinon.spy()
+    libp2p.on('peer:discovery', spy)
+
+    libp2p.start()
+    await deferred.promise
+    expect(spy.getCall(0).args).to.eql([remotePeerInfo])
+  })
+})


### PR DESCRIPTION
This cleans up a few things in the main libp2p file for async.

* Removed the state machine as we really don't need it
* Removed promisify usage
* Ping is currently disabled, that will be refactored in a followup PR
* Autodial is now working with the async code
* `hangUp` now correctly interacts with the registrar to close connections
  * `hangUp` now only accepts a PeerId to simplify the api
* Fixed an issue with TransportManager for dial only nodes