### PR TITLE
fix: protocols change event

### DIFF
--- a/src/peer-store/index.js
+++ b/src/peer-store/index.js
@@ -132,19 +132,16 @@ class PeerStore extends EventEmitter {
         multiaddrs: recorded.multiaddrs.toArray()
       })
     }
-
-    // Update protocols
-    // TODO: better track added and removed protocols
-    const protocolsIntersection = new Set(
-      [...recorded.protocols].filter((p) => peerInfo.protocols.has(p))
-    )
-
-    if (protocolsIntersection.size !== peerInfo.protocols.size ||
-      protocolsIntersection.size !== recorded.protocols.size) {
-      for (const protocol of peerInfo.protocols) {
+    
+    let isProtocolsChanged = false
+    for (const protocol of peerInfo.protocols) {
+      if (!recorded.protocols.has(protocol)) {
+        isProtocolsChanged = true
         recorded.protocols.add(protocol)
       }
+    }
 
+    if (isProtocolsChanged) {
       this.emit('change:protocols', {
         peerInfo: recorded,
         protocols: Array.from(recorded.protocols)


### PR DESCRIPTION
I was spelunking last night and found that pubsub was constantly having it's `onConnect` handler fired from the multicodec topology.

It was because bitswap was calling `dialProtocol` to connect to a peer. `dialProtocol` makes a `PeerInfo` out of the multiaddr it's given but it has no `protocols` i.e. `[]`. This is passed to `peerStore.update()` where we compare `[]` with an array of populated protocols. Obviously there is no intersection here so `change:protocols` was being emitted, even though no protocols were added or removed.

This logic needs to be improved and tested properly but I just wanted to send a PR to document my findings.