### PR TITLE
chore: rewrite peer-store submit and retrieve docs

### DIFF
--- a/src/peer-store/README.md
+++ b/src/peer-store/README.md
@@ -6,7 +6,7 @@ The PeerStore manages the high level operations on its inner books. Moreover, th
 
 ## Submitting records to the PeerStore
 
-Several libp2p subsystems will perform operations that might gather relevant informations about peers.
+Several libp2p subsystems will perform operations that might gather relevant information about peers.
 
 ### Identify
 - The Identify protocol automatically runs on every connection when multiplexing is enabled. The protocol will put the multiaddrs and protocols provided by the peer to the PeerStore.
@@ -15,14 +15,14 @@ Several libp2p subsystems will perform operations that might gather relevant inf
 - Taking into account that the Identify protocol records are directly from the peer, they should be considered the source of truth and weighted accordingly.
 
 ### Peer Discovery
-- Libp2p discovery protocols aim to discover new peers in the network. In a typical discovery protocol, addresses of the peer are discovered along its peer id. Once this happens, a libp2p discovery protocol should emit a `peer` event with the information of the discovered peer and this information it added to the PeerStore by libp2p.
+- Libp2p discovery protocols aim to discover new peers in the network. In a typical discovery protocol, addresses of the peer are discovered along with its peer id. Once this happens, a libp2p discovery protocol should emit a `peer` event with the information of the discovered peer and this information will be added to the PeerStore by libp2p.
 
 ### Dialer
-- Libp2p API supports dialing a peer through its `multiaddr`. This way, if the node is able to establish a connection with the peer listening on the given `multiaddr`, this peer and its multiaddr should be added to the PeerStore.
+- Libp2p API supports dialing a peer given a `multiaddr`, and no prior knowledge of the peer. If the node is able to establish a connection with the peer, it and its multiaddr is added to the PeerStore.
 - When a connection is being upgraded, more precisely after its encryption, or even in a discovery protocol, a libp2p node can get to know other parties public keys. In this scenario, libp2p will add the peer's public key to its `KeyBook`.
 
 ### DHT
