### PR TITLE
docs: remove Tech Lead from README

### DIFF
--- a/README.md
+++ b/README.md
@@ -39,10 +39,6 @@ If you are looking for the documentation of the latest release, you can view the
 
 [**`Weekly Core Dev Calls`**](https://github.com/ipfs/pm/issues/650)
 
-## Tech Lead
-
-[David Dias](https://github.com/diasdavid/)
-
 ## Lead Maintainer
 
 [Jacob Heun](https://github.com/jacobheun/)


### PR DESCRIPTION
I've been effectively not contributing as Tech Lead for a several months now, so not worth having my name there and mislead folks.

I see this is a natural transition, specially after all the great work from @jacobheun and @vasco-santos as the Lead Maintainers of the entire set of libp2p modules. You've made the project so much better, thank you for taking really great care of it, as you can imagine, it means a lot to me ❤️