### PR TITLE
feat: address management

### DIFF
--- a/doc/API.md
+++ b/doc/API.md
@@ -366,10 +366,9 @@ const latency = await libp2p.ping(otherPeerId)
 
 ## multiaddrs
 
-Get peer advertising multiaddrs. This computes the advertising multiaddrs of the peer by
-joining the multiaddrs that libp2p transports are listening on with the announce multiaddrs
-provided in hte libp2p config. No announce multiaddrs will be filtered out, even when
-using random ports in the provided multiaddrs.
+Gets the multiaddrs the libp2p node announces to the network. This computes the advertising multiaddrs 
+of the peer by joining the multiaddrs that libp2p transports are listening on with the announce multiaddrs
+provided in the libp2p config. Configured no announce multiaddrs will be filtered out of the advertised addresses.
 
 `libp2p.multiaddrs`
 
@@ -465,6 +464,7 @@ Get the multiaddrs that libp2p transports are using to listen on.
 // ...
 const listenMa = libp2p.transportManager.getAddrs()
 // [ <Multiaddr 047f00000106f9ba - /ip4/127.0.0.1/tcp/63930> ]
+```
 
 ### contentRouting.findProviders
 

--- a/doc/API.md
+++ b/doc/API.md
@@ -11,9 +11,10 @@
   * [`handle`](#handle)
   * [`unhandle`](#unhandle)
   * [`ping`](#ping)
-  * [`addressManager.listen`](#addressManagerlisten)
-  * [`addressManager.announce`](#addressManagerannounce)
-  * [`addressManager.noAnnounce`](#addressManagernoannounce)
+  * [`getAdvertisingMultiaddrs`](#getadvertisingmultiaddrs)
+  * [`addressManager.getListenMultiaddrs`](#addressmanagergetlistenmultiaddrs)
+  * [`addressmger.getAnnounceMultiaddrs`](#addressmanagergetannouncemultiaddrs)
+  * [`addressManager.getNoAnnounceMultiaddrs`](#addressmanagergetnoannouncemultiaddrs)
   * [`contentRouting.findProviders`](#contentroutingfindproviders)
   * [`contentRouting.provide`](#contentroutingprovide)
   * [`contentRouting.put`](#contentroutingput)
@@ -66,7 +67,7 @@ Creates an instance of Libp2p.
 |------|------|-------------|
 | options | `object` | libp2p options |
 | options.modules | `Array<object>` | libp2p modules to use |
-| [options.addresses] | `{ listen: Array<Multiaddr> }` | Addresses to use for transport listening and to announce to the network |
+| [options.addresses] | `{ listen: Array<string>, announce: Array<string>, noAnnounce: Array<string> }` | Addresses for transport listening and to advertise to the network |
 | [options.config] | `object` | libp2p modules configuration and core configuration |
 | [options.connectionManager] | `object` | libp2p Connection Manager configuration |
 | [options.datastore] | `object` | must implement [ipfs/interface-datastore](https://github.com/ipfs/interface-datastore) (in memory datastore will be used if not provided) |
@@ -363,43 +364,107 @@ Pings a given peer and get the operation's latency.
 const latency = await libp2p.ping(otherPeerId)
 ```
 
-### addressManager.listen
+## getAdvertisingMultiaddrs
 
-Getter for getting the addresses that the peer is using for listening on libp2p transports.
+Get peer advertising multiaddrs. This computes the advertising multiaddrs of the peer by
+joining the multiaddrs that libp2p transports are listening on with the announce multiaddrs
+provided in hte libp2p config. No announce multiaddrs will be filtered out, even when
+using random ports in the provided multiaddrs.
 
-`libp2p.addressManager.listen`
+`libp2p.getAdvertisingMultiaddrs()`
+
+#### Returns
+
+| Type | Description |
+|------|-------------|
+| `Array<Multiaddr>` | Advertising multiaddrs |
 
 #### Example
 
 ```js
 // ...
-const listenAddresses = libp2p.addressManager.listen
+const listenMa = libp2p.getAdvertisingMultiaddrs()
 // [ <Multiaddr 047f00000106f9ba - /ip4/127.0.0.1/tcp/63930> ]
 ```
 
-### addressManager.announce
+### addressManager.getListenMultiaddrs
 
-Getter for getting the addresses that the peer is announcing to other peers in the network.
+Get the multiaddrs that were provided for listening on libp2p transports.
 
-`libp2p.addressManager.announce`
+`libp2p.addressManager.getListenMultiaddrs()`
+
+#### Returns
+
+| Type | Description |
+|------|-------------|
+| `Array<Multiaddr>` | Provided listening multiaddrs |
+
+#### Example
 
 ```js
 // ...
-const announceAddresses = libp2p.addressManager.announce
+const listenMa = libp2p.addressManager.getListenMultiaddrs()
+// [ <Multiaddr 047f00000106f9ba - /ip4/127.0.0.1/tcp/63930> ]
+```
+
+### addressManager.getAnnounceMultiaddrs
+
+Get the multiaddrs that were provided to announce to the network.
+
+`libp2p.addressManager.getAnnounceMultiaddrs()`
+
+#### Returns
+
+| Type | Description |
+|------|-------------|
+| `Array<Multiaddr>` | Provided announce multiaddrs |
+
+#### Example
+
+```js
+// ...
+const announceMa = libp2p.addressManager.getAnnounceMultiaddrs()
 // [ <Multiaddr 047f00000106f9ba - /dns4/peer.io/...> ]
 ```
 
-### addressManager.noAnnounce
+### addressManager.getNoAnnounceMultiaddrs
 
-Getter for getting the addresses that the peer is not announcing in the network.
+Get the multiaddrs that were provided to not announce to the network.
 
-`libp2p.addressManager.noAnnounce`
+`libp2p.addressManager.getNoAnnounceMultiaddrs()`
+
+#### Returns
+
+| Type | Description |
+|------|-------------|
+| `Array<Multiaddr>` | Provided noAnnounce multiaddrs |
+
+#### Example
 
 ```js
 // ...
-const noAnnounceAddresses = libp2p.addressManager.noAnnounce
+const noAnnounceMa = libp2p.addressManager.getNoAnnounceMultiaddrs()
 // [ <Multiaddr 047f00000106f9ba - /ip4/127.0.0.1/tcp/63930> ]
 ```
+
+### transportManager.getAddrs
+
+Get the multiaddrs that libp2p transports are using to listen on.
+
+`libp2p.transportManager.getAddrs()`
+
+#### Returns
+
+| Type | Description |
+|------|-------------|
+| `Array<Multiaddr>` | listening multiaddrs |
+
+#### Example
+
+```js
+// ...
+const listenMa = libp2p.transportManager.getAddrs()
+// [ <Multiaddr 047f00000106f9ba - /ip4/127.0.0.1/tcp/63930> ]
 
 ### contentRouting.findProviders
 

--- a/doc/API.md
+++ b/doc/API.md
@@ -11,10 +11,10 @@
   * [`handle`](#handle)
   * [`unhandle`](#unhandle)
   * [`ping`](#ping)
-  * [`getAdvertisingMultiaddrs`](#getadvertisingmultiaddrs)
-  * [`addressManager.getListenMultiaddrs`](#addressmanagergetlistenmultiaddrs)
-  * [`addressmger.getAnnounceMultiaddrs`](#addressmanagergetannouncemultiaddrs)
-  * [`addressManager.getNoAnnounceMultiaddrs`](#addressmanagergetnoannouncemultiaddrs)
+  * [`multiaddrs`](#multiaddrs)
+  * [`addressManager.getListenAddrs`](#addressmanagergetlistenaddrs)
+  * [`addressmger.getAnnounceAddrs`](#addressmanagergetannounceaddrs)
+  * [`addressManager.getNoAnnounceAddrs`](#addressmanagergetnoannounceaddrs)
   * [`contentRouting.findProviders`](#contentroutingfindproviders)
   * [`contentRouting.provide`](#contentroutingprovide)
   * [`contentRouting.put`](#contentroutingput)
@@ -364,14 +364,14 @@ Pings a given peer and get the operation's latency.
 const latency = await libp2p.ping(otherPeerId)
 ```
 
-## getAdvertisingMultiaddrs
+## multiaddrs
 
 Get peer advertising multiaddrs. This computes the advertising multiaddrs of the peer by
 joining the multiaddrs that libp2p transports are listening on with the announce multiaddrs
 provided in hte libp2p config. No announce multiaddrs will be filtered out, even when
 using random ports in the provided multiaddrs.
 
-`libp2p.getAdvertisingMultiaddrs()`
+`libp2p.multiaddrs`
 
 #### Returns
 
@@ -383,15 +383,15 @@ using random ports in the provided multiaddrs.
 
 ```js
 // ...
-const listenMa = libp2p.getAdvertisingMultiaddrs()
+const listenMa = libp2p.multiaddrs
 // [ <Multiaddr 047f00000106f9ba - /ip4/127.0.0.1/tcp/63930> ]
 ```
 
-### addressManager.getListenMultiaddrs
+### addressManager.getListenAddrs
 
 Get the multiaddrs that were provided for listening on libp2p transports.
 
-`libp2p.addressManager.getListenMultiaddrs()`
+`libp2p.addressManager.getListenAddrs()`
 
 #### Returns
 
@@ -403,15 +403,15 @@ Get the multiaddrs that were provided for listening on libp2p transports.
 
 ```js
 // ...
-const listenMa = libp2p.addressManager.getListenMultiaddrs()
+const listenMa = libp2p.addressManager.getListenAddrs()
 // [ <Multiaddr 047f00000106f9ba - /ip4/127.0.0.1/tcp/63930> ]
 ```
 
-### addressManager.getAnnounceMultiaddrs
+### addressManager.getAnnounceAddrs
 
 Get the multiaddrs that were provided to announce to the network.
 
-`libp2p.addressManager.getAnnounceMultiaddrs()`
+`libp2p.addressManager.getAnnounceAddrs()`
 
 #### Returns
 
@@ -423,15 +423,15 @@ Get the multiaddrs that were provided to announce to the network.
 
 ```js
 // ...
-const announceMa = libp2p.addressManager.getAnnounceMultiaddrs()
+const announceMa = libp2p.addressManager.getAnnounceAddrs()
 // [ <Multiaddr 047f00000106f9ba - /dns4/peer.io/...> ]
 ```
 
-### addressManager.getNoAnnounceMultiaddrs
+### addressManager.getNoAnnounceAddrs
 
 Get the multiaddrs that were provided to not announce to the network.
 
