### PR TITLE
chore: uncomment local peer public key after connect test

### DIFF
--- a/package.json
+++ b/package.json
@@ -106,7 +106,7 @@
     "libp2p-kad-dht": "^0.19.1",
     "libp2p-mdns": "^0.14.1",
     "libp2p-mplex": "^0.9.5",
-    "libp2p-noise": "^1.1.0",
+    "libp2p-noise": "^1.1.1",
     "libp2p-secio": "^0.12.4",
     "libp2p-tcp": "^0.14.1",
     "libp2p-webrtc-star": "^0.18.0",

--- a/test/peer-store/peer-store.node.js
+++ b/test/peer-store/peer-store.node.js
@@ -40,9 +40,8 @@ describe('libp2p.peerStore', () => {
     const localPeers = libp2p.peerStore.peers
     expect(localPeers.size).to.equal(1)
 
-    // TODO: needs https://github.com/NodeFactoryIo/js-libp2p-noise/issues/58
-    // const publicKeyInLocalPeer = localPeers.get(remoteIdStr).id.pubKey
-    // expect(publicKeyInLocalPeer.bytes).to.equalBytes(remoteLibp2p.peerId.pubKey.bytes)
+    const publicKeyInLocalPeer = localPeers.get(remoteIdStr).id.pubKey
+    expect(publicKeyInLocalPeer.bytes).to.equalBytes(remoteLibp2p.peerId.pubKey.bytes)
 
     const remotePeers = remoteLibp2p.peerStore.peers
     expect(remotePeers.size).to.equal(1)


### PR DESCRIPTION
This got pending on a `noise` update after #626 got merged.