### PR TITLE
fix: libp2p connections getter

### DIFF
--- a/package.json
+++ b/package.json
@@ -105,8 +105,7 @@
     "p-times": "^2.1.0",
     "p-wait-for": "^3.1.0",
     "sinon": "^9.0.0",
-    "streaming-iterables": "^4.1.0",
-    "wrtc": "^0.4.1"
+    "streaming-iterables": "^4.1.0"
   },
   "contributors": [
     "David Dias <daviddias.p@gmail.com>",

--- a/src/index.js
+++ b/src/index.js
@@ -248,7 +248,7 @@ class Libp2p extends EventEmitter {
    * @returns {Map<string, Connection[]>}
    */
   get connections () {
-    return this.registrar.connections
+    return this.connectionManager.connections
   }
 
   /**

--- a/test/content-routing/dht/configuration.node.js
+++ b/test/content-routing/dht/configuration.node.js
@@ -6,13 +6,12 @@ chai.use(require('dirty-chai'))
 const { expect } = chai
 
 const mergeOptions = require('merge-options')
-const multiaddr = require('multiaddr')
 
 const { create } = require('../../../src')
 const { baseOptions, subsystemOptions } = require('./utils')
 const peerUtils = require('../../utils/creators/peer')
 
-const listenAddr = multiaddr('/ip4/127.0.0.1/tcp/0')
+const listenAddr = '/ip4/127.0.0.1/tcp/0'
 
 describe('DHT subsystem is configurable', () => {
   let libp2p

--- a/test/content-routing/dht/operation.node.js
+++ b/test/content-routing/dht/operation.node.js
@@ -5,9 +5,9 @@ const chai = require('chai')
 chai.use(require('dirty-chai'))
 const { expect } = chai
 
+const multiaddr = require('multiaddr')
 const pWaitFor = require('p-wait-for')
 const mergeOptions = require('merge-options')
-const multiaddr = require('multiaddr')
 
 const { create } = require('../../../src')
 const { subsystemOptions, subsystemMulticodecs } = require('./utils')

--- a/test/core/listening.node.js
+++ b/test/core/listening.node.js
@@ -5,13 +5,12 @@ const chai = require('chai')
 chai.use(require('dirty-chai'))
 const { expect } = chai
 
-const multiaddr = require('multiaddr')
 const Transport = require('libp2p-tcp')
 
 const { create } = require('../../src')
 const peerUtils = require('../utils/creators/peer')
 
-const listenAddr = multiaddr('/ip4/0.0.0.0/tcp/0')
+const listenAddr = '/ip4/0.0.0.0/tcp/0'
 
 describe('Listening', () => {
   let peerId

--- a/test/dialing/relay.node.js
+++ b/test/dialing/relay.node.js
@@ -18,7 +18,7 @@ const baseOptions = require('../utils/base-options')
 const Libp2p = require('../../src')
 const { codes: Errors } = require('../../src/errors')
 
-const listenAddr = multiaddr('/ip4/0.0.0.0/tcp/0')
+const listenAddr = '/ip4/0.0.0.0/tcp/0'
 
 describe('Dialing (via relay, TCP)', () => {
   let srcLibp2p


### PR DESCRIPTION
After #611 registrar does not keep the connections anymore. This introduced a bug that was not covered in the tests, which is the `libp2p.connections` getter. This getter was using the older `connections` property from the registrar.

This PR fixes the above issue, adds a test for it and removes redundant `multiaddr` creation on a few tests.