### PR TITLE
refactor: examples/delegated-routing

### DIFF
--- a/examples/delegated-routing/.env
+++ b/examples/delegated-routing/.env
@@ -1,3 +1,3 @@
 # required because react-scripts scans *up* the tree from this project and finds
-# a conflicting version of eslint in the node_modules dir for js-ipfs.
+# a conflicting version of webpack in the node_modules dir for js-libp2p (aegir).
 SKIP_PREFLIGHT_CHECK=true

--- a/examples/delegated-routing/.env
+++ b/examples/delegated-routing/.env
@@ -1,0 +1,3 @@
+# required because react-scripts scans *up* the tree from this project and finds
+# a conflicting version of eslint in the node_modules dir for js-ipfs.
+SKIP_PREFLIGHT_CHECK=true

--- a/examples/delegated-routing/README.md
+++ b/examples/delegated-routing/README.md
@@ -10,7 +10,7 @@ especially useful when your libp2p node will have limited resources, making runn
 also highly useful if your node is generating content, but can't reliably be on the network. You can use delegate nodes
 to provide content on your behalf.
 
-The starting [Libp2p Bundle](./src/libp2p-bundle.js) in this example starts by disabling the DHT and adding the Delegated Peer and Content Routers.
+The starting [Libp2p Configuration](./src/libp2p-configuration.js) in this example starts by disabling the DHT and adding the Delegated Peer and Content Routers.
 Once you've completed the example, you should try enabled the DHT and see what kind of results you get! You can also enable the
 various Peer Discovery modules and see the impact it has on your Peer count.
 
@@ -23,7 +23,9 @@ various Peer Discovery modules and see the impact it has on your Peer count.
 2. Run the IPFS daemon: `ipfs daemon`
 3. The daemon will output a line about its API address, like `API server listening on /ip4/127.0.0.1/tcp/8080`
 4. In another window output the addresses of the node: `ipfs id`. Make note of the websocket address, it will contain `/ws/` in the address.
-5. In `./src/libp2p-bundle.js` check if the host and port of your node are correct, according to the previous step. If they are different, replace them.
+  - If there is no websocket address, you will need to add it in the ipfs config file (`~/.ipfs/config`)
+  - Add to Swarm Addresses something like: `"/ip4/127.0.0.1/tcp/4010/ws"`
+5. In `./src/libp2p-configuration.js` check if the host and port of your node are correct, according to the previous step. If they are different, replace them.
 6. In `./src/App.js` replace `BootstrapNode` with your nodes Websocket address from step 4.
 7. Start this example:
 

--- a/examples/delegated-routing/README.md
+++ b/examples/delegated-routing/README.md
@@ -36,7 +36,7 @@ This should open your browser to http://localhost:3000. If it does not, go ahead
 
 ### Finding Content via the Delegate
 1. Add a file to your IPFS node. From this example root you can do `ipfs add ./README.md` to add the example readme.
-2. Copy the hash from line 5, it will look something like *Qmf33vz4HJFkqgH7XPP1uA6atYKTX1BWQEQthzpKcAdeyZ*.
+2. Copy the hash from line 5, it will look something like *QmV8QZ1m4fi57fbmaYDAkaTSTjHZVLUJmsqvaP6EcUyUNb*.
 3. In the browser, paste the hash into the *Hash* field and hit `Find`. The readme contents should display.
 
 This will do a few things:

