### PR TITLE
feat: coalescing dial support

### DIFF
--- a/doc/API.md
+++ b/doc/API.md
@@ -92,7 +92,7 @@ Required keys in the `options` object:
 
 </details>
 
-Once you have a libp2p instance, you are able to listen to several events it emmits, so that you can be noticed of relevant network events.
+Once you have a libp2p instance, you are able to listen to several events it emits, so that you can be noticed of relevant network events.
 
 <details><summary>Events</summary>
 

--- a/doc/API.md
+++ b/doc/API.md
@@ -22,6 +22,7 @@
   * [`pubsub.publish`](#pubsubpublish)
   * [`pubsub.subscribe`](#pubsubsubscribe)
   * [`pubsub.unsubscribe`](#pubsubunsubscribe)
+  * [`connectionManager.setPeerValue`](#connectionmanagersetpeervalue)
   * [`metrics.global`](#metricsglobal)
   * [`metrics.peers`](#metricspeers)
   * [`metrics.protocols`](#metricsprotocols)
@@ -666,12 +667,8 @@ Enables users to change the value of certain peers in a range of 0 to 1. Peers w
 #### Example
 
 ```js
-const topic = 'topic'
-const handler = (msg) => {
-  // msg.data - pubsub data received
-}
-
-libp2p.pubsub.unsubscribe(topic, handler)
+libp2p.connectionManager.setPeerValue(highPriorityPeerId, 1)
+libp2p.connectionManager.setPeerValue(lowPriorityPeerId, 0)
 ```
 
 ### metrics.global

--- a/doc/DIALER.md
+++ b/doc/DIALER.md
@@ -1,6 +1,7 @@
 # js-libp2p Dialer
 
 **Synopsis**
+* Parallel dials to the same peer will yield the same connection/error when the first dial settles.
 * All Dial Requests in js-libp2p must request a token(s) from the Dialer.
   * The number of tokens requested should be between 1 and the MAX_PER_PEER_DIALS max set in the Dialer.
   * If the number of available tokens is less than requested, the Dialer may return less than requested.

--- a/src/circuit/index.js
+++ b/src/circuit/index.js
@@ -109,7 +109,7 @@ class Circuit {
     let disconnectOnFailure = false
     let relayConnection = this._registrar.getConnection(new PeerInfo(relayPeer))
     if (!relayConnection) {
-      relayConnection = await this._dialer.connectToMultiaddr(relayAddr, options)
+      relayConnection = await this._dialer.connectToPeer(relayAddr, options)
       disconnectOnFailure = true
     }
 

--- a/src/circuit/listener.js
+++ b/src/circuit/listener.js
@@ -24,7 +24,7 @@ module.exports = (circuit) => {
   listener.listen = async (addr) => {
     const [addrString] = String(addr).split('/p2p-circuit').slice(-1)
 
-    const relayConn = await circuit._dialer.connectToMultiaddr(multiaddr(addrString))
+    const relayConn = await circuit._dialer.connectToPeer(multiaddr(addrString))
     const relayedAddr = relayConn.remoteAddr.encapsulate('/p2p-circuit')
 
     listeningAddrs.set(relayConn.remotePeer.toB58String(), relayedAddr)

--- a/src/dialer/dial-request.js
+++ b/src/dialer/dial-request.js
@@ -29,6 +29,7 @@ class DialRequest {
     this.addrs = addrs
     this.dialer = dialer
     this.dialAction = dialAction
+    this.id = Math.random().toFixed(5)
   }
 
   /**
@@ -49,6 +50,7 @@ class DialRequest {
     const dialAbortControllers = this.addrs.map(() => new AbortController())
     let completedDials = 0
 
+    log('%s starting dial to %d addresses', this.id, this.addrs.length)
     try {
       return await pAny(this.addrs.map(async (addr, i) => {
         const token = await tokenHolder.shift() // get token
@@ -68,6 +70,7 @@ class DialRequest {
           }
         }
 
+        log('%s returning connection', this.id)
         return conn
       }))
     } finally {

--- a/src/dialer/dial-request.js
+++ b/src/dialer/dial-request.js
@@ -29,7 +29,6 @@ class DialRequest {
     this.addrs = addrs
     this.dialer = dialer
     this.dialAction = dialAction
-    this.id = Math.random().toFixed(5)
   }
 
   /**
@@ -50,7 +49,6 @@ class DialRequest {
     const dialAbortControllers = this.addrs.map(() => new AbortController())
     let completedDials = 0
 
-    log('%s starting dial to %d addresses', this.id, this.addrs.length)
     try {
       return await pAny(this.addrs.map(async (addr, i) => {
         const token = await tokenHolder.shift() // get token
@@ -70,7 +68,6 @@ class DialRequest {
           }
         }
 
-        log('%s returning connection', this.id)
         return conn
       }))
     } finally {

--- a/src/dialer/index.js
+++ b/src/dialer/index.js
@@ -91,10 +91,17 @@ class Dialer {
   }
 
   /**
+   * @typedef DialTarget
+   * @property {string} id
+   * @property {Multiaddr[]} addrs
+   */
+
+  /**
    * Creates a DialTarget. The DialTarget is used to create and track
    * the DialRequest to a given peer.
+   * @private
    * @param {PeerInfo|Multiaddr} peer A PeerId or Multiaddr
-   * @returns {{ id: string, addrs: Multiaddr[] }}
+   * @returns {DialTarget}
    */
   _createDialTarget (peer) {
     const dialable = Dialer.getDialable(peer)
@@ -112,6 +119,22 @@ class Dialer {
     }
   }
 
+  /**
+   * @typedef PendingDial
+   * @property {DialRequest} dialRequest
+   * @property {TimeoutController} controller
+   * @property {Promise} promise
+   * @property {function():void} destroy
+   */
+
+  /**
+   * Creates a PendingDial that wraps the underlying DialRequest
+   * @private
+   * @param {DialTarget} dialTarget
+   * @param {object} [options]
+   * @param {AbortSignal} [options.signal] An AbortController signal
+   * @returns {PendingDial}
+   */
   _createPendingDial (dialTarget, options) {
     const dialAction = (addr, options) => {
       if (options.signal.aborted) throw errCode(new Error('already aborted'), 'ERR_ALREADY_ABORTED')

--- a/src/dialer/index.js
+++ b/src/dialer/index.js
@@ -111,7 +111,6 @@ class Dialer {
         addrs: [dialable]
       }
     }
-    // Check the peerstore first, and then fallback to the instance
     const addrs = this.peerStore.multiaddrsForPeer(dialable)
     return {
       id: dialable.id.toString(),

--- a/src/index.js
+++ b/src/index.js
@@ -421,7 +421,7 @@ class Libp2p extends EventEmitter {
     if (this._config.peerDiscovery.autoDial === true && !this.registrar.getConnection(peerInfo)) {
       const minPeers = this._options.connectionManager.minPeers || 0
       if (minPeers > this.connectionManager._connections.size) {
-        log('connecting to discovered peer %s', peerInfo.id.toString(), this.connectionManager._connections.size)
+        log('connecting to discovered peer %s', peerInfo.id.toString())
         try {
           await this.dialer.connectToPeer(peerInfo)
         } catch (err) {

--- a/src/index.js
+++ b/src/index.js
@@ -51,8 +51,6 @@ class Libp2p extends EventEmitter {
     this._transport = [] // Transport instances/references
     this._discovery = new Map() // Discovery service instances/references
 
-    this.peerStore = new PeerStore()
-
     if (this._options.metrics.enabled) {
       this.metrics = new Metrics(this._options.metrics)
     }

--- a/src/index.js
+++ b/src/index.js
@@ -64,6 +64,13 @@ class Libp2p extends EventEmitter {
         this.connectionManager.onConnect(connection)
         this.emit('peer:connect', peerInfo)
 
+        log(
+          'Connect= %s:%s > Total Connections: %d; Peers Connected: %d',
+          this.peerInfo.id.toB58String().slice(0, 8),
+          connection.remotePeer.toB58String().slice(0,8),
+          this.connectionManager._connections.size,
+          this.registrar.connections.size
+        )
         // Run identify for every connection
         if (this.identifyService) {
           this.identifyService.identify(connection, connection.remotePeer)
@@ -75,6 +82,13 @@ class Libp2p extends EventEmitter {
         this.registrar.onDisconnect(peerInfo, connection)
         this.connectionManager.onDisconnect(connection)
 
+        log(
+          'Disconnect= %s:%s > Total Connections: %d; Peers Connected: %d',
+          this.peerInfo.id.toB58String().slice(0, 8),
+          connection.remotePeer.toB58String().slice(0,8),
+          this.connectionManager._connections.size,
+          this.registrar.connections.size
+        )
         // If there are no connections to the peer, disconnect
         if (!this.registrar.getConnection(peerInfo)) {
           this.emit('peer:disconnect', peerInfo)

--- a/src/index.js
+++ b/src/index.js
@@ -59,7 +59,7 @@ class Libp2p extends EventEmitter {
       localPeer: this.peerInfo.id,
       metrics: this.metrics,
       onConnection: (connection) => {
-        const peerInfo = this.peerStore.put(new PeerInfo(connection.remotePeer), true)
+        const peerInfo = this.peerStore.put(new PeerInfo(connection.remotePeer), { silent: true })
         this.registrar.onConnect(peerInfo, connection)
         this.connectionManager.onConnect(connection)
         this.emit('peer:connect', peerInfo)
@@ -266,7 +266,7 @@ class Libp2p extends EventEmitter {
     const dialable = Dialer.getDialable(peer)
     let connection
     if (PeerInfo.isPeerInfo(dialable)) {
-      this.peerStore.put(dialable, true)
+      this.peerStore.put(dialable, { silent: true })
       connection = this.registrar.getConnection(dialable)
     }
 

--- a/src/index.js
+++ b/src/index.js
@@ -64,13 +64,6 @@ class Libp2p extends EventEmitter {
         this.connectionManager.onConnect(connection)
         this.emit('peer:connect', peerInfo)
 
-        log(
-          'Connect= %s:%s > Total Connections: %d; Peers Connected: %d',
-          this.peerInfo.id.toB58String().slice(0, 8),
-          connection.remotePeer.toB58String().slice(0,8),
-          this.connectionManager._connections.size,
-          this.registrar.connections.size
-        )
         // Run identify for every connection
         if (this.identifyService) {
           this.identifyService.identify(connection, connection.remotePeer)
@@ -82,13 +75,6 @@ class Libp2p extends EventEmitter {
         this.registrar.onDisconnect(peerInfo, connection)
         this.connectionManager.onDisconnect(connection)
 
-        log(
-          'Disconnect= %s:%s > Total Connections: %d; Peers Connected: %d',
-          this.peerInfo.id.toB58String().slice(0, 8),
-          connection.remotePeer.toB58String().slice(0,8),
-          this.connectionManager._connections.size,
-          this.registrar.connections.size
-        )
         // If there are no connections to the peer, disconnect
         if (!this.registrar.getConnection(peerInfo)) {
           this.emit('peer:disconnect', peerInfo)

--- a/src/peer-store/index.js
+++ b/src/peer-store/index.js
@@ -36,11 +36,15 @@ class PeerStore extends EventEmitter {
 
   /**
    * Stores the peerInfo of a new peer.
-   * If already exist, its info is updated.
+   * If already exist, its info is updated. If `silent` is set to
+   * true, no 'peer' event will be emitted. This can be useful if you
+   * are already in the process of dialing the peer. The peer is technically
+   * known, but may not have been added to the PeerStore yet.
    * @param {PeerInfo} peerInfo
+   * @param {boolean} [silent] (Default=false)
    * @return {PeerInfo}
    */
-  put (peerInfo) {
+  put (peerInfo, silent = false) {
     assert(PeerInfo.isPeerInfo(peerInfo), 'peerInfo must be an instance of peer-info')
 
     let peer
@@ -50,8 +54,8 @@ class PeerStore extends EventEmitter {
     } else {
       peer = this.add(peerInfo)
 
-      // Emit the new peer found
-      this.emit('peer', peerInfo)
+      // Emit the peer if silent = false
+      !silent && this.emit('peer', peerInfo)
     }
     return peer
   }
@@ -219,13 +223,12 @@ class PeerStore extends EventEmitter {
   }
 
   /**
-   * Returns the known multiaddrs for a given `PeerId`
-   * @param {PeerId} peerId
+   * Returns the known multiaddrs for a given `PeerInfo`
+   * @param {PeerInfo} peer
    * @returns {Array<Multiaddr>}
    */
-  multiaddrsForPeer (peerId) {
-    const peerInfo = this.get(peerId.toB58String())
-    return peerInfo.multiaddrs.toArray()
+  multiaddrsForPeer (peer) {
+    return this.put(peer, true).multiaddrs.toArray()
   }
 }
 

--- a/src/peer-store/index.js
+++ b/src/peer-store/index.js
@@ -41,10 +41,11 @@ class PeerStore extends EventEmitter {
    * are already in the process of dialing the peer. The peer is technically
    * known, but may not have been added to the PeerStore yet.
    * @param {PeerInfo} peerInfo
-   * @param {boolean} [silent] (Default=false)
+   * @param {object} [options]
+   * @param {boolean} [options.silent] (Default=false)
    * @return {PeerInfo}
    */
-  put (peerInfo, silent = false) {
+  put (peerInfo, options = { silent: false }) {
     assert(PeerInfo.isPeerInfo(peerInfo), 'peerInfo must be an instance of peer-info')
 
     let peer
@@ -55,7 +56,7 @@ class PeerStore extends EventEmitter {
       peer = this.add(peerInfo)
 
       // Emit the peer if silent = false
-      !silent && this.emit('peer', peerInfo)
+      !options.silent && this.emit('peer', peerInfo)
     }
     return peer
   }

--- a/src/registrar.js
+++ b/src/registrar.js
@@ -119,8 +119,11 @@ class Registrar {
     assert(PeerInfo.isPeerInfo(peerInfo), 'peerInfo must be an instance of peer-info')
 
     const connections = this.connections.get(peerInfo.id.toString())
-    // TODO: what should we return
-    return connections ? connections[0] : null
+    // Return the first, open connection
+    if (connections) {
+      return connections.find(connection => connection.stat.status === 'open')
+    }
+    return null
   }
 
   /**

--- a/src/upgrader.js
+++ b/src/upgrader.js
@@ -251,6 +251,7 @@ class Upgrader {
     maConn.timeline = new Proxy(_timeline, {
       set: (...args) => {
         if (args[1] === 'close' && args[2] && !_timeline.close) {
+          connection.close()
           this.onConnectionEnd(connection)
         }
 

--- a/src/upgrader.js
+++ b/src/upgrader.js
@@ -251,7 +251,7 @@ class Upgrader {
     maConn.timeline = new Proxy(_timeline, {
       set: (...args) => {
         if (args[1] === 'close' && args[2] && !_timeline.close) {
-          connection.close()
+          connection.stat.status = 'closed'
           this.onConnectionEnd(connection)
         }
 

--- a/src/upgrader.js
+++ b/src/upgrader.js
@@ -98,7 +98,6 @@ class Upgrader {
     } catch (err) {
       log.error('Failed to upgrade inbound connection', err)
       await maConn.close(err)
-      // TODO: We shouldn't throw here, as there isn't anything to catch the failure
       throw err
     }
 
@@ -248,9 +247,10 @@ class Upgrader {
     pipe(muxedConnection, muxer, muxedConnection)
 
     maConn.timeline.upgraded = Date.now()
-    const timelineProxy = new Proxy(maConn.timeline, {
+    const _timeline = maConn.timeline
+    maConn.timeline = new Proxy(_timeline, {
       set: (...args) => {
-        if (args[1] === 'close' && args[2]) {
+        if (args[1] === 'close' && args[2] && !_timeline.close) {
           this.onConnectionEnd(connection)
         }
 
@@ -266,7 +266,7 @@ class Upgrader {
       remotePeer: remotePeer,
       stat: {
         direction,
-        timeline: timelineProxy,
+        timeline: maConn.timeline,
         multiplexer: Muxer.multicodec,
         encryption: cryptoProtocol
       },

--- a/test/dialing/relay.node.js
+++ b/test/dialing/relay.node.js
@@ -42,13 +42,19 @@ describe('Dialing (via relay, TCP)', () => {
       // Reset multiaddrs and start
       libp2p.peerInfo.multiaddrs.clear()
       libp2p.peerInfo.multiaddrs.add('/ip4/0.0.0.0/tcp/0')
-      libp2p.start()
+      return libp2p.start()
     }))
   })
 
   afterEach(() => {
     // Stop each node
-    return Promise.all([srcLibp2p, relayLibp2p, dstLibp2p].map(libp2p => libp2p.stop()))
+    return Promise.all([srcLibp2p, relayLibp2p, dstLibp2p].map(async libp2p => {
+      await libp2p.stop()
+      // Clear the peer stores
+      for (const peerId of libp2p.peerStore.peers.keys()) {
+        libp2p.peerStore.remove(peerId)
+      }
+    }))
   })
 
   it('should be able to connect to a peer over a relay with active connections', async () => {

--- a/test/identify/index.spec.js
+++ b/test/identify/index.spec.js
@@ -200,7 +200,7 @@ describe('Identify', () => {
       sinon.spy(libp2p.identifyService, 'identify')
       sinon.spy(libp2p.peerStore, 'replace')
 
-      const connection = await libp2p.dialer.connectToMultiaddr(remoteAddr)
+      const connection = await libp2p.dialer.connectToPeer(remoteAddr)
       expect(connection).to.exist()
       // Wait for nextTick to trigger the identify call
       await delay(1)
@@ -221,7 +221,7 @@ describe('Identify', () => {
       sinon.spy(libp2p.identifyService, 'push')
       sinon.spy(libp2p.peerStore, 'update')
 
-      const connection = await libp2p.dialer.connectToMultiaddr(remoteAddr)
+      const connection = await libp2p.dialer.connectToPeer(remoteAddr)
       expect(connection).to.exist()
       // Wait for nextTick to trigger the identify call
       await delay(1)


### PR DESCRIPTION
* Parallel dials to the same peer / multiaddr will now settle at the same time with the same result
* Removed `connectToMultiaddr`, all dials now go directly through `connectToPeer`
* Fixed an issue with closed inbound connections not getting removed from tracking
* `PeerStore.put` now allows you to update a peer without firing the `peer` event. This helps prevent duplicate dialing when dialing a new multiaddr directly. (For example: `ipfs swarm connect [addr]`)