### PR TITLE
chore: issue template mentioning js-libp2p

### DIFF
--- a/ISSUE_TEMPLATE.md
+++ b/ISSUE_TEMPLATE.md
@@ -37,7 +37,7 @@ One of following:
 
 <!--
 This is for you! Please read, and then delete this text before posting it.
-The js-ipfs issues are only for bug reports and directly actionable features.
+The js-libp2p issues are only for bug reports and directly actionable features.
 
 Read https://github.com/ipfs/community/blob/master/CONTRIBUTING.md#reporting-issues if your issue doesn't fit either of those categories.
 -->


### PR DESCRIPTION
The issue template is currently mentioning ipfs instead of libp2p