### PR TITLE
fix: pass libp2p to discovery services

### DIFF
--- a/src/index.js
+++ b/src/index.js
@@ -478,7 +478,7 @@ class Libp2p extends EventEmitter {
         let discoveryService
 
         if (typeof DiscoveryService === 'function') {
-          discoveryService = new DiscoveryService(Object.assign({}, config, { peerInfo: this.peerInfo }))
+          discoveryService = new DiscoveryService(Object.assign({}, config, { peerInfo: this.peerInfo, libp2p: this }))
         } else {
           discoveryService = DiscoveryService
         }

--- a/src/peer-store/index.js
+++ b/src/peer-store/index.js
@@ -243,7 +243,8 @@ class PeerStore extends EventEmitter {
    */
   multiaddrsForPeer (peer) {
     return this.put(peer, true).multiaddrs.toArray().map(addr => {
-      if (addr.getPeerId()) return addr
+      const idString = addr.getPeerId()
+      if (idString && idString === peer.id.toB58String()) return addr
       return addr.encapsulate(`/p2p/${peer.id.toB58String()}`)
     })
   }

--- a/test/peer-store/peer-store.spec.js
+++ b/test/peer-store/peer-store.spec.js
@@ -161,19 +161,22 @@ describe('peer-store', () => {
     expect(peerStore.peers.size).to.equal(0)
   })
 
-  it('should be able to remove a peer from store through its b58str id', async () => {
-    const [peerInfo] = await peerUtils.createPeerInfo()
+  it('should be able to get the multiaddrs for a peer', async () => {
+    const [peerInfo, relayInfo] = await peerUtils.createPeerInfo({ number: 2 })
     const id = peerInfo.id
     const ma1 = multiaddr('/ip4/127.0.0.1/tcp/4001')
     const ma2 = multiaddr('/ip4/127.0.0.1/tcp/4002/ws')
+    const ma3 = multiaddr(`/ip4/127.0.0.1/tcp/4003/ws/p2p/${relayInfo.id.toB58String()}/p2p-circuit`)
 
     peerInfo.multiaddrs.add(ma1)
     peerInfo.multiaddrs.add(ma2)
+    peerInfo.multiaddrs.add(ma3)
 
     const multiaddrs = peerStore.multiaddrsForPeer(peerInfo)
     const expectedAddrs = [
       ma1.encapsulate(`/p2p/${id.toB58String()}`),
-      ma2.encapsulate(`/p2p/${id.toB58String()}`)
+      ma2.encapsulate(`/p2p/${id.toB58String()}`),
+      ma3.encapsulate(`/p2p/${id.toB58String()}`)
     ]
 
     expect(multiaddrs).to.eql(expectedAddrs)


### PR DESCRIPTION
This adds support for passing libp2p to discovery services when creating them which makes it easier for discovery services to extend the behavior of other libp2p systems. This is value for discovery systems that may wish to use systems such as pubsub.

**Additional fix**
There was also an issue where a peers relay addresses were not being properly returned. This was due to the fact that `PeerStore.multiaddrsForPeer` was not checking the PeerId contained in the address. When we are listening on a relay we will have the PeerId of that relay in the address, so we should check to verify that the peerid in the multiaddr is not ours before returning.