### PR TITLE
fix: registrar should filter the disconnected conn

### DIFF
--- a/src/registrar.js
+++ b/src/registrar.js
@@ -99,7 +99,7 @@ class Registrar {
     let storedConn = this.connections.get(id)
 
     if (storedConn && storedConn.length > 1) {
-      storedConn = storedConn.filter((conn) => conn.id === connection.id)
+      storedConn = storedConn.filter((conn) => conn.id !== connection.id)
       this.connections.set(id, storedConn)
     } else if (storedConn) {
       for (const [, topology] of this.topologies) {

--- a/test/registrar/utils.js
+++ b/test/registrar/utils.js
@@ -27,7 +27,8 @@ module.exports.createMockConnection = async (properties = {}) => {
       },
       direction: 'outbound',
       encryption: '/secio/1.0.0',
-      multiplexer: '/mplex/6.7.0'
+      multiplexer: '/mplex/6.7.0',
+      status: 'open'
     },
     newStream: (protocols) => {
       const id = streamId++


### PR DESCRIPTION
Noticed this bug on interop tests after #518 got merged. Connections were being lost and pubsub tests were hanging