### PR TITLE
Fix link to streaming-iterables' repo

### DIFF
--- a/doc/STREAMING_ITERABLES.md
+++ b/doc/STREAMING_ITERABLES.md
@@ -161,4 +161,4 @@ const duplex = {
 [it-pipe]: https://github.com/alanshaw/it-pipe
 [it-pushable]: https://github.com/alanshaw/it-pushable
 [it-reader]: https://github.com/alanshaw/it-reader
-[streaming-iterables]: https://github.com/bustle/streaming-iterables
+[streaming-iterables]: https://github.com/reconbot/streaming-iterables


### PR DESCRIPTION
You can confirm the link at npm https://www.npmjs.com/package/streaming-iterables