--- a/examples/delegated-routing/README.md
+++ b/examples/delegated-routing/README.md
@@ -1,7 +1,3 @@
-❗❗Outdated: This example is still not refactored with the `0.27.*` release. 
-WIP on [libp2p/js-libp2p#507](https://github.com/libp2p/js-libp2p/pull/507)
-======
-
 # Delegated Routing with Libp2p and IPFS
 
 This example shows how to use delegated peer and content routing. The [Peer and Content Routing Example](../peer-and-content-routing) focuses
@@ -21,7 +17,7 @@ various Peer Discovery modules and see the impact it has on your Peer count.
 
 1. Install IPFS locally if you dont already have it. [Install Guide](https://docs.ipfs.io/introduction/install/)
 2. Run the IPFS daemon: `ipfs daemon`
-3. The daemon will output a line about its API address, like `API server listening on /ip4/127.0.0.1/tcp/8080`
+3. The daemon will output a line about its API address, like `API server listening on /ip4/127.0.0.1/tcp/5001`
 4. In another window output the addresses of the node: `ipfs id`. Make note of the websocket address, it will contain `/ws/` in the address.
   - If there is no websocket address, you will need to add it in the ipfs config file (`~/.ipfs/config`)
   - Add to Swarm Addresses something like: `"/ip4/127.0.0.1/tcp/4010/ws"`

--- a/examples/delegated-routing/README.md
+++ b/examples/delegated-routing/README.md
@@ -1,29 +1,21 @@
 # Delegated Routing with Libp2p and IPFS
 
-This example shows how to use delegated peer and content routing. The [Peer and Content Routing Example](../peer-and-content-routing) focuses
-on the DHT implementation. This example takes that a step further and introduces delegated routing. Delegated routing is
-especially useful when your libp2p node will have limited resources, making running a DHT impractical. It's
-also highly useful if your node is generating content, but can't reliably be on the network. You can use delegate nodes
-to provide content on your behalf.
+This example shows how to use delegated peer and content routing. The [Peer and Content Routing Example](../peer-and-content-routing) focuses on the DHT implementation. This example takes that a step further and introduces delegated routing. Delegated routing is especially useful when your libp2p node will have limited resources, making running a DHT impractical. It's also highly useful if your node is generating content, but can't reliably be on the network. You can use delegate nodes to provide content on your behalf.
 
 The starting [Libp2p Configuration](./src/libp2p-configuration.js) in this example starts by disabling the DHT and adding the Delegated Peer and Content Routers.
-Once you've completed the example, you should try enabled the DHT and see what kind of results you get! You can also enable the
-various Peer Discovery modules and see the impact it has on your Peer count.
+Once you've completed the example, you should try enabled the DHT and see what kind of results you get! You can also enable the various Peer Discovery modules and see the impact it has on your Peer count.
 
-## Prerequisite
-**NOTE**: This example is currently dependent on a clone of the [delegated routing support branch of go-ipfs](https://github.com/ipfs/go-ipfs/pull/4595).
+This example uses a publicly known delegated routing node. This aims to ease experimentation, but you should not rely on this in production.
 
 ## Running this example
 
 1. Install IPFS locally if you dont already have it. [Install Guide](https://docs.ipfs.io/introduction/install/)
 2. Run the IPFS daemon: `ipfs daemon`
-3. The daemon will output a line about its API address, like `API server listening on /ip4/127.0.0.1/tcp/5001`
-4. In another window output the addresses of the node: `ipfs id`. Make note of the websocket address, it will contain `/ws/` in the address.
+3. In another window output the addresses of the node: `ipfs id`. Make note of the websocket address, it will contain `/ws/` in the address.
   - If there is no websocket address, you will need to add it in the ipfs config file (`~/.ipfs/config`)
   - Add to Swarm Addresses something like: `"/ip4/127.0.0.1/tcp/4010/ws"`
-5. In `./src/libp2p-configuration.js` check if the host and port of your node are correct, according to the previous step. If they are different, replace them.
-6. In `./src/App.js` replace `BootstrapNode` with your nodes Websocket address from step 4.
-7. Start this example:
+4. In `./src/App.js` replace `BootstrapNode` with your nodes Websocket address from the step above.
+5. Start this example:
 
 ```sh
 npm install
@@ -32,7 +24,7 @@ npm start
 
 This should open your browser to http://localhost:3000. If it does not, go ahead and do that now.
 
-8. Your browser should show you connected to at least 1 peer.
+6. Your browser should show you connected to at least 1 peer.
 
 ### Finding Content via the Delegate
 1. Add a file to your IPFS node. From this example root you can do `ipfs add ./README.md` to add the example readme.
@@ -46,6 +38,10 @@ This will do a few things:
 
 ### Finding Peers via the Delegate
 1. Get a list of your delegate nodes peer by querying the IPFS daemon: `ipfs swarm peers`
-2. Copy one of the CIDs from the list of peer addresses, this will be the last portion of the address and will look something like `QmdoG8DpzYUZMVP5dGmgmigZwR1RE8Cf6SxMPg1SBXJAQ8`.
+2. Copy one of the CIDs from the list of peer addresses, this will be the last portion of the address and will look something like `QmSb5LGwyVTCSgi5etuBnKhkEgH68cDxfwp3rtc94Fegv4`.
 3. In your browser, paste the CID into the *Peer* field and hit `Find`.
 4. You should see information about the peer including its addresses.
+
+## Going to production?
+
+TODO

--- a/examples/delegated-routing/package.json
+++ b/examples/delegated-routing/package.json
@@ -3,19 +3,18 @@
   "version": "0.1.0",
   "private": true,
   "dependencies": {
-    "ipfs": "~0.34.4",
-    "libp2p": "github:libp2p/js-libp2p#master",
-    "libp2p-delegated-content-routing": "~0.2.2",
-    "libp2p-delegated-peer-routing": "~0.2.2",
-    "libp2p-kad-dht": "~0.14.12",
-    "libp2p-mplex": "~0.8.5",
-    "libp2p-secio": "~0.11.1",
-    "libp2p-webrtc-star": "~0.15.8",
-    "libp2p-websocket-star": "~0.10.2",
-    "libp2p-websockets": "~0.12.2",
-    "react": "^16.8.6",
-    "react-dom": "^16.8.6",
-    "react-scripts": "2.1.8"
+    "ipfs": "~0.40.0",
+    "libp2p": "../..",
+    "libp2p-delegated-content-routing": "~0.4.1",
+    "libp2p-delegated-peer-routing": "~0.4.0",
+    "libp2p-kad-dht": "~0.18.2",
+    "libp2p-mplex": "~0.9.3",
+    "libp2p-secio": "~0.12.1",
+    "libp2p-webrtc-star": "~0.17.0",
+    "libp2p-websockets": "~0.13.1",
+    "react": "^16.12.0",
+    "react-dom": "^16.12.0",
+    "react-scripts": "3.3.0"
   },
   "scripts": {
     "start": "react-scripts start"

--- a/examples/delegated-routing/package.json
+++ b/examples/delegated-routing/package.json
@@ -12,6 +12,7 @@
     "libp2p-secio": "~0.12.5",
     "libp2p-webrtc-star": "~0.18.6",
     "libp2p-websockets": "~0.13.6",
+    "peer-id": "^0.13.13",
     "react": "^16.8.6",
     "react-dom": "^16.8.6",
     "react-scripts": "^3.2.0"

--- a/examples/delegated-routing/package.json
+++ b/examples/delegated-routing/package.json
@@ -3,18 +3,18 @@
   "version": "0.1.0",
   "private": true,
   "dependencies": {
-    "ipfs": "~0.40.0",
+    "ipfs": "~0.47.0",
     "libp2p": "../..",
-    "libp2p-delegated-content-routing": "~0.4.1",
-    "libp2p-delegated-peer-routing": "~0.4.0",
-    "libp2p-kad-dht": "~0.18.2",
-    "libp2p-mplex": "~0.9.3",
-    "libp2p-secio": "~0.12.1",
-    "libp2p-webrtc-star": "~0.17.0",
-    "libp2p-websockets": "~0.13.1",
-    "react": "^16.12.0",
-    "react-dom": "^16.12.0",
-    "react-scripts": "3.3.0"
+    "libp2p-delegated-content-routing": "~0.5.0",
+    "libp2p-delegated-peer-routing": "~0.5.0",
+    "libp2p-kad-dht": "~0.19.7",
+    "libp2p-mplex": "~0.9.5",
+    "libp2p-secio": "~0.12.5",
+    "libp2p-webrtc-star": "~0.18.6",
+    "libp2p-websockets": "~0.13.6",
+    "react": "^16.8.6",
+    "react-dom": "^16.8.6",
+    "react-scripts": "^3.2.0"
   },
   "scripts": {
     "start": "react-scripts start"

--- a/examples/delegated-routing/src/App.js
+++ b/examples/delegated-routing/src/App.js
@@ -5,7 +5,7 @@ import React from 'react'
 import Ipfs from 'ipfs'
 import libp2pConfig from './libp2p-configuration'
 
-const BootstrapNode = '/ip4/127.0.0.1/tcp/4004/ws/ipfs/QmPHafDaco9vynQ93MHv5cRSW6UCECycCGdTRafL8X5WEj'
+const BootstrapNode = '/ip4/127.0.0.1/tcp/4010/ws/p2p/QmZrsjJ7v9QoJNjDJmjsQ8947wiK3UnaPPLQvrTSRDAZ2d'
 
 class App extends React.Component {
   constructor (props) {
@@ -64,8 +64,8 @@ class App extends React.Component {
     })
   }
 
-  componentDidMount () {
-    window.ipfs = this.ipfs = new Ipfs({
+  async componentDidMount () {
+    window.ipfs = this.ipfs = await Ipfs.create({
       config: {
         Addresses: {
           Swarm: []
@@ -88,21 +88,14 @@ class App extends React.Component {
       libp2p: libp2pConfig
     })
 
-    this.ipfs.on('ready', async () => {
-      if (this.peerInterval) {
-        clearInterval(this.peerInterval)
-      }
+    await this.ipfs.swarm.connect(BootstrapNode)
+    console.log('Connected!')
 
+    this.peerInterval = setInterval(async () => {
+      const peers = await this.ipfs.swarm.peers()
 
-      await this.ipfs.swarm.connect(BootstrapNode)
-      console.log('Connected!')
-
-      this.peerInterval = setInterval(async () => {
-        const peers = await this.ipfs.swarm.peers()
-
-        if (peers) this.setState({peers: peers.length})
-      }, 2500)
-    })
+      if (peers) this.setState({ peers: peers.length })
+    }, 2500)
   }
 
   render () {

--- a/examples/delegated-routing/src/App.js
+++ b/examples/delegated-routing/src/App.js
@@ -16,7 +16,7 @@ class App extends React.Component {
       // This hash is the IPFS readme
       hash: 'QmPZ9gcCEpqKTo6aq61g2nXGUhM4iCL3ewB6LDXZCtioEB',
       // This peer is one of the Bootstrap nodes for IPFS
-      peer: 'QmV6kA2fB8kTr6jc3pL5zbNsjKbmPUHAPKKHRBYe1kDEyc',
+      peer: 'QmSoLnSGccFuZQJzRadHn95W2CrSFmZuTdDWP8HXaHca9z',
       isLoading: 0
     }
     this.peerInterval = null

--- a/examples/delegated-routing/src/App.js
+++ b/examples/delegated-routing/src/App.js
@@ -4,6 +4,7 @@
 import React from 'react'
 import Ipfs from 'ipfs'
 import libp2pConfig from './libp2p-configuration'
+import PeerId from 'peer-id'
 
 const BootstrapNode = '/ip4/127.0.0.1/tcp/4010/ws/p2p/QmZrsjJ7v9QoJNjDJmjsQ8947wiK3UnaPPLQvrTSRDAZ2d'
 
@@ -43,10 +44,13 @@ class App extends React.Component {
       isLoading: this.state.isLoading + 1
     })
 
-    const data = await this.ipfs.cat(this.state.hash)
+    const chunks = []
+    for await (const chunk of this.ipfs.cat(this.state.hash)) {
+      chunks.push(chunk)
+    }
 
     this.setState({
-      response: data.toString(),
+      response: Buffer.concat(chunks).toString(),
       isLoading: this.state.isLoading - 1
     })
   }
@@ -56,7 +60,8 @@ class App extends React.Component {
       isLoading: this.state.isLoading + 1
     })
 
-    const results = await this.ipfs.dht.findpeer(this.state.peer)
+    const peerId = PeerId.createFromB58String(this.state.peer)
+    const results = await this.ipfs.libp2p.peerRouting.findPeer(peerId)
 
     this.setState({
       response: JSON.stringify(results, null, 2),

--- a/examples/delegated-routing/src/libp2p-configuration.js
+++ b/examples/delegated-routing/src/libp2p-configuration.js
@@ -12,9 +12,9 @@ const DelegatedContentRouter = require('libp2p-delegated-content-routing')
 
 export default function Libp2pConfiguration ({peerId}) {
   const delegatedApiOptions = {
-    host: '127.0.0.1',
-    protocol: 'http',
-    port: '5001'
+    protocol: 'https',
+    port: 443,
+    host: 'node0.delegate.ipfs.io'
   }
 
   return new Libp2p({

--- a/examples/delegated-routing/src/libp2p-configuration.js
+++ b/examples/delegated-routing/src/libp2p-configuration.js
@@ -3,7 +3,6 @@
 
 const Libp2p = require('libp2p')
 const Websockets = require('libp2p-websockets')
-const WebSocketStar = require('libp2p-websocket-star')
 const WebRTCStar = require('libp2p-webrtc-star')
 const MPLEX = require('libp2p-mplex')
 const SECIO = require('libp2p-secio')
@@ -11,18 +10,16 @@ const KadDHT = require('libp2p-kad-dht')
 const DelegatedPeerRouter = require('libp2p-delegated-peer-routing')
 const DelegatedContentRouter = require('libp2p-delegated-content-routing')
 
-export default function Libp2pBundle ({peerInfo, peerBook}) {
+export default function Libp2pConfiguration ({peerInfo}) {
   const wrtcstar = new WebRTCStar({id: peerInfo.id})
-  const wsstar = new WebSocketStar({id: peerInfo.id})
   const delegatedApiOptions = {
-    host: '0.0.0.0',
+    host: '127.0.0.1',
     protocol: 'http',
-    port: '8080'
+    port: '5001'
   }
 
   return new Libp2p({
     peerInfo,
-    peerBook,
     // Lets limit the connection managers peers and have it check peer health less frequently
     connectionManager: {
       maxPeers: 10,
@@ -36,12 +33,10 @@ export default function Libp2pBundle ({peerInfo, peerBook}) {
         new DelegatedPeerRouter(delegatedApiOptions)
       ],
       peerDiscovery: [
-        wrtcstar.discovery,
-        wsstar.discovery
+        wrtcstar.discovery
       ],
       transport: [
         wrtcstar,
-        wsstar,
         Websockets
       ],
       streamMuxer: [

--- a/examples/delegated-routing/src/libp2p-configuration.js
+++ b/examples/delegated-routing/src/libp2p-configuration.js
@@ -10,8 +10,7 @@ const KadDHT = require('libp2p-kad-dht')
 const DelegatedPeerRouter = require('libp2p-delegated-peer-routing')
 const DelegatedContentRouter = require('libp2p-delegated-content-routing')
 
-export default function Libp2pConfiguration ({peerInfo}) {
-  const wrtcstar = new WebRTCStar({id: peerInfo.id})
+export default function Libp2pConfiguration ({peerId}) {
   const delegatedApiOptions = {
     host: '127.0.0.1',
     protocol: 'http',
@@ -19,7 +18,7 @@ export default function Libp2pConfiguration ({peerInfo}) {
   }
 
   return new Libp2p({
-    peerInfo,
+    peerId,
     // Lets limit the connection managers peers and have it check peer health less frequently
     connectionManager: {
       maxPeers: 10,
@@ -27,16 +26,13 @@ export default function Libp2pConfiguration ({peerInfo}) {
     },
     modules: {
       contentRouting: [
-        new DelegatedContentRouter(peerInfo.id, delegatedApiOptions)
+        new DelegatedContentRouter(peerId, delegatedApiOptions)
       ],
       peerRouting: [
         new DelegatedPeerRouter(delegatedApiOptions)
       ],
-      peerDiscovery: [
-        wrtcstar.discovery
-      ],
       transport: [
-        wrtcstar,
+        WebRTCStar,
         Websockets
       ],
       streamMuxer: [


### PR DESCRIPTION
This PR refactors the `delegated-routing` example to the refactored async `js-libp2p`.