### PR TITLE
Clear old discovery modules upon reconnect

### DIFF
--- a/src/index.js
+++ b/src/index.js
@@ -225,6 +225,8 @@ class Libp2p extends EventEmitter {
 
       await Promise.all(Array.from(this._discovery.values(), s => s.stop()))
 
+      this._discovery = new Map()
+
       this.connectionManager.stop()
 
       await Promise.all([


### PR DESCRIPTION
Clear `libp2p._discovery` upon `libp2p.start()` in order to avoid lingering modules.

An alternative would be to initialize once (without starting) and call `service.start/stop` in conjunction with `libp2p.start/stop`. Let me know, happy to alter if so.