### PR TITLE
refactor: examples/protocol-and-stream-muxing

### DIFF
--- a/examples/protocol-and-stream-muxing/1.js
+++ b/examples/protocol-and-stream-muxing/1.js
@@ -44,9 +44,13 @@ const createNode = async () => {
     )
   })
 
-  // semver matching
+  // multiple protocols
   /*
-  node2.handle('/another-protocol/1.0.1', ({ stream }) => {
+  node2.handle(['/another-protocol/1.0.0', '/another-protocol/2.0.0'], ({ protocol, stream }) => {
+    if (protocol === '/another-protocol/2.0.0') {
+      // handle backwards compatibility
+    }
+
     pipe(
       stream,
       async function (source) {

--- a/examples/protocol-and-stream-muxing/1.js
+++ b/examples/protocol-and-stream-muxing/1.js
@@ -1,102 +1,81 @@
 'use strict'
 
-const libp2p = require('../../')
+const Libp2p = require('../../')
 const TCP = require('libp2p-tcp')
+const MPLEX = require('libp2p-mplex')
+const SECIO = require('libp2p-secio')
 const PeerInfo = require('peer-info')
-const waterfall = require('async/waterfall')
-const parallel = require('async/parallel')
-const pull = require('pull-stream')
-const defaultsDeep = require('@nodeutils/defaults-deep')
 
-class MyBundle extends libp2p {
-  constructor (_options) {
-    const defaults = {
-      modules: {
-        transport: [ TCP ]
-      }
+const pipe = require('it-pipe')
+const { map } = require('streaming-iterables')
+const { toBuffer } = require('it-buffer')
+
+const createNode = async () => {
+  const peerInfo = await PeerInfo.create()
+  peerInfo.multiaddrs.add('/ip4/0.0.0.0/tcp/0')
+
+  const node = await Libp2p.create({
+    peerInfo,
+    modules: {
+      transport: [TCP],
+      streamMuxer: [MPLEX], // TODO: should not need this
+      connEncryption: [SECIO] // TODO: should not need this
     }
+  })
 
-    super(defaultsDeep(_options, defaults))
-  }
+  await node.start()
+
+  return node
 }
 
-function createNode (callback) {
-  let node
-
-  waterfall([
-    (cb) => PeerInfo.create(cb),
-    (peerInfo, cb) => {
-      peerInfo.multiaddrs.add('/ip4/0.0.0.0/tcp/0')
-      node = new MyBundle({
-        peerInfo
-      })
-      node.start(cb)
-    }
-  ], (err) => callback(err, node))
-}
-
-parallel([
-  (cb) => createNode(cb),
-  (cb) => createNode(cb)
-], (err, nodes) => {
-  if (err) { throw err }
-
-  const node1 = nodes[0]
-  const node2 = nodes[1]
+;(async () => {
+  const [node1, node2] = await Promise.all([
+    createNode(),
+    createNode()
+  ])
 
   // exact matching
-  node2.handle('/your-protocol', (protocol, conn) => {
-    pull(
-      conn,
-      pull.map((v) => v.toString()),
-      pull.log()
+  node2.handle('/your-protocol', ({ stream }) => {
+    pipe(
+      stream,
+      toBuffer,
+      map(String),
+      source => (async function () {
+        for await (const msg of source) {
+          console.log(msg)
+        }
+      })()
     )
   })
 
   // semver matching
   /*
-  node2.handle('/another-protocol/1.0.1', (protocol, conn) => {
-    pull(
-      conn,
-      pull.map((v) => v.toString()),
-      pull.log()
+  node2.handle('/another-protocol/1.0.1', ({ stream }) => {
+    pipe(
+      stream,
+      toBuffer,
+      map(String),
+      source => (async function () {
+        for await (const msg of source) {
+          console.log(msg)
+        }
+      })()
     )
   })
   */
 
