### PR TITLE
fix: await peer discovery start in libp2p start

### DIFF
--- a/src/index.js
+++ b/src/index.js
@@ -399,7 +399,7 @@ class Libp2p extends EventEmitter {
    * Called when libp2p has started and before it returns
    * @private
    */
-  _onDidStart () {
+  async _onDidStart () {
     this._isStarted = true
 
     this.connectionManager.start()
@@ -410,7 +410,7 @@ class Libp2p extends EventEmitter {
     })
 
     // Peer discovery
-    this._setupPeerDiscovery()
+    await this._setupPeerDiscovery()
 
     // Once we start, emit and dial any peers we may have already discovered
     for (const peerInfo of this.peerStore.peers.values()) {


### PR DESCRIPTION
`_setupPeerDiscovery` returns a `Promise` that resolves after all discovery modules are started.
Because we are not awaiting `_setupPeerDiscovery` in the call to `libp2p.start`, we run into a situation where underlying discovery modules have not been started until after the top-level `start` has resolved.
This can lead to unintended behavior where discovery modules may be started after the libp2p instance has been stopped.

eg:
```typescript

async function startStopNode() {
  const node = createLibp2pWithDiscoveryModules();
  await node.start();
  // after ^ statement, the libp2p instance has started
  // but the discovery modules haven't, the `d.start()` calls are in a promise that hasn't been executed yet
  await node.stop();
  // after ^ statement, the libp2p instance has stopped
  // and each discovery module has called `d.stop()`
  // however the discovery modules have not actually been started.
  // eventually, the original `d.start()` calls are executed (leading to inconsistent state: libp2p stopped, discovery modules started)
}
```

This is a minimal fix to await `_setupPeerDiscovery` in the process of starting a libp2p node. The new behavior now awaits all peer discovery modules being `start`ed before resolving that the lib2p node has started.