### PR TITLE
feat: peer store operations has, get and remove should support peer id instances

### DIFF
--- a/src/peer-store/index.js
+++ b/src/peer-store/index.js
@@ -7,6 +7,7 @@ log.error = debug('libp2p:peer-store:error')
 
 const { EventEmitter } = require('events')
 
+const PeerId = require('peer-id')
 const PeerInfo = require('peer-info')
 
 /**
@@ -160,10 +161,15 @@ class PeerStore extends EventEmitter {
 
   /**
    * Get the info to the given id.
-   * @param {string} peerId b58str id
+   * @param {PeerId|string} peerId b58str id
    * @returns {PeerInfo}
    */
   get (peerId) {
+    // TODO: deprecate this and just accept `PeerId` instances
+    if (PeerId.isPeerId(peerId)) {
+      peerId = peerId.toB58String()
+    }
+
     const peerInfo = this.peers.get(peerId)
 
     if (peerInfo) {
@@ -175,19 +181,29 @@ class PeerStore extends EventEmitter {
 
   /**
    * Has the info to the given id.
-   * @param {string} peerId b58str id
+   * @param {PeerId|string} peerId b58str id
    * @returns {boolean}
    */
   has (peerId) {
+    // TODO: deprecate this and just accept `PeerId` instances
+    if (PeerId.isPeerId(peerId)) {
+      peerId = peerId.toB58String()
+    }
+
     return this.peers.has(peerId)
   }
 
   /**
    * Removes the Peer with the matching `peerId` from the PeerStore
-   * @param {string} peerId b58str id
+   * @param {PeerId|string} peerId b58str id
    * @returns {boolean} true if found and removed
    */
   remove (peerId) {
+    // TODO: deprecate this and just accept `PeerId` instances
+    if (PeerId.isPeerId(peerId)) {
+      peerId = peerId.toB58String()
+    }
+
     return this.peers.delete(peerId)
   }
 

--- a/test/peer-store/peer-store.spec.js
+++ b/test/peer-store/peer-store.spec.js
@@ -138,7 +138,7 @@ describe('peer-store', () => {
 
   it('should be able to retrieve a peer from store through its b58str id', async () => {
     const [peerInfo] = await peerUtils.createPeerInfo()
-    const id = peerInfo.id.toB58String()
+    const id = peerInfo.id
 
     let retrievedPeer = peerStore.get(id)
     expect(retrievedPeer).to.not.exist()
@@ -155,7 +155,7 @@ describe('peer-store', () => {
 
   it('should be able to remove a peer from store through its b58str id', async () => {
     const [peerInfo] = await peerUtils.createPeerInfo()
-    const id = peerInfo.id.toB58String()
+    const id = peerInfo.id
 
     let removed = peerStore.remove(id)
     expect(removed).to.eql(false)


### PR DESCRIPTION
Aiming to support `base32` peer identifiers as a default in the future, we should support `peer-store` operations with the `peer-id` instance instead of its string representation.

For now I did not deprecate the string representation since we have several modules using it. However, I will create an issue to deprecate it in the future