### PR TITLE
feat: add libp2p.connections getter

### DIFF
--- a/doc/API.md
+++ b/doc/API.md
@@ -181,6 +181,29 @@ const libp2p = await Libp2p.create(options)
 await libp2p.stop()
 ```
 
+### connections
+
+A Getter that returns a Map of the current Connections libp2p has to other peers.
+
+`libp2p.connections`
+
+#### Returns
+
+| Type | Description |
+|------|-------------|
+| `Map<string, Array<Connection>>` | A map of [`PeerId`][peer-id] strings to [`Connection`][connection] Arrays |
+
+#### Example
+
+```js
+for (const [peerId, connections] of libp2p.connections) {
+  for (const connection of connections) {
+    console.log(peerId, connection.remoteAddr.toString())
+    // Logs the PeerId string and the observed remote multiaddr of each Connection
+  }
+}
+```
+
 ### dial
 
 Dials to another peer in the network and establishes the connection.
@@ -191,7 +214,7 @@ Dials to another peer in the network and establishes the connection.
 
 | Name | Type | Description |
 |------|------|-------------|
-| peer | [PeerInfo](https://github.com/libp2p/js-peer-info), [PeerId](https://github.com/libp2p/js-peer-id), [multiaddr](https://github.com/multiformats/js-multiaddr), `string` | peer to dial |
+| peer | [PeerInfo](https://github.com/libp2p/js-peer-info), [PeerId][peer-id], [multiaddr](https://github.com/multiformats/js-multiaddr), `string` | peer to dial |
 | [options] | `Object` | dial options |
 | [options.signal] | [`AbortSignal`](https://developer.mozilla.org/en-US/docs/Web/API/AbortSignal) | An `AbortSignal` instance obtained from an [`AbortController`](https://developer.mozilla.org/en-US/docs/Web/API/AbortController) that can be used to abort the connection before it completes |
 
@@ -199,7 +222,7 @@ Dials to another peer in the network and establishes the connection.
 
 | Type | Description |
 |------|-------------|
-| `Promise<Connection>` | Promise resolves with the [Connection](https://github.com/libp2p/js-interfaces/tree/master/src/connection) instance |
+| `Promise<Connection>` | Promise resolves with the [Connection][connection] instance |
 
 #### Example
 
@@ -226,7 +249,7 @@ Dials to another peer in the network and selects a protocol to communicate with 
 
 | Name | Type | Description |
 |------|------|-------------|
-| peer | [PeerInfo](https://github.com/libp2p/js-peer-info), [PeerId](https://github.com/libp2p/js-peer-id), [multiaddr](https://github.com/multiformats/js-multiaddr), `string` | peer to dial |
+| peer | [PeerInfo](https://github.com/libp2p/js-peer-info), [PeerId][peer-id], [multiaddr](https://github.com/multiformats/js-multiaddr), `string` | peer to dial |
 | protocols | `String|Array<String>` |  A list of protocols (or single protocol) to negotiate with. Protocols are attempted in order until a match is made. (e.g '/ipfs/bitswap/1.1.0') |
 | [options] | `Object` | dial options |
 | [options.signal] | [`AbortSignal`](https://developer.mozilla.org/en-US/docs/Web/API/AbortSignal) | An `AbortSignal` instance obtained from an [`AbortController`](https://developer.mozilla.org/en-US/docs/Web/API/AbortController) that can be used to abort the connection before it completes |
@@ -259,7 +282,7 @@ Attempts to gracefully close an open connection to the given peer. If the connec
 
 | Name | Type | Description |
 |------|------|-------------|
-| peer | [PeerInfo](https://github.com/libp2p/js-peer-info), [PeerId](https://github.com/libp2p/js-peer-id), [multiaddr](https://github.com/multiformats/js-multiaddr), `string` | peer to hang up |
+| peer | [PeerInfo](https://github.com/libp2p/js-peer-info), [PeerId][peer-id], [multiaddr](https://github.com/multiformats/js-multiaddr), `string` | peer to hang up |
 
 #### Returns
 
@@ -355,7 +378,7 @@ Iterates over all peer routers in series to find the given peer. If the DHT is e
 
 | Name | Type | Description |
 |------|------|-------------|
-| peerId | [`PeerId`](https://github.com/libp2p/js-peer-id) | ID of the peer to find |
+| peerId | [`PeerId`][peer-id] | ID of the peer to find |
 | options | `Object` | operation options |
 | options.timeout | `number` | maximum time the query should run |
 
@@ -773,3 +796,6 @@ console.log(peerStats.toJSON())
     - `['60000']<MovingAverage>`: The [MovingAverage](https://www.npmjs.com/package/moving-averages) at a 1 minute interval.
     - `['300000']<MovingAverage>`: The [MovingAverage](https://www.npmjs.com/package/moving-averages) at a 5 minute interval.
     - `['900000']<MovingAverage>`: The [MovingAverage](https://www.npmjs.com/package/moving-averages) at a 15 minute interval.
+
+[connection]: https://github.com/libp2p/js-interfaces/tree/master/src/connection
+[peer-id]: https://github.com/libp2p/js-peer-id

--- a/src/index.js
+++ b/src/index.js
@@ -297,7 +297,7 @@ class Libp2p extends EventEmitter {
   /**
    * Disconnects all connections to the given `peer`
    *
-   * @param {PeerInfo|PeerId|multiaddr|string} peer The the to close connections to
+   * @param {PeerInfo|PeerId|multiaddr|string} peer the peer to close connections to
    * @returns {Promise<void>}
    */
   hangUp (peer) {

--- a/src/index.js
+++ b/src/index.js
@@ -288,12 +288,13 @@ class Libp2p extends EventEmitter {
   /**
    * Disconnects all connections to the given `peer`
    *
-   * @param {PeerId} peer The PeerId to close connections to
+   * @param {PeerInfo|PeerId|multiaddr|string} peer The the to close connections to
    * @returns {Promise<void>}
    */
   hangUp (peer) {
+    const peerInfo = getPeerInfo(peer, this.peerStore)
     return Promise.all(
-      this.registrar.connections.get(peer.toString()).map(connection => {
+      this.registrar.connections.get(peerInfo.id.toString()).map(connection => {
         return connection.close()
       })
     )

--- a/src/index.js
+++ b/src/index.js
@@ -241,6 +241,15 @@ class Libp2p extends EventEmitter {
   }
 
   /**
+   * Gets a Map of the current connections. The keys are the stringified
+   * `PeerId` of the peer. The value is an array of Connections to that peer.
+   * @returns {Map<string, Connection[]>}
+   */
+  get connections () {
+    return this.registrar.connections
+  }
+
+  /**
    * Dials to the provided peer. If successful, the `PeerInfo` of the
    * peer will be added to the nodes `peerStore`
    *

--- a/test/dialing/direct.node.js
+++ b/test/dialing/direct.node.js
@@ -296,6 +296,23 @@ describe('Dialing (direct, TCP)', () => {
       expect(connection.stat.timeline.close).to.exist()
     })
 
+    it('should be able to use hangup by address string to close connections', async () => {
+      libp2p = new Libp2p({
+        peerInfo,
+        modules: {
+          transport: [Transport],
+          streamMuxer: [Muxer],
+          connEncryption: [Crypto]
+        }
+      })
+
+      const connection = await libp2p.dial(`${remoteAddr.toString()}/p2p/${remotePeerInfo.id.toString()}`)
+      expect(connection).to.exist()
+      expect(connection.stat.timeline.close).to.not.exist()
+      await libp2p.hangUp(connection.remotePeer)
+      expect(connection.stat.timeline.close).to.exist()
+    })
+
     it('should use the protectors when provided for connecting', async () => {
       const protector = new Protector(swarmKeyBuffer)
       libp2p = new Libp2p({

--- a/test/registrar/registrar.node.js
+++ b/test/registrar/registrar.node.js
@@ -61,12 +61,12 @@ describe('registrar on dial', () => {
     }))
 
     await libp2p.dial(remoteAddr)
-    expect(libp2p.registrar.connections.size).to.equal(1)
+    expect(libp2p.connections.size).to.equal(1)
 
     sinon.spy(libp2p.registrar, 'close')
 
     await libp2p.stop()
     expect(libp2p.registrar.close.callCount).to.equal(1)
-    expect(libp2p.registrar.connections.size).to.equal(0)
+    expect(libp2p.connections.size).to.equal(0)
   })
 })


### PR DESCRIPTION
* Adds `libp2p.connections` getter to allow users to more easily get existing connections.
* Fixes `libp2p.hangUp(peer)` to take arguments that the API doc specifies.