### PR TITLE
fix: conn mngr min/max connection values

### DIFF
--- a/package.json
+++ b/package.json
@@ -59,7 +59,7 @@
     "libp2p-crypto": "^0.17.1",
     "libp2p-interfaces": "^0.1.5",
     "mafmt": "^7.0.0",
-    "merge-options": "^1.0.1",
+    "merge-options": "^2.0.0",
     "moving-average": "^1.0.0",
     "multiaddr": "^7.2.1",
     "multistream-select": "^0.15.0",

--- a/src/connection-manager/index.js
+++ b/src/connection-manager/index.js
@@ -37,7 +37,7 @@ class ConnectionManager {
     this._libp2p = libp2p
     this._registrar = libp2p.registrar
     this._peerId = libp2p.peerInfo.id.toString()
-    this._options = mergeOptions(defaultOptions, options)
+    this._options = mergeOptions.call({ ignoreUndefined: true }, defaultOptions, options)
     assert(
       this._options.maxConnections > this._options.minConnections,
       'Connection Manager maxConnections must be greater than minConnections'


### PR DESCRIPTION
Fixes the case when options are passed with `maxConnections` and/or `minConnections` set to `undefined`:

```js
{
  defaultOptions: {
    maxConnections: Infinity,
    minConnections: 0,
    maxData: Infinity,
    maxSentData: Infinity,
    maxReceivedData: Infinity,
    maxEventLoopDelay: Infinity,
    pollInterval: 2000,
    movingAverageInterval: 60000,
    defaultPeerValue: 1
  },
  options: {
    minPeers: 25,
    maxConnections: undefined,
    minConnections: undefined
  }
}
// These are the values this._options ends up with:
{ maxConnections: undefined, minConnections: undefined }
```
```console
      1) "before all" hook in "custom config"
(node:67176) UnhandledPromiseRejectionWarning: AssertionError [ERR_ASSERTION]: Connection Manager maxConnections must be greater than minConnections
    at new ConnectionManager (node_modules/libp2p/src/connection-manager/index.js:43:5)
    at new Libp2p (node_modules/libp2p/src/index.js:92:30)
    at Object.module.exports [as libp2p] (src/core/components/libp2p.js:27:10)
    at Proxy.start (src/core/components/start.js:48:31)
    at async Daemon.start (src/cli/daemon.js:63:31)
    at async startHttpAPI (test/http-api/routes.js:29:5)
    at async Context.<anonymous> (test/http-api/routes.js:48:7)
```