-- On some DHT operations, such as finding providers for a given CID, nodes can exchange peer data as part of the query. This peer data can include unkwown peers multiaddrs and is also stored on the PeerStore.
+- On some DHT operations, such as finding providers for a given CID, nodes may exchange peer data as part of the query. This passive peer discovery should result in the DHT emitting the `peer` event in the same way [Peer Discovery](#peerdiscovery) does.
 
 ## Retrieving records from the PeerStore
 
@@ -33,7 +33,6 @@ When data in the PeerStore is updated the PeerStore will emit events based on th
 
 ### Protocols
 - When the known protocols of a peer change, the PeerStore emits a [`change:protocols` event][peer-store-events].
-  - Libp2p topologies will be particularly interested in this, so that the subsystem can open streams with relevant peers for them
 
 ### Multiaddrs
 - When the known listening `multiaddrs` of a peer change, the PeerStore emits a [`change:multiaddrs` event][peer-store-events].

--- a/src/peer-store/README.md
+++ b/src/peer-store/README.md
@@ -4,33 +4,39 @@ Libp2p's PeerStore is responsible for keeping an updated register with the relev
 
 The PeerStore manages the high level operations on its inner books. Moreover, the PeerStore should be responsible for notifying interested parties of relevant events, through its Event Emitter.
 
-## Data gathering
+## Submitting records to the PeerStore
 
-Several libp2p subsystems will perform operations, which will gather relevant information about peers. Some operations might not have this as an end goal, but can also gather important data.
+Several libp2p subsystems will perform operations that might gather relevant informations about peers.
 
-In a libp2p node's life, it will discover peers through its discovery protocols. In a typical discovery protocol, addresses of the peer are discovered along with its peer id. Once this happens, the PeerStore should collect this information for future (or immediate) usage by other subsystems. When the information is stored, the PeerStore should inform interested parties of the peer discovered (`peer` event).
+### Identify
+- The Identify protocol automatically runs on every connection when multiplexing is enabled. The protocol will put the multiaddrs and protocols provided by the peer to the PeerStore.
+- In the background, the Identify Service is also waiting for protocol change notifications of peers via the IdentifyPush protocol. Peers may leverage the `identify-push` message to communicate protocol changes to all connected peers, so that their PeerStore can be updated with the updated protocols.
+- While it is currently not supported in js-libp2p, future iterations may also support the [IdentifyDelta protocol](https://github.com/libp2p/specs/pull/176).
+- Taking into account that the Identify protocol records are directly from the peer, they should be considered the source of truth and weighted accordingly.
 
-Taking into account a different scenario, a peer might perform/receive a dial request to/from a unkwown peer. In such a scenario, the PeerStore must store the peer's multiaddr once a connection is established.
+### Peer Discovery
+- Libp2p discovery protocols aim to discover new peers in the network. In a typical discovery protocol, addresses of the peer are discovered along its peer id. Once this happens, a libp2p discovery protocol should emit a `peer` event with the information of the discovered peer and this information it added to the PeerStore by libp2p.
 
-When a connection is being upgraded, more precisely after its encryption, or even in a discovery protocol, a libp2p node can get to know other parties public keys. In this scenario, libp2p will add the peer's public key to its `KeyBook`.
+### Dialer
+- Libp2p API supports dialing a peer through its `multiaddr`. This way, if the node is able to establish a connection with the peer listening on the given `multiaddr`, this peer and its multiaddr should be added to the PeerStore.
+- When a connection is being upgraded, more precisely after its encryption, or even in a discovery protocol, a libp2p node can get to know other parties public keys. In this scenario, libp2p will add the peer's public key to its `KeyBook`.
 
-After a connection is established with a peer, the Identify protocol will run automatically. A stream is created and peers exchange their information (Multiaddrs, running protocols and their public key). Once this information is obtained, it should be added to the PeerStore. In this specific case, as we are speaking to the source of truth, we should ensure the PeerStore is prioritizing these records. If the recorded `multiaddrs` or `protocols` have changed, interested parties must be informed via the `change:multiaddrs` or `change:protocols` events respectively.
+### DHT
+- On some DHT operations, such as finding providers for a given CID, nodes can exchange peer data as part of the query. This peer data can include unkwown peers multiaddrs and is also stored on the PeerStore.
 
-In the background, the Identify Service is also waiting for protocol change notifications of peers via the IdentifyPush protocol. Peers may leverage the `identify-push` message to communicate protocol changes to all connected peers, so that their PeerStore can be updated with the updated protocols. As the `identify-push` also sends complete and updated information, the data in the PeerStore can be replaced.
+## Retrieving records from the PeerStore
 
-(To consider: Should we not replace until we get to multiaddr confidence? we might loose true information as we will talk with older nodes on the network.)
+When data in the PeerStore is updated the PeerStore will emit events based on the changes, to allow applications and other subsystems to take action on those changes. Any subsystem interested in these notifications should subscribe the [`PeerStore events`][peer-store-events].
 
-While it is currently not supported in js-libp2p, future iterations may also support the [IdentifyDelta protocol](https://github.com/libp2p/specs/pull/176).
+### Peer
+- Each time a new peer is discovered, the PeerStore should emit a [`peer` event][peer-store-events], so that interested parties can leverage this peer and establish a connection with it.
 
-It is also possible to gather relevant information for peers from other protocols / subsystems. For instance, in `DHT` operations, nodes can exchange peer data as part of the `DHT` operation. In this case, we can learn additional information about a peer we already know. In this scenario the PeerStore should not replace the existing data it has, just add it.
+### Protocols
+- When the known protocols of a peer change, the PeerStore emits a [`change:protocols` event][peer-store-events].
+  - Libp2p topologies will be particularly interested in this, so that the subsystem can open streams with relevant peers for them
 
-## Data Consumption
-
-When the PeerStore data is updated, this information might be important for different parties.
-
-Every time a peer needs to dial another peer, it is essential that it knows the multiaddrs used by the peer, in order to perform a successful dial to it. The same is true for pinging a peer. While the `AddressBook` is going to keep its data updated, it will also emit `change:multiaddrs` events so that subsystems/users interested in knowing these changes can be notified instead of polling the `AddressBook`.
-
-Everytime a peer starts/stops supporting a protocol, libp2p subsystems or users might need to act accordingly. `js-libp2p` registrar orchestrates known peers, established connections and protocol topologies. This way, once a protocol is supported for a peer, the topology of that protocol should be informed that a new peer may be used and the subsystem can decide if it should open a new stream with that peer or not. For these situations, the `ProtoBook` will emit `change:protocols` events whenever supported protocols of a peer change.
+### Multiaddrs
+- When the known listening `multiaddrs` of a peer change, the PeerStore emits a [`change:multiaddrs` event][peer-store-events].
 
 ## PeerStore implementation
 
@@ -132,3 +138,4 @@ Metadata is stored under the following key pattern:
 - When improving libp2p configuration, we should think about a possible way of allowing the configuration of Bootstrap to be influenced by the persisted peers, as a way to decrease the load on Bootstrap nodes.
 
 [peer-id]: https://github.com/libp2p/js-peer-id
+[peer-store-events]: ../../doc/API.md#libp2ppeerstore


### PR DESCRIPTION
As a follow up PR from #590 , more specific on this review comment: https://github.com/libp2p/js-libp2p/pull/590#discussion_r406099716 the writing format for the use cases when peer store records are submitted and retrieved is changed