### PR TITLE
chore: add modules to update in 0.28.x migration

### DIFF
--- a/doc/migrations/v0.27-v.28.md
+++ b/doc/migrations/v0.27-v.28.md
@@ -10,6 +10,7 @@ A migration guide for refactoring your application code from libp2p v0.27.x to v
   - [API Implications](#api-implications)
 - [Connection Manager and Registrar](#connection-manager-and-registrar)
 - [Events](#events)
+- [Module Updates](#module-updates)
 
 ## PeerStore API
 
@@ -319,6 +320,21 @@ libp2p.on('peer:discovery', (peerInfo) => {
 libp2p.on('peer:discovery', (peerId) => {
 // peerId instance
 })
+```
+
+## Module Updates
+
+With `libp2p@0.28` you should update the following libp2p modules if you are relying on them:
+
+```json
+"libp2p-bootstrap": "^0.11.0",
+"libp2p-delegated-content-routing": "^0.5.0",
+"libp2p-delegated-peer-routing": "^0.5.0",
+"libp2p-floodsub": "^0.21.0",
+"libp2p-gossipsub": "^0.4.0",
+"libp2p-kad-dht": "^0.19.1",
+"libp2p-mdns": "^0.14.1",
+"libp2p-webrtc-star": "^0.18.0"
 ```
 
 [connection]: https://github.com/libp2p/js-interfaces/tree/master/src/connection


### PR DESCRIPTION
Adding modules to update in the `0.28.x` release per #694 