### PR TITLE
fix: clean up peer discovery flow

### DIFF
--- a/src/identify/index.js
+++ b/src/identify/index.js
@@ -148,10 +148,9 @@ class IdentifyService {
    *
    * @async
    * @param {Connection} connection
-   * @param {PeerID} expectedPeer The PeerId the identify response should match
    * @returns {Promise<void>}
    */
-  async identify (connection, expectedPeer) {
+  async identify (connection) {
     const { stream } = await connection.newStream(MULTICODEC_IDENTIFY)
     const [data] = await pipe(
       stream,
@@ -181,7 +180,7 @@ class IdentifyService {
 
     const id = await PeerId.createFromPubKey(publicKey)
     const peerInfo = new PeerInfo(id)
-    if (expectedPeer && expectedPeer.toB58String() !== id.toB58String()) {
+    if (connection.remotePeer.toString() !== id.toString()) {
       throw errCode(new Error('identified peer does not match the expected peer'), codes.ERR_INVALID_PEER)
     }
 
@@ -192,7 +191,7 @@ class IdentifyService {
     IdentifyService.updatePeerAddresses(peerInfo, listenAddrs)
     IdentifyService.updatePeerProtocols(peerInfo, protocols)
 
-    this.registrar.peerStore.update(peerInfo)
+    this.registrar.peerStore.replace(peerInfo)
     // TODO: Track our observed address so that we can score it
     log('received observed address of %s', observedAddr)
   }
@@ -283,7 +282,7 @@ class IdentifyService {
     IdentifyService.updatePeerProtocols(peerInfo, message.protocols)
 
     // Update the peer in the PeerStore
-    this.registrar.peerStore.update(peerInfo)
+    this.registrar.peerStore.replace(peerInfo)
   }
 }
 

--- a/src/peer-store/index.js
+++ b/src/peer-store/index.js
@@ -45,7 +45,7 @@ class PeerStore extends EventEmitter {
 
     let peer
     // Already know the peer?
-    if (this.peers.has(peerInfo.id.toB58String())) {
+    if (this.has(peerInfo.id)) {
       peer = this.update(peerInfo)
     } else {
       peer = this.add(peerInfo)
@@ -118,15 +118,12 @@ class PeerStore extends EventEmitter {
 
     if (multiaddrsIntersection.length !== peerInfo.multiaddrs.size ||
       multiaddrsIntersection.length !== recorded.multiaddrs.size) {
-      // recorded.multiaddrs = peerInfo.multiaddrs
-      recorded.multiaddrs.clear()
-
       for (const ma of peerInfo.multiaddrs.toArray()) {
         recorded.multiaddrs.add(ma)
       }
 
       this.emit('change:multiaddrs', {
-        peerInfo: peerInfo,
+        peerInfo: recorded,
         multiaddrs: recorded.multiaddrs.toArray()
       })
     }
@@ -139,14 +136,12 @@ class PeerStore extends EventEmitter {
 
     if (protocolsIntersection.size !== peerInfo.protocols.size ||
       protocolsIntersection.size !== recorded.protocols.size) {
-      recorded.protocols.clear()
-
       for (const protocol of peerInfo.protocols) {
         recorded.protocols.add(protocol)
       }
 
       this.emit('change:protocols', {
-        peerInfo: peerInfo,
+        peerInfo: recorded,
         protocols: Array.from(recorded.protocols)
       })
     }
@@ -170,13 +165,7 @@ class PeerStore extends EventEmitter {
       peerId = peerId.toB58String()
     }
 
-    const peerInfo = this.peers.get(peerId)
-
-    if (peerInfo) {
-      return peerInfo
-    }
-
-    return undefined
+    return this.peers.get(peerId)
   }
 
   /**
@@ -217,6 +206,16 @@ class PeerStore extends EventEmitter {
 
     this.remove(peerInfo.id.toB58String())
     this.add(peerInfo)
+
+    // This should be cleaned up in PeerStore v2
+    this.emit('change:multiaddrs', {
+      peerInfo,
+      multiaddrs: peerInfo.multiaddrs.toArray()
+    })
+    this.emit('change:protocols', {
+      peerInfo,
+      protocols: Array.from(peerInfo.protocols)
+    })
   }
 }
 

--- a/test/dialing/direct.spec.js
+++ b/test/dialing/direct.spec.js
@@ -216,7 +216,8 @@ describe('Dialing (direct, WebSockets)', () => {
       })
 
       sinon.spy(libp2p.dialer.identifyService, 'identify')
-      sinon.spy(libp2p.peerStore, 'update')
+      sinon.spy(libp2p.peerStore, 'replace')
+      sinon.spy(libp2p.upgrader, 'onConnection')
 
       const connection = await libp2p.dialer.connectToMultiaddr(remoteAddr)
       expect(connection).to.exist()
@@ -225,7 +226,7 @@ describe('Dialing (direct, WebSockets)', () => {
       expect(libp2p.dialer.identifyService.identify.callCount).to.equal(1)
       await libp2p.dialer.identifyService.identify.firstCall.returnValue
 
-      expect(libp2p.peerStore.update.callCount).to.equal(1)
+      expect(libp2p.peerStore.replace.callCount).to.equal(1)
     })
 
     it('should be able to use hangup to close connections', async () => {

--- a/test/peer-discovery/index.node.js
+++ b/test/peer-discovery/index.node.js
@@ -48,6 +48,7 @@ describe('peer discovery scenarios', () => {
       },
       config: {
         peerDiscovery: {
+          autoDial: false,
           bootstrap: {
             enabled: true,
             list: bootstrappers
@@ -84,6 +85,7 @@ describe('peer discovery scenarios', () => {
       },
       config: {
         peerDiscovery: {
+          autoDial: false,
           mdns: {
             enabled: true,
             interval: 200, // discover quickly
@@ -132,11 +134,14 @@ describe('peer discovery scenarios', () => {
         dht: KadDht
       },
       config: {
+        peerDiscovery: {
+          autoDial: false
+        },
         dht: {
           randomWalk: {
             enabled: true,
             delay: 100, // start the first query quickly
-            interval: 99e3, // We dont need to run this again
+            interval: 1000,
             timeout: 3000
           },
           enabled: true

--- a/test/peer-discovery/index.node.js
+++ b/test/peer-discovery/index.node.js
@@ -111,9 +111,11 @@ describe('peer discovery scenarios', () => {
       }
     })
 
-    await remoteLibp2p1.start()
-    await remoteLibp2p2.start()
-    await libp2p.start()
+    await Promise.all([
+      remoteLibp2p1.start(),
+      remoteLibp2p2.start(),
+      libp2p.start()
+    ])
 
     await deferred.promise
 
@@ -133,8 +135,8 @@ describe('peer discovery scenarios', () => {
         dht: {
           randomWalk: {
             enabled: true,
-            delay: 100,
-            interval: 200, // start the query sooner
+            delay: 100, // start the first query quickly
+            interval: 99e3, // We dont need to run this again
             timeout: 3000
           },
           enabled: true
@@ -153,9 +155,11 @@ describe('peer discovery scenarios', () => {
       }
     })
 
-    await remoteLibp2p1.start()
-    await remoteLibp2p2.start()
-    await libp2p.start()
+    await Promise.all([
+      remoteLibp2p1.start(),
+      remoteLibp2p2.start(),
+      libp2p.start()
+    ])
 
     // Topology:
     // A -> B
@@ -166,7 +170,9 @@ describe('peer discovery scenarios', () => {
     ])
 
     await deferred.promise
-    await remoteLibp2p1.stop()
-    await remoteLibp2p2.stop()
+    return Promise.all([
+      remoteLibp2p1.stop(),
+      remoteLibp2p2.stop()
+    ])
   })
 })

--- a/test/peer-discovery/index.node.js
+++ b/test/peer-discovery/index.node.js
@@ -157,8 +157,7 @@ describe('peer discovery scenarios', () => {
 
     await Promise.all([
       remoteLibp2p1.start(),
-      remoteLibp2p2.start(),
-      libp2p.start()
+      remoteLibp2p2.start()
     ])
 
     // Topology:
@@ -168,6 +167,8 @@ describe('peer discovery scenarios', () => {
       libp2p.dial(remotePeerInfo1),
       remoteLibp2p2.dial(remotePeerInfo1)
     ])
+
+    libp2p.start()
 
     await deferred.promise
     return Promise.all([

--- a/test/peer-store/peer-store.spec.js
+++ b/test/peer-store/peer-store.spec.js
@@ -56,7 +56,6 @@ describe('peer-store', () => {
     // Put the peer in the store
     peerStore.put(peerInfo)
 
-    sinon.spy(peerStore, 'put')
     sinon.spy(peerStore, 'add')
     sinon.spy(peerStore, 'update')
 
@@ -75,7 +74,6 @@ describe('peer-store', () => {
 
     peerStore.put(peerInfo)
 
-    expect(peerStore.put.callCount).to.equal(1)
     expect(peerStore.add.callCount).to.equal(0)
     expect(peerStore.update.callCount).to.equal(1)
   })

--- a/test/registrar/registrar.spec.js
+++ b/test/registrar/registrar.spec.js
@@ -166,7 +166,7 @@ describe('registrar', () => {
 
       // Remove protocol to peer and update it
       peerInfo.protocols.delete(multicodec)
-      peerStore.put(peerInfo)
+      peerStore.replace(peerInfo)
 
       await onDisconnectDefer.promise
     })


### PR DESCRIPTION
* `peerStore.update` no longer replaces existing protocols and multiaddrs, this is inline with PeerBook.
* Identify will now call `peerStore.replace()` instead of `peerStore.update()`. As we are talking directly with the target peer, we should consider them the source of truth. With Multiaddr confidence in the future and PeerStore v2, this may may change.
* All PeerDiscovery `peer` events will now be directed to the peerStore directly.
* `peer:discovery` events are now being Proxied from the PeerStore. This also ensures we won't discover a peer twice.
* `PeerStore.replace()` will always trigger `change:multiaddrs` and `change:protocols` events. This is an oversimplification and may not indicate an actual change, but this is probably better reserved for PeerStore v2 work.