### PR TITLE
chore: rename peer-store properties

### DIFF
--- a/doc/API.md
+++ b/doc/API.md
@@ -381,7 +381,7 @@ Iterates over all peer routers in series to find the given peer. If the DHT is e
 
 ```js
 // ...
-const peerData = await libp2p.peerRouting.findPeer(peerId, options)
+const peer = await libp2p.peerRouting.findPeer(peerId, options)
 ```
 
 ### contentRouting.findProviders
@@ -585,7 +585,7 @@ peerStore.addressBook.delete(peerId)
 
 ### peerStore.addressBook.get
 
-Get the known [`MultiaddrInfos`][multiaddr-info] of a provided peer.
+Get the known [`Addresses`][address] of a provided peer.
 
 `peerStore.addressBook.get(peerId)`
 
@@ -599,7 +599,7 @@ Get the known [`MultiaddrInfos`][multiaddr-info] of a provided peer.
 
 | Type | Description |
 |------|-------------|
-| `Array<MultiaddrInfo>` | Array of peer's multiaddr with their relevant information [`MultiaddrInfo`][multiaddr-info] |
+| `Array<Address>` | Array of peer's [`Addresses`][address] containing the multiaddr and its metadata |
 
 #### Example
 
@@ -818,7 +818,7 @@ peerStore.delete(peerId2)
 
 ### peerStore.get
 
-Get the stored information of a given peer, namely its [`PeerId`][peer-id], known [`MultiaddrInfos`][multiaddr-info] and supported protocols.
+Get the stored information of a given peer, namely its [`PeerId`][peer-id], known [`Addresses`][address] and supported protocols.
 
 `peerStore.get(peerId)`
 
@@ -832,7 +832,7 @@ Get the stored information of a given peer, namely its [`PeerId`][peer-id], know
 
 | Type | Description |
 |------|-------------|
-| `{ id: PeerId, multiaddrInfos: Array<MultiaddrInfo>, protocols: Array<string> }` | Peer information of the provided peer |
+| `{ id: PeerId, addresses: Array<Address>, protocols: Array<string> }` | Peer information of the provided peer |
 
 #### Example
 
@@ -844,7 +844,7 @@ peerStore.protoBook.set(peerId, protocols)
 peerStore.get(peerId)
 // {
 //   id: {},
-//   MultiaddrInfos: [...],
+//   addresses: [...],
 //   protocols: [...]
 // }
 ```
@@ -859,13 +859,13 @@ Get all the stored information of every peer.
 
 | Type | Description |
 |------|-------------|
-| `Map<string, { id: PeerId, multiaddrInfos: Array<MultiaddrInfo>, protocols: Array<string> }>` | Peer data of every peer known |
+| `Map<string, { id: PeerId, addresses: Array<Address>, protocols: Array<string> }>` | Peer data of every peer known |
 
 #### Example
 
 ```js
