### PR TITLE
chore: remove wrtc devdep

### DIFF
--- a/package.json
+++ b/package.json
@@ -106,8 +106,7 @@
     "p-defer": "^3.0.0",
     "p-times": "^3.0.0",
     "p-wait-for": "^3.1.0",
-    "sinon": "^9.0.2",
-    "wrtc": "^0.4.1"
+    "sinon": "^9.0.2"
   },
   "contributors": [
     "David Dias <daviddias.p@gmail.com>",


### PR DESCRIPTION
`wrtc` dev dependency is not needed anympre