### PR TITLE
Make export explicitly `default` so that rollup can consume libp2p

### DIFF
--- a/src/index.js
+++ b/src/index.js
@@ -504,7 +504,7 @@ class Libp2p extends EventEmitter {
   }
 }
 
-module.exports = Libp2p
+module.exports.default = Libp2p
 /**
  * Like `new Libp2p(options)` except it will create a `PeerInfo`
  * instance if one is not provided in options.

--- a/src/index.js
+++ b/src/index.js
@@ -504,6 +504,7 @@ class Libp2p extends EventEmitter {
   }
 }
 
+module.exports = Libp2p
 module.exports.default = Libp2p
 /**
  * Like `new Libp2p(options)` except it will create a `PeerInfo`


### PR DESCRIPTION
I'm trying to use js-libp2p in a (browser library) project that is using Rollup.js for bundling. When just using JavaScript, I get a warning from Rollup:

```
(!) Import of non-existent export
index.js
1: import Libp2p from 'libp2p'
```

When using TypeScript, this becomes an error:

```
[!] Error: 'default' is not exported by node_modules/src/index.js, imported by src/Main.ts
https://rollupjs.org/guide/en/#error-name-is-not-exported-by-module
src/Main.ts (4:7)
4: import Libp2p from 'libp2p'
          ^
Error: 'default' is not exported by node_modules/src/index.js, imported by src/Main.ts
```

This error can be fixed by the simple change in this pull request. Thanks!