### PR TITLE
feat: add ConnectionManager#getAll

### DIFF
--- a/src/connection-manager/index.js
+++ b/src/connection-manager/index.js
@@ -230,6 +230,26 @@ class ConnectionManager extends EventEmitter {
   }
 
   /**
+   * Get all open connections with a peer.
+   * @param {PeerId} peerId
+   * @returns {Array<Connection>}
+   */
+  getAll (peerId) {
+    if (!PeerId.isPeerId(peerId)) {
+      throw errcode(new Error('peerId must be an instance of peer-id'), ERR_INVALID_PARAMETERS)
+    }
+
+    const id = peerId.toB58String()
+    const connections = this.connections.get(id)
+
+    // Return all open connections
+    if (connections) {
+      return connections.filter(connection => connection.stat.status === 'open')
+    }
+    return []
+  }
+
+  /**
    * If the event loop is slow, maybe close a connection
    * @private
    * @param {*} summary The LatencyMonitor summary

--- a/src/connection-manager/index.js
+++ b/src/connection-manager/index.js
@@ -215,16 +215,9 @@ class ConnectionManager extends EventEmitter {
    * @returns {Connection}
    */
   get (peerId) {
-    if (!PeerId.isPeerId(peerId)) {
-      throw errcode(new Error('peerId must be an instance of peer-id'), ERR_INVALID_PARAMETERS)
-    }
-
-    const id = peerId.toB58String()
-    const connections = this.connections.get(id)
-
-    // Return the first, open connection
-    if (connections) {
-      return connections.find(connection => connection.stat.status === 'open')
+    const connections = this.getAll(peerId)
+    if (connections.length) {
+      return connections[0]
     }
     return null
   }


### PR DESCRIPTION
The implementation is _almost_ identical to `ConnectionManager#get` except instead of returning the first open connection or null, `getAll` returns an array of _all_ open connections (or an empty array).

Perhaps `get` could be refactored to use `getAll` to avoid code duplication?

Open to any suggestions, naming, implementation, otherwise

See https://github.com/ChainSafe/js-libp2p-gossipsub/pull/83#discussion_r437279222