### PR TITLE
fix(test): improve flakey random walk discovery test

### DIFF
--- a/test/peer-discovery/index.node.js
+++ b/test/peer-discovery/index.node.js
@@ -139,7 +139,7 @@ describe('peer discovery scenarios', () => {
         },
         dht: {
           randomWalk: {
-            enabled: true,
+            enabled: false,
             delay: 1000, // start the first query quickly
             interval: 10000,
             timeout: 5000
@@ -149,7 +149,11 @@ describe('peer discovery scenarios', () => {
       }
     })
 
-    libp2p = new Libp2p(getConfig(peerInfo))
+    const localConfig = getConfig(peerInfo)
+    // Only run random walk on our local node
+    localConfig.config.dht.randomWalk.enabled = true
+    libp2p = new Libp2p(localConfig)
+
     const remoteLibp2p1 = new Libp2p(getConfig(remotePeerInfo1))
     const remoteLibp2p2 = new Libp2p(getConfig(remotePeerInfo2))
 

--- a/test/peer-discovery/index.node.js
+++ b/test/peer-discovery/index.node.js
@@ -142,7 +142,7 @@ describe('peer discovery scenarios', () => {
             enabled: true,
             delay: 1000, // start the first query quickly
             interval: 10000,
-            timeout: 1000
+            timeout: 5000
           },
           enabled: true
         }
@@ -161,6 +161,7 @@ describe('peer discovery scenarios', () => {
     })
 
     await Promise.all([
+      libp2p.start(),
       remoteLibp2p1.start(),
       remoteLibp2p2.start()
     ])
@@ -172,8 +173,6 @@ describe('peer discovery scenarios', () => {
       libp2p.dial(remotePeerInfo1),
       remoteLibp2p2.dial(remotePeerInfo1)
     ])
-
-    libp2p.start()
 
     await deferred.promise
     return Promise.all([


### PR DESCRIPTION
The test previously had each of the 3 peers running random walk, and started the local libp2p node after the connections were made.

This isolates the random walking to only the local node to ensure it is the only node performing active discovery.

Resolves https://github.com/libp2p/js-libp2p/issues/560