### PR TITLE
Reset peer store after stop

### DIFF
--- a/src/index.js
+++ b/src/index.js
@@ -244,6 +244,7 @@ class Libp2p extends EventEmitter {
         this.emit('error', err)
       }
     }
+    this.peerStore.clear()
     this._isStarted = false
     log('libp2p has stopped')
   }

--- a/src/peer-store/index.js
+++ b/src/peer-store/index.js
@@ -218,6 +218,13 @@ class PeerStore extends EventEmitter {
   }
 
   /**
+   * Clears all entries from the PeerStore
+   */
+  clear () {
+    this.peers.clear()
+  }
+
+  /**
    * Completely replaces the existing peers metadata with the given `peerInfo`
    * @param {PeerInfo} peerInfo
    * @returns {void}

--- a/src/peer-store/index.js
+++ b/src/peer-store/index.js
@@ -176,6 +176,9 @@ class PeerStore extends EventEmitter {
    */
   get (peerId) {
     // TODO: deprecate this and just accept `PeerId` instances
+    if (PeerInfo.isPeerInfo(peerId)) {
+      peerId = peerId.id
+    }
     if (PeerId.isPeerId(peerId)) {
       peerId = peerId.toB58String()
     }
@@ -190,6 +193,9 @@ class PeerStore extends EventEmitter {
    */
   has (peerId) {
     // TODO: deprecate this and just accept `PeerId` instances
+    if (PeerInfo.isPeerInfo(peerId)) {
+      peerId = peerId.id
+    }
     if (PeerId.isPeerId(peerId)) {
       peerId = peerId.toB58String()
     }

--- a/test/core/peer-store.node.js
+++ b/test/core/peer-store.node.js
@@ -1,0 +1,36 @@
+'use strict'
+/* eslint-env mocha */
+
+const chai = require('chai')
+chai.use(require('dirty-chai'))
+const { expect } = chai
+
+const Transport = require('libp2p-tcp')
+
+const { create } = require('../../src')
+const peerUtils = require('../utils/creators/peer')
+
+describe('Peer store', () => {
+  let peerInfoSelf
+  let libp2p
+
+  before(async () => {
+    [peerInfoSelf] = await peerUtils.createPeerInfo()
+  })
+
+  it('should should remove peers after stop', async () => {
+    libp2p = await create({
+      peerInfoSelf,
+      modules: {
+        transport: [Transport]
+      }
+    })
+
+    await libp2p.start()
+    const [peerInfoFriend] = await peerUtils.createPeerInfo()
+    libp2p.peerStore.add(peerInfoFriend)
+    expect(libp2p.peerStore.has(peerInfoFriend.id)).to.equal(true)
+    await libp2p.stop()
+    // expect(libp2p.peerStore.has(peerInfoFriend.id)).to.equal(false)
+  })
+})


### PR DESCRIPTION
- Clear up has/get to accept `PeerInfo` for parity
- Clear peer store after stop, to avoid lingering peers upon reconnect
- Add tests