### PR TITLE
fix: onConnect should not add addr to the addressBook

### DIFF
--- a/src/connection-manager/index.js
+++ b/src/connection-manager/index.js
@@ -182,7 +182,6 @@ class ConnectionManager extends EventEmitter {
       this.emit('peer:connect', connection)
     }
 
-    this._libp2p.peerStore.addressBook.add(peerId, [connection.remoteAddr])
     this._libp2p.peerStore.keyBook.set(peerId, peerId.pubKey)
 
     if (!this._peerValues.has(peerIdStr)) {

--- a/test/identify/index.spec.js
+++ b/test/identify/index.spec.js
@@ -242,8 +242,8 @@ describe('Identify', () => {
       expect(connection).to.exist()
 
       // Wait for peer store to be updated
-      // Dialer._createDialTarget (add), Connected (add), Identify (replace)
-      await pWaitFor(() => peerStoreSpySet.callCount === 1 && peerStoreSpyAdd.callCount === 2)
+      // Dialer._createDialTarget (add), Identify (replace)
+      await pWaitFor(() => peerStoreSpySet.callCount === 1 && peerStoreSpyAdd.callCount === 1)
       expect(libp2p.identifyService.identify.callCount).to.equal(1)
 
       // The connection should have no open streams

--- a/test/peer-store/peer-store.node.js
+++ b/test/peer-store/peer-store.node.js
@@ -24,7 +24,6 @@ describe('libp2p.peerStore', () => {
   })
 
   it('adds peer address to AddressBook and keys to the keybook when establishing connection', async () => {
-    const idStr = libp2p.peerId.toB58String()
     const remoteIdStr = remoteLibp2p.peerId.toB58String()
 
     const spyAddressBook = sinon.spy(libp2p.peerStore.addressBook, 'add')
@@ -44,9 +43,7 @@ describe('libp2p.peerStore', () => {
     // const publicKeyInLocalPeer = localPeers.get(remoteIdStr).id.pubKey
     // expect(publicKeyInLocalPeer.bytes).to.equalBytes(remoteLibp2p.peerId.pubKey.bytes)
 
-    const remotePeers = remoteLibp2p.peerStore.peers
-    expect(remotePeers.size).to.equal(1)
-    const publicKeyInRemotePeer = remotePeers.get(idStr).id.pubKey
+    const publicKeyInRemotePeer = remoteLibp2p.peerStore.keyBook.get(libp2p.peerId)
     expect(publicKeyInRemotePeer).to.exist()
     expect(publicKeyInRemotePeer.bytes).to.equalBytes(libp2p.peerId.pubKey.bytes)
   })


### PR DESCRIPTION
On the `KeyBook` PR, I added in the `onConnect` handler the addr of the connection to the addressBook and the public key to the keyBook.

I realised when updating the libp2p-daemon PR that this is not correct! This is adding to the addressBook the multiaddr with the port where the connection between these 2 nodes is established, not the listening multiaddr of the peer. This is problematic because the DHT will provide these multiaddrs in the `findProviders` / `findPeer`.

The correct multiaddrs will be added once the identifyService finishes