-`libp2p.addressManager.getNoAnnounceMultiaddrs()`
+`libp2p.addressManager.getNoAnnounceAddrs()`
 
 #### Returns
 
@@ -443,7 +443,7 @@ Get the multiaddrs that were provided to not announce to the network.
 
 ```js
 // ...
-const noAnnounceMa = libp2p.addressManager.getNoAnnounceMultiaddrs()
+const noAnnounceMa = libp2p.addressManager.getNoAnnounceAddrs()
 // [ <Multiaddr 047f00000106f9ba - /ip4/127.0.0.1/tcp/63930> ]
 ```
 

--- a/doc/API.md
+++ b/doc/API.md
@@ -11,6 +11,9 @@
   * [`handle`](#handle)
   * [`unhandle`](#unhandle)
   * [`ping`](#ping)
+  * [`addressManager.listen`](#addressManagerlisten)
+  * [`addressManager.announce`](#addressManagerannounce)
+  * [`addressManager.noAnnounce`](#addressManagernoannounce)
   * [`contentRouting.findProviders`](#contentroutingfindproviders)
   * [`contentRouting.provide`](#contentroutingprovide)
   * [`contentRouting.put`](#contentroutingput)
@@ -360,31 +363,42 @@ Pings a given peer and get the operation's latency.
 const latency = await libp2p.ping(otherPeerId)
 ```
 
-### peerRouting.findPeer
+### addressManager.listen
 
-Iterates over all peer routers in series to find the given peer. If the DHT is enabled, it will be tried first.
+Getter for getting the addresses that the peer is using for listening on libp2p transports.
 
-`libp2p.peerRouting.findPeer(peerId, options)`
-
-#### Parameters
-
-| Name | Type | Description |
-|------|------|-------------|
-| peerId | [`PeerId`][peer-id] | ID of the peer to find |
-| options | `object` | operation options |
-| options.timeout | `number` | maximum time the query should run |
-
-#### Returns
-
-| Type | Description |
-|------|-------------|
-| `Promise<{ id: PeerId, multiaddrs: Multiaddr[] }>` | Peer data of a known peer |
+`libp2p.addressManager.listen`
 
 #### Example
 
 ```js
 // ...
-const peer = await libp2p.peerRouting.findPeer(peerId, options)
+const listenAddresses = libp2p.addressManager.listen
+// [ <Multiaddr 047f00000106f9ba - /ip4/127.0.0.1/tcp/63930> ]
+```
+
+### addressManager.announce
+
+Getter for getting the addresses that the peer is announcing to other peers in the network.
+
+`libp2p.addressManager.announce`
+
+```js
+// ...
+const announceAddresses = libp2p.addressManager.announce
+// [ <Multiaddr 047f00000106f9ba - /dns4/peer.io/...> ]
+```
+
+### addressManager.noAnnounce
+
+Getter for getting the addresses that the peer is not announcing in the network.
+
+`libp2p.addressManager.noAnnounce`
+
+```js
+// ...
+const noAnnounceAddresses = libp2p.addressManager.noAnnounce
+// [ <Multiaddr 047f00000106f9ba - /ip4/127.0.0.1/tcp/63930> ]
 ```
 
 ### contentRouting.findProviders
@@ -531,6 +545,33 @@ Queries the DHT for the n values stored for the given key (without sorting).
 
 const key = '/key'
 const { from, val } = await libp2p.contentRouting.get(key)
+```
+
+### peerRouting.findPeer
+
+Iterates over all peer routers in series to find the given peer. If the DHT is enabled, it will be tried first.
+
+`libp2p.peerRouting.findPeer(peerId, options)`
+
+#### Parameters
+
+| Name | Type | Description |
+|------|------|-------------|
+| peerId | [`PeerId`][peer-id] | ID of the peer to find |
+| options | `object` | operation options |
+| options.timeout | `number` | maximum time the query should run |
+
+#### Returns
+
+| Type | Description |
+|------|-------------|
+| `Promise<{ id: PeerId, multiaddrs: Multiaddr[] }>` | Peer data of a known peer |
+
+#### Example
+
+```js
+// ...
+const peer = await libp2p.peerRouting.findPeer(peerId, options)
 ```
 
 ### peerStore.addressBook.add

--- a/doc/CONFIGURATION.md
+++ b/doc/CONFIGURATION.md
@@ -204,14 +204,18 @@ Moreover, the majority of the modules can be customized via option parameters. T
 Besides the `modules` and `config`, libp2p allows other internal options and configurations:
 - `datastore`: an instance of [ipfs/interface-datastore](https://github.com/ipfs/interface-datastore/) modules.
   - This is used in modules such as the DHT. If it is not provided, `js-libp2p` will use an in memory datastore.
-- `peerInfo`: a previously created instance of [libp2p/js-peer-info](https://github.com/libp2p/js-peer-info).
+- `peerId`: a previously computed instance of [libp2p/js-peer-id](https://github.com/libp2p/js-peer-id).
   - This is particularly useful if you want to reuse the same `peer-id`, as well as for modules like `libp2p-delegated-content-routing`, which need a `peer-id` in their instantiation.
-
-TODO: Add listen/announce addresses and remove peerInfo!!
+- `addresses`: an object containing `listen`, `announce` and `noAnnounce` properties with `Array<string>`:
+  - `listen` addresses will be provided to the libp2p underlying transports for listening on them.
+  - `announce` addresses will be used to compute the advertises that the node should advertise to the network.
+  - `noAnnounce` addresses will be used as a filter to compute the advertises that the node should advertise to the network.
 
 ### Examples
 
 #### Basic setup
+
+TODO: should we add to the basic setup the configuration of listen addresses? we should probably make it a required option?
 
 ```js
 // Creating a libp2p node with:
@@ -534,7 +538,6 @@ const node = await Libp2p.create({
 ## Configuration examples
 
 As libp2p is designed to be a modular networking library, its usage will vary based on individual project needs. We've included links to some existing project configurations for your reference, in case you wish to replicate their configuration:
-
 
 - [libp2p-ipfs-nodejs](https://github.com/ipfs/js-ipfs/tree/master/src/core/runtime/libp2p-nodejs.js) - libp2p configuration used by js-ipfs when running in Node.js
 - [libp2p-ipfs-browser](https://github.com/ipfs/js-ipfs/tree/master/src/core/runtime/libp2p-browser.js) - libp2p configuration used by js-ipfs when running in a Browser (that supports WebRTC)

--- a/doc/CONFIGURATION.md
+++ b/doc/CONFIGURATION.md
@@ -207,6 +207,8 @@ Besides the `modules` and `config`, libp2p allows other internal options and con
 - `peerInfo`: a previously created instance of [libp2p/js-peer-info](https://github.com/libp2p/js-peer-info).
   - This is particularly useful if you want to reuse the same `peer-id`, as well as for modules like `libp2p-delegated-content-routing`, which need a `peer-id` in their instantiation.
 
+TODO: Add listen/announce addresses and remove peerInfo!!
+
 ### Examples
 
 #### Basic setup

--- a/doc/CONFIGURATION.md
+++ b/doc/CONFIGURATION.md
@@ -204,7 +204,7 @@ Moreover, the majority of the modules can be customized via option parameters. T
 Besides the `modules` and `config`, libp2p allows other internal options and configurations:
 - `datastore`: an instance of [ipfs/interface-datastore](https://github.com/ipfs/interface-datastore/) modules.
   - This is used in modules such as the DHT. If it is not provided, `js-libp2p` will use an in memory datastore.
-- `peerId`: a previously computed instance of [libp2p/js-peer-id](https://github.com/libp2p/js-peer-id).
+- `peerId`: the identity of the node, an instance of [libp2p/js-peer-id](https://github.com/libp2p/js-peer-id).
   - This is particularly useful if you want to reuse the same `peer-id`, as well as for modules like `libp2p-delegated-content-routing`, which need a `peer-id` in their instantiation.
 - `addresses`: an object containing `listen`, `announce` and `noAnnounce` properties with `Array<string>`:
   - `listen` addresses will be provided to the libp2p underlying transports for listening on them.
@@ -214,8 +214,6 @@ Besides the `modules` and `config`, libp2p allows other internal options and con
 ### Examples
 
 #### Basic setup
-
-TODO: should we add to the basic setup the configuration of listen addresses? we should probably make it a required option?
 
 ```js
 // Creating a libp2p node with:

--- a/doc/GETTING_STARTED.md
+++ b/doc/GETTING_STARTED.md
@@ -136,8 +136,6 @@ If you want to know more about libp2p stream multiplexing, you should read the f
 
 Now that you have configured a [**Transport**][transport], [**Crypto**][crypto] and [**Stream Multiplexer**](streamMuxer) module, you can start your libp2p node. We can start and stop libp2p using the [`libp2p.start()`](./API.md#start) and [`libp2p.stop()`](./API.md#stop) methods.
 
-TODO: add listen addresses here?
-
 ```js
 const Libp2p = require('libp2p')
 const WebSockets = require('libp2p-websockets')
@@ -145,6 +143,9 @@ const SECIO = require('libp2p-secio')
 const MPLEX = require('libp2p-mplex')
 
 const node = await Libp2p.create({
+  addresses: {
+    listen: ['/ip4/127.0.0.1/tcp/8000/ws']
+  },
   modules: {
     transport: [WebSockets],
     connEncryption: [SECIO],
@@ -155,6 +156,12 @@ const node = await Libp2p.create({
 // start libp2p
 await node.start()
 console.log('libp2p has started')
+
+const listenAddrs = node.transportManager.getAddrs()
+console.log('libp2p is listening on the following addresses: ', listenAddrs)
+
+const advertiseAddrs = node.multiaddrs
+console.log('libp2p is advertising the following addresses: ', advertiseAddrs)
 
 // stop libp2p
 await node.stop()

--- a/doc/GETTING_STARTED.md
+++ b/doc/GETTING_STARTED.md
@@ -136,6 +136,8 @@ If you want to know more about libp2p stream multiplexing, you should read the f
 
 Now that you have configured a [**Transport**][transport], [**Crypto**][crypto] and [**Stream Multiplexer**](streamMuxer) module, you can start your libp2p node. We can start and stop libp2p using the [`libp2p.start()`](./API.md#start) and [`libp2p.stop()`](./API.md#stop) methods.
 
+TODO: add listen addresses here?
+
 ```js
 const Libp2p = require('libp2p')
 const WebSockets = require('libp2p-websockets')

--- a/package.json
+++ b/package.json
@@ -94,7 +94,7 @@
     "libp2p-floodsub": "^0.21.0",
     "libp2p-gossipsub": "^0.4.0",
     "libp2p-kad-dht": "^0.19.1",
-    "libp2p-mdns": "^0.14.0",
+    "libp2p-mdns": "libp2p/js-libp2p-mdns#chore/use-address-manager",
     "libp2p-mplex": "^0.9.1",
     "libp2p-secio": "^0.12.1",
     "libp2p-tcp": "^0.14.1",

--- a/package.json
+++ b/package.json
@@ -94,7 +94,7 @@
     "libp2p-floodsub": "^0.21.0",
     "libp2p-gossipsub": "^0.4.0",
     "libp2p-kad-dht": "^0.19.1",
-    "libp2p-mdns": "libp2p/js-libp2p-mdns#chore/use-address-manager",
+    "libp2p-mdns": "^0.14.1",
     "libp2p-mplex": "^0.9.1",
     "libp2p-secio": "^0.12.1",
     "libp2p-tcp": "^0.14.1",

--- a/src/address-manager/README.md
+++ b/src/address-manager/README.md
@@ -1,0 +1,49 @@
+# Address Manager
+
+The Address manager is responsible for keeping an updated register of the peer's addresses. It includes 3 different types of Addresses: `Listen Addresses`, `Announce Addresses` and `No Announce Addresses`.
+
+These Addresses should be specified in your libp2p [configuration](../../doc/CONFIGURATION.md) when you create your node.
+
+## Listen Addresses
+
+A libp2p node should have a set of listen addresses, which will be used by libp2p underlying transports to listen for dials from other nodes in the network.
+
+Before a libp2p node starts, a set of listen addresses should be provided to the AddressManager, so that when the node is started, the libp2p transports can use them to listen for connections. Accordingly, listen addresses should be specified through the libp2p configuration, in order to have the `AddressManager` created with them.
+
+It is important pointing out that libp2p accepts to listen on addresses that intend to rely on any available local port. In this context, the provided listen addresses might not be exactly the same as the ones used by the transports. For example tcp may replace `/ip4/0.0.0.0/tcp/0` with something like `/ip4/0.0.0.0/tcp/8989`. As a consequence, libp2p should take into account this when advertising its addresses.
+
+## Announce Addresses
+
+In some scenarios, a libp2p node will need to announce addresses that it is not listening on. In other words, Announce Addresses are an amendment to the Listen Addresses that aim to enable other nodes to achieve connectivity to this node.
+
+Scenarios for Announce Addresses include:
+- when you setup a libp2p node in your private network at home, but you need to announce your public IP Address to the outside world;
+- when you want to announce a DNS address, which maps to your public IP Address.
+
+## No Announce Addresses
+
+While we need to add Announce Addresses to enable peers' connectivity, we can also not announce addresses that will not be reachable. This way, No Announce Addresses should be specified so that they are not announced by the peer as addresses that other peers can use to dial it.
+
+As stated into the Listen Addresses section, Listen Addresses might get modified after libp2p transports get in action and use them to listen for new connections. This way, libp2p should also take into account these changes so that they can be matched when No Announce Addresses are being filtered out for advertising addresses.
+
+## Implementation
+
+When a libp2p node is created, the Address Manager will be populated from the provided addresses through the libp2p configuration. Once the node is started, the Transport Manager component will gather the listen addresses from the Address Manager, so that the libp2p transports use them to listen on.
+
+Libp2p will use the the Address Manager as the source of truth when advertising the peers addresses. After all transports are ready, other libp2p components/subsystems will kickoff, namely the Identify Service and the DHT. Both of them will announce the node addresses to the other peers in the network. The announce and noAnnounce addresses will have an important role here and will be gathered by libp2p to compute its current addresses to advertise everytime it is needed.
+
+## Future Considerations
+
+### Dynamic address modifications 
+
+In a future iteration, we can enable these addresses to be modified in runtime. For this, the Address Manager should be responsible for notifying interested subsystems of these changes, through an Event Emitter.
+
+#### Modify Listen Addresses
+
+While adding new addresses to listen on runtime is a feasible operation, removing one listen address might have bad implications for the node, since all the connections using that listen address will be closed. With this in mind and taking also into consideration the lack of good use cases for removing listen addresses, the Address Manager API only allows libp2p users to add new Listen Addresses on runtime.
+
+Every time a new listen address is added, the Address Manager should emit an event with the new multiaddrs to listen. The Transport Manager should listen to this events and act accordingly.
+
+#### Modify Announce Addresses
+
+When the announce addresses are modified, the Address Manager should emit an event so that other subsystems can act accordingly. For example, libp2p identify service should use the libp2p push protocol to inform other peers about these changes.

--- a/src/address-manager/index.js
+++ b/src/address-manager/index.js
@@ -7,7 +7,7 @@ log.error = debug('libp2p:addresses:error')
 const multiaddr = require('multiaddr')
 
 /**
- * Responsible for managing the peer addresses.
+ * Responsible for managing this peers addresses.
  * Peers can specify their listen, announce and noAnnounce addresses.
  * The listen addresses will be used by the libp2p transports to listen for new connections,
  * while the announce an noAnnounce addresses will be combined with the listen addresses for
@@ -31,7 +31,7 @@ class AddressManager {
    * Get peer listen multiaddrs.
    * @return {Array<Multiaddr>}
    */
-  getListenMultiaddrs () {
+  getListenAddrs () {
     return Array.from(this.listen).map((a) => multiaddr(a))
   }
 
@@ -39,7 +39,7 @@ class AddressManager {
    * Get peer announcing multiaddrs.
    * @return {Array<Multiaddr>}
    */
-  getAnnounceMultiaddrs () {
+  getAnnounceAddrs () {
     return Array.from(this.announce).map((a) => multiaddr(a))
   }
 
@@ -47,7 +47,7 @@ class AddressManager {
    * Get peer noAnnouncing multiaddrs.
    * @return {Array<Multiaddr>}
    */
-  getNoAnnounceMultiaddrs () {
+  getNoAnnounceAddrs () {
     return Array.from(this.noAnnounce).map((a) => multiaddr(a))
   }
 }

--- a/src/address-manager/index.js
+++ b/src/address-manager/index.js
@@ -1,0 +1,55 @@
+'use strict'
+
+const debug = require('debug')
+const log = debug('libp2p:addresses')
+log.error = debug('libp2p:addresses:error')
+
+const multiaddr = require('multiaddr')
+
+/**
+ * Responsible for managing the peer addresses.
+ * Peers can specify their listen, announce and noAnnounce addresses.
+ * The listen addresses will be used by the libp2p transports to listen for new connections,
+ * while the announce an noAnnounce addresses will be combined with the listen addresses for
+ * address adverstising to other peers in the network.
+ */
+class AddressManager {
+  /**
+   * @constructor
+   * @param {object} [options]
+   * @param {Array<string>} [options.listen = []] list of multiaddrs string representation to listen.
+   * @param {Array<string>} [options.announce = []] list of multiaddrs string representation to announce.
+   * @param {Array<string>} [options.noAnnounce = []] list of multiaddrs string representation to not announce.
+   */
+  constructor ({ listen = [], announce = [], noAnnounce = [] } = {}) {
+    this.listen = new Set(listen)
+    this.announce = new Set(announce)
+    this.noAnnounce = new Set(noAnnounce)
+  }
+
+  /**
+   * Get peer listen multiaddrs.
+   * @return {Array<Multiaddr>}
+   */
+  getListenMultiaddrs () {
+    return Array.from(this.listen).map((a) => multiaddr(a))
+  }
+
+  /**
+   * Get peer announcing multiaddrs.
+   * @return {Array<Multiaddr>}
+   */
+  getAnnounceMultiaddrs () {
+    return Array.from(this.announce).map((a) => multiaddr(a))
+  }
+
+  /**
+   * Get peer noAnnouncing multiaddrs.
+   * @return {Array<Multiaddr>}
+   */
+  getNoAnnounceMultiaddrs () {
+    return Array.from(this.noAnnounce).map((a) => multiaddr(a))
+  }
+}
+
+module.exports = AddressManager

--- a/src/circuit/index.js
+++ b/src/circuit/index.js
@@ -122,7 +122,7 @@ class Circuit {
           type: CircuitPB.Type.HOP,
           srcPeer: {
             id: this.peerId.toBytes(),
-            addrs: this.addressManager.getListenMultiaddrs().map(addr => addr.buffer)
+            addrs: this.addressManager.getListenAddrs().map(addr => addr.buffer)
           },
           dstPeer: {
             id: destinationPeer.toBytes(),

--- a/src/circuit/index.js
+++ b/src/circuit/index.js
@@ -32,7 +32,7 @@ class Circuit {
     this._connectionManager = libp2p.connectionManager
     this._upgrader = upgrader
     this._options = libp2p._config.relay
-    this.addresses = libp2p.addresses
+    this.addressManager = libp2p.addressManager
     this.peerId = libp2p.peerId
     this._registrar.handle(multicodec, this._onProtocol.bind(this))
   }
@@ -122,7 +122,7 @@ class Circuit {
           type: CircuitPB.Type.HOP,
           srcPeer: {
             id: this.peerId.toBytes(),
-            addrs: this.addresses.listen.map(addr => addr.buffer)
+            addrs: this.addressManager.getListenMultiaddrs().map(addr => addr.buffer)
           },
           dstPeer: {
             id: destinationPeer.toBytes(),

--- a/src/circuit/index.js
+++ b/src/circuit/index.js
@@ -32,7 +32,7 @@ class Circuit {
     this._connectionManager = libp2p.connectionManager
     this._upgrader = upgrader
     this._options = libp2p._config.relay
-    this.addressManager = libp2p.addressManager
+    this._libp2p = libp2p
     this.peerId = libp2p.peerId
     this._registrar.handle(multicodec, this._onProtocol.bind(this))
   }
@@ -122,7 +122,7 @@ class Circuit {
           type: CircuitPB.Type.HOP,
           srcPeer: {
             id: this.peerId.toBytes(),
-            addrs: this.addressManager.getListenAddrs().map(addr => addr.buffer)
+            addrs: this._libp2p.multiaddrs.map(addr => addr.buffer)
           },
           dstPeer: {
             id: destinationPeer.toBytes(),

--- a/src/config.js
+++ b/src/config.js
@@ -5,7 +5,9 @@ const Constants = require('./constants')
 
 const DefaultConfig = {
   addresses: {
-    listen: []
+    listen: [],
+    announce: [],
+    noAnnounce: []
   },
   connectionManager: {
     minPeers: 25

--- a/src/identify/index.js
+++ b/src/identify/index.js
@@ -48,16 +48,16 @@ class IdentifyService {
    * @param {Libp2p} options.libp2p
    * @param {Map<string, handler>} options.protocols A reference to the protocols we support
    */
-  constructor (options) {
+  constructor ({ libp2p, protocols }) {
     /**
      * @property {PeerStore}
      */
-    this.peerStore = options.libp2p.peerStore
+    this.peerStore = libp2p.peerStore
 
     /**
      * @property {ConnectionManager}
      */
-    this.connectionManager = options.libp2p.connectionManager
+    this.connectionManager = libp2p.connectionManager
 
     this.connectionManager.on('peer:connect', (connection) => {
       const peerId = connection.remotePeer
@@ -68,14 +68,14 @@ class IdentifyService {
     /**
      * @property {PeerId}
      */
-    this.peerId = options.libp2p.peerId
+    this.peerId = libp2p.peerId
 
     /**
      * @property {AddressManager}
      */
-    this._libp2p = options.libp2p
+    this._libp2p = libp2p
 
-    this._protocols = options.protocols
+    this._protocols = protocols
 
     this.handleMessage = this.handleMessage.bind(this)
   }
@@ -92,7 +92,7 @@ class IdentifyService {
 
         await pipe(
           [{
-            listenAddrs: this._libp2p.getAdvertisingMultiaddrs().map((ma) => ma.buffer),
+            listenAddrs: this._libp2p.multiaddrs.map((ma) => ma.buffer),
             protocols: Array.from(this._protocols.keys())
           }],
           pb.encode(Message),
@@ -217,7 +217,7 @@ class IdentifyService {
       protocolVersion: PROTOCOL_VERSION,
       agentVersion: AGENT_VERSION,
       publicKey,
-      listenAddrs: this._libp2p.getAdvertisingMultiaddrs().map((ma) => ma.buffer),
+      listenAddrs: this._libp2p.multiaddrs.map((ma) => ma.buffer),
       observedAddr: connection.remoteAddr.buffer,
       protocols: Array.from(this._protocols.keys())
     })

--- a/src/identify/index.js
+++ b/src/identify/index.js
@@ -45,22 +45,20 @@ class IdentifyService {
   /**
    * @constructor
    * @param {object} options
-   * @param {PeerStore} options.peerStore
-   * @param {ConnectionManager} options.connectionManager
+   * @param {Libp2p} options.libp2p
    * @param {Map<string, handler>} options.protocols A reference to the protocols we support
-   * @param {PeerId} options.peerId The peer running the identify service
-   * @param {{ listen: Array<Multiaddr>}} options.addresses The peer addresses
    */
   constructor (options) {
     /**
      * @property {PeerStore}
      */
-    this.peerStore = options.peerStore
+    this.peerStore = options.libp2p.peerStore
 
     /**
      * @property {ConnectionManager}
      */
-    this.connectionManager = options.connectionManager
+    this.connectionManager = options.libp2p.connectionManager
+
     this.connectionManager.on('peer:connect', (connection) => {
       const peerId = connection.remotePeer
 
@@ -70,9 +68,12 @@ class IdentifyService {
     /**
      * @property {PeerId}
      */
-    this.peerId = options.peerId
+    this.peerId = options.libp2p.peerId
 
-    this.addresses = options.addresses || {}
+    /**
+     * @property {AddressManager}
+     */
+    this._libp2p = options.libp2p
 
     this._protocols = options.protocols
 
@@ -91,7 +92,7 @@ class IdentifyService {
 
         await pipe(
           [{
-            listenAddrs: this.addresses.listen.map((ma) => ma.buffer),
+            listenAddrs: this._libp2p.getAdvertisingMultiaddrs().map((ma) => ma.buffer),
             protocols: Array.from(this._protocols.keys())
           }],
           pb.encode(Message),
@@ -216,7 +217,7 @@ class IdentifyService {
       protocolVersion: PROTOCOL_VERSION,
       agentVersion: AGENT_VERSION,
       publicKey,
-      listenAddrs: this.addresses.listen.map((ma) => ma.buffer),
+      listenAddrs: this._libp2p.getAdvertisingMultiaddrs().map((ma) => ma.buffer),
       observedAddr: connection.remoteAddr.buffer,
       protocols: Array.from(this._protocols.keys())
     })

--- a/src/index.js
+++ b/src/index.js
@@ -297,25 +297,15 @@ class Libp2p extends EventEmitter {
    * Get peer advertising multiaddrs by concating the addresses used
    * by transports to listen with the announce addresses.
    * Duplicated addresses and noAnnounce addresses are filtered out.
-   * This takes into account random ports on matching noAnnounce addresses.
    * @return {Array<Multiaddr>}
    */
-  getAdvertisingMultiaddrs () {
+  get multiaddrs () {
     // Filter noAnnounce multiaddrs
-    const filterMa = this.addressManager.getNoAnnounceMultiaddrs()
-
-    // Special filter for noAnnounce addresses using a random port
-    // eg /ip4/0.0.0.0/tcp/0 => /ip4/192.168.1.0/tcp/58751
-    const filterSpecial = filterMa
-      .map((ma) => ({
-        protos: ma.protos(),
-        ...ma.toOptions()
-      }))
-      .filter((op) => op.port === 0)
+    const filterMa = this.addressManager.getNoAnnounceAddrs()
 
     // Create advertising list
     return this.transportManager.getAddrs()
-      .concat(this.addressManager.getAnnounceMultiaddrs())
+      .concat(this.addressManager.getAnnounceAddrs())
       .filter((ma, index, array) => {
         // Filter out if repeated
         if (array.findIndex((otherMa) => otherMa.equals(ma)) !== index) {
@@ -327,16 +317,6 @@ class Libp2p extends EventEmitter {
           return false
         }
 
-        // Filter out if in the special filter
-        const options = ma.toOptions()
-        if (filterSpecial.find((op) =>
-          op.family === options.family &&
-          op.host === options.host &&
-          op.transport === options.transport &&
-          op.protos.length === ma.protos().length
-        )) {
-          return false
-        }
         return true
       })
   }

--- a/src/index.js
+++ b/src/index.js
@@ -188,8 +188,7 @@ class Libp2p extends EventEmitter {
    */
   async start () {
     log('libp2p is starting')
-    // TODO: consider validate listen addresses on start?
-    // depend on transports?
+
     try {
       await this._onStarting()
       await this._onDidStart()

--- a/src/index.js
+++ b/src/index.js
@@ -14,6 +14,7 @@ const getPeer = require('./get-peer')
 const { validate: validateConfig } = require('./config')
 const { codes } = require('./errors')
 
+const AddressManager = require('./address-manager')
 const ConnectionManager = require('./connection-manager')
 const Circuit = require('./circuit')
 const Dialer = require('./dialer')
@@ -47,6 +48,7 @@ class Libp2p extends EventEmitter {
 
     // Addresses {listen, announce, noAnnounce}
     this.addresses = this._options.addresses
+    this.addressManager = new AddressManager(this._options.addresses)
 
     this._modules = this._options.modules
     this._config = this._options.config
@@ -122,10 +124,7 @@ class Libp2p extends EventEmitter {
 
       // Add the identify service since we can multiplex
       this.identifyService = new IdentifyService({
-        peerStore: this.peerStore,
-        connectionManager: this.connectionManager,
-        peerId: this.peerId,
-        addresses: this.addresses,
+        libp2p: this,
         protocols: this.upgrader.protocols
       })
       this.handle(Object.values(IDENTIFY_PROTOCOLS), this.identifyService.handleMessage)
@@ -189,6 +188,8 @@ class Libp2p extends EventEmitter {
    */
   async start () {
     log('libp2p is starting')
+    // TODO: consider validate listen addresses on start?
+    // depend on transports?
     try {
       await this._onStarting()
       await this._onDidStart()
@@ -293,6 +294,54 @@ class Libp2p extends EventEmitter {
   }
 
   /**
+   * Get peer advertising multiaddrs by concating the addresses used
+   * by transports to listen with the announce addresses.
+   * Duplicated addresses and noAnnounce addresses are filtered out.
+   * This takes into account random ports on matching noAnnounce addresses.
+   * @return {Array<Multiaddr>}
+   */
+  getAdvertisingMultiaddrs () {
+    // Filter noAnnounce multiaddrs
+    const filterMa = this.addressManager.getNoAnnounceMultiaddrs()
+
+    // Special filter for noAnnounce addresses using a random port
+    // eg /ip4/0.0.0.0/tcp/0 => /ip4/192.168.1.0/tcp/58751
+    const filterSpecial = filterMa
+      .map((ma) => ({
+        protos: ma.protos(),
+        ...ma.toOptions()
+      }))
+      .filter((op) => op.port === 0)
+
+    // Create advertising list
+    return this.transportManager.getAddrs()
+      .concat(this.addressManager.getAnnounceMultiaddrs())
+      .filter((ma, index, array) => {
+        // Filter out if repeated
+        if (array.findIndex((otherMa) => otherMa.equals(ma)) !== index) {
+          return false
+        }
+
+        // Filter out if in noAnnounceMultiaddrs
+        if (filterMa.find((fm) => fm.equals(ma))) {
+          return false
+        }
+
+        // Filter out if in the special filter
+        const options = ma.toOptions()
+        if (filterSpecial.find((op) =>
+          op.family === options.family &&
+          op.host === options.host &&
+          op.transport === options.transport &&
+          op.protos.length === ma.protos().length
+        )) {
+          return false
+        }
+        return true
+      })
+  }
+
+  /**
    * Disconnects all connections to the given `peer`
    * @param {PeerId|multiaddr|string} peer the peer to close connections to
    * @returns {Promise<void>}
@@ -353,14 +402,8 @@ class Libp2p extends EventEmitter {
   }
 
   async _onStarting () {
-    // Listen on the addresses provided
-    const multiaddrs = this.addresses.listen
-
-    await this.transportManager.listen(multiaddrs)
-
-    // The addresses may change once the listener starts
-    // eg /ip4/0.0.0.0/tcp/0 => /ip4/192.168.1.0/tcp/58751
-    this.addresses.listen = this.transportManager.getAddrs()
+    // Listen on the provided transports
+    await this.transportManager.listen()
 
     if (this._config.pubsub.enabled) {
       this.pubsub && this.pubsub.start()
@@ -466,7 +509,6 @@ class Libp2p extends EventEmitter {
         if (typeof DiscoveryService === 'function') {
           discoveryService = new DiscoveryService(Object.assign({}, config, {
             peerId: this.peerId,
-            multiaddrs: this.addresses.listen,
             libp2p: this
           }))
         } else {

--- a/src/transport-manager.js
+++ b/src/transport-manager.js
@@ -131,7 +131,7 @@ class TransportManager {
    * @async
    */
   async listen () {
-    const addrs = this.libp2p.addressManager.getListenMultiaddrs()
+    const addrs = this.libp2p.addressManager.getListenAddrs()
 
     if (addrs.length === 0) {
       log('no addresses were provided for listening, this node is dial only')

--- a/src/transport-manager.js
+++ b/src/transport-manager.js
@@ -127,11 +127,13 @@ class TransportManager {
   }
 
   /**
-   * Starts listeners for each given Multiaddr.
+   * Starts listeners for each listen Multiaddr.
+   * Update listen multiaddrs of the Address Manager after the operation.
    * @async
-   * @param {Multiaddr[]} addrs
    */
-  async listen (addrs) {
+  async listen () {
+    const addrs = this.libp2p.addressManager.getListenMultiaddrs()
+
     if (addrs.length === 0) {
       log('no addresses were provided for listening, this node is dial only')
       return

--- a/src/transport-manager.js
+++ b/src/transport-manager.js
@@ -128,7 +128,6 @@ class TransportManager {
 
   /**
    * Starts listeners for each listen Multiaddr.
-   * Update listen multiaddrs of the Address Manager after the operation.
    * @async
    */
   async listen () {

--- a/test/addresses/address-manager.spec.js
+++ b/test/addresses/address-manager.spec.js
@@ -32,7 +32,7 @@ describe('Address Manager', () => {
     expect(am.announce.size).to.equal(0)
     expect(am.noAnnounce.size).to.equal(0)
 
-    const listenMultiaddrs = am.getListenMultiaddrs()
+    const listenMultiaddrs = am.getListenAddrs()
     expect(listenMultiaddrs.length).to.equal(2)
     expect(listenMultiaddrs[0].equals(multiaddr(listenAddresses[0]))).to.equal(true)
     expect(listenMultiaddrs[1].equals(multiaddr(listenAddresses[1]))).to.equal(true)
@@ -48,7 +48,7 @@ describe('Address Manager', () => {
     expect(am.announce.size).to.equal(announceAddreses.length)
     expect(am.noAnnounce.size).to.equal(0)
 
-    const announceMultiaddrs = am.getAnnounceMultiaddrs()
+    const announceMultiaddrs = am.getAnnounceAddrs()
     expect(announceMultiaddrs.length).to.equal(1)
     expect(announceMultiaddrs[0].equals(multiaddr(announceAddreses[0]))).to.equal(true)
   })
@@ -63,7 +63,7 @@ describe('Address Manager', () => {
     expect(am.announce.size).to.equal(0)
     expect(am.noAnnounce.size).to.equal(listenAddresses.length)
 
-    const noAnnounceMultiaddrs = am.getNoAnnounceMultiaddrs()
+    const noAnnounceMultiaddrs = am.getNoAnnounceAddrs()
     expect(noAnnounceMultiaddrs.length).to.equal(2)
     expect(noAnnounceMultiaddrs[0].equals(multiaddr(listenAddresses[0]))).to.equal(true)
     expect(noAnnounceMultiaddrs[1].equals(multiaddr(listenAddresses[1]))).to.equal(true)

--- a/test/addresses/address-manager.spec.js
+++ b/test/addresses/address-manager.spec.js
@@ -1,0 +1,93 @@
+'use strict'
+/* eslint-env mocha */
+
+const chai = require('chai')
+chai.use(require('dirty-chai'))
+chai.use(require('chai-as-promised'))
+const { expect } = chai
+
+const multiaddr = require('multiaddr')
+
+const AddressManager = require('../../src/address-manager')
+const peerUtils = require('../utils/creators/peer')
+
+const listenAddresses = ['/ip4/127.0.0.1/tcp/15006/ws', '/ip4/127.0.0.1/tcp/15008/ws']
+const announceAddreses = ['/dns4/peer.io']
+
+describe('Address Manager', () => {
+  it('should not need any addresses', () => {
+    const am = new AddressManager()
+
+    expect(am.listen.size).to.equal(0)
+    expect(am.announce.size).to.equal(0)
+    expect(am.noAnnounce.size).to.equal(0)
+  })
+
+  it('should return listen multiaddrs on get', () => {
+    const am = new AddressManager({
+      listen: listenAddresses
+    })
+
+    expect(am.listen.size).to.equal(listenAddresses.length)
+    expect(am.announce.size).to.equal(0)
+    expect(am.noAnnounce.size).to.equal(0)
+
+    const listenMultiaddrs = am.getListenMultiaddrs()
+    expect(listenMultiaddrs.length).to.equal(2)
+    expect(listenMultiaddrs[0].equals(multiaddr(listenAddresses[0]))).to.equal(true)
+    expect(listenMultiaddrs[1].equals(multiaddr(listenAddresses[1]))).to.equal(true)
+  })
+
+  it('should return announce multiaddrs on get', () => {
+    const am = new AddressManager({
+      listen: listenAddresses,
+      announce: announceAddreses
+    })
+
+    expect(am.listen.size).to.equal(listenAddresses.length)
+    expect(am.announce.size).to.equal(announceAddreses.length)
+    expect(am.noAnnounce.size).to.equal(0)
+
+    const announceMultiaddrs = am.getAnnounceMultiaddrs()
+    expect(announceMultiaddrs.length).to.equal(1)
+    expect(announceMultiaddrs[0].equals(multiaddr(announceAddreses[0]))).to.equal(true)
+  })
+
+  it('should return noAnnounce multiaddrs on get', () => {
+    const am = new AddressManager({
+      listen: listenAddresses,
+      noAnnounce: listenAddresses
+    })
+
+    expect(am.listen.size).to.equal(listenAddresses.length)
+    expect(am.announce.size).to.equal(0)
+    expect(am.noAnnounce.size).to.equal(listenAddresses.length)
+
+    const noAnnounceMultiaddrs = am.getNoAnnounceMultiaddrs()
+    expect(noAnnounceMultiaddrs.length).to.equal(2)
+    expect(noAnnounceMultiaddrs[0].equals(multiaddr(listenAddresses[0]))).to.equal(true)
+    expect(noAnnounceMultiaddrs[1].equals(multiaddr(listenAddresses[1]))).to.equal(true)
+  })
+})
+
+describe('libp2p.addressManager', () => {
+  let libp2p
+  afterEach(() => libp2p && libp2p.stop())
+
+  it('should populate the AddressManager from the config', async () => {
+    [libp2p] = await peerUtils.createPeer({
+      started: false,
+      config: {
+        addresses: {
+          listen: listenAddresses,
+          announce: announceAddreses,
+          noAnnounce: listenAddresses
+        }
+      }
+    })
+
+    expect(libp2p.addressManager.listen.size).to.equal(listenAddresses.length)
+    expect(libp2p.addressManager.announce.size).to.equal(announceAddreses.length)
+    expect(libp2p.addressManager.noAnnounce.size).to.equal(listenAddresses.length)
+  })
+})

--- a/test/addresses/addresses.node.js
+++ b/test/addresses/addresses.node.js
@@ -13,7 +13,7 @@ const peerUtils = require('../utils/creators/peer')
 const listenAddresses = ['/ip4/127.0.0.1/tcp/0', '/ip4/127.0.0.1/tcp/8000/ws']
 const announceAddreses = ['/dns4/peer.io']
 
-describe('libp2p.getAdvertisingMultiaddrs', () => {
+describe('libp2p.multiaddrs', () => {
   let libp2p
 
   afterEach(() => libp2p && libp2p.stop())
@@ -58,12 +58,12 @@ describe('libp2p.getAdvertisingMultiaddrs', () => {
 
     const tmListen = libp2p.transportManager.getAddrs().map((ma) => ma.toString())
 
-    const spyAnnounce = sinon.spy(libp2p.addressManager, 'getAnnounceMultiaddrs')
-    const spyNoAnnounce = sinon.spy(libp2p.addressManager, 'getNoAnnounceMultiaddrs')
-    const spyListen = sinon.spy(libp2p.addressManager, 'getListenMultiaddrs')
+    const spyAnnounce = sinon.spy(libp2p.addressManager, 'getAnnounceAddrs')
+    const spyNoAnnounce = sinon.spy(libp2p.addressManager, 'getNoAnnounceAddrs')
+    const spyListen = sinon.spy(libp2p.addressManager, 'getListenAddrs')
     const spyTranspMgr = sinon.spy(libp2p.transportManager, 'getAddrs')
 
-    const advertiseMultiaddrs = libp2p.getAdvertisingMultiaddrs().map((ma) => ma.toString())
+    const advertiseMultiaddrs = libp2p.multiaddrs.map((ma) => ma.toString())
 
     expect(spyAnnounce).to.have.property('callCount', 1)
     expect(spyNoAnnounce).to.have.property('callCount', 1)
@@ -92,7 +92,7 @@ describe('libp2p.getAdvertisingMultiaddrs', () => {
       }
     })
 
-    const advertiseMultiaddrs = libp2p.getAdvertisingMultiaddrs().map((ma) => ma.toString())
+    const advertiseMultiaddrs = libp2p.multiaddrs.map((ma) => ma.toString())
 
     // Announce 2 listen (transport), ignoring duplicated in announce
     expect(advertiseMultiaddrs.length).to.equal(2)
@@ -111,33 +111,7 @@ describe('libp2p.getAdvertisingMultiaddrs', () => {
       }
     })
 
-    const advertiseMultiaddrs = libp2p.getAdvertisingMultiaddrs().map((ma) => ma.toString())
-
-    // Announce 1 listen (transport) not in the noAnnounce and the announce
-    expect(advertiseMultiaddrs.length).to.equal(2)
-
-    announceAddreses.forEach((m) => {
-      expect(advertiseMultiaddrs).to.include(m)
-    })
-    noAnnounce.forEach((m) => {
-      expect(advertiseMultiaddrs).to.not.include(m)
-    })
-  })
-
-  it('should not advertise noAnnounce addresses with random port switch', async () => {
-    const noAnnounce = [listenAddresses[0]]
-    ;[libp2p] = await peerUtils.createPeer({
-      config: {
-        ...AddressesOptions,
-        addresses: {
-          listen: listenAddresses,
-          announce: announceAddreses,
-          noAnnounce
-        }
-      }
-    })
-
-    const advertiseMultiaddrs = libp2p.getAdvertisingMultiaddrs().map((ma) => ma.toString())
+    const advertiseMultiaddrs = libp2p.multiaddrs.map((ma) => ma.toString())
 
     // Announce 1 listen (transport) not in the noAnnounce and the announce
     expect(advertiseMultiaddrs.length).to.equal(2)

--- a/test/addresses/addresses.node.js
+++ b/test/addresses/addresses.node.js
@@ -1,0 +1,152 @@
+'use strict'
+/* eslint-env mocha */
+
+const chai = require('chai')
+chai.use(require('dirty-chai'))
+chai.use(require('chai-as-promised'))
+const { expect } = chai
+const sinon = require('sinon')
+
+const { AddressesOptions } = require('./utils')
+const peerUtils = require('../utils/creators/peer')
+
+const listenAddresses = ['/ip4/127.0.0.1/tcp/0', '/ip4/127.0.0.1/tcp/8000/ws']
+const announceAddreses = ['/dns4/peer.io']
+
+describe('libp2p.getAdvertisingMultiaddrs', () => {
+  let libp2p
+
+  afterEach(() => libp2p && libp2p.stop())
+
+  it('should keep listen addresses after start, even if changed', async () => {
+    [libp2p] = await peerUtils.createPeer({
+      started: false,
+      config: {
+        ...AddressesOptions,
+        addresses: {
+          listen: listenAddresses,
+          announce: announceAddreses
+        }
+      }
+    })
+
+    let listenAddrs = libp2p.addressManager.listen
+    expect(listenAddrs.size).to.equal(listenAddresses.length)
+    expect(listenAddrs.has(listenAddresses[0])).to.equal(true)
+    expect(listenAddrs.has(listenAddresses[1])).to.equal(true)
+
+    // Should not replace listen addresses after transport listen
+    // Only transportManager has visibility of the port used
+    await libp2p.start()
+
+    listenAddrs = libp2p.addressManager.listen
+    expect(listenAddrs.size).to.equal(listenAddresses.length)
+    expect(listenAddrs.has(listenAddresses[0])).to.equal(true)
+    expect(listenAddrs.has(listenAddresses[1])).to.equal(true)
+  })
+
+  it('should advertise all addresses if noAnnounce addresses are not provided, but with correct ports', async () => {
+    [libp2p] = await peerUtils.createPeer({
+      config: {
+        ...AddressesOptions,
+        addresses: {
+          listen: listenAddresses,
+          announce: announceAddreses
+        }
+      }
+    })
+
+    const tmListen = libp2p.transportManager.getAddrs().map((ma) => ma.toString())
+
+    const spyAnnounce = sinon.spy(libp2p.addressManager, 'getAnnounceMultiaddrs')
+    const spyNoAnnounce = sinon.spy(libp2p.addressManager, 'getNoAnnounceMultiaddrs')
+    const spyListen = sinon.spy(libp2p.addressManager, 'getListenMultiaddrs')
+    const spyTranspMgr = sinon.spy(libp2p.transportManager, 'getAddrs')
+
+    const advertiseMultiaddrs = libp2p.getAdvertisingMultiaddrs().map((ma) => ma.toString())
+
+    expect(spyAnnounce).to.have.property('callCount', 1)
+    expect(spyNoAnnounce).to.have.property('callCount', 1)
+    expect(spyListen).to.have.property('callCount', 0) // Listen addr should not be used
+    expect(spyTranspMgr).to.have.property('callCount', 1)
+
+    // Announce 2 listen (transport) + 1 announce
+    expect(advertiseMultiaddrs.length).to.equal(3)
+    tmListen.forEach((m) => {
+      expect(advertiseMultiaddrs).to.include(m)
+    })
+    announceAddreses.forEach((m) => {
+      expect(advertiseMultiaddrs).to.include(m)
+    })
+    expect(advertiseMultiaddrs).to.not.include(listenAddresses[0]) // Random Port switch
+  })
+
+  it('should remove replicated addresses', async () => {
+    [libp2p] = await peerUtils.createPeer({
+      config: {
+        ...AddressesOptions,
+        addresses: {
+          listen: listenAddresses,
+          announce: [listenAddresses[1]]
+        }
+      }
+    })
+
+    const advertiseMultiaddrs = libp2p.getAdvertisingMultiaddrs().map((ma) => ma.toString())
+
+    // Announce 2 listen (transport), ignoring duplicated in announce
+    expect(advertiseMultiaddrs.length).to.equal(2)
+  })
+
+  it('should not advertise noAnnounce addresses', async () => {
+    const noAnnounce = [listenAddresses[1]]
+    ;[libp2p] = await peerUtils.createPeer({
+      config: {
+        ...AddressesOptions,
+        addresses: {
+          listen: listenAddresses,
+          announce: announceAddreses,
+          noAnnounce
+        }
+      }
+    })
+
+    const advertiseMultiaddrs = libp2p.getAdvertisingMultiaddrs().map((ma) => ma.toString())
+
+    // Announce 1 listen (transport) not in the noAnnounce and the announce
+    expect(advertiseMultiaddrs.length).to.equal(2)
+
+    announceAddreses.forEach((m) => {
+      expect(advertiseMultiaddrs).to.include(m)
+    })
+    noAnnounce.forEach((m) => {
+      expect(advertiseMultiaddrs).to.not.include(m)
+    })
+  })
+
+  it('should not advertise noAnnounce addresses with random port switch', async () => {
+    const noAnnounce = [listenAddresses[0]]
+    ;[libp2p] = await peerUtils.createPeer({
+      config: {
+        ...AddressesOptions,
+        addresses: {
+          listen: listenAddresses,
+          announce: announceAddreses,
+          noAnnounce
+        }
+      }
+    })
+
+    const advertiseMultiaddrs = libp2p.getAdvertisingMultiaddrs().map((ma) => ma.toString())
+
+    // Announce 1 listen (transport) not in the noAnnounce and the announce
+    expect(advertiseMultiaddrs.length).to.equal(2)
+
+    announceAddreses.forEach((m) => {
+      expect(advertiseMultiaddrs).to.include(m)
+    })
+    noAnnounce.forEach((m) => {
+      expect(advertiseMultiaddrs).to.not.include(m)
+    })
+  })
+})

--- a/test/addresses/utils.js
+++ b/test/addresses/utils.js
@@ -1,0 +1,16 @@
+'use strict'
+
+const Transport1 = require('libp2p-tcp')
+const Transport2 = require('libp2p-websockets')
+const mergeOptions = require('merge-options')
+const baseOptions = require('../utils/base-options')
+
+module.exports.baseOptions = baseOptions
+
+const AddressesOptions = mergeOptions(baseOptions, {
+  modules: {
+    transport: [Transport1, Transport2]
+  }
+})
+
+module.exports.AddressesOptions = AddressesOptions

--- a/test/core/listening.node.js
+++ b/test/core/listening.node.js
@@ -38,7 +38,7 @@ describe('Listening', () => {
 
     await libp2p.start()
 
-    const addrs = libp2p.addresses.listen
+    const addrs = libp2p.transportManager.getAddrs()
 
     // Should get something like:
     //   /ip4/127.0.0.1/tcp/50866

--- a/test/core/ping.node.js
+++ b/test/core/ping.node.js
@@ -21,8 +21,8 @@ describe('ping', () => {
       config: baseOptions
     })
 
-    nodes[0].peerStore.addressBook.set(nodes[1].peerId, nodes[1].getAdvertisingMultiaddrs())
-    nodes[1].peerStore.addressBook.set(nodes[0].peerId, nodes[0].getAdvertisingMultiaddrs())
+    nodes[0].peerStore.addressBook.set(nodes[1].peerId, nodes[1].multiaddrs)
+    nodes[1].peerStore.addressBook.set(nodes[0].peerId, nodes[0].multiaddrs)
   })
 
   it('ping once from peer0 to peer1', async () => {

--- a/test/core/ping.node.js
+++ b/test/core/ping.node.js
@@ -21,8 +21,8 @@ describe('ping', () => {
       config: baseOptions
     })
 
-    nodes[0].peerStore.addressBook.set(nodes[1].peerId, nodes[1].addresses.listen)
-    nodes[1].peerStore.addressBook.set(nodes[0].peerId, nodes[0].addresses.listen)
+    nodes[0].peerStore.addressBook.set(nodes[1].peerId, nodes[1].getAdvertisingMultiaddrs())
+    nodes[1].peerStore.addressBook.set(nodes[0].peerId, nodes[0].getAdvertisingMultiaddrs())
   })
 
   it('ping once from peer0 to peer1', async () => {

--- a/test/dialing/direct.node.js
+++ b/test/dialing/direct.node.js
@@ -281,7 +281,7 @@ describe('Dialing (direct, TCP)', () => {
       })
 
       sinon.spy(libp2p.dialer, 'connectToPeer')
-      libp2p.peerStore.addressBook.set(remotePeerId, remoteLibp2p.getAdvertisingMultiaddrs())
+      libp2p.peerStore.addressBook.set(remotePeerId, remoteLibp2p.multiaddrs)
 
       const connection = await libp2p.dial(remotePeerId)
       expect(connection).to.exist()
@@ -363,7 +363,7 @@ describe('Dialing (direct, TCP)', () => {
 
       const fullAddress = remoteAddr.encapsulate(`/p2p/${remoteLibp2p.peerId.toB58String()}`)
 
-      libp2p.peerStore.addressBook.set(remotePeerId, remoteLibp2p.getAdvertisingMultiaddrs())
+      libp2p.peerStore.addressBook.set(remotePeerId, remoteLibp2p.multiaddrs)
       const dialResults = await Promise.all([...new Array(dials)].map((_, index) => {
         if (index % 2 === 0) return libp2p.dial(remoteLibp2p.peerId)
         return libp2p.dial(fullAddress)
@@ -393,7 +393,7 @@ describe('Dialing (direct, TCP)', () => {
       const error = new Error('Boom')
       sinon.stub(libp2p.transportManager, 'dial').callsFake(() => Promise.reject(error))
 
-      libp2p.peerStore.addressBook.set(remotePeerId, remoteLibp2p.getAdvertisingMultiaddrs())
+      libp2p.peerStore.addressBook.set(remotePeerId, remoteLibp2p.multiaddrs)
       const dialResults = await pSettle([...new Array(dials)].map((_, index) => {
         if (index % 2 === 0) return libp2p.dial(remoteLibp2p.peerId)
         return libp2p.dial(remoteAddr)

--- a/test/dialing/relay.node.js
+++ b/test/dialing/relay.node.js
@@ -154,13 +154,13 @@ describe('Dialing (via relay, TCP)', () => {
 
     // Connect the destination peer and the relay
     const tcpAddrs = dstLibp2p.transportManager.getAddrs()
-    sinon.stub(dstLibp2p.addressManager, 'getListenMultiaddrs').returns([multiaddr(`${relayAddr}/p2p-circuit`)])
+    sinon.stub(dstLibp2p.addressManager, 'getListenAddrs').returns([multiaddr(`${relayAddr}/p2p-circuit`)])
 
     await dstLibp2p.transportManager.listen()
     expect(dstLibp2p.transportManager.getAddrs()).to.have.deep.members([...tcpAddrs, dialAddr.decapsulate('p2p')])
 
     // Tamper with the our multiaddrs for the circuit message
-    sinon.stub(srcLibp2p.addressManager, 'getListenMultiaddrs').returns([{
+    sinon.stub(srcLibp2p.addressManager, 'getListenAddrs').returns([{
       buffer: Buffer.from('an invalid multiaddr')
     }])
 

--- a/test/dialing/relay.node.js
+++ b/test/dialing/relay.node.js
@@ -160,7 +160,7 @@ describe('Dialing (via relay, TCP)', () => {
     expect(dstLibp2p.transportManager.getAddrs()).to.have.deep.members([...tcpAddrs, dialAddr.decapsulate('p2p')])
 
     // Tamper with the our multiaddrs for the circuit message
-    sinon.stub(srcLibp2p.addressManager, 'getListenAddrs').returns([{
+    sinon.stub(srcLibp2p, 'multiaddrs').value([{
       buffer: Buffer.from('an invalid multiaddr')
     }])
 

--- a/test/dialing/relay.node.js
+++ b/test/dialing/relay.node.js
@@ -5,6 +5,7 @@ const chai = require('chai')
 chai.use(require('dirty-chai'))
 chai.use(require('chai-as-promised'))
 const { expect } = chai
+const sinon = require('sinon')
 
 const multiaddr = require('multiaddr')
 const { collect } = require('streaming-iterables')
@@ -24,7 +25,7 @@ describe('Dialing (via relay, TCP)', () => {
   let relayLibp2p
   let dstLibp2p
 
-  before(async () => {
+  beforeEach(async () => {
     const peerIds = await createPeerId({ number: 3 })
     // Create 3 nodes, and turn HOP on for the relay
     ;[srcLibp2p, relayLibp2p, dstLibp2p] = peerIds.map((peerId, index) => {
@@ -68,7 +69,9 @@ describe('Dialing (via relay, TCP)', () => {
       .encapsulate(`/p2p-circuit/p2p/${dstLibp2p.peerId.toB58String()}`)
 
     const tcpAddrs = dstLibp2p.transportManager.getAddrs()
-    await dstLibp2p.transportManager.listen([multiaddr(`/p2p-circuit${relayAddr}/p2p/${relayIdString}`)])
+    sinon.stub(dstLibp2p.addressManager, 'listen').value([multiaddr(`/p2p-circuit${relayAddr}/p2p/${relayIdString}`)])
+
+    await dstLibp2p.transportManager.listen()
     expect(dstLibp2p.transportManager.getAddrs()).to.have.deep.members([...tcpAddrs, dialAddr.decapsulate('p2p')])
 
     const connection = await srcLibp2p.dial(dialAddr)
@@ -151,13 +154,15 @@ describe('Dialing (via relay, TCP)', () => {
 
     // Connect the destination peer and the relay
     const tcpAddrs = dstLibp2p.transportManager.getAddrs()
-    await dstLibp2p.transportManager.listen([multiaddr(`${relayAddr}/p2p-circuit`)])
+    sinon.stub(dstLibp2p.addressManager, 'getListenMultiaddrs').returns([multiaddr(`${relayAddr}/p2p-circuit`)])
+
+    await dstLibp2p.transportManager.listen()
     expect(dstLibp2p.transportManager.getAddrs()).to.have.deep.members([...tcpAddrs, dialAddr.decapsulate('p2p')])
 
     // Tamper with the our multiaddrs for the circuit message
-    srcLibp2p.addresses.listen = [{
+    sinon.stub(srcLibp2p.addressManager, 'getListenMultiaddrs').returns([{
       buffer: Buffer.from('an invalid multiaddr')
-    }]
+    }])
 
     await expect(srcLibp2p.dial(dialAddr))
       .to.eventually.be.rejectedWith(AggregateError)

--- a/test/identify/index.spec.js
+++ b/test/identify/index.spec.js
@@ -44,28 +44,28 @@ describe('Identify', () => {
 
   it('should be able to identify another peer', async () => {
     const localIdentify = new IdentifyService({
-      peerId: localPeer,
-      addresses: {
-        listen: []
-      },
-      protocols,
-      connectionManager: new EventEmitter(),
-      peerStore: {
-        addressBook: {
-          set: () => { }
+      libp2p: {
+        peerId: localPeer,
+        connectionManager: new EventEmitter(),
+        peerStore: {
+          addressBook: {
+            set: () => { }
+          },
+          protoBook: {
+            set: () => { }
+          }
         },
-        protoBook: {
-          set: () => { }
-        }
-      }
+        getAdvertisingMultiaddrs: () => []
+      },
+      protocols
     })
     const remoteIdentify = new IdentifyService({
-      peerId: remotePeer,
-      addresses: {
-        listen: []
+      libp2p: {
+        peerId: remotePeer,
+        connectionManager: new EventEmitter(),
+        getAdvertisingMultiaddrs: () => []
       },
-      protocols,
-      connectionManager: new EventEmitter()
+      protocols
     })
 
     const observedAddr = multiaddr('/ip4/127.0.0.1/tcp/1234')
@@ -97,28 +97,28 @@ describe('Identify', () => {
 
   it('should throw if identified peer is the wrong peer', async () => {
     const localIdentify = new IdentifyService({
-      peerId: localPeer,
-      addresses: {
-        listen: []
-      },
-      protocols,
-      connectionManager: new EventEmitter(),
-      peerStore: {
-        addressBook: {
-          set: () => { }
+      libp2p: {
+        peerId: localPeer,
+        connectionManager: new EventEmitter(),
+        peerStore: {
+          addressBook: {
+            set: () => { }
+          },
+          protoBook: {
+            set: () => { }
+          }
         },
-        protoBook: {
-          set: () => { }
-        }
-      }
+        getAdvertisingMultiaddrs: () => []
+      },
+      protocols
     })
     const remoteIdentify = new IdentifyService({
-      peerId: remotePeer,
-      addresses: {
-        listen: []
+      libp2p: {
+        peerId: remotePeer,
+        connectionManager: new EventEmitter(),
+        getAdvertisingMultiaddrs: () => []
       },
-      protocols,
-      connectionManager: new EventEmitter()
+      protocols
     })
 
     const observedAddr = multiaddr('/ip4/127.0.0.1/tcp/1234')
@@ -150,11 +150,11 @@ describe('Identify', () => {
       connectionManager.getConnection = () => {}
 
       const localIdentify = new IdentifyService({
-        peerId: localPeer,
-        addresses: {
-          listen: [listeningAddr]
+        libp2p: {
+          peerId: localPeer,
+          connectionManager: new EventEmitter(),
+          getAdvertisingMultiaddrs: () => [listeningAddr]
         },
-        connectionManager,
         protocols: new Map([
           [multicodecs.IDENTIFY],
           [multicodecs.IDENTIFY_PUSH],
@@ -162,18 +162,18 @@ describe('Identify', () => {
         ])
       })
       const remoteIdentify = new IdentifyService({
-        peerId: remotePeer,
-        addresses: {
-          listen: []
-        },
-        connectionManager,
-        peerStore: {
-          addressBook: {
-            set: () => { }
+        libp2p: {
+          peerId: remotePeer,
+          connectionManager,
+          peerStore: {
+            addressBook: {
+              set: () => { }
+            },
+            protoBook: {
+              set: () => { }
+            }
           },
-          protoBook: {
-            set: () => { }
-          }
+          getAdvertisingMultiaddrs: () => []
         }
       })
 

--- a/test/identify/index.spec.js
+++ b/test/identify/index.spec.js
@@ -55,7 +55,7 @@ describe('Identify', () => {
             set: () => { }
           }
         },
-        getAdvertisingMultiaddrs: () => []
+        multiaddrs: []
       },
       protocols
     })
@@ -63,7 +63,7 @@ describe('Identify', () => {
       libp2p: {
         peerId: remotePeer,
         connectionManager: new EventEmitter(),
-        getAdvertisingMultiaddrs: () => []
+        multiaddrs: []
       },
       protocols
     })
@@ -108,7 +108,7 @@ describe('Identify', () => {
             set: () => { }
           }
         },
-        getAdvertisingMultiaddrs: () => []
+        multiaddrs: []
       },
       protocols
     })
@@ -116,7 +116,7 @@ describe('Identify', () => {
       libp2p: {
         peerId: remotePeer,
         connectionManager: new EventEmitter(),
-        getAdvertisingMultiaddrs: () => []
+        multiaddrs: []
       },
       protocols
     })
@@ -153,7 +153,7 @@ describe('Identify', () => {
         libp2p: {
           peerId: localPeer,
           connectionManager: new EventEmitter(),
-          getAdvertisingMultiaddrs: () => [listeningAddr]
+          multiaddrs: [listeningAddr]
         },
         protocols: new Map([
           [multicodecs.IDENTIFY],
@@ -173,7 +173,7 @@ describe('Identify', () => {
               set: () => { }
             }
           },
-          getAdvertisingMultiaddrs: () => []
+          multiaddrs: []
         }
       })
 

--- a/test/peer-discovery/index.node.js
+++ b/test/peer-discovery/index.node.js
@@ -177,8 +177,8 @@ describe('peer discovery scenarios', () => {
       remoteLibp2p2.start()
     ])
 
-    libp2p.peerStore.addressBook.set(remotePeerId1, remoteLibp2p1.getAdvertisingMultiaddrs())
-    remoteLibp2p2.peerStore.addressBook.set(remotePeerId1, remoteLibp2p1.getAdvertisingMultiaddrs())
+    libp2p.peerStore.addressBook.set(remotePeerId1, remoteLibp2p1.multiaddrs)
+    remoteLibp2p2.peerStore.addressBook.set(remotePeerId1, remoteLibp2p1.multiaddrs)
 
     // Topology:
     // A -> B

--- a/test/peer-discovery/index.node.js
+++ b/test/peer-discovery/index.node.js
@@ -177,8 +177,8 @@ describe('peer discovery scenarios', () => {
       remoteLibp2p2.start()
     ])
 
-    libp2p.peerStore.addressBook.set(remotePeerId1, remoteLibp2p1.addresses.listen)
-    remoteLibp2p2.peerStore.addressBook.set(remotePeerId1, remoteLibp2p1.addresses.listen)
+    libp2p.peerStore.addressBook.set(remotePeerId1, remoteLibp2p1.getAdvertisingMultiaddrs())
+    remoteLibp2p2.peerStore.addressBook.set(remotePeerId1, remoteLibp2p1.getAdvertisingMultiaddrs())
 
     // Topology:
     // A -> B

--- a/test/pubsub/implementations.node.js
+++ b/test/pubsub/implementations.node.js
@@ -75,7 +75,7 @@ describe('Pubsub subsystem is able to use different implementations', () => {
     ])
 
     const libp2pId = libp2p.peerId.toB58String()
-    libp2p.peerStore.addressBook.set(remotePeerId, remoteLibp2p.addresses.listen)
+    libp2p.peerStore.addressBook.set(remotePeerId, remoteLibp2p.getAdvertisingMultiaddrs())
 
     const connection = await libp2p.dialProtocol(remotePeerId, multicodec)
     expect(connection).to.exist()

--- a/test/pubsub/implementations.node.js
+++ b/test/pubsub/implementations.node.js
@@ -75,7 +75,7 @@ describe('Pubsub subsystem is able to use different implementations', () => {
     ])
 
     const libp2pId = libp2p.peerId.toB58String()
-    libp2p.peerStore.addressBook.set(remotePeerId, remoteLibp2p.getAdvertisingMultiaddrs())
+    libp2p.peerStore.addressBook.set(remotePeerId, remoteLibp2p.multiaddrs)
 
     const connection = await libp2p.dialProtocol(remotePeerId, multicodec)
     expect(connection).to.exist()

--- a/test/pubsub/operation.node.js
+++ b/test/pubsub/operation.node.js
@@ -47,7 +47,7 @@ describe('Pubsub subsystem operates correctly', () => {
         remoteLibp2p.start()
       ])
 
-      libp2p.peerStore.addressBook.set(remotePeerId, remoteLibp2p.getAdvertisingMultiaddrs())
+      libp2p.peerStore.addressBook.set(remotePeerId, remoteLibp2p.multiaddrs)
     })
 
     afterEach(() => Promise.all([
@@ -124,7 +124,7 @@ describe('Pubsub subsystem operates correctly', () => {
       await libp2p.start()
       await remoteLibp2p.start()
 
-      libp2p.peerStore.addressBook.set(remotePeerId, remoteLibp2p.getAdvertisingMultiaddrs())
+      libp2p.peerStore.addressBook.set(remotePeerId, remoteLibp2p.multiaddrs)
     })
 
     afterEach(() => Promise.all([

--- a/test/pubsub/operation.node.js
+++ b/test/pubsub/operation.node.js
@@ -47,7 +47,7 @@ describe('Pubsub subsystem operates correctly', () => {
         remoteLibp2p.start()
       ])
 
-      libp2p.peerStore.addressBook.set(remotePeerId, remoteLibp2p.addresses.listen)
+      libp2p.peerStore.addressBook.set(remotePeerId, remoteLibp2p.getAdvertisingMultiaddrs())
     })
 
     afterEach(() => Promise.all([
@@ -124,7 +124,7 @@ describe('Pubsub subsystem operates correctly', () => {
       await libp2p.start()
       await remoteLibp2p.start()
 
-      libp2p.peerStore.addressBook.set(remotePeerId, remoteLibp2p.addresses.listen)
+      libp2p.peerStore.addressBook.set(remotePeerId, remoteLibp2p.getAdvertisingMultiaddrs())
     })
 
     afterEach(() => Promise.all([

--- a/test/transports/transport-manager.node.js
+++ b/test/transports/transport-manager.node.js
@@ -4,6 +4,8 @@
 const chai = require('chai')
 chai.use(require('dirty-chai'))
 const { expect } = chai
+
+const AddressManager = require('../../src/address-manager')
 const TransportManager = require('../../src/transport-manager')
 const Transport = require('libp2p-tcp')
 const multiaddr = require('multiaddr')
@@ -18,7 +20,9 @@ describe('Transport Manager (TCP)', () => {
 
   before(() => {
     tm = new TransportManager({
-      libp2p: {},
+      libp2p: {
+        addressManager: new AddressManager({ listen: addrs })
+      },
       upgrader: mockUpgrader,
       onConnection: () => {}
     })
@@ -37,7 +41,7 @@ describe('Transport Manager (TCP)', () => {
 
   it('should be able to listen', async () => {
     tm.add(Transport.prototype[Symbol.toStringTag], Transport)
-    await tm.listen(addrs)
+    await tm.listen()
     expect(tm._listeners).to.have.key(Transport.prototype[Symbol.toStringTag])
     expect(tm._listeners.get(Transport.prototype[Symbol.toStringTag])).to.have.length(addrs.length)
     // Ephemeral ip addresses may result in multiple listeners
@@ -48,7 +52,7 @@ describe('Transport Manager (TCP)', () => {
 
   it('should be able to dial', async () => {
     tm.add(Transport.prototype[Symbol.toStringTag], Transport)
-    await tm.listen(addrs)
+    await tm.listen()
     const addr = tm.getAddrs().shift()
     const connection = await tm.dial(addr)
     expect(connection).to.exist()

--- a/test/transports/transport-manager.spec.js
+++ b/test/transports/transport-manager.spec.js
@@ -9,6 +9,7 @@ const sinon = require('sinon')
 
 const multiaddr = require('multiaddr')
 const Transport = require('libp2p-websockets')
+const AddressManager = require('../../src/address-manager')
 const TransportManager = require('../../src/transport-manager')
 const mockUpgrader = require('../utils/mockUpgrader')
 const { MULTIADDRS_WEBSOCKETS } = require('../fixtures/browser')
@@ -17,12 +18,16 @@ const Libp2p = require('../../src')
 const Peers = require('../fixtures/peers')
 const PeerId = require('peer-id')
 
+const listenAddr = multiaddr('/ip4/127.0.0.1/tcp/0')
+
 describe('Transport Manager (WebSockets)', () => {
   let tm
 
   before(() => {
     tm = new TransportManager({
-      libp2p: {},
+      libp2p: {
+        addressManager: new AddressManager({ listen: [listenAddr] })
+      },
       upgrader: mockUpgrader,
       onConnection: () => {}
     })
@@ -78,9 +83,8 @@ describe('Transport Manager (WebSockets)', () => {
 
   it('should fail to listen with no valid address', async () => {
     tm.add(Transport.prototype[Symbol.toStringTag], Transport)
-    const addrs = [multiaddr('/ip4/127.0.0.1/tcp/0')]
 
-    await expect(tm.listen(addrs))
+    await expect(tm.listen())
       .to.eventually.be.rejected()
       .and.to.have.property('code', ErrorCodes.ERR_NO_VALID_ADDRESSES)
   })

--- a/test/utils/creators/peer.js
+++ b/test/utils/creators/peer.js
@@ -21,13 +21,14 @@ const listenAddr = multiaddr('/ip4/127.0.0.1/tcp/0')
  * @param {boolean} [properties.populateAddressBooks] nodes addressBooks should be populated with other peers (default: true)
  * @return {Promise<Array<Libp2p>>}
  */
-async function createPeer ({ number = 1, fixture = true, started = true, populateAddressBooks = true, config = defaultOptions } = {}) {
+async function createPeer ({ number = 1, fixture = true, started = true, populateAddressBooks = true, config = {} } = {}) {
   const peerIds = await createPeerId({ number, fixture })
 
   const addresses = started ? { listen: [listenAddr] } : {}
   const peers = await pTimes(number, (i) => Libp2p.create({
     peerId: peerIds[i],
     addresses,
+    ...defaultOptions,
     ...config
   }))
 
@@ -44,7 +45,7 @@ function _populateAddressBooks (peers) {
   for (let i = 0; i < peers.length; i++) {
     for (let j = 0; j < peers.length; j++) {
       if (i !== j) {
-        peers[i].peerStore.addressBook.set(peers[j].peerId, peers[j].addresses.listen)
+        peers[i].peerStore.addressBook.set(peers[j].peerId, peers[j].getAdvertisingMultiaddrs())
       }
     }
   }

--- a/test/utils/creators/peer.js
+++ b/test/utils/creators/peer.js
@@ -45,7 +45,7 @@ function _populateAddressBooks (peers) {
   for (let i = 0; i < peers.length; i++) {
     for (let j = 0; j < peers.length; j++) {
       if (i !== j) {
-        peers[i].peerStore.addressBook.set(peers[j].peerId, peers[j].getAdvertisingMultiaddrs())
+        peers[i].peerStore.addressBook.set(peers[j].peerId, peers[j].multiaddrs)
       }
     }
   }


### PR DESCRIPTION
This PR adds an Address Management component. This component aims to allow users to add to the libp2p configuration `{ listen, announce, noAnnounce }` addresses.

These addresses will be used by each subsystem according to their needs. The details for the reasoning for these addresses are detailed on `/src/address-manager/README.md`, which should be read in this branch (last commit)

Needs:

- [x]  Address Manager tests
- [x] Remove multiaddrs from discovery
- [x]  Consider Listen addresses update on `noAnnounce` addresses filtering
- [x]  Improve configuration doc

Closes #202 

Depends on:
- [x]  #610 
- [x]  #613 
- [x]  #611 
- [x] [libp2p/js-libp2p-mdns#91](https://github.com/libp2p/js-libp2p-mdns/pull/91)