### PR TITLE
Adding HOP_RELAY_REFUSED code.

### DIFF
--- a/src/circuit/circuit/dialer.js
+++ b/src/circuit/circuit/dialer.js
@@ -143,9 +143,7 @@ class Dialer {
       relay = null
     }
 
-    if (!cb) {
-      cb = () => {}
-    }
+    cb = cb || (() => { })
 
     dstMa = multiaddr(dstMa)
     // if no relay provided, dial on all available relays until one succeeds

--- a/src/circuit/protocol/index.js
+++ b/src/circuit/protocol/index.js
@@ -14,6 +14,7 @@ message CircuitRelay {
     HOP_CANT_OPEN_DST_STREAM   = 262;
     HOP_CANT_SPEAK_RELAY       = 270;
     HOP_CANT_RELAY_TO_SELF     = 280;
+    HOP_RELAY_REFUSED          = 290;
     STOP_SRC_ADDR_TOO_LONG     = 320;
     STOP_DST_ADDR_TOO_LONG     = 321;
     STOP_SRC_MULTIADDR_INVALID = 350;
@@ -23,9 +24,9 @@ message CircuitRelay {
   }
 
   enum Type { // RPC identifier, either HOP, STOP or STATUS
-    HOP = 1;
-    STOP = 2;
-    STATUS = 3;
+    HOP     = 1;
+    STOP    = 2;
+    STATUS  = 3;
     CAN_HOP = 4;
   }
 


### PR DESCRIPTION
That doesn't add circuit filter but at least this follow libp2p/go-libp2p-circuit#86 code.
Its not critical to merge this because if you got this code the relay attempt is over anyway.