### PR TITLE
feat: certified addressbook

### DIFF
--- a/.aegir.js
+++ b/.aegir.js
@@ -45,7 +45,7 @@ const after = async () => {
 }
 
 module.exports = {
-  bundlesize: { maxSize: '202kB' },
+  bundlesize: { maxSize: '205kB' },
   hooks: {
     pre: before,
     post: after

--- a/doc/API.md
+++ b/doc/API.md
@@ -816,6 +816,7 @@ peerStore.addressBook.getMultiaddrsForPeer(peerId)
 
 Set known `multiaddrs` of a given peer. This will replace previously stored multiaddrs, if available.
 Replacing stored multiaddrs might result in losing obtained certified addresses, which is not desirable.
+Consider using `addressBook.add()` if you're not sure this is what you want to do.
 
 `peerStore.addressBook.set(peerId, multiaddrs)`
 

--- a/doc/API.md
+++ b/doc/API.md
@@ -814,7 +814,8 @@ peerStore.addressBook.getMultiaddrsForPeer(peerId)
 
 ### peerStore.addressBook.set
 
-Set known `multiaddrs` of a given peer.
+Set known `multiaddrs` of a given peer. This will replace previously stored multiaddrs, if available.
+Replacing stored multiaddrs might result in losing obtained certified addresses, which is not desirable.
 
 `peerStore.addressBook.set(peerId, multiaddrs)`
 

--- a/src/identify/index.js
+++ b/src/identify/index.js
@@ -184,13 +184,14 @@ class IdentifyService {
     try {
       const envelope = await Envelope.openAndCertify(signedPeerRecord, PeerRecord.DOMAIN)
       if (this.peerStore.addressBook.consumePeerRecord(envelope)) {
+        this.peerStore.protoBook.set(id, protocols)
         return
       }
     } catch (err) {
       log('received invalid envelope, discard it and fallback to listenAddrs is available', err)
     }
 
-    // Update peers data in PeerStore
+    // LEGACY: Update peers data in PeerStore
     try {
       this.peerStore.addressBook.set(id, listenAddrs.map((addr) => multiaddr(addr)))
     } catch (err) {
@@ -289,19 +290,14 @@ class IdentifyService {
     try {
       const envelope = await Envelope.openAndCertify(message.signedPeerRecord, PeerRecord.DOMAIN)
       if (this.peerStore.addressBook.consumePeerRecord(envelope)) {
+        this.peerStore.protoBook.set(id, message.protocols)
         return
       }
     } catch (err) {
-<<<<<<< HEAD
       log('received invalid envelope, discard it and fallback to listenAddrs is available', err)
-      // Try Legacy
-      addresses = message.listenAddrs
-=======
-      log('received invalid envelope, discard it and fallback to listenAddrs is available')
->>>>>>> chore: add certified peer records to persisted peer store
     }
 
-    // Update peers data in PeerStore
+    // LEGACY: Update peers data in PeerStore
     try {
       this.peerStore.addressBook.set(id, message.listenAddrs.map((addr) => multiaddr(addr)))
     } catch (err) {
@@ -316,7 +312,7 @@ class IdentifyService {
    * Get self signed peer record raw envelope.
    * @return {Buffer}
    */
-  async _getSelfPeerRecord() {
+  async _getSelfPeerRecord () {
     const selfSignedPeerRecord = this.peerStore.addressBook.getRawEnvelope(this.peerId)
 
     // TODO: support invalidation when dynamic multiaddrs are supported

--- a/src/index.js
+++ b/src/index.js
@@ -51,10 +51,11 @@ class Libp2p extends EventEmitter {
 
     this.peerStore = (this.datastore && this._options.peerStore.persistence)
       ? new PersistentPeerStore({
+        peerId: this.peerId,
         datastore: this.datastore,
         ...this._options.peerStore
       })
-      : new PeerStore()
+      : new PeerStore({ peerId: this.peerId })
 
     // Addresses {listen, announce, noAnnounce}
     this.addresses = this._options.addresses

--- a/src/peer-store/address-book.js
+++ b/src/peer-store/address-book.js
@@ -125,9 +125,10 @@ class AddressBook extends Book {
   }
 
   /**
-   * Get a peer raw envelope.
+   * Get the raw Envelope for a peer. Returns
+   * undefined if no Envelope is found.
    * @param {PeerId} peerId
-   * @return {Buffer}
+   * @return {Buffer|undefined}
    */
   getRawEnvelope (peerId) {
     const entry = this.data.get(peerId.toB58String())
@@ -141,8 +142,9 @@ class AddressBook extends Book {
 
   /**
    * Get an Envelope containing a PeerRecord for the given peer.
+   * Returns undefined if no record exists.
    * @param {PeerId} peerId
-   * @return {Promise<Envelope>}
+   * @return {Promise<Envelope|void>}
    */
   getPeerRecord (peerId) {
     const raw = this.getRawEnvelope(peerId)

--- a/src/peer-store/address-book.js
+++ b/src/peer-store/address-book.js
@@ -158,6 +158,8 @@ class AddressBook extends Book {
 
   /**
    * Set known multiaddrs of a provided peer.
+   * This will replace previously stored multiaddrs, if available.
+   * Replacing stored multiaddrs might result in losing obtained certified addresses.
    * @override
    * @param {PeerId} peerId
    * @param {Array<Multiaddr>} multiaddrs

--- a/src/peer-store/address-book.js
+++ b/src/peer-store/address-book.js
@@ -88,7 +88,7 @@ class AddressBook extends Book {
     }
 
     // Verify peerId
-    if (peerRecord.peerId.toB58String() !== envelope.peerId.toB58String()) {
+    if (!peerRecord.peerId.equals(envelope.peerId)) {
       log('signing key does not match PeerId in the PeerRecord')
       return false
     }
@@ -220,10 +220,10 @@ class AddressBook extends Book {
     const id = peerId.toB58String()
 
     const entry = this.data.get(id) || {}
-    const rec = entry.addresses
+    const rec = entry.addresses || []
 
     // Add recorded uniquely to the new array (Union)
-    rec && rec.forEach((addr) => {
+    rec.forEach((addr) => {
       if (!addresses.find(r => r.multiaddr.equals(addr.multiaddr))) {
         addresses.push(addr)
       }
@@ -244,7 +244,7 @@ class AddressBook extends Book {
     log(`added provided multiaddrs for ${id}`)
 
     // Notify the existance of a new peer
-    if (!rec) {
+    if (!entry.addresses) {
       this._ps.emit('peer', peerId)
     }
 

--- a/src/peer-store/address-book.js
+++ b/src/peer-store/address-book.js
@@ -9,10 +9,12 @@ const multiaddr = require('multiaddr')
 const PeerId = require('peer-id')
 
 const Book = require('./book')
+const PeerRecord = require('../record/peer-record')
 
 const {
   codes: { ERR_INVALID_PARAMETERS }
 } = require('../errors')
+const Envelope = require('../record/envelope')
 
 /**
  * The AddressBook is responsible for keeping the known multiaddrs
@@ -23,7 +25,22 @@ class AddressBook extends Book {
    * Address object
    * @typedef {Object} Address
    * @property {Multiaddr} multiaddr peer multiaddr.
+   * @property {boolean} isCertified obtained from a signed peer record.
    */
+
+  /**
+  * CertifiedRecord object
+  * @typedef {Object} CertifiedRecord
+  * @property {Buffer} raw raw envelope.
+  * @property {number} seqNumber seq counter.
+  */
+
+  /**
+  * Entry object for the addressBook
+  * @typedef {Object} Entry
+  * @property {Array<Address>} addresses peer Addresses.
+  * @property {CertifiedRecord} record certified peer record.
+  */
 
   /**
   * @constructor
@@ -39,14 +56,93 @@ class AddressBook extends Book {
       peerStore,
       eventName: 'change:multiaddrs',
       eventProperty: 'multiaddrs',
-      eventTransformer: (data) => data.map((address) => address.multiaddr)
+      eventTransformer: (data) => {
+        if (!data.addresses) {
+          return []
+        }
+        return data.addresses.map((address) => address.multiaddr)
+      }
     })
 
     /**
-     * Map known peers to their known Addresses.
-     * @type {Map<string, Array<Address>>}
+     * Map known peers to their known Address Entries.
+     * @type {Map<string, Array<Entry>>}
      */
     this.data = new Map()
+  }
+
+  /**
+   * ConsumePeerRecord adds addresses from a signed peer.PeerRecord contained in a record envelope.
+   * This will return a boolean that indicates if the record was successfully processed and integrated
+   * into the AddressBook.
+   * @param {Envelope} envelope
+   * @return {boolean}
+   */
+  consumePeerRecord (envelope) {
+    let peerRecord
+    try {
+      peerRecord = PeerRecord.createFromProtobuf(envelope.payload)
+    } catch (err) {
+      log.error('invalid peer record received')
+      return false
+    }
+
+    // Verify peerId
+    if (peerRecord.peerId.toB58String() !== envelope.peerId.toB58String()) {
+      log('signing key does not match PeerId in the PeerRecord')
+      return false
+    }
+
+    const peerId = peerRecord.peerId
+    const id = peerId.toB58String()
+    const entry = this.data.get(id) || {}
+    const storedRecord = entry.record
+
+    // ensure seq is greater than, or equal to, the last received
+    if (storedRecord &&
+      storedRecord.seqNumber >= peerRecord.seqNumber) {
+      return false
+    }
+
+    // ensure the record has multiaddrs
+    if (!peerRecord.multiaddrs || !peerRecord.multiaddrs.length) {
+      return false
+    }
+
+    const addresses = this._toAddresses(peerRecord.multiaddrs, true)
+
+    // TODO: new record with different addresses from stored record
+    // - Remove the older ones?
+    // - Change to uncertified?
+
+    // TODO: events
+    // Should a multiaddr only modified to certified trigger an event?
+    // - Needed for persistent peer store
+    this._setData(peerId, {
+      addresses,
+      record: {
+        raw: envelope.marshal(),
+        seqNumber: peerRecord.seqNumber
+      }
+    })
+    log(`stored provided peer record for ${id}`)
+
+    return true
+  }
+
+  /**
+   * Get an Envelope containing a PeerRecord for the given peer.
+   * @param {PeerId} peerId
+   * @return {Promise<Envelope>}
+   */
+  getPeerRecord (peerId) {
+    const entry = this.data.get(peerId.toB58String())
+
+    if (!entry || !entry.record || !entry.record.raw) {
+      return
+    }
+
+    return Envelope.createFromProtobuf(entry.record.raw)
   }
 
   /**
@@ -64,7 +160,8 @@ class AddressBook extends Book {
 
     const addresses = this._toAddresses(multiaddrs)
     const id = peerId.toB58String()
-    const rec = this.data.get(id)
+    const entry = this.data.get(id) || {}
+    const rec = entry.addresses
 
     // Not replace multiaddrs
     if (!addresses.length) {
@@ -83,7 +180,10 @@ class AddressBook extends Book {
       }
     }
 
-    this._setData(peerId, addresses)
+    this._setData(peerId, {
+      addresses,
+      record: entry.record
+    })
     log(`stored provided multiaddrs for ${id}`)
 
     // Notify the existance of a new peer
@@ -109,7 +209,9 @@ class AddressBook extends Book {
 
     const addresses = this._toAddresses(multiaddrs)
     const id = peerId.toB58String()
-    const rec = this.data.get(id)
+
+    const entry = this.data.get(id) || {}
+    const rec = entry.addresses
 
     // Add recorded uniquely to the new array (Union)
     rec && rec.forEach((mi) => {
@@ -125,7 +227,10 @@ class AddressBook extends Book {
       return this
     }
 
-    this._setData(peerId, addresses)
+    this._setData(peerId, {
+      addresses,
+      record: entry.record
+    })
 
     log(`added provided multiaddrs for ${id}`)
 
@@ -138,12 +243,30 @@ class AddressBook extends Book {
   }
 
   /**
+   * Get the known data of a provided peer.
+   * @override
+   * @param {PeerId} peerId
+   * @returns {Array<data>}
+   */
+  get (peerId) {
+    // TODO: should we return Entry instead??
+    if (!PeerId.isPeerId(peerId)) {
+      throw errcode(new Error('peerId must be an instance of peer-id'), ERR_INVALID_PARAMETERS)
+    }
+
+    const entry = this.data.get(peerId.toB58String())
+
+    return entry && entry.addresses ? [...entry.addresses] : undefined
+  }
+
+  /**
    * Transforms received multiaddrs into Address.
    * @private
    * @param {Array<Multiaddr>} multiaddrs
+   * @param {boolean} [isCertified]
    * @returns {Array<Address>}
    */
-  _toAddresses (multiaddrs) {
+  _toAddresses (multiaddrs, isCertified = false) {
     if (!multiaddrs) {
       log.error('multiaddrs must be provided to store data')
       throw errcode(new Error('multiaddrs must be provided'), ERR_INVALID_PARAMETERS)
@@ -158,7 +281,8 @@ class AddressBook extends Book {
       }
 
       addresses.push({
-        multiaddr: addr
+        multiaddr: addr,
+        isCertified
       })
     })
 
@@ -176,13 +300,13 @@ class AddressBook extends Book {
       throw errcode(new Error('peerId must be an instance of peer-id'), ERR_INVALID_PARAMETERS)
     }
 
-    const record = this.data.get(peerId.toB58String())
+    const entry = this.data.get(peerId.toB58String())
 
-    if (!record) {
+    if (!entry || !entry.addresses) {
       return undefined
     }
 
-    return record.map((address) => {
+    return entry.addresses.map((address) => {
       const multiaddr = address.multiaddr
 
       const idString = multiaddr.getPeerId()

--- a/src/peer-store/address-book.js
+++ b/src/peer-store/address-book.js
@@ -160,6 +160,7 @@ class AddressBook extends Book {
    * Set known multiaddrs of a provided peer.
    * This will replace previously stored multiaddrs, if available.
    * Replacing stored multiaddrs might result in losing obtained certified addresses.
+   * If you are not sure, it's recommended to use `add` instead.
    * @override
    * @param {PeerId} peerId
    * @param {Array<Multiaddr>} multiaddrs

--- a/src/peer-store/index.js
+++ b/src/peer-store/index.js
@@ -37,7 +37,7 @@ class PeerStore extends EventEmitter {
   /**
    * @constructor
    */
-  constructor ({ peerId } = {}) {
+  constructor ({ peerId }) {
     super()
 
     this._peerId = peerId

--- a/src/peer-store/index.js
+++ b/src/peer-store/index.js
@@ -37,8 +37,10 @@ class PeerStore extends EventEmitter {
   /**
    * @constructor
    */
-  constructor () {
+  constructor ({ peerId } = {}) {
     super()
+
+    this._peerId = peerId
 
     /**
      * AddressBook containing a map of peerIdStr to Address.
@@ -72,7 +74,7 @@ class PeerStore extends EventEmitter {
   stop () {}
 
   /**
-   * Get all the stored information of every peer.
+   * Get all the stored information of every peer known.
    * @returns {Map<string, Peer>}
    */
   get peers () {
@@ -82,6 +84,9 @@ class PeerStore extends EventEmitter {
       ...this.protoBook.data.keys(),
       ...this.metadataBook.data.keys()
     ])
+
+    // Remove self peer if present
+    this._peerId && storedPeers.delete(this._peerId.toB58String())
 
     const peersData = new Map()
     storedPeers.forEach((idStr) => {

--- a/src/peer-store/persistent/index.js
+++ b/src/peer-store/persistent/index.js
@@ -296,9 +296,11 @@ class PersistentPeerStore extends PeerStore {
 
           this.addressBook._setData(
             peerId,
-            decoded.addrs.map((address) => ({
-              multiaddr: multiaddr(address.multiaddr)
-            })),
+            {
+              addresses: decoded.addrs.map((address) => ({
+                multiaddr: multiaddr(address.multiaddr)
+              }))
+            },
             { emit: false })
           break
         case 'keys':

--- a/src/peer-store/persistent/index.js
+++ b/src/peer-store/persistent/index.js
@@ -189,13 +189,15 @@ class PersistentPeerStore extends PeerStore {
 
       const encodedData = Addresses.encode({
         addrs: entry.addresses.map((address) => ({
-          multiaddr: address.multiaddr.buffer
+          multiaddr: address.multiaddr.buffer,
+          isCertified: address.isCertified
         })),
         certified_record: entry.record ? {
           seq: entry.record.seqNumber,
           raw: entry.record.raw
         } : undefined
       })
+
       batch.put(key, encodedData)
     } catch (err) {
       log.error(err)
@@ -302,7 +304,8 @@ class PersistentPeerStore extends PeerStore {
             peerId,
             {
               addresses: decoded.addrs.map((address) => ({
-                multiaddr: multiaddr(address.multiaddr)
+                multiaddr: multiaddr(address.multiaddr),
+                isCertified: Boolean(address.isCertified)
               })),
               record: decoded.certified_record ? {
                 raw: decoded.certified_record.raw,

--- a/src/peer-store/persistent/index.js
+++ b/src/peer-store/persistent/index.js
@@ -28,11 +28,12 @@ class PersistentPeerStore extends PeerStore {
   /**
    * @constructor
    * @param {Object} properties
+   * @param {PeerId} properties.peerId
    * @param {Datastore} properties.datastore Datastore to persist data.
    * @param {number} [properties.threshold = 5] Number of dirty peers allowed before commit data.
    */
-  constructor ({ datastore, threshold = 5 }) {
-    super()
+  constructor ({ peerId, datastore, threshold = 5 }) {
+    super({ peerId })
 
     /**
      * Backend datastore used to persist data.

--- a/src/peer-store/persistent/pb/address-book.proto.js
+++ b/src/peer-store/persistent/pb/address-book.proto.js
@@ -7,6 +7,9 @@ message Addresses {
   // Address represents a single multiaddr.
   message Address {
     required bytes multiaddr = 1;
+
+    // Flag to indicate if the address comes from a certified source.
+    optional bool isCertified = 2;
   }
 
   // CertifiedRecord contains a serialized signed PeerRecord used to

--- a/src/peer-store/persistent/pb/address-book.proto.js
+++ b/src/peer-store/persistent/pb/address-book.proto.js
@@ -4,11 +4,26 @@ const protons = require('protons')
 
 const message = `
 message Addresses {
+  // Address represents a single multiaddr.
   message Address {
     required bytes multiaddr = 1;
   }
 
+  // CertifiedRecord contains a serialized signed PeerRecord used to
+  // populate the signedAddrs list.
+  message CertifiedRecord {
+    // The Seq counter from the signed PeerRecord envelope
+    uint64 seq = 1;
+
+    // The serialized bytes of the SignedEnvelope containing the PeerRecord.
+    bytes raw = 2;
+  }
+
+  // The known multiaddrs.
   repeated Address addrs = 1;
+
+  // The most recently received signed PeerRecord.
+  CertifiedRecord certified_record = 2;
 }
 `
 

--- a/src/record/envelope/index.js
+++ b/src/record/envelope/index.js
@@ -112,7 +112,12 @@ const formatSignaturePayload = (domain, payloadType, payload) => {
   ])
 }
 
-const unmarshalEnvelope = async (data) => {
+/**
+ * Unmarshal a serialized Envelope protobuf message.
+ * @param {Buffer} data
+ * @return {Promise<Envelope>}
+ */
+Envelope.createFromProtobuf = async (data) => {
   const envelopeData = Protobuf.decode(data)
   const peerId = await PeerId.createFromPubKey(envelopeData.public_key)
 
@@ -123,13 +128,6 @@ const unmarshalEnvelope = async (data) => {
     signature: envelopeData.signature
   })
 }
-
-/**
- * Unmarshal a serialized Envelope protobuf message.
- * @param {Buffer} data
- * @return {Promise<Envelope>}
- */
-Envelope.createFromProtobuf = unmarshalEnvelope
 
 /**
 * Seal marshals the given Record, places the marshaled bytes inside an Envelope
@@ -163,7 +161,7 @@ Envelope.seal = async (record, peerId) => {
  * @return {Envelope}
  */
 Envelope.openAndCertify = async (data, domain) => {
-  const envelope = await unmarshalEnvelope(data)
+  const envelope = await Envelope.createFromProtobuf(data)
   const valid = await envelope.validate(domain)
 
   if (!valid) {

--- a/src/record/envelope/index.js
+++ b/src/record/envelope/index.js
@@ -112,11 +112,6 @@ const formatSignaturePayload = (domain, payloadType, payload) => {
   ])
 }
 
-/**
- * Unmarshal a serialized Envelope protobuf message.
- * @param {Buffer} data
- * @return {Envelope}
- */
 const unmarshalEnvelope = async (data) => {
   const envelopeData = Protobuf.decode(data)
   const peerId = await PeerId.createFromPubKey(envelopeData.public_key)
@@ -128,6 +123,13 @@ const unmarshalEnvelope = async (data) => {
     signature: envelopeData.signature
   })
 }
+
+/**
+ * Unmarshal a serialized Envelope protobuf message.
+ * @param {Buffer} data
+ * @return {Promise<Envelope>}
+ */
+Envelope.createFromProtobuf = unmarshalEnvelope
 
 /**
 * Seal marshals the given Record, places the marshaled bytes inside an Envelope

--- a/test/dialing/direct.node.js
+++ b/test/dialing/direct.node.js
@@ -55,7 +55,7 @@ describe('Dialing (direct, TCP)', () => {
     })
     remoteTM.add(Transport.prototype[Symbol.toStringTag], Transport)
 
-    peerStore = new PeerStore()
+    peerStore = new PeerStore({ peerId: remotePeerId })
     localTM = new TransportManager({
       libp2p: {},
       upgrader: mockUpgrader
@@ -97,13 +97,13 @@ describe('Dialing (direct, TCP)', () => {
   })
 
   it('should be able to connect to a given peer id', async () => {
-    const peerStore = new PeerStore()
+    const peerId = await PeerId.createFromJSON(Peers[0])
+    const peerStore = new PeerStore({ peerId })
     const dialer = new Dialer({
       transportManager: localTM,
       peerStore
     })
 
-    const peerId = await PeerId.createFromJSON(Peers[0])
     peerStore.addressBook.set(peerId, [remoteAddr])
 
     const connection = await dialer.connectToPeer(peerId)

--- a/test/dialing/direct.spec.js
+++ b/test/dialing/direct.spec.js
@@ -363,7 +363,7 @@ describe('Dialing (direct, WebSockets)', () => {
       const connection = await libp2p.dial(remoteAddr)
       expect(connection).to.exist()
 
-      sinon.spy(libp2p.peerStore.addressBook, 'set')
+      sinon.spy(libp2p.peerStore.addressBook, 'consumePeerRecord')
       sinon.spy(libp2p.peerStore.protoBook, 'set')
 
       // Wait for onConnection to be called
@@ -372,7 +372,8 @@ describe('Dialing (direct, WebSockets)', () => {
       expect(libp2p.identifyService.identify.callCount).to.equal(1)
       await libp2p.identifyService.identify.firstCall.returnValue
 
-      expect(libp2p.peerStore.addressBook.set.callCount).to.equal(1)
+      // Self + New peer
+      expect(libp2p.peerStore.addressBook.consumePeerRecord.callCount).to.equal(2)
       expect(libp2p.peerStore.protoBook.set.callCount).to.equal(1)
     })
 

--- a/test/identify/index.spec.js
+++ b/test/identify/index.spec.js
@@ -73,7 +73,7 @@ describe('Identify', () => {
     const [local, remote] = duplexPair()
     sinon.stub(localConnectionMock, 'newStream').returns({ stream: local, protocol: multicodecs.IDENTIFY })
 
-    sinon.spy(localIdentify.peerStore.addressBook, 'set')
+    sinon.spy(localIdentify.peerStore.addressBook, 'consumePeerRecord')
     sinon.spy(localIdentify.peerStore.protoBook, 'set')
 
     // Run identify
@@ -86,15 +86,15 @@ describe('Identify', () => {
       })
     ])
 
-    expect(localIdentify.peerStore.addressBook.set.callCount).to.equal(1)
+    expect(localIdentify.peerStore.addressBook.consumePeerRecord.callCount).to.equal(1)
     expect(localIdentify.peerStore.protoBook.set.callCount).to.equal(1)
 
     // Validate the remote peer gets updated in the peer store
-    const call = localIdentify.peerStore.addressBook.set.firstCall
-    expect(call.args[0].id.bytes).to.equal(remotePeer.bytes)
-    expect(call.args[1]).to.exist()
-    expect(call.args[1]).have.lengthOf(listenMaddrs.length)
-    expect(call.args[1][0].equals(listenMaddrs[0]))
+    const addresses = localIdentify.peerStore.addressBook.get(remotePeer)
+    expect(addresses).to.exist()
+    expect(addresses).have.lengthOf(listenMaddrs.length)
+    expect(addresses.map((a) => a.multiaddr)[0].equals(listenMaddrs[0]))
+    expect(addresses.map((a) => a.isCertified)[0]).to.eql(true)
   })
 
   // LEGACY
@@ -127,7 +127,7 @@ describe('Identify', () => {
     sinon.stub(localConnectionMock, 'newStream').returns({ stream: local, protocol: multicodecs.IDENTIFY })
     sinon.stub(Envelope, 'openAndCertify').throws()
 
-    sinon.spy(localIdentify.peerStore.addressBook, 'consumePeerRecord')
+    sinon.spy(localIdentify.peerStore.addressBook, 'set')
     sinon.spy(localIdentify.peerStore.protoBook, 'set')
 
     // Run identify
@@ -140,15 +140,15 @@ describe('Identify', () => {
       })
     ])
 
-    expect(localIdentify.peerStore.addressBook.consumePeerRecord.callCount).to.equal(1)
+    expect(localIdentify.peerStore.addressBook.set.callCount).to.equal(1)
     expect(localIdentify.peerStore.protoBook.set.callCount).to.equal(1)
 
     // Validate the remote peer gets updated in the peer store
-    const addresses = localIdentify.peerStore.addressBook.get(remotePeer)
-    expect(addresses).to.exist()
-    expect(addresses).have.lengthOf(listenMaddrs.length)
-    expect(addresses.map((a) => a.multiaddr)[0].equals(listenMaddrs[0]))
-    expect(addresses.map((a) => a.isCertified)[0]).to.eql(true)
+    const call = localIdentify.peerStore.addressBook.set.firstCall
+    expect(call.args[0].id.bytes).to.equal(remotePeer.bytes)
+    expect(call.args[1]).to.exist()
+    expect(call.args[1]).have.lengthOf(listenMaddrs.length)
+    expect(call.args[1][0].equals(listenMaddrs[0]))
   })
 
   it('should throw if identified peer is the wrong peer', async () => {
@@ -290,7 +290,7 @@ describe('Identify', () => {
       sinon.stub(localConnectionMock, 'newStream').returns({ stream: local, protocol: multicodecs.IDENTIFY_PUSH })
       sinon.stub(Envelope, 'openAndCertify').throws()
 
-      sinon.spy(remoteIdentify.peerStore.addressBook, 'consumePeerRecord')
+      sinon.spy(remoteIdentify.peerStore.addressBook, 'set')
       sinon.spy(remoteIdentify.peerStore.protoBook, 'set')
 
       // Run identify
@@ -303,13 +303,12 @@ describe('Identify', () => {
         })
       ])
 
-      expect(remoteIdentify.peerStore.addressBook.consumePeerRecord.callCount).to.equal(1)
+      expect(remoteIdentify.peerStore.addressBook.set.callCount).to.equal(1)
       expect(remoteIdentify.peerStore.protoBook.set.callCount).to.equal(1)
 
-      const addresses = localIdentify.peerStore.addressBook.get(localPeer)
-      expect(addresses).to.exist()
-      expect(addresses).have.lengthOf(listenMaddrs.length)
-      expect(addresses.map((a) => a.multiaddr)).to.eql(listenMaddrs)
+      const [peerId, multiaddrs] = remoteIdentify.peerStore.addressBook.set.firstCall.args
+      expect(peerId.bytes).to.eql(localPeer.bytes)
+      expect(multiaddrs).to.eql(listenMaddrs)
 
       const [peerId2, protocols] = remoteIdentify.peerStore.protoBook.set.firstCall.args
       expect(peerId2.bytes).to.eql(localPeer.bytes)

--- a/test/identify/index.spec.js
+++ b/test/identify/index.spec.js
@@ -50,7 +50,7 @@ describe('Identify', () => {
       libp2p: {
         peerId: localPeer,
         connectionManager: new EventEmitter(),
-        peerStore: new PeerStore(),
+        peerStore: new PeerStore({ peerId: localPeer }),
         multiaddrs: listenMaddrs
       },
       protocols
@@ -60,7 +60,7 @@ describe('Identify', () => {
       libp2p: {
         peerId: remotePeer,
         connectionManager: new EventEmitter(),
-        peerStore: new PeerStore(),
+        peerStore: new PeerStore({ peerId: remotePeer }),
         multiaddrs: listenMaddrs
       },
       protocols
@@ -103,7 +103,7 @@ describe('Identify', () => {
       libp2p: {
         peerId: localPeer,
         connectionManager: new EventEmitter(),
-        peerStore: new PeerStore(),
+        peerStore: new PeerStore({ peerId: localPeer }),
         multiaddrs: listenMaddrs
       },
       protocols
@@ -113,7 +113,7 @@ describe('Identify', () => {
       libp2p: {
         peerId: remotePeer,
         connectionManager: new EventEmitter(),
-        peerStore: new PeerStore(),
+        peerStore: new PeerStore({ peerId: remotePeer }),
         multiaddrs: listenMaddrs
       },
       protocols
@@ -156,7 +156,7 @@ describe('Identify', () => {
       libp2p: {
         peerId: localPeer,
         connectionManager: new EventEmitter(),
-        peerStore: new PeerStore(),
+        peerStore: new PeerStore({ peerId: localPeer }),
         multiaddrs: []
       },
       protocols
@@ -165,7 +165,7 @@ describe('Identify', () => {
       libp2p: {
         peerId: remotePeer,
         connectionManager: new EventEmitter(),
-        peerStore: new PeerStore(),
+        peerStore: new PeerStore({ peerId: remotePeer }),
         multiaddrs: []
       },
       protocols
@@ -202,7 +202,7 @@ describe('Identify', () => {
         libp2p: {
           peerId: localPeer,
           connectionManager: new EventEmitter(),
-          peerStore: new PeerStore(),
+          peerStore: new PeerStore({ peerId: localPeer }),
           multiaddrs: listenMaddrs
         },
         protocols: new Map([
@@ -215,7 +215,7 @@ describe('Identify', () => {
         libp2p: {
           peerId: remotePeer,
           connectionManager,
-          peerStore: new PeerStore(),
+          peerStore: new PeerStore({ peerId: remotePeer }),
           multiaddrs: []
         }
       })
@@ -263,7 +263,7 @@ describe('Identify', () => {
         libp2p: {
           peerId: localPeer,
           connectionManager: new EventEmitter(),
-          peerStore: new PeerStore(),
+          peerStore: new PeerStore({ peerId: localPeer }),
           multiaddrs: listenMaddrs
         },
         protocols: new Map([
@@ -276,7 +276,7 @@ describe('Identify', () => {
         libp2p: {
           peerId: remotePeer,
           connectionManager,
-          peerStore: new PeerStore(),
+          peerStore: new PeerStore({ peerId: remotePeer }),
           multiaddrs: []
         }
       })

--- a/test/peer-store/address-book.spec.js
+++ b/test/peer-store/address-book.spec.js
@@ -459,7 +459,8 @@ describe('addressBook', () => {
         return defer.promise
       })
 
-      it('with same data currently in AddressBook (not certified)', async () => {
+      it('emits change:multiaddrs event with same data currently in AddressBook (not certified)', async () => {
+        const defer = pDefer()
         const multiaddrs = [addr1, addr2]
 
         // Set addressBook data
@@ -482,9 +483,18 @@ describe('addressBook', () => {
         })
         const envelope = await Envelope.seal(peerRecord, peerId)
 
+        peerStore.once('change:multiaddrs', ({ peerId, multiaddrs }) => {
+          expect(peerId).to.exist()
+          expect(multiaddrs).to.eql(multiaddrs)
+          defer.resolve()
+        })
+
         // consume peer record
         const consumed = ab.consumePeerRecord(envelope)
         expect(consumed).to.eql(true)
+
+        // Wait event
+        await defer.promise
 
         // Validate data exists and certified
         addrs = ab.get(peerId)
@@ -496,7 +506,8 @@ describe('addressBook', () => {
         })
       })
 
-      it('with previous partial data in AddressBook (not certified)', async () => {
+      it('emits change:multiaddrs event with previous partial data in AddressBook (not certified)', async () => {
+        const defer = pDefer()
         const multiaddrs = [addr1, addr2]
 
         // Set addressBook data
@@ -516,9 +527,18 @@ describe('addressBook', () => {
         })
         const envelope = await Envelope.seal(peerRecord, peerId)
 
+        peerStore.once('change:multiaddrs', ({ peerId, multiaddrs }) => {
+          expect(peerId).to.exist()
+          expect(multiaddrs).to.eql(multiaddrs)
+          defer.resolve()
+        })
+
         // consume peer record
         const consumed = ab.consumePeerRecord(envelope)
         expect(consumed).to.eql(true)
+
+        // Wait event
+        await defer.promise
 
         // Validate data exists and certified
         addrs = ab.get(peerId)
@@ -531,6 +551,7 @@ describe('addressBook', () => {
       })
 
       it('with previous different data in AddressBook (not certified)', async () => {
+        const defer = pDefer()
         const multiaddrsUncertified = [addr3]
         const multiaddrsCertified = [addr1, addr2]
 
@@ -553,9 +574,18 @@ describe('addressBook', () => {
         })
         const envelope = await Envelope.seal(peerRecord, peerId)
 
+        peerStore.once('change:multiaddrs', ({ peerId, multiaddrs }) => {
+          expect(peerId).to.exist()
+          expect(multiaddrs).to.eql(multiaddrs)
+          defer.resolve()
+        })
+
         // consume peer record
         const consumed = ab.consumePeerRecord(envelope)
         expect(consumed).to.eql(true)
+
+        // Wait event
+        await defer.promise
 
         // Validate data exists and certified
         addrs = ab.get(peerId)
@@ -565,7 +595,6 @@ describe('addressBook', () => {
           expect(addr.isCertified).to.eql(true)
           expect(multiaddrsCertified[index].equals(addr.multiaddr)).to.eql(true)
         })
-        // TODO: should it has the older one?
       })
     })
 

--- a/test/peer-store/address-book.spec.js
+++ b/test/peer-store/address-book.spec.js
@@ -36,7 +36,7 @@ describe('addressBook', () => {
     let peerStore, ab
 
     beforeEach(() => {
-      peerStore = new PeerStore()
+      peerStore = new PeerStore({ peerId })
       ab = peerStore.addressBook
     })
 
@@ -150,7 +150,7 @@ describe('addressBook', () => {
     let peerStore, ab
 
     beforeEach(() => {
-      peerStore = new PeerStore()
+      peerStore = new PeerStore({ peerId })
       ab = peerStore.addressBook
     })
 
@@ -278,7 +278,7 @@ describe('addressBook', () => {
     let peerStore, ab
 
     beforeEach(() => {
-      peerStore = new PeerStore()
+      peerStore = new PeerStore({ peerId })
       ab = peerStore.addressBook
     })
 
@@ -313,7 +313,7 @@ describe('addressBook', () => {
     let peerStore, ab
 
     beforeEach(() => {
-      peerStore = new PeerStore()
+      peerStore = new PeerStore({ peerId })
       ab = peerStore.addressBook
     })
 
@@ -349,7 +349,7 @@ describe('addressBook', () => {
     let peerStore, ab
 
     beforeEach(() => {
-      peerStore = new PeerStore()
+      peerStore = new PeerStore({ peerId })
       ab = peerStore.addressBook
     })
 
@@ -405,9 +405,9 @@ describe('addressBook', () => {
   describe('certified records', () => {
     let peerStore, ab
 
-    describe('consumes successfully a valid peer record and stores its data', () => {
+    describe('consumes a valid peer record and stores its data', () => {
       beforeEach(() => {
-        peerStore = new PeerStore()
+        peerStore = new PeerStore({ peerId })
         ab = peerStore.addressBook
       })
 
@@ -600,7 +600,7 @@ describe('addressBook', () => {
 
     describe('fails to consume invalid peer records', () => {
       beforeEach(() => {
-        peerStore = new PeerStore()
+        peerStore = new PeerStore({ peerId })
         ab = peerStore.addressBook
       })
 

--- a/test/peer-store/address-book.spec.js
+++ b/test/peer-store/address-book.spec.js
@@ -425,7 +425,7 @@ describe('addressBook', () => {
 
         // Validate stored envelope
         const storedEnvelope = await ab.getPeerRecord(peerId)
-        expect(envelope.isEqual(storedEnvelope)).to.eql(true)
+        expect(envelope.equals(storedEnvelope)).to.eql(true)
 
         // Validate AddressBook addresses
         const addrs = ab.get(peerId)

--- a/test/peer-store/key-book.spec.js
+++ b/test/peer-store/key-book.spec.js
@@ -19,7 +19,7 @@ describe('keyBook', () => {
 
   beforeEach(async () => {
     [peerId] = await peerUtils.createPeerId()
-    peerStore = new PeerStore()
+    peerStore = new PeerStore({ peerId })
     kb = peerStore.keyBook
   })
 

--- a/test/peer-store/metadata-book.spec.js
+++ b/test/peer-store/metadata-book.spec.js
@@ -25,7 +25,7 @@ describe('metadataBook', () => {
     let peerStore, mb
 
     beforeEach(() => {
-      peerStore = new PeerStore()
+      peerStore = new PeerStore({ peerId })
       mb = peerStore.metadataBook
     })
 
@@ -158,7 +158,7 @@ describe('metadataBook', () => {
     let peerStore, mb
 
     beforeEach(() => {
-      peerStore = new PeerStore()
+      peerStore = new PeerStore({ peerId })
       mb = peerStore.metadataBook
     })
 
@@ -194,7 +194,7 @@ describe('metadataBook', () => {
     let peerStore, mb
 
     beforeEach(() => {
-      peerStore = new PeerStore()
+      peerStore = new PeerStore({ peerId })
       mb = peerStore.metadataBook
     })
 
@@ -243,7 +243,7 @@ describe('metadataBook', () => {
     let peerStore, mb
 
     beforeEach(() => {
-      peerStore = new PeerStore()
+      peerStore = new PeerStore({ peerId })
       mb = peerStore.metadataBook
     })
 
@@ -300,7 +300,7 @@ describe('metadataBook', () => {
     let peerStore, mb
 
     beforeEach(() => {
-      peerStore = new PeerStore()
+      peerStore = new PeerStore({ peerId })
       mb = peerStore.metadataBook
     })
 

--- a/test/peer-store/peer-store.spec.js
+++ b/test/peer-store/peer-store.spec.js
@@ -23,7 +23,7 @@ describe('peer-store', () => {
   let peerIds
   before(async () => {
     peerIds = await peerUtils.createPeerId({
-      number: 4
+      number: 5
     })
   })
 
@@ -31,7 +31,7 @@ describe('peer-store', () => {
     let peerStore
 
     beforeEach(() => {
-      peerStore = new PeerStore()
+      peerStore = new PeerStore({ peerId: peerIds[4] })
     })
 
     it('has an empty map of peers', () => {
@@ -61,7 +61,7 @@ describe('peer-store', () => {
     let peerStore
 
     beforeEach(() => {
-      peerStore = new PeerStore()
+      peerStore = new PeerStore({ peerId: peerIds[4] })
 
       // Add peer0 with { addr1, addr2 } and { proto1 }
       peerStore.addressBook.set(peerIds[0], [addr1, addr2])
@@ -163,7 +163,7 @@ describe('peer-store', () => {
     let peerStore
 
     beforeEach(() => {
-      peerStore = new PeerStore()
+      peerStore = new PeerStore({ peerId: peerIds[4] })
     })
 
     it('returns peers if only addresses are known', () => {

--- a/test/peer-store/persisted-peer-store.spec.js
+++ b/test/peer-store/persisted-peer-store.spec.js
@@ -210,6 +210,8 @@ describe('Persisted PeerStore', () => {
         throw new Error('Datastore should be empty')
       }
     })
+
+    // TODO: certified?
   })
 
   describe('setup with content not stored per change (threshold 2)', () => {

--- a/test/peer-store/persisted-peer-store.spec.js
+++ b/test/peer-store/persisted-peer-store.spec.js
@@ -310,10 +310,10 @@ describe('Persisted PeerStore', () => {
 
       // Validate stored envelopes
       const storedEnvelope0 = await peerStore.addressBook.getPeerRecord(peers[0])
-      expect(envelope0.isEqual(storedEnvelope0)).to.eql(true)
+      expect(envelope0.equals(storedEnvelope0)).to.eql(true)
 
       const storedEnvelope1 = await peerStore.addressBook.getPeerRecord(peers[1])
-      expect(envelope1.isEqual(storedEnvelope1)).to.eql(true)
+      expect(envelope1.equals(storedEnvelope1)).to.eql(true)
 
       // Validate multiaddrs
       const storedPeer0 = peerStore.get(peers[0])

--- a/test/peer-store/persisted-peer-store.spec.js
+++ b/test/peer-store/persisted-peer-store.spec.js
@@ -17,11 +17,16 @@ const peerUtils = require('../utils/creators/peer')
 
 describe('Persisted PeerStore', () => {
   let datastore, peerStore
+  let peerId
+
+  before(async () => {
+    [peerId] = await peerUtils.createPeerId({ fixture: false })
+  })
 
   describe('start and stop flows', () => {
     beforeEach(() => {
       datastore = new MemoryDatastore()
-      peerStore = new PeerStore({ datastore })
+      peerStore = new PeerStore({ datastore, peerId })
     })
 
     afterEach(() => peerStore.stop())
@@ -54,7 +59,7 @@ describe('Persisted PeerStore', () => {
   describe('simple setup with content stored per change (threshold 1)', () => {
     beforeEach(() => {
       datastore = new MemoryDatastore()
-      peerStore = new PeerStore({ datastore, threshold: 1 })
+      peerStore = new PeerStore({ datastore, peerId, threshold: 1 })
     })
 
     afterEach(() => peerStore.stop())
@@ -319,10 +324,12 @@ describe('Persisted PeerStore', () => {
       const storedPeer0 = peerStore.get(peers[0])
       expect(storedPeer0.id.toB58String()).to.eql(peers[0].toB58String())
       expect(storedPeer0.addresses.map((a) => a.multiaddr.toString())).to.have.members([multiaddrs[0].toString()])
+      expect(storedPeer0.addresses.map((a) => a.isCertified)).to.have.members([true])
 
       const storedPeer1 = peerStore.get(peers[1])
       expect(storedPeer1.id.toB58String()).to.eql(peers[1].toB58String())
       expect(storedPeer1.addresses.map((a) => a.multiaddr.toString())).to.have.members([multiaddrs[1].toString()])
+      expect(storedPeer1.addresses.map((a) => a.isCertified)).to.have.members([true])
     })
 
     it('should delete certified peer records from the datastore on delete', async () => {
@@ -377,7 +384,7 @@ describe('Persisted PeerStore', () => {
   describe('setup with content not stored per change (threshold 2)', () => {
     beforeEach(() => {
       datastore = new MemoryDatastore()
-      peerStore = new PeerStore({ datastore, threshold: 2 })
+      peerStore = new PeerStore({ datastore, peerId, threshold: 2 })
     })
 
     afterEach(() => peerStore.stop())

--- a/test/peer-store/persisted-peer-store.spec.js
+++ b/test/peer-store/persisted-peer-store.spec.js
@@ -533,7 +533,7 @@ describe('libp2p.peerStore (Persisted)', () => {
 
     it('should load content to the peerStore when a new node is started with the same datastore', async () => {
       const commitSpy = sinon.spy(libp2p.peerStore, '_commitData')
-      const peers = await peerUtils.createPeerId({ number: 2 })
+      const peers = await peerUtils.createPeerId({ number: 3 })
       const multiaddrs = [
         multiaddr('/ip4/156.10.1.22/tcp/1000'),
         multiaddr('/ip4/156.10.1.23/tcp/1000')
@@ -543,15 +543,15 @@ describe('libp2p.peerStore (Persisted)', () => {
       await libp2p.start()
 
       // AddressBook
-      libp2p.peerStore.addressBook.set(peers[0], [multiaddrs[0]])
-      libp2p.peerStore.addressBook.set(peers[1], [multiaddrs[1]])
+      libp2p.peerStore.addressBook.set(peers[1], [multiaddrs[0]])
+      libp2p.peerStore.addressBook.set(peers[2], [multiaddrs[1]])
 
       // let batch commit complete
       await Promise.all(commitSpy.returnValues)
 
       // ProtoBook
-      libp2p.peerStore.protoBook.set(peers[0], protocols)
       libp2p.peerStore.protoBook.set(peers[1], protocols)
+      libp2p.peerStore.protoBook.set(peers[2], protocols)
 
       // let batch commit complete
       await Promise.all(commitSpy.returnValues)
@@ -582,13 +582,13 @@ describe('libp2p.peerStore (Persisted)', () => {
       expect(newNode.peerStore.peers.size).to.equal(2)
 
       // Validate data
-      const peer0 = newNode.peerStore.get(peers[0])
-      expect(peer0.id.toB58String()).to.eql(peers[0].toB58String())
+      const peer0 = newNode.peerStore.get(peers[1])
+      expect(peer0.id.toB58String()).to.eql(peers[1].toB58String())
       expect(peer0.protocols).to.have.members(protocols)
       expect(peer0.addresses.map((a) => a.multiaddr.toString())).to.have.members([multiaddrs[0].toString()])
 
-      const peer1 = newNode.peerStore.get(peers[1])
-      expect(peer1.id.toB58String()).to.eql(peers[1].toB58String())
+      const peer1 = newNode.peerStore.get(peers[2])
+      expect(peer1.id.toB58String()).to.eql(peers[2].toB58String())
       expect(peer1.protocols).to.have.members(protocols)
       expect(peer1.addresses.map((a) => a.multiaddr.toString())).to.have.members([multiaddrs[1].toString()])
 

--- a/test/peer-store/proto-book.spec.js
+++ b/test/peer-store/proto-book.spec.js
@@ -27,7 +27,7 @@ describe('protoBook', () => {
     let peerStore, pb
 
     beforeEach(() => {
-      peerStore = new PeerStore()
+      peerStore = new PeerStore({ peerId })
       pb = peerStore.protoBook
     })
 
@@ -121,7 +121,7 @@ describe('protoBook', () => {
     let peerStore, pb
 
     beforeEach(() => {
-      peerStore = new PeerStore()
+      peerStore = new PeerStore({ peerId })
       pb = peerStore.protoBook
     })
 
@@ -228,7 +228,7 @@ describe('protoBook', () => {
     let peerStore, pb
 
     beforeEach(() => {
-      peerStore = new PeerStore()
+      peerStore = new PeerStore({ peerId })
       pb = peerStore.protoBook
     })
 
@@ -258,7 +258,7 @@ describe('protoBook', () => {
     let peerStore, pb
 
     beforeEach(() => {
-      peerStore = new PeerStore()
+      peerStore = new PeerStore({ peerId })
       pb = peerStore.protoBook
     })
 

--- a/test/registrar/registrar.spec.js
+++ b/test/registrar/registrar.spec.js
@@ -21,10 +21,15 @@ const multicodec = '/test/1.0.0'
 describe('registrar', () => {
   let peerStore
   let registrar
+  let peerId
+
+  before(async () => {
+    [peerId] = await peerUtils.createPeerId()
+  })
 
   describe('errors', () => {
     beforeEach(() => {
-      peerStore = new PeerStore()
+      peerStore = new PeerStore({ peerId })
       registrar = new Registrar({ peerStore, connectionManager: new EventEmitter() })
     })
 


### PR DESCRIPTION
This PR adds the signed peer records in the AddressBook as part of #653 

Remaining:

- [x] Identify service should use these new features to store self and fetch it

Needs:

- [x] #681 
- [x] #682

The protobuf definition for persistence was inspired (copied) from go-libp2p, and the API to consume and get the records was inspired on go-libp2p CertifiedAddressBook [interface](https://github.com/libp2p/go-libp2p-core/blob/master/peerstore/peerstore.go#L147).

---

The AddressBook was previously holding `Map<string, Array<Address>>`, which mapped a peer id string identifier to an Array of Address (object with multiaddr property). It was changed to `Map<string, Array<Entry>>`, where the Entry is an object containing `{ addresses: Array<Address>, record: { raw: Buffer, seqNumber: number} }`. The Address now also includes a `isCertified` property that aims to allow subsystems to filter known multiaddrs of a peer that are certified without a need to unmarshall the record. The `raw` envelope is stored for being exchanged easily with other peers.

There are 3 remaining questions to be answered:

1. When the AddressBook receives a new peer record, should it replace the previously stored multiaddrs (not certified) by the new ones, or should it merge? If it merges, when the AddressBook receives a new peer record with different addresses from a previously stored record, what happens to the previously addresses marked as certified?
2. We emit `change:multiaddrs` when a peer has new multiaddrs. The question is, what if we already know a multiaddr but it is now certified? From the persistence layer standpoint, it is important to receive the event, but is this expected from a regular listener of the events?
3. (this we talked before, and we should just delay a decision and add it to Future Work section): When loading from the datastore on restart, should we ignore the multiaddrs stored that are not in the signed peer record?