-for (let [peerIdString, peerData] of peerStore.peers.entries()) {
-  // peerData
+for (let [peerIdString, peer] of peerStore.peers.entries()) {
+  // peer { id, addresses, protocols }
 }
 ```
 
@@ -1184,7 +1184,7 @@ This event will be triggered anytime we are disconnected from another peer, rega
     - `['300000']<MovingAverage>`: The [MovingAverage](https://www.npmjs.com/package/moving-averages) at a 5 minute interval.
     - `['900000']<MovingAverage>`: The [MovingAverage](https://www.npmjs.com/package/moving-averages) at a 15 minute interval.
 
-[multiaddr-info]: https://github.com/libp2p/js-libp2p/tree/master/src/peer-store/address-book.js
+[address]: https://github.com/libp2p/js-libp2p/tree/master/src/peer-store/address-book.js
 [cid]: https://github.com/multiformats/js-cid
 [connection]: https://github.com/libp2p/js-interfaces/tree/master/src/connection
 [multiaddr]: https://github.com/multiformats/js-multiaddr

--- a/package.json
+++ b/package.json
@@ -93,7 +93,7 @@
     "libp2p-delegated-peer-routing": "^0.5.0",
     "libp2p-floodsub": "^0.21.0",
     "libp2p-gossipsub": "^0.4.0",
-    "libp2p-kad-dht": "^0.19.0",
+    "libp2p-kad-dht": "libp2p/js-libp2p-kad-dht#chore/rename-peer-store-properties",
     "libp2p-mdns": "^0.14.0",
     "libp2p-mplex": "^0.9.1",
     "libp2p-secio": "^0.12.1",

--- a/package.json
+++ b/package.json
@@ -93,7 +93,7 @@
     "libp2p-delegated-peer-routing": "^0.5.0",
     "libp2p-floodsub": "^0.21.0",
     "libp2p-gossipsub": "^0.4.0",
-    "libp2p-kad-dht": "libp2p/js-libp2p-kad-dht#chore/rename-peer-store-properties",
+    "libp2p-kad-dht": "^0.19.1",
     "libp2p-mdns": "^0.14.0",
     "libp2p-mplex": "^0.9.1",
     "libp2p-secio": "^0.12.1",

--- a/src/content-routing.js
+++ b/src/content-routing.js
@@ -42,8 +42,8 @@ module.exports = (node) => {
         })
       )
 
-      for (const peerData of result) {
-        yield peerData
+      for (const peer of result) {
+        yield peer
       }
     },
 

--- a/src/index.js
+++ b/src/index.js
@@ -267,7 +267,7 @@ class Libp2p extends EventEmitter {
   }
 
   /**
-   * Dials to the provided peer. If successful, the known `PeerData` of the
+   * Dials to the provided peer. If successful, the known `Peer` data of the
    * peer will be added to the nodes `peerStore`
    * @param {PeerId|Multiaddr|string} peer The peer to dial
    * @param {object} options
@@ -280,7 +280,7 @@ class Libp2p extends EventEmitter {
 
   /**
    * Dials to the provided peer and handshakes with the given protocol.
-   * If successful, the known `PeerData` of the peer will be added to the nodes `peerStore`,
+   * If successful, the known `Peer` data of the peer will be added to the nodes `peerStore`,
    * and the `Connection` will be returned
    * @async
    * @param {PeerId|Multiaddr|string} peer The peer to dial
@@ -295,7 +295,7 @@ class Libp2p extends EventEmitter {
 
     if (!connection) {
       connection = await this.dialer.connectToPeer(peer, options)
-    } else {
+    } else if (multiaddrs) {
       this.peerStore.addressBook.add(id, multiaddrs)
     }
 
@@ -412,9 +412,9 @@ class Libp2p extends EventEmitter {
     await this._setupPeerDiscovery()
 
     // Once we start, emit and dial any peers we may have already discovered
-    for (const peerData of this.peerStore.peers.values()) {
-      this.emit('peer:discovery', peerData.id)
-      this._maybeConnect(peerData.id)
+    for (const peer of this.peerStore.peers.values()) {
+      this.emit('peer:discovery', peer.id)
+      this._maybeConnect(peer.id)
     }
   }
 
@@ -422,16 +422,16 @@ class Libp2p extends EventEmitter {
    * Called whenever peer discovery services emit `peer` events.
    * Known peers may be emitted.
    * @private
-   * @param {PeerDara} peerData
+   * @param {PeerDara} peer
    */
-  _onDiscoveryPeer (peerData) {
-    if (peerData.id.toB58String() === this.peerId.toB58String()) {
+  _onDiscoveryPeer (peer) {
+    if (peer.id.toB58String() === this.peerId.toB58String()) {
       log.error(new Error(codes.ERR_DISCOVERED_SELF))
       return
     }
 
-    peerData.multiaddrs && this.peerStore.addressBook.add(peerData.id, peerData.multiaddrs)
-    peerData.protocols && this.peerStore.protoBook.set(peerData.id, peerData.protocols)
+    peer.multiaddrs && this.peerStore.addressBook.add(peer.id, peer.multiaddrs)
+    peer.protocols && this.peerStore.protoBook.set(peer.id, peer.protocols)
   }
 
   /**

--- a/src/peer-store/README.md
+++ b/src/peer-store/README.md
@@ -40,9 +40,9 @@ The PeerStore wraps four main components: `addressBook`, `keyBook`, `protocolBoo
 
 The `addressBook` keeps the known multiaddrs of a peer. The multiaddrs of each peer may change over time and the Address Book must account for this.
 
-`Map<string, multiaddrInfo>`
+`Map<string, Address>`
 
-A `peerId.toString()` identifier mapping to a `multiaddrInfo` object, which should have the following structure:
+A `peerId.toString()` identifier mapping to a `Address` object, which should have the following structure:
 
 ```js
 {

--- a/src/peer-store/index.js
+++ b/src/peer-store/index.js
@@ -23,10 +23,10 @@ const {
  */
 class PeerStore extends EventEmitter {
   /**
-   * PeerData object
-   * @typedef {Object} PeerData
+   * Peer object
+   * @typedef {Object} Peer
    * @property {PeerId} id peer's peer-id instance.
-   * @property {Array<multiaddrInfo>} multiaddrsInfos peer's information of the multiaddrs.
+   * @property {Array<Address>} addresses peer's addresses containing its multiaddrs and metadata.
    * @property {Array<string>} protocols peer's supported protocols.
    */
 
@@ -34,7 +34,7 @@ class PeerStore extends EventEmitter {
     super()
 
     /**
-     * AddressBook containing a map of peerIdStr to multiaddrsInfo
+     * AddressBook containing a map of peerIdStr to Address
      */
     this.addressBook = new AddressBook(this)
 
@@ -53,17 +53,17 @@ class PeerStore extends EventEmitter {
 
   /**
    * Get all the stored information of every peer.
-   * @returns {Map<string, PeerData>}
+   * @returns {Map<string, Peer>}
    */
   get peers () {
     const peersData = new Map()
 
     // AddressBook
-    for (const [idStr, multiaddrInfos] of this.addressBook.data.entries()) {
+    for (const [idStr, addresses] of this.addressBook.data.entries()) {
       const id = PeerId.createFromCID(idStr)
       peersData.set(idStr, {
         id,
-        multiaddrInfos,
+        addresses,
         protocols: this.protoBook.get(id) || []
       })
     }
@@ -75,7 +75,7 @@ class PeerStore extends EventEmitter {
       if (!pData) {
         peersData.set(idStr, {
           id: PeerId.createFromCID(idStr),
-          multiaddrInfos: [],
+          addresses: [],
           protocols: Array.from(protocols)
         })
       }
@@ -98,7 +98,7 @@ class PeerStore extends EventEmitter {
   /**
    * Get the stored information of a given peer.
    * @param {PeerId} peerId
-   * @returns {PeerData}
+   * @returns {Peer}
    */
   get (peerId) {
     if (!PeerId.isPeerId(peerId)) {
@@ -106,16 +106,16 @@ class PeerStore extends EventEmitter {
     }
 
     const id = this.peerIds.get(peerId.toB58String())
-    const multiaddrInfos = this.addressBook.get(peerId)
+    const addresses = this.addressBook.get(peerId)
     const protocols = this.protoBook.get(peerId)
 
-    if (!multiaddrInfos && !protocols) {
+    if (!addresses && !protocols) {
       return undefined
     }
 
     return {
       id: id || peerId,
-      multiaddrInfos: multiaddrInfos || [],
+      addresses: addresses || [],
       protocols: protocols || []
     }
   }

--- a/test/peer-routing/peer-routing.node.js
+++ b/test/peer-routing/peer-routing.node.js
@@ -121,9 +121,9 @@ describe('peer-routing', () => {
           'X-Chunked-Output', '1'
         ])
 
-      const peerData = await node.peerRouting.findPeer(peerKey)
+      const peer = await node.peerRouting.findPeer(peerKey)
 
-      expect(peerData.id).to.equal(peerKey)
+      expect(peer.id).to.equal(peerKey)
       expect(mockApi.isDone()).to.equal(true)
     })
 

--- a/test/peer-store/address-book.spec.js
+++ b/test/peer-store/address-book.spec.js
@@ -69,8 +69,8 @@ describe('addressBook', () => {
       })
 
       ab.set(peerId, supportedMultiaddrs)
-      const multiaddrInfos = ab.get(peerId)
-      const multiaddrs = multiaddrInfos.map((mi) => mi.multiaddr)
+      const addresses = ab.get(peerId)
+      const multiaddrs = addresses.map((mi) => mi.multiaddr)
       expect(multiaddrs).to.have.deep.members(supportedMultiaddrs)
 
       return defer.promise
@@ -95,8 +95,8 @@ describe('addressBook', () => {
 
       // set 2 (same content)
       ab.set(peerId, supportedMultiaddrsB)
-      const multiaddrInfos = ab.get(peerId)
-      const multiaddrs = multiaddrInfos.map((mi) => mi.multiaddr)
+      const addresses = ab.get(peerId)
+      const multiaddrs = addresses.map((mi) => mi.multiaddr)
       expect(multiaddrs).to.have.deep.members(supportedMultiaddrsB)
 
       await defer.promise
@@ -177,14 +177,14 @@ describe('addressBook', () => {
 
       // Replace
       ab.set(peerId, supportedMultiaddrsA)
-      let multiaddrInfos = ab.get(peerId)
-      let multiaddrs = multiaddrInfos.map((mi) => mi.multiaddr)
+      let addresses = ab.get(peerId)
+      let multiaddrs = addresses.map((mi) => mi.multiaddr)
       expect(multiaddrs).to.have.deep.members(supportedMultiaddrsA)
 
       // Add
       ab.add(peerId, supportedMultiaddrsB)
-      multiaddrInfos = ab.get(peerId)
-      multiaddrs = multiaddrInfos.map((mi) => mi.multiaddr)
+      addresses = ab.get(peerId)
+      multiaddrs = addresses.map((mi) => mi.multiaddr)
       expect(multiaddrs).to.have.deep.members(finalMultiaddrs)
 
       return defer.promise
@@ -210,8 +210,8 @@ describe('addressBook', () => {
 
       // set 2 (content already existing)
       ab.add(peerId, supportedMultiaddrsB)
-      const multiaddrInfos = ab.get(peerId)
-      const multiaddrs = multiaddrInfos.map((mi) => mi.multiaddr)
+      const addresses = ab.get(peerId)
+      const multiaddrs = addresses.map((mi) => mi.multiaddr)
       expect(multiaddrs).to.have.deep.members(finalMultiaddrs)
 
       await defer.promise
@@ -261,9 +261,9 @@ describe('addressBook', () => {
     })
 
     it('returns undefined if no multiaddrs are known for the provided peer', () => {
-      const multiaddrInfos = ab.get(peerId)
+      const addresses = ab.get(peerId)
 
-      expect(multiaddrInfos).to.not.exist()
+      expect(addresses).to.not.exist()
     })
 
     it('returns the multiaddrs stored', () => {
@@ -271,8 +271,8 @@ describe('addressBook', () => {
 
       ab.set(peerId, supportedMultiaddrs)
 
-      const multiaddrInfos = ab.get(peerId)
-      const multiaddrs = multiaddrInfos.map((mi) => mi.multiaddr)
+      const addresses = ab.get(peerId)
+      const multiaddrs = addresses.map((mi) => mi.multiaddr)
       expect(multiaddrs).to.have.deep.members(supportedMultiaddrs)
     })
   })
@@ -292,9 +292,9 @@ describe('addressBook', () => {
     })
 
     it('returns undefined if no multiaddrs are known for the provided peer', () => {
-      const multiaddrInfos = ab.getMultiaddrsForPeer(peerId)
+      const addresses = ab.getMultiaddrsForPeer(peerId)
 
-      expect(multiaddrInfos).to.not.exist()
+      expect(addresses).to.not.exist()
     })
 
     it('returns the multiaddrs stored', () => {

--- a/test/peer-store/peer-store.spec.js
+++ b/test/peer-store/peer-store.spec.js
@@ -45,8 +45,8 @@ describe('peer-store', () => {
     })
 
     it('returns undefined on trying to find a non existant peerId', () => {
-      const peerInfo = peerStore.get(peerIds[0])
-      expect(peerInfo).to.not.exist()
+      const peer = peerStore.get(peerIds[0])
+      expect(peer).to.not.exist()
     })
   })
 
@@ -102,29 +102,29 @@ describe('peer-store', () => {
     })
 
     it('gets the stored information of a peer in all its books', () => {
-      const peerInfo = peerStore.get(peerIds[0])
-      expect(peerInfo).to.exist()
-      expect(peerInfo.protocols).to.have.members([proto1])
+      const peer = peerStore.get(peerIds[0])
+      expect(peer).to.exist()
+      expect(peer.protocols).to.have.members([proto1])
 
-      const peerMultiaddrs = peerInfo.multiaddrInfos.map((mi) => mi.multiaddr)
+      const peerMultiaddrs = peer.addresses.map((mi) => mi.multiaddr)
       expect(peerMultiaddrs).to.have.members([addr1, addr2])
     })
 
     it('gets the stored information of a peer that is not present in all its books', () => {
-      const peerInfo = peerStore.get(peerIds[2])
-      expect(peerInfo).to.exist()
-      expect(peerInfo.protocols.length).to.eql(0)
+      const peers = peerStore.get(peerIds[2])
+      expect(peers).to.exist()
+      expect(peers.protocols.length).to.eql(0)
 
-      const peerMultiaddrs = peerInfo.multiaddrInfos.map((mi) => mi.multiaddr)
+      const peerMultiaddrs = peers.addresses.map((mi) => mi.multiaddr)
       expect(peerMultiaddrs).to.have.members([addr4])
     })
 
     it('can find all the peers supporting a protocol', () => {
       const peerSupporting2 = []
 
-      for (const [, peerInfo] of peerStore.peers.entries()) {
-        if (peerInfo.protocols.includes(proto2)) {
-          peerSupporting2.push(peerInfo)
+      for (const [, peer] of peerStore.peers.entries()) {
+        if (peer.protocols.includes(proto2)) {
+          peerSupporting2.push(peer)
         }
       }
 
@@ -136,11 +136,11 @@ describe('peer-store', () => {
     it('can find all the peers listening on a given address', () => {
       const peerListenint4 = []
 
-      for (const [, peerInfo] of peerStore.peers.entries()) {
-        const multiaddrs = peerInfo.multiaddrInfos.map((mi) => mi.multiaddr)
+      for (const [, peer] of peerStore.peers.entries()) {
+        const multiaddrs = peer.addresses.map((mi) => mi.multiaddr)
 
         if (multiaddrs.includes(addr4)) {
-          peerListenint4.push(peerInfo)
+          peerListenint4.push(peer)
         }
       }
 


### PR DESCRIPTION
Per [libp2p/js-libp2p#610](https://github.com/libp2p/js-libp2p/pull/610) review, we are renaming `MultiaddrInfo` into `Address`, and `peerStore.get` return value from `PeerData` into `peer` with an `addresses` property instead of `multiaddrInfos`.

This needs:

- [x] [libp2p/js-libp2p-kad-dht#184](https://github.com/libp2p/js-libp2p-kad-dht/pull/184) - bidirectional