### PR TITLE
fix: catch pipe errors

### DIFF
--- a/src/identify/index.js
+++ b/src/identify/index.js
@@ -208,7 +208,7 @@ class IdentifyService {
    * @param {*} options.stream
    * @param {Connection} options.connection
    */
-  _handleIdentify ({ connection, stream }) {
+  async _handleIdentify ({ connection, stream }) {
     let publicKey = Buffer.alloc(0)
     if (this.peerId.pubKey) {
       publicKey = this.peerId.pubKey.bytes
@@ -223,12 +223,16 @@ class IdentifyService {
       protocols: Array.from(this._protocols.keys())
     })
 
-    pipe(
-      [message],
-      lp.encode(),
-      stream,
-      consume
-    )
+    try {
+      await pipe(
+        [message],
+        lp.encode(),
+        stream,
+        consume
+      )
+    } catch (err) {
+      log.error('could not respond to identify request', err)
+    }
   }
 
   /**

--- a/src/identify/index.js
+++ b/src/identify/index.js
@@ -243,17 +243,16 @@ class IdentifyService {
    * @param {Connection} options.connection
    */
   async _handlePush ({ connection, stream }) {
-    const [data] = await pipe(
-      [],
-      stream,
-      lp.decode(),
-      take(1),
-      toBuffer,
-      collect
-    )
-
     let message
     try {
+      const [data] = await pipe(
+        [],
+        stream,
+        lp.decode(),
+        take(1),
+        toBuffer,
+        collect
+      )
       message = Message.decode(data)
     } catch (err) {
       return log.error('received invalid message', err)

--- a/src/metrics/index.js
+++ b/src/metrics/index.js
@@ -215,7 +215,7 @@ class Metrics {
 
     const _sink = stream.sink
     stream.sink = source => {
-      pipe(
+      return pipe(
         source,
         tap(chunk => metrics._onMessage({
           remotePeer,

--- a/src/pnet/index.js
+++ b/src/pnet/index.js
@@ -17,7 +17,7 @@ const handshake = require('it-handshake')
 const { NONCE_LENGTH } = require('./key-generator')
 const debug = require('debug')
 const log = debug('libp2p:pnet')
-log.err = debug('libp2p:pnet:err')
+log.error = debug('libp2p:pnet:err')
 
 /**
  * Takes a Private Shared Key (psk) and provides a `protect` method
@@ -69,7 +69,7 @@ class Protector {
       // Decrypt all inbound traffic
       createUnboxStream(remoteNonce, this.psk),
       external
-    )
+    ).catch(log.error)
 
     return internal
   }

--- a/src/upgrader.js
+++ b/src/upgrader.js
@@ -258,7 +258,7 @@ class Upgrader {
       }
 
       // Pipe all data through the muxer
-      pipe(upgradedConn, muxer, upgradedConn)
+      pipe(upgradedConn, muxer, upgradedConn).catch(log.error)
     }
 
     const _timeline = maConn.timeline


### PR DESCRIPTION
There were some pipe errors not being caught. This can result in unhandled exceptions being thrown.

While working on replicating https://github.com/libp2p/js-libp2p-tcp/issues/130 I noticed that we aren't catching all errors that can be thrown by `pipe`, which includes tcp reset errors. 

related: https://github.com/libp2p/js-libp2p-mplex/issues/111