### PR TITLE
fix: stop stream after first pong received

### DIFF
--- a/src/ping/index.js
+++ b/src/ping/index.js
@@ -8,7 +8,7 @@ const errCode = require('err-code')
 const crypto = require('libp2p-crypto')
 const pipe = require('it-pipe')
 const { toBuffer } = require('it-buffer')
-const { collect } = require('streaming-iterables')
+const { collect, take } = require('streaming-iterables')
 
 const { PROTOCOL, PING_LENGTH } = require('./constants')
 
@@ -29,6 +29,7 @@ async function ping (node, peer) {
   const [result] = await pipe(
     [data],
     stream,
+    stream => take(1, stream),
     toBuffer,
     collect
   )


### PR DESCRIPTION
When connecting to go-IPFS from a webworker, the stream opened by the ping protocol is never closed.

The change here uses `take` to only receive one buffer from the remote node before closing the stream.