### PR TITLE
Fix dialer.connectToPeer to throw a clean error

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -44,3 +44,4 @@ test/test-data/go-ipfs-repo/LOG.old
 # while testing npm5
 package-lock.json
 yarn.lock
+/.idea/

--- a/package.json
+++ b/package.json
@@ -111,6 +111,7 @@
     "libp2p-tcp": "^0.14.1",
     "libp2p-webrtc-star": "^0.18.0",
     "libp2p-websockets": "^0.13.1",
+    "mocha": "^8.0.1",
     "multihashes": "^0.4.19",
     "nock": "^12.0.3",
     "p-defer": "^3.0.0",

--- a/src/dialer/index.js
+++ b/src/dialer/index.js
@@ -70,7 +70,7 @@ class Dialer {
   async connectToPeer (peer, options = {}) {
     const dialTarget = this._createDialTarget(peer)
 
-    if (!dialTarget.addrs.length) {
+    if (!dialTarget.addrs || !dialTarget.addrs.length) {
       throw errCode(new Error('The dial request has no addresses'), codes.ERR_NO_VALID_ADDRESSES)
     }
     const pendingDial = this._pendingDials.get(dialTarget.id) || this._createPendingDial(dialTarget, options)

--- a/test/dialing/direct.node.js
+++ b/test/dialing/direct.node.js
@@ -96,6 +96,14 @@ describe('Dialing (direct, TCP)', () => {
       .and.to.have.nested.property('._errors[0].code', ErrorCodes.ERR_TRANSPORT_UNAVAILABLE)
   })
 
+  it('should fail appropriately if peer has no addresses', async () => {
+    const dialer = new Dialer({ transportManager: localTM, peerStore })
+    const peer = new PeerId(Buffer.from("QmfEa1LrSt2R7KiZ31yPo3TT8ipfyDfrMRkaQix3rcXeTo"))
+    await expect(dialer.connectToPeer(peer))
+      .to.eventually.be.rejectedWith(Error)
+      .and.to.have.nested.property('.code', ErrorCodes.ERR_NO_VALID_ADDRESSES)
+  })
+
   it('should be able to connect to a given peer id', async () => {
     const peerStore = new PeerStore()
     const dialer = new Dialer({

--- a/test/dialing/direct.node.js
+++ b/test/dialing/direct.node.js
@@ -98,7 +98,7 @@ describe('Dialing (direct, TCP)', () => {
 
   it('should fail appropriately if peer has no addresses', async () => {
     const dialer = new Dialer({ transportManager: localTM, peerStore })
-    const peer = new PeerId(Buffer.from("QmfEa1LrSt2R7KiZ31yPo3TT8ipfyDfrMRkaQix3rcXeTo"))
+    const peer = new PeerId(Buffer.from('QmfEa1LrSt2R7KiZ31yPo3TT8ipfyDfrMRkaQix3rcXeTo'))
     await expect(dialer.connectToPeer(peer))
       .to.eventually.be.rejectedWith(Error)
       .and.to.have.nested.property('.code', ErrorCodes.ERR_NO_VALID_ADDRESSES)


### PR DESCRIPTION
 when dialTarget.addrs is undefined

Fixes #672 