### PR TITLE
fix: upgrader should not need muxers

### DIFF
--- a/src/upgrader.js
+++ b/src/upgrader.js
@@ -64,7 +64,7 @@ class Upgrader {
   async upgradeInbound (maConn) {
     let encryptedConn
     let remotePeer
-    let muxedConnection
+    let upgradedConn
     let Muxer
     let cryptoProtocol
     let setPeer
@@ -94,7 +94,11 @@ class Upgrader {
       } = await this._encryptInbound(this.localPeer, protectedConn, this.cryptos))
 
       // Multiplex the connection
-      ;({ stream: muxedConnection, Muxer } = await this._multiplexInbound(encryptedConn, this.muxers))
+      if (this.muxers.size) {
+        ({ stream: upgradedConn, Muxer } = await this._multiplexInbound(encryptedConn, this.muxers))
+      } else {
+        upgradedConn = encryptedConn
+      }
     } catch (err) {
       log.error('Failed to upgrade inbound connection', err)
       await maConn.close(err)
@@ -112,7 +116,7 @@ class Upgrader {
       cryptoProtocol,
       direction: 'inbound',
       maConn,
-      muxedConnection,
+      upgradedConn,
       Muxer,
       remotePeer
     })
@@ -134,7 +138,7 @@ class Upgrader {
 
     let encryptedConn
     let remotePeer
-    let muxedConnection
+    let upgradedConn
     let cryptoProtocol
     let Muxer
     let setPeer
@@ -164,7 +168,11 @@ class Upgrader {
       } = await this._encryptOutbound(this.localPeer, protectedConn, remotePeerId, this.cryptos))
 
       // Multiplex the connection
-      ;({ stream: muxedConnection, Muxer } = await this._multiplexOutbound(encryptedConn, this.muxers))
+      if (this.muxers.size) {
+        ({ stream: upgradedConn, Muxer } = await this._multiplexOutbound(encryptedConn, this.muxers))
+      } else {
+        upgradedConn = encryptedConn
+      }
     } catch (err) {
       log.error('Failed to upgrade outbound connection', err)
       await maConn.close(err)
@@ -182,7 +190,7 @@ class Upgrader {
       cryptoProtocol,
       direction: 'outbound',
       maConn,
-      muxedConnection,
+      upgradedConn,
       Muxer,
       remotePeer
     })
@@ -195,7 +203,7 @@ class Upgrader {
    * @param {string} cryptoProtocol The crypto protocol that was negotiated
    * @param {string} direction One of ['inbound', 'outbound']
    * @param {MultiaddrConnection} maConn The transport layer connection
-   * @param {*} muxedConnection A duplex connection returned from multiplexer selection
+   * @param {*} upgradedConn A duplex connection returned from multiplexer selection
    * @param {Muxer} Muxer The muxer to be used for muxing
    * @param {PeerId} remotePeer The peer the connection is with
    * @returns {Connection}
@@ -204,10 +212,34 @@ class Upgrader {
     cryptoProtocol,
     direction,
     maConn,
-    muxedConnection,
+    upgradedConn,
     Muxer,
     remotePeer
   }) {
+    if (!Muxer) {
+      // Create the connection
+      maConn.timeline.upgraded = Date.now()
+
+      const connection = new Connection({
+        localAddr: maConn.localAddr,
+        remoteAddr: maConn.remoteAddr,
+        localPeer: this.localPeer,
+        remotePeer: remotePeer,
+        stat: {
+          direction,
+          timeline: maConn.timeline,
+          encryption: cryptoProtocol
+        },
+        newStream: () => { throw new Error('connection is not multiplexed') },
+        getStreams: () => { throw new Error('connection is not multiplexed') },
+        close: err => maConn.close(err)
+      })
+
+      this.onConnection(connection)
+
+      return connection
+    }
+
     // Create the muxer
     const muxer = new Muxer({
       // Run anytime a remote stream is created
@@ -244,7 +276,7 @@ class Upgrader {
     }
 
     // Pipe all data through the muxer
-    pipe(muxedConnection, muxer, muxedConnection)
+    pipe(upgradedConn, muxer, upgradedConn)
 
     maConn.timeline.upgraded = Date.now()
     const _timeline = maConn.timeline

--- a/test/upgrading/upgrader.spec.js
+++ b/test/upgrading/upgrader.spec.js
@@ -116,6 +116,26 @@ describe('Upgrader', () => {
     expect(result).to.eql([hello])
   })
 
+  it('should upgrade with only crypto', async () => {
+    const { inbound, outbound } = mockMultiaddrConnPair({ addrs, remotePeer })
+
+    // No available muxers
+    const muxers = new Map()
+    sinon.stub(localUpgrader, 'muxers').value(muxers)
+    sinon.stub(remoteUpgrader, 'muxers').value(muxers)
+
+    const cryptos = new Map([[Crypto.protocol, Crypto]])
+    sinon.stub(localUpgrader, 'cryptos').value(cryptos)
+    sinon.stub(remoteUpgrader, 'cryptos').value(cryptos)
+
+    const connections = await Promise.all([
+      localUpgrader.upgradeOutbound(outbound),
+      remoteUpgrader.upgradeInbound(inbound)
+    ])
+
+    expect(connections).to.have.length(2)
+  })
+
   it('should use a private connection protector when provided', async () => {
     const { inbound, outbound } = mockMultiaddrConnPair({ addrs, remotePeer })
 

--- a/test/upgrading/upgrader.spec.js
+++ b/test/upgrading/upgrader.spec.js
@@ -136,6 +136,13 @@ describe('Upgrader', () => {
     expect(connections).to.have.length(2)
 
     await expect(connections[0].newStream('/echo/1.0.0')).to.be.rejected()
+
+    // Verify the MultiaddrConnection close method is called
+    sinon.spy(inbound, 'close')
+    sinon.spy(outbound, 'close')
+    await Promise.all(connections.map(conn => conn.close()))
+    expect(inbound.close.callCount).to.equal(1)
+    expect(outbound.close.callCount).to.equal(1)
   })
 
   it('should use a private connection protector when provided', async () => {

--- a/test/upgrading/upgrader.spec.js
+++ b/test/upgrading/upgrader.spec.js
@@ -134,6 +134,8 @@ describe('Upgrader', () => {
     ])
 
     expect(connections).to.have.length(2)
+
+    await expect(connections[0].newStream('/echo/1.0.0')).to.be.rejected()
   })
 
   it('should use a private connection protector when provided', async () => {


### PR DESCRIPTION
With the current codebase, having a `streamMuxer` is mandatory, which was not the case before. This PR allows a connection to be upgraded just with crypto.

Note: the `connection` properties regarding multiplexers are throwing an error now.