### PR TITLE
chore: use interop release

### DIFF
--- a/package.json
+++ b/package.json
@@ -92,7 +92,7 @@
     "datastore-level": "^1.1.0",
     "delay": "^4.3.0",
     "dirty-chai": "^2.0.1",
-    "interop-libp2p": "libp2p/interop#chore/update-libp2p-daemon-with-peerstore",
+    "interop-libp2p": "^0.1.0",
     "ipfs-http-client": "^44.0.0",
     "it-concat": "^1.0.0",
     "it-pair": "^1.0.0",


### PR DESCRIPTION
Per `libp2p@0.28` release and [libp2p/interop#36](https://github.com/libp2p/interop/pull/36) merged, we can now use its new version instead of relying in the branch