### PR TITLE
fix: make circuit relay listening addresses more forgiving

### DIFF
--- a/src/circuit/listener.js
+++ b/src/circuit/listener.js
@@ -22,7 +22,7 @@ module.exports = (circuit) => {
    * @return {void}
    */
   listener.listen = async (addr) => {
-    const [addrString] = String(addr).split('/p2p-circuit').slice(-1)
+    const addrString = String(addr).split('/p2p-circuit').find(a => a !== '')
 
     const relayConn = await circuit._dialer.connectToPeer(multiaddr(addrString))
     const relayedAddr = relayConn.remoteAddr.encapsulate('/p2p-circuit')

--- a/test/content-routing/content-routing.node.js
+++ b/test/content-routing/content-routing.node.js
@@ -155,10 +155,7 @@ describe('content-routing', () => {
       const mockApi = nock('http://0.0.0.0:60197')
         // mock the refs call
         .post('/api/v0/refs')
-        .query({
-          recursive: false,
-          arg: cid.toBaseEncodedString()
-        })
+        .query(true)
         .reply(200, null, [
           'Content-Type', 'application/json',
           'X-Chunked-Output', '1'
@@ -174,10 +171,7 @@ describe('content-routing', () => {
       const mockApi = nock('http://0.0.0.0:60197')
         // mock the refs call
         .post('/api/v0/refs')
-        .query({
-          recursive: false,
-          arg: cid.toBaseEncodedString()
-        })
+        .query(true)
         .reply(502, 'Bad Gateway', ['Content-Type', 'application/json'])
 
       await expect(node.contentRouting.provide(cid))
@@ -192,9 +186,7 @@ describe('content-routing', () => {
 
       const mockApi = nock('http://0.0.0.0:60197')
         .post('/api/v0/dht/findprovs')
-        .query({
-          arg: cid.toBaseEncodedString()
-        })
+        .query(true)
         .reply(200, `{"Extra":"","ID":"QmWKqWXCtRXEeCQTo3FoZ7g4AfnGiauYYiczvNxFCHicbB","Responses":[{"Addrs":["/ip4/0.0.0.0/tcp/0"],"ID":"${provider}"}],"Type":4}\n`, [
           'Content-Type', 'application/json',
           'X-Chunked-Output', '1'
@@ -214,9 +206,7 @@ describe('content-routing', () => {
       const cid = new CID('QmU621oD8AhHw6t25vVyfYKmL9VV3PTgc52FngEhTGACFB')
       const mockApi = nock('http://0.0.0.0:60197')
         .post('/api/v0/dht/findprovs')
-        .query({
-          arg: cid.toBaseEncodedString()
-        })
+        .query(true)
         .reply(502, 'Bad Gateway', [
           'X-Chunked-Output', '1'
         ])

--- a/test/dialing/relay.node.js
+++ b/test/dialing/relay.node.js
@@ -149,7 +149,7 @@ describe('Dialing (via relay, TCP)', () => {
 
     // Connect the destination peer and the relay
     const tcpAddrs = dstLibp2p.transportManager.getAddrs()
-    await dstLibp2p.transportManager.listen([multiaddr(`/p2p-circuit${relayAddr}`)])
+    await dstLibp2p.transportManager.listen([multiaddr(`${relayAddr}/p2p-circuit`)])
     expect(dstLibp2p.transportManager.getAddrs()).to.have.deep.members([...tcpAddrs, dialAddr.decapsulate('p2p')])
 
     // Tamper with the our multiaddrs for the circuit message

--- a/test/peer-routing/peer-routing.node.js
+++ b/test/peer-routing/peer-routing.node.js
@@ -115,9 +115,7 @@ describe('peer-routing', () => {
       const peerKey = 'QmTp9VkYvnHyrqKQuFPiuZkiX9gPcqj6x5LJ1rmWuSySnL'
       const mockApi = nock('http://0.0.0.0:60197')
         .post('/api/v0/dht/findpeer')
-        .query({
-          arg: peerKey
-        })
+        .query(true)
         .reply(200, `{"Extra":"","ID":"some other id","Responses":null,"Type":0}\n{"Extra":"","ID":"","Responses":[{"Addrs":["/ip4/127.0.0.1/tcp/4001"],"ID":"${peerKey}"}],"Type":2}\n`, [
           'Content-Type', 'application/json',
           'X-Chunked-Output', '1'
@@ -133,9 +131,7 @@ describe('peer-routing', () => {
       const peerKey = 'key of a peer not on the network'
       const mockApi = nock('http://0.0.0.0:60197')
         .post('/api/v0/dht/findpeer')
-        .query({
-          arg: peerKey
-        })
+        .query(true)
         .reply(200, '{"Extra":"","ID":"some other id","Responses":null,"Type":6}\n{"Extra":"","ID":"yet another id","Responses":null,"Type":0}\n{"Extra":"routing:not found","ID":"","Responses":null,"Type":3}\n', [
           'Content-Type', 'application/json',
           'X-Chunked-Output', '1'
@@ -151,9 +147,7 @@ describe('peer-routing', () => {
       const peerKey = 'key of a peer not on the network'
       const mockApi = nock('http://0.0.0.0:60197')
         .post('/api/v0/dht/findpeer')
-        .query({
-          arg: peerKey
-        })
+        .query(true)
         .reply(502)
 
       await expect(node.peerRouting.findPeer(peerKey))


### PR DESCRIPTION
* Makes the delegate tests less restrictive, we don't need to mock the query params, validation should be done in the modules themselves. This should make libp2p tests more resilient to non breaking, additive changes.

This makes setting a relay address a bit more lenient. You can now use:
```
/p2p-circuit/ip4/0.0.0.0/tcp/9090/p2p/QmRelay
// or
/ip4/0.0.0.0/tcp/9090/p2p/QmRelay/p2p-circuit
```
You could previously only do the former. Both will result in the same announced address: `/ip4/0.0.0.0/tcp/9090/p2p/QmRelay/p2p-circuit/p2p/QmOurId`

