### PR TITLE
fix: always emit when a connection is made

### DIFF
--- a/src/connection-manager/index.js
+++ b/src/connection-manager/index.js
@@ -175,11 +175,11 @@ class ConnectionManager extends EventEmitter {
     const peerIdStr = peerId.toB58String()
     const storedConn = this.connections.get(peerIdStr)
 
+    this.emit('peer:connect', connection)
     if (storedConn) {
       storedConn.push(connection)
     } else {
       this.connections.set(peerIdStr, [connection])
-      this.emit('peer:connect', connection)
     }
 
     this._libp2p.peerStore.keyBook.set(peerId, peerId.pubKey)


### PR DESCRIPTION
This is a bit noisy but matches the current behavior of 0.27. The problem with only emitting the first connection is that a parallel dial to a peer may result in the first connection being closed by the dialer. This would cause identify to fail and never be run again for the peer.

We should attempt to reduce the noise in the future and be more intelligent with the notifications, but that might be best to do during the connection manager overhaul.