### PR TITLE
fix: expose the muxed stream interface on inbound streams

### DIFF
--- a/src/upgrader.js
+++ b/src/upgrader.js
@@ -232,7 +232,7 @@ class Upgrader {
             log('%s: incoming stream opened on %s', direction, protocol)
             if (this.metrics) this.metrics.trackStream({ stream, remotePeer, protocol })
             connection.addStream(muxedStream, { protocol })
-            this._onStream({ connection, stream, protocol })
+            this._onStream({ connection, stream: { ...muxedStream, ...stream }, protocol })
           } catch (err) {
             log.error(err)
           }


### PR DESCRIPTION
Inbound streams aren't exposing the muxed stream interface (id, timeline, close, etc). Outbound streams are already doing this.