-  // custom func matching
-  /*
-  node2.handle('/custom-match-func', (protocol, conn) => {
-    pull(
-      conn,
-      pull.map((v) => v.toString()),
-      pull.log()
-    )
-  }, (myProtocol, requestedProtocol, callback) => {
-    if (myProtocol.indexOf(requestedProtocol)) {
-      callback(null, true)
-    } else {
-      callback(null, false)
-    }
-  })
-  */
-
-  node1.dialProtocol(node2.peerInfo, '/your-protocol', (err, conn) => {
-    if (err) { throw err }
-    pull(pull.values(['my own protocol, wow!']), conn)
-  })
+  const { stream } = await node1.dialProtocol(node2.peerInfo, ['/your-protocol'])
+  await pipe(
+    ['my own protocol, wow!'],
+    stream
+  )
 
   /*
-  node1.dialProtocol(node2.peerInfo, '/another-protocol/1.0.0', (err, conn) => {
-    if (err) { throw err }
-    pull(pull.values(['semver me please']), conn)
-  })
-  */
+  const { stream } = node1.dialProtocol(node2.peerInfo, ['/another-protocol/1.0.0'])
 
-  /*
-  node1.dialProtocol(node2.peerInfo, '/custom-match-func/some-query', (err, conn) => {
-    if (err) { throw err }
-    pull(pull.values(['do I fall into your criteria?']), conn)
-  })
+  await pipe(
+    ['my own protocol, wow!'],
+    stream
+  )
   */
-})
+})();

--- a/examples/protocol-and-stream-muxing/1.js
+++ b/examples/protocol-and-stream-muxing/1.js
@@ -7,8 +7,6 @@ const SECIO = require('libp2p-secio')
 const PeerInfo = require('peer-info')
 
 const pipe = require('it-pipe')
-const { map } = require('streaming-iterables')
-const { toBuffer } = require('it-buffer')
 
 const createNode = async () => {
   const peerInfo = await PeerInfo.create()
@@ -18,8 +16,8 @@ const createNode = async () => {
     peerInfo,
     modules: {
       transport: [TCP],
-      streamMuxer: [MPLEX], // TODO: should not need this
-      connEncryption: [SECIO] // TODO: should not need this
+      streamMuxer: [MPLEX],
+      connEncryption: [SECIO]
     }
   })
 
@@ -38,13 +36,11 @@ const createNode = async () => {
   node2.handle('/your-protocol', ({ stream }) => {
     pipe(
       stream,
-      toBuffer,
-      map(String),
-      source => (async function () {
+      async function (source) {
         for await (const msg of source) {
-          console.log(msg)
+          console.log(msg.toString())
         }
-      })()
+      }
     )
   })
 
@@ -53,13 +49,11 @@ const createNode = async () => {
   node2.handle('/another-protocol/1.0.1', ({ stream }) => {
     pipe(
       stream,
-      toBuffer,
-      map(String),
-      source => (async function () {
+      async function (source) {
         for await (const msg of source) {
-          console.log(msg)
+          console.log(msg.toString())
         }
-      })()
+      }
     )
   })
   */

--- a/examples/protocol-and-stream-muxing/2.js
+++ b/examples/protocol-and-stream-muxing/2.js
@@ -7,7 +7,6 @@ const SECIO = require('libp2p-secio')
 const PeerInfo = require('peer-info')
 
 const pipe = require('it-pipe')
-const { toBuffer } = require('it-buffer')
 
 const createNode = async () => {
   const peerInfo = await PeerInfo.create()
@@ -18,7 +17,7 @@ const createNode = async () => {
     modules: {
       transport: [TCP],
       streamMuxer: [MPLEX],
-      connEncryption: [SECIO] // TODO: should not need this
+      connEncryption: [SECIO]
     }
   })
 
@@ -36,12 +35,11 @@ const createNode = async () => {
   node2.handle(['/a', '/b'], ({ protocol, stream }) => {
     pipe(
       stream,
-      toBuffer,
-      source => (async function () {
+      async function (source) {
         for await (const msg of source) {
           console.log(`from: ${protocol}, msg: ${msg.toString()}`)
         }
-      })()
+      }
     )
   })
 

--- a/examples/protocol-and-stream-muxing/2.js
+++ b/examples/protocol-and-stream-muxing/2.js
@@ -1,83 +1,65 @@
 'use strict'
 
-const libp2p = require('../../')
+const Libp2p = require('../../')
 const TCP = require('libp2p-tcp')
-const SPDY = require('libp2p-spdy')
+const MPLEX = require('libp2p-mplex')
+const SECIO = require('libp2p-secio')
 const PeerInfo = require('peer-info')
-const waterfall = require('async/waterfall')
-const parallel = require('async/parallel')
-const series = require('async/series')
-const pull = require('pull-stream')
-const defaultsDeep = require('@nodeutils/defaults-deep')
 
-class MyBundle extends libp2p {
-  constructor (_options) {
-    const defaults = {
-      modules: {
-        transport: [ TCP ],
-        streamMuxer: [ SPDY ]
-      }
+const pipe = require('it-pipe')
+const { toBuffer } = require('it-buffer')
+
+const createNode = async () => {
+  const peerInfo = await PeerInfo.create()
+  peerInfo.multiaddrs.add('/ip4/0.0.0.0/tcp/0')
+
+  const node = await Libp2p.create({
+    peerInfo,
+    modules: {
+      transport: [TCP],
+      streamMuxer: [MPLEX],
+      connEncryption: [SECIO] // TODO: should not need this
     }
-
-    super(defaultsDeep(_options, defaults))
-  }
-}
-
-function createNode (callback) {
-  let node
-
-  waterfall([
-    (cb) => PeerInfo.create(cb),
-    (peerInfo, cb) => {
-      peerInfo.multiaddrs.add('/ip4/0.0.0.0/tcp/0')
-      node = new MyBundle({
-        peerInfo
-      })
-      node.start(cb)
-    }
-  ], (err) => callback(err, node))
-}
-
-parallel([
-  (cb) => createNode(cb),
-  (cb) => createNode(cb)
-], (err, nodes) => {
-  if (err) { throw err }
-
-  const node1 = nodes[0]
-  const node2 = nodes[1]
-
-  node2.handle('/a', (protocol, conn) => {
-    pull(
-      conn,
-      pull.map((v) => v.toString()),
-      pull.log()
-    )
   })
 
-  node2.handle('/b', (protocol, conn) => {
-    pull(
-      conn,
-      pull.map((v) => v.toString()),
-      pull.log()
-    )
-  })
+  await node.start()
 
-  series([
-    (cb) => node1.dialProtocol(node2.peerInfo, '/a', (err, conn) => {
-      if (err) { throw err }
-      pull(pull.values(['protocol (a)']), conn)
-      cb()
-    }),
-    (cb) => node1.dialProtocol(node2.peerInfo, '/b', (err, conn) => {
-      if (err) { throw err }
-      pull(pull.values(['protocol (b)']), conn)
-      cb()
-    }),
-    (cb) => node1.dialProtocol(node2.peerInfo, '/b', (err, conn) => {
-      if (err) { throw err }
-      pull(pull.values(['another conn on protocol (b)']), conn)
-      cb()
-    })
+  return node
+}
+
+;(async () => {
+  const [node1, node2] = await Promise.all([
+    createNode(),
+    createNode()
   ])
-})
+
+  node2.handle(['/a', '/b'], ({ protocol, stream }) => {
+    pipe(
+      stream,
+      toBuffer,
+      source => (async function () {
+        for await (const msg of source) {
+          console.log(`from: ${protocol}, msg: ${msg.toString()}`)
+        }
+      })()
+    )
+  })
+
+  const { stream: stream1 } = await node1.dialProtocol(node2.peerInfo, ['/a'])
+  await pipe(
+    ['protocol (a)'],
+    stream1
+  )
+
+  const { stream: stream2 } = await node1.dialProtocol(node2.peerInfo, ['/b'])
+  await pipe(
+    ['protocol (b)'],
+    stream2
+  )
+
+  const { stream: stream3 } = await node1.dialProtocol(node2.peerInfo, ['/b'])
+  await pipe(
+    ['another stream on protocol (b)'],
+    stream3
+  )
+})();

--- a/examples/protocol-and-stream-muxing/3.js
+++ b/examples/protocol-and-stream-muxing/3.js
@@ -8,7 +8,6 @@ const SECIO = require('libp2p-secio')
 const PeerInfo = require('peer-info')
 
 const pipe = require('it-pipe')
-const { toBuffer } = require('it-buffer')
 
 const createNode = async () => {
   const peerInfo = await PeerInfo.create()
@@ -19,7 +18,7 @@ const createNode = async () => {
     modules: {
       transport: [TCP],
       streamMuxer: [MPLEX],
-      connEncryption: [SECIO] // TODO: should not need this
+      connEncryption: [SECIO]
     }
   })
 
@@ -37,24 +36,22 @@ const createNode = async () => {
   node1.handle('/node-1', ({ stream }) => {
     pipe(
       stream,
-      toBuffer,
-      source => (async function () {
+      async function (source) {
         for await (const msg of source) {
           console.log(msg.toString())
         }
-      })()
+      }
     )
   })
 
   node2.handle('/node-2', ({ stream }) => {
     pipe(
       stream,
-      toBuffer,
-      source => (async function () {
+      async function (source) {
         for await (const msg of source) {
           console.log(msg.toString())
         }
-      })()
+      }
     )
   })
 

--- a/examples/protocol-and-stream-muxing/3.js
+++ b/examples/protocol-and-stream-muxing/3.js
@@ -1,88 +1,72 @@
 /* eslint-disable no-console */
 'use strict'
 
-const libp2p = require('../../')
+const Libp2p = require('../../')
 const TCP = require('libp2p-tcp')
-const SPDY = require('libp2p-spdy')
+const MPLEX = require('libp2p-mplex')
+const SECIO = require('libp2p-secio')
 const PeerInfo = require('peer-info')
-const waterfall = require('async/waterfall')
-const parallel = require('async/parallel')
-const series = require('async/series')
-const pull = require('pull-stream')
-const defaultsDeep = require('@nodeutils/defaults-deep')
 
-class MyBundle extends libp2p {
-  constructor (_options) {
-    const defaults = {
-      modules: {
-        transport: [ TCP ],
-        streamMuxer: [ SPDY ]
-      }
+const pipe = require('it-pipe')
+const { toBuffer } = require('it-buffer')
+
+const createNode = async () => {
+  const peerInfo = await PeerInfo.create()
+  peerInfo.multiaddrs.add('/ip4/0.0.0.0/tcp/0')
+
+  const node = await Libp2p.create({
+    peerInfo,
+    modules: {
+      transport: [TCP],
+      streamMuxer: [MPLEX],
+      connEncryption: [SECIO] // TODO: should not need this
     }
+  })
 
-    super(defaultsDeep(_options, defaults))
-  }
+  await node.start()
+
+  return node
 }
 
-function createNode (callback) {
-  let node
-
-  waterfall([
-    (cb) => PeerInfo.create(cb),
-    (peerInfo, cb) => {
-      peerInfo.multiaddrs.add('/ip4/0.0.0.0/tcp/0')
-      node = new MyBundle({
-        peerInfo
-      })
-      node.start(cb)
-    }
-  ], (err) => callback(err, node))
-}
-
-parallel([
-  (cb) => createNode(cb),
-  (cb) => createNode(cb)
-], (err, nodes) => {
-  if (err) { throw err }
-
-  const node1 = nodes[0]
-  const node2 = nodes[1]
-
-  node1.handle('/node-1', (protocol, conn) => {
-    pull(
-      conn,
-      pull.map((v) => v.toString()),
-      pull.log()
+;(async () => {
+  const [node1, node2] = await Promise.all([
+    createNode(),
+    createNode()
+  ])
+  
+  node1.handle('/node-1', ({ stream }) => {
+    pipe(
+      stream,
+      toBuffer,
+      source => (async function () {
+        for await (const msg of source) {
+          console.log(msg.toString())
+        }
+      })()
     )
   })
 
-  node2.handle('/node-2', (protocol, conn) => {
-    pull(
-      conn,
-      pull.map((v) => v.toString()),
-      pull.log()
+  node2.handle('/node-2', ({ stream }) => {
+    pipe(
+      stream,
+      toBuffer,
+      source => (async function () {
+        for await (const msg of source) {
+          console.log(msg.toString())
+        }
+      })()
     )
   })
 
-  series([
-    (cb) => node1.dialProtocol(node2.peerInfo, '/node-2', (err, conn) => {
-      if (err) { throw err }
-      pull(pull.values(['from 1 to 2']), conn)
-      cb()
-    }),
-    (cb) => node2.dialProtocol(node1.peerInfo, '/node-1', (err, conn) => {
-      if (err) { throw err }
-      pull(pull.values(['from 2 to 1']), conn)
-      cb()
-    })
-  ], (err) => {
-    if (err) { throw err }
-    console.log('Addresses by which both peers are connected')
-    node1.peerBook
-      .getAllArray()
-      .forEach((peer) => console.log('node 1 to node 2:', peer.isConnected().toString()))
-    node2.peerBook
-      .getAllArray()
-      .forEach((peer) => console.log('node 2 to node 1:', peer.isConnected().toString()))
-  })
-})
+  const { stream: stream1 } = await node1.dialProtocol(node2.peerInfo, ['/node-2'])
+  await pipe(
+    ['from 1 to 2'],
+    stream1
+  )
+
+  const { stream: stream2 } = await node2.dialProtocol(node1.peerInfo, ['/node-1'])
+  await pipe(
+    ['from 2 to 1'],
+    stream2
+  )
+})();

--- a/examples/protocol-and-stream-muxing/README.md
+++ b/examples/protocol-and-stream-muxing/README.md
@@ -53,13 +53,11 @@ You might have seen this in the [Transports](../transports) examples. However, w
 node2.handle('/another-protocol/1.0.1', ({ stream }) => {
   pipe(
     stream,
-    toBuffer,
-    map(String),
-    source => (async function () {
+    async function (source) {
       for await (const msg of source) {
-        console.log(msg)
+        console.log(msg.toString())
       }
-    })()
+    }
   )
 })
 // ...
@@ -83,13 +81,11 @@ node2.handle(['/another-protocol/1.0.0', '/another-protocol/2.0.0'], ({ protocol
 
   pipe(
     stream,
-    toBuffer,
-    map(String),
-    source => (async function () {
+    async function (source) {
       for await (const msg of source) {
-        console.log(msg)
+        console.log(msg.toString())
       }
-    })()
+    }
   )
 })
 ```
@@ -126,12 +122,11 @@ With this, we can dial as many times as we want to a peer and always reuse the s
 node2.handle(['/a', '/b'], ({ protocol, stream }) => {
   pipe(
     stream,
-    toBuffer,
-    source => (async function () {
+    async function (source) {
       for await (const msg of source) {
         console.log(`from: ${protocol}, msg: ${msg.toString()}`)
       }
-    })()
+    }
   )
 })
 

--- a/examples/protocol-and-stream-muxing/README.md
+++ b/examples/protocol-and-stream-muxing/README.md
@@ -100,9 +100,9 @@ Try all of this out by executing [1.js](./1.js).
 
 The examples above would require a node to create a whole new connection for every time it dials in one of the protocols, this is a waste of resources and also it might be simply not possible (e.g lack of file descriptors, not enough ports being open, etc). What we really want is to dial a connection once and then multiplex several virtual connections (stream) over a single connection, this is where _stream multiplexing_ comes into play.
 
-Stream multiplexing is a old concept, in fact it happens in many of the layers of the [OSI System](https://en.wikipedia.org/wiki/OSI_model). In libp2p, we make this feature to our avail by letting the user pick which module for stream multiplexing to use.
+Stream multiplexing is an old concept, in fact it happens in many of the layers of the [OSI System](https://en.wikipedia.org/wiki/OSI_model). In libp2p, we make this feature to our avail by letting the user pick which module for stream multiplexing to use.
 
-Currently, we have [libp2p-mplex](https://github.com/libp2p/js-libp2p-mplex) and pluging it in is as easy as adding another transport. Let's revisit our libp2p configuration.
+Currently, we have [libp2p-mplex](https://github.com/libp2p/js-libp2p-mplex) and pluging it in is as easy as adding a transport. Let's revisit our libp2p configuration.
 
 ```JavaScript
 const Libp2p = require('libp2p')

--- a/examples/protocol-and-stream-muxing/README.md
+++ b/examples/protocol-and-stream-muxing/README.md
@@ -25,11 +25,9 @@ const node2 = nodes[1]
 node2.handle('/your-protocol', ({ stream }) => {
   pipe(
     stream,
-    toBuffer,
-    map(String),
     source => (async function () {
       for await (const msg of source) {
-        console.log(msg)
+        console.log(msg.toString())
       }
     })()
   )

--- a/examples/protocol-and-stream-muxing/README.md
+++ b/examples/protocol-and-stream-muxing/README.md
@@ -6,23 +6,32 @@ The feature of agreeing on a protocol over an established connection is what we 
 
 # 1. Handle multiple protocols
 
-Let's see _protocol multiplexing_ in action! You will need the following modules for this example: `libp2p`, `libp2p-tcp`, `peer-info`, `async` and `pull-stream`. This example reuses the base left by the [Transports](../transports) example. You can see the complete solution at [1.js](./1.js).
+Let's see _protocol multiplexing_ in action! You will need the following modules for this example: `libp2p`, `libp2p-tcp`, `peer-info`, `it-pipe`, `it-buffer` and `streaming-iterables`. This example reuses the base left by the [Transports](../transports) example. You can see the complete solution at [1.js](./1.js).
 
 After creating the nodes, we need to tell libp2p which protocols to handle.
 
 ```JavaScript
+const pipe = require('it-pipe')
+const { map } = require('streaming-iterables')
+const { toBuffer } = require('it-buffer')
+
 // ...
 const node1 = nodes[0]
 const node2 = nodes[1]
 
-// Here we are telling libp2p that is someone dials this node to talk with the `/your-protocol`
-// multicodec, the protocol identifier, please call this callback and give it the connection
+// Here we are telling libp2p that if someone dials this node to talk with the `/your-protocol`
+// multicodec, the protocol identifier, please call this handler and give it the stream
 // so that incomming data can be handled
-node2.handle('/your-protocol', (protocol, conn) => {
-  pull(
-    conn,
-    pull.map((v) => v.toString()),
-    pull.log()
+node2.handle('/your-protocol', ({ stream }) => {
+  pipe(
+    stream,
+    toBuffer,
+    map(String),
+    source => (async function () {
+      for await (const msg of source) {
+        console.log(msg)
+      }
+    })()
   )
 })
 ```
@@ -30,53 +39,58 @@ node2.handle('/your-protocol', (protocol, conn) => {
 After the protocol is _handled_, now we can dial to it.
 
 ```JavaScript
-node1.dialProtocol(node2.peerInfo, '/your-protocol', (err, conn) => {
-  if (err) { throw err }
-  pull(pull.values(['my own protocol, wow!']), conn)
-})
+const { stream } = await node1.dialProtocol(node2.peerInfo, ['/your-protocol'])
+
+await pipe(
+  ['my own protocol, wow!'],
+  stream
+)
 ```
 
 You might have seen this in the [Transports](../transports) examples. However, what it was not explained is that you can do more than exact string matching, for example, you can use semver.
 
 ```JavaScript
-node2.handle('/another-protocol/1.0.1', (protocol, conn) => {
-  pull(
-    conn,
-    pull.map((v) => v.toString()),
-    pull.log()
+node2.handle('/another-protocol/1.0.1', ({ stream }) => {
+  pipe(
+    stream,
+    toBuffer,
+    map(String),
+    source => (async function () {
+      for await (const msg of source) {
+        console.log(msg)
+      }
+    })()
   )
 })
 // ...
-node1.dialProtocol(node2.peerInfo, '/another-protocol/1.0.0', (err, conn) => {
-  if (err) { throw err }
-  pull(pull.values(['semver me please']), conn)
-})
+const { stream } = await node1.dialProtocol(node2.peerInfo, ['/another-protocol/1.0.0'])
+
+await pipe(
+  ['my own protocol, wow!'],
+  stream
+)
 ```
 
 This feature is super power for network protocols. It works in the same way as versioning your RPC/REST API, but for anything that goes in the wire. We had to use this feature to upgrade protocols within the IPFS Stack (i.e Bitswap) and we successfully managed to do so without any network splits.
 
-There is still one last feature, you can create your custom match functions.
+There is still one last feature, you can provide multiple protocols for the same handler. If you have a backwards incompatible change, but it only requires minor changes to the code, you may prefer to do protocol checking instead of having multiple handlers
 
 ```JavaScript
-node2.handle('/custom-match-func', (protocol, conn) => {
-  pull(
-    conn,
-    pull.map((v) => v.toString()),
-    pull.log()
-  )
-}, (myProtocol, requestedProtocol, callback) => {
-  // This is all custom. I'm checking the base path matches, think of this
-  // as a HTTP routing table.
-  if (myProtocol.indexOf(requestedProtocol)) {
-    callback(null, true)
-  } else {
-    callback(null, false)
+node2.handle(['/another-protocol/1.0.0', '/another-protocol/2.0.0'], ({ protocol, stream }) => {
+  if (protocol === '/another-protocol/2.0.0') {
+    // handle backwards compatibility
   }
-})
-// ...
-node1.dialProtocol(node2.peerInfo, '/custom-match-func/some-query', (err, conn) => {
-  if (err) { throw err }
-  pull(pull.values(['do I fall into your criteria?']), conn)
+
+  pipe(
+    stream,
+    toBuffer,
+    map(String),
+    source => (async function () {
+      for await (const msg of source) {
+        console.log(msg)
+      }
+    })()
+  )
 })
 ```
 
@@ -84,77 +98,69 @@ Try all of this out by executing [1.js](./1.js).
 
 # 2. Reuse existing connection
 
-The example above would require a node to create a whole new connection for every time it dials in one of the protocols, this is a waste of resources and also it might be simply not possible (e.g lack of file descriptors, not enough ports being open, etc). What we really want is to dial a connection once and then multiplex several virtual connections (stream) over a single connection, this is where _stream multiplexing_ comes into play.
+The examples above would require a node to create a whole new connection for every time it dials in one of the protocols, this is a waste of resources and also it might be simply not possible (e.g lack of file descriptors, not enough ports being open, etc). What we really want is to dial a connection once and then multiplex several virtual connections (stream) over a single connection, this is where _stream multiplexing_ comes into play.
 
-Stream multiplexing is a old concept, in fact it happens in many of the layers of the [OSI System](https://en.wikipedia.org/wiki/OSI_model), in libp2p we make this feature to our avail by letting the user pick which module for stream multiplexing to use.
+Stream multiplexing is a old concept, in fact it happens in many of the layers of the [OSI System](https://en.wikipedia.org/wiki/OSI_model). In libp2p, we make this feature to our avail by letting the user pick which module for stream multiplexing to use.
 
-Currently, we have two available [libp2p-spdy](https://github.com/libp2p/js-libp2p-spdy) and [libp2p-mplex](https://github.com/libp2p/js-libp2p-mplex) and pluging them in is as easy as adding another transport. Let's revisit our libp2p bundle.
+Currently, we have [libp2p-mplex](https://github.com/libp2p/js-libp2p-mplex) and pluging it in is as easy as adding another transport. Let's revisit our libp2p configuration.
 
 ```JavaScript
-const SPDY = require('libp2p-spdy')
+const Libp2p = require('libp2p')
+const TCP = require('libp2p-tcp')
+const MPLEX = require('libp2p-mplex')
 //...
-class MyBundle extends libp2p {
-  constructor (_options) {
-    const defaults = {
-      modules: {
-        transport: [ TCP ],
-        // Here we are adding the SPDY muxer to our libp2p bundle.
-      // Thanks to protocol muxing, a libp2p bundle can support multiple Stream Muxers at the same
-      // time and pick the right one when dialing to a node
-        streamMuxer: [ SPDY ]
-      }
-    }
 
-    super(defaultsDeep(_options, defaults))
-  }
+const createNode = () => {
+  return Libp2p.create({
+    modules: {
+      transport: [ TCP ],
+      streamMuxer: [ Mplex ]
+    }
+  })
 }
 ```
 
 With this, we can dial as many times as we want to a peer and always reuse the same established underlying connection.
 
 ```JavaScript
-node2.handle('/a', (protocol, conn) => {
-  pull(
-    conn,
-    pull.map((v) => v.toString()),
-    pull.log()
+node2.handle(['/a', '/b'], ({ protocol, stream }) => {
+  pipe(
+    stream,
+    toBuffer,
+    source => (async function () {
+      for await (const msg of source) {
+        console.log(`from: ${protocol}, msg: ${msg.toString()}`)
+      }
+    })()
   )
 })
 
-node2.handle('/b', (protocol, conn) => {
-  pull(
-    conn,
-    pull.map((v) => v.toString()),
-    pull.log()
-  )
-})
+const { stream } = await node1.dialProtocol(node2.peerInfo, ['/a'])
+await pipe(
+  ['protocol (a)'],
+  stream
+)
 
-series([
-  (cb) => node1.dialProtocol(node2.peerInfo, '/a', (err, conn) => {
-    if (err) { throw err }
-    pull(pull.values(['protocol (a)']), conn)
-    cb()
-  }),
-  (cb) => node1.dialProtocol(node2.peerInfo, '/b', (err, conn) => {
-    if (err) { throw err }
-    pull(pull.values(['protocol (b)']), conn)
-    cb()
-  }),
-  (cb) => node1.dialProtocol(node2.peerInfo, '/b', (err, conn) => {
-    if (err) { throw err }
-    pull(pull.values(['another conn on protocol (b)']), conn)
-    cb()
-  })
-])
+const { stream: stream2 } = await node1.dialProtocol(node2.peerInfo, ['/b'])
+await pipe(
+  ['protocol (b)'],
+  stream2
+)
+
+const { stream: stream3 } = await node1.dialProtocol(node2.peerInfo, ['/b'])
+await pipe(
+  ['another stream on protocol (b)'],
+  stream3
+)
 ```
 
 By running [2.js](./2.js) you should see the following result:
 
 ```
 > node 2.js
-protocol (a)
-protocol (b)
-another protocol (b)
+from: /a, msg: protocol (a)
+from: /b, msg: protocol (b)
+from: /b, msg: another stream on protocol (b)
 ```
 
 # 3. Bidirectional connections
@@ -168,8 +174,5 @@ You can see this working on example [3.js](./3.js). The result should look like 
 ```Bash
 > node 3.js
 from 1 to 2
-Addresses by which both peers are connected
-node 1 to node 2: /ip4/127.0.0.1/tcp/50629/p2p/QmZwMKTo6wG4Te9A6M2eJnWDpR8uhsGed4YRegnV5DcKiv
-node 2 to node 1: /ip4/127.0.0.1/tcp/50630/p2p/QmRgormJQeDyXhDKma11eUtksoh8vWmeBoxghVt4meauW9
 from 2 to 1
 ```


### PR DESCRIPTION
This PR refactors the `protocol-and-stream-muxing` example to the refactored async `js-libp2p`.

Needs:

- [x] #490 - this work is on top of the token dialer branch