### PR TITLE
fix: not dial all known peers in parallel on startup

### DIFF
--- a/.aegir.js
+++ b/.aegir.js
@@ -45,7 +45,7 @@ const after = async () => {
 }
 
 module.exports = {
-  bundlesize: { maxSize: '200kB' },
+  bundlesize: { maxSize: '202kB' },
   hooks: {
     pre: before,
     post: after

--- a/doc/CONFIGURATION.md
+++ b/doc/CONFIGURATION.md
@@ -270,7 +270,7 @@ const node = await Libp2p.create({
   },
   config: {
     peerDiscovery: {
-      autoDial: true,             // Auto connect to discovered peers (limited by ConnectionManager minPeers)
+      autoDial: true,             // Auto connect to discovered peers (limited by ConnectionManager minConnections)
       // The `tag` property will be searched when creating the instance of your Peer Discovery service.
       // The associated object, will be passed to the service when it is instantiated.
       [MulticastDNS.tag]: {

--- a/doc/GETTING_STARTED.md
+++ b/doc/GETTING_STARTED.md
@@ -217,7 +217,7 @@ const node = await Libp2p.create({
   },
   config: {
     peerDiscovery: {
-      autoDial: true, // Auto connect to discovered peers (limited by ConnectionManager minPeers)
+      autoDial: true, // Auto connect to discovered peers (limited by ConnectionManager minConnections)
       // The `tag` property will be searched when creating the instance of your Peer Discovery service.
       // The associated object, will be passed to the service when it is instantiated.
       [Bootstrap.tag]: {

--- a/src/config.js
+++ b/src/config.js
@@ -12,7 +12,7 @@ const DefaultConfig = {
     noAnnounce: []
   },
   connectionManager: {
-    minPeers: 25
+    minConnections: 25
   },
   transportManager: {
     faultTolerance: FaultTolerance.FATAL_ALL

--- a/src/connection-manager/index.js
+++ b/src/connection-manager/index.js
@@ -291,10 +291,17 @@ class ConnectionManager extends EventEmitter {
   async _autoDial () {
     const minConnections = this._options.minConnections
 
+    const recursiveTimeoutTrigger = () => {
+      if (this._autoDialTimeout) {
+        this._autoDialTimeout.reschedule(this._options.autoDialInterval)
+      } else {
+        this._autoDialTimeout = retimer(this._autoDial, this._options.autoDialInterval)
+      }
+    }
+
     // Already has enough connections
     if (this.size >= minConnections) {
-      this._autoDialTimeout = retimer(this._autoDial, this._options.autoDialInterval)
-
+      recursiveTimeoutTrigger()
       return
     }
 
@@ -325,7 +332,7 @@ class ConnectionManager extends EventEmitter {
       }
     }
 
-    this._autoDialTimeout = retimer(this._autoDial, this._options.autoDialInterval)
+    recursiveTimeoutTrigger()
   }
 
   /**

--- a/src/index.js
+++ b/src/index.js
@@ -65,6 +65,9 @@ class Libp2p extends EventEmitter {
     this._discovery = new Map() // Discovery service instances/references
 
     // Create the Connection Manager
+    if (this._options.connectionManager.minPeers) { // Remove in 0.29
+      this._options.connectionManager.minConnections = this._options.connectionManager.minPeers
+    }
     this.connectionManager = new ConnectionManager(this, {
       autoDial: this._config.peerDiscovery.autoDial,
       ...this._options.connectionManager

--- a/src/index.js
+++ b/src/index.js
@@ -501,15 +501,15 @@ class Libp2p extends EventEmitter {
   /**
    * Will dial to the given `peerId` if the current number of
    * connected peers is less than the configured `ConnectionManager`
-   * minPeers.
+   * minConnections.
    * @private
    * @param {PeerId} peerId
    */
   async _maybeConnect (peerId) {
     // If auto dialing is on and we have no connection to the peer, check if we should dial
     if (this._config.peerDiscovery.autoDial === true && !this.connectionManager.get(peerId)) {
-      const minPeers = this._options.connectionManager.minPeers || 0
-      if (minPeers > this.connectionManager.size) {
+      const minConnections = this._options.connectionManager.minConnections || 0
+      if (minConnections > this.connectionManager.size) {
         log('connecting to discovered peer %s', peerId.toB58String())
         try {
           await this.dialer.connectToPeer(peerId)

--- a/src/index.js
+++ b/src/index.js
@@ -65,7 +65,10 @@ class Libp2p extends EventEmitter {
     this._discovery = new Map() // Discovery service instances/references
 
     // Create the Connection Manager
-    this.connectionManager = new ConnectionManager(this, this._options.connectionManager)
+    this.connectionManager = new ConnectionManager(this, {
+      autoDial: this._config.peerDiscovery.autoDial,
+      ...this._options.connectionManager
+    })
 
     // Create Metrics
     if (this._options.metrics.enabled) {

--- a/test/connection-manager/index.node.js
+++ b/test/connection-manager/index.node.js
@@ -226,7 +226,7 @@ describe('libp2p.connections', () => {
 
     it('should connect to peers in the PeerStore when a peer disconnected', async () => {
       const minConnections = 1
-      const maybeConnectInterval = 1000
+      const autoDialInterval = 1000
 
       const [libp2p] = await peerUtils.createPeer({
         fixture: false,
@@ -236,7 +236,7 @@ describe('libp2p.connections', () => {
           },
           connectionManager: {
             minConnections,
-            maybeConnectInterval
+            autoDialInterval
           }
         }
       })

--- a/test/connection-manager/index.node.js
+++ b/test/connection-manager/index.node.js
@@ -243,18 +243,18 @@ describe('libp2p.connections', () => {
 
       // Populate PeerStore after starting (discovery)
       libp2p.peerStore.addressBook.set(nodes[0].peerId, nodes[0].multiaddrs)
-      libp2p.peerStore.addressBook.set(nodes[1].peerId, nodes[1].multiaddrs)
-      libp2p.peerStore.protoBook.set(nodes[1].peerId, ['/protocol-min-conns'])
 
       // Wait for peer to connect
       const conn = await libp2p.dial(nodes[0].peerId)
       expect(libp2p.connectionManager.get(nodes[0].peerId)).to.exist()
-      expect(libp2p.connectionManager.get(nodes[1].peerId)).to.not.exist()
 
       await conn.close()
-      await pWaitFor(() => libp2p.connectionManager.size === minConnections)
-      expect(libp2p.connectionManager.get(nodes[0].peerId)).to.not.exist()
-      expect(libp2p.connectionManager.get(nodes[1].peerId)).to.exist()
+      // Closed
+      await pWaitFor(() => libp2p.connectionManager.size === 0)
+      // Connected
+      await pWaitFor(() => libp2p.connectionManager.size === 1)
+
+      expect(libp2p.connectionManager.get(nodes[0].peerId)).to.exist()
 
       await libp2p.stop()
     })

--- a/test/connection-manager/index.node.js
+++ b/test/connection-manager/index.node.js
@@ -7,6 +7,9 @@ chai.use(require('chai-as-promised'))
 const { expect } = chai
 const sinon = require('sinon')
 
+const delay = require('delay')
+const pWaitFor = require('p-wait-for')
+
 const peerUtils = require('../utils/creators/peer')
 const mockConnection = require('../utils/mockConnection')
 const baseOptions = require('../utils/base-options.browser')
@@ -111,5 +114,146 @@ describe('libp2p.connections', () => {
 
     await libp2p.stop()
     await remoteLibp2p.stop()
+  })
+
+  describe('proactive connections', () => {
+    let nodes = []
+
+    beforeEach(async () => {
+      nodes = await peerUtils.createPeer({
+        number: 2,
+        config: {
+          addresses: {
+            listen: ['/ip4/127.0.0.1/tcp/0/ws']
+          }
+        }
+      })
+    })
+
+    afterEach(async () => {
+      await Promise.all(nodes.map((node) => node.stop()))
+      sinon.reset()
+    })
+
+    it('should connect to all the peers stored in the PeerStore, if their number is below minConnections', async () => {
+      const [libp2p] = await peerUtils.createPeer({
+        fixture: false,
+        started: false,
+        config: {
+          addresses: {
+            listen: ['/ip4/127.0.0.1/tcp/0/ws']
+          },
+          connectionManager: {
+            minConnections: 3
+          }
+        }
+      })
+
+      // Populate PeerStore before starting
+      libp2p.peerStore.addressBook.set(nodes[0].peerId, nodes[0].multiaddrs)
+      libp2p.peerStore.addressBook.set(nodes[1].peerId, nodes[1].multiaddrs)
+
+      await libp2p.start()
+
+      // Wait for peers to connect
+      await pWaitFor(() => libp2p.connectionManager.size === 2)
+
+      await libp2p.stop()
+    })
+
+    it('should connect to all the peers stored in the PeerStore until reaching the minConnections', async () => {
+      const minConnections = 1
+      const [libp2p] = await peerUtils.createPeer({
+        fixture: false,
+        started: false,
+        config: {
+          addresses: {
+            listen: ['/ip4/127.0.0.1/tcp/0/ws']
+          },
+          connectionManager: {
+            minConnections
+          }
+        }
+      })
+
+      // Populate PeerStore before starting
+      libp2p.peerStore.addressBook.set(nodes[0].peerId, nodes[0].multiaddrs)
+      libp2p.peerStore.addressBook.set(nodes[1].peerId, nodes[1].multiaddrs)
+
+      await libp2p.start()
+
+      // Wait for peer to connect
+      await pWaitFor(() => libp2p.connectionManager.size === minConnections)
+
+      // Wait more time to guarantee no other connection happened
+      await delay(200)
+      expect(libp2p.connectionManager.size).to.eql(minConnections)
+
+      await libp2p.stop()
+    })
+
+    it('should connect to all the peers stored in the PeerStore until reaching the minConnections sorted', async () => {
+      const minConnections = 1
+      const [libp2p] = await peerUtils.createPeer({
+        fixture: false,
+        started: false,
+        config: {
+          addresses: {
+            listen: ['/ip4/127.0.0.1/tcp/0/ws']
+          },
+          connectionManager: {
+            minConnections
+          }
+        }
+      })
+
+      // Populate PeerStore before starting
+      libp2p.peerStore.addressBook.set(nodes[0].peerId, nodes[0].multiaddrs)
+      libp2p.peerStore.addressBook.set(nodes[1].peerId, nodes[1].multiaddrs)
+      libp2p.peerStore.protoBook.set(nodes[1].peerId, ['/protocol-min-conns'])
+
+      await libp2p.start()
+
+      // Wait for peer to connect
+      await pWaitFor(() => libp2p.connectionManager.size === minConnections)
+
+      // Should have connected to the peer with protocols
+      expect(libp2p.connectionManager.get(nodes[0].peerId)).to.not.exist()
+      expect(libp2p.connectionManager.get(nodes[1].peerId)).to.exist()
+
+      await libp2p.stop()
+    })
+
+    it('should connect to peers in the PeerStore when a peer disconnected', async () => {
+      const minConnections = 1
+      const [libp2p] = await peerUtils.createPeer({
+        fixture: false,
+        config: {
+          addresses: {
+            listen: ['/ip4/127.0.0.1/tcp/0/ws']
+          },
+          connectionManager: {
+            minConnections
+          }
+        }
+      })
+
+      // Populate PeerStore after starting (discovery)
+      libp2p.peerStore.addressBook.set(nodes[0].peerId, nodes[0].multiaddrs)
+      libp2p.peerStore.addressBook.set(nodes[1].peerId, nodes[1].multiaddrs)
+      libp2p.peerStore.protoBook.set(nodes[1].peerId, ['/protocol-min-conns'])
+
+      // Wait for peer to connect
+      const conn = await libp2p.dial(nodes[0].peerId)
+      expect(libp2p.connectionManager.get(nodes[0].peerId)).to.exist()
+      expect(libp2p.connectionManager.get(nodes[1].peerId)).to.not.exist()
+
+      await conn.close()
+      await pWaitFor(() => libp2p.connectionManager.size === minConnections)
+      expect(libp2p.connectionManager.get(nodes[0].peerId)).to.not.exist()
+      expect(libp2p.connectionManager.get(nodes[1].peerId)).to.exist()
+
+      await libp2p.stop()
+    })
   })
 })

--- a/test/connection-manager/index.node.js
+++ b/test/connection-manager/index.node.js
@@ -226,6 +226,8 @@ describe('libp2p.connections', () => {
 
     it('should connect to peers in the PeerStore when a peer disconnected', async () => {
       const minConnections = 1
+      const maybeConnectInterval = 1000
+
       const [libp2p] = await peerUtils.createPeer({
         fixture: false,
         config: {
@@ -233,7 +235,8 @@ describe('libp2p.connections', () => {
             listen: ['/ip4/127.0.0.1/tcp/0/ws']
           },
           connectionManager: {
-            minConnections
+            minConnections,
+            maybeConnectInterval
           }
         }
       })

--- a/test/connection-manager/index.spec.js
+++ b/test/connection-manager/index.spec.js
@@ -58,7 +58,8 @@ describe('Connection Manager', () => {
       config: {
         modules: baseOptions.modules,
         connectionManager: {
-          maxConnections: max
+          maxConnections: max,
+          minConnections: 2
         }
       },
       started: false
@@ -96,7 +97,8 @@ describe('Connection Manager', () => {
       config: {
         modules: baseOptions.modules,
         connectionManager: {
-          maxConnections: max
+          maxConnections: max,
+          minConnections: 0
         }
       },
       started: false

--- a/test/peer-discovery/index.spec.js
+++ b/test/peer-discovery/index.spec.js
@@ -31,10 +31,13 @@ describe('peer discovery', () => {
       sinon.reset()
     })
 
-    it('should dial know peers on startup', async () => {
+    it('should dial know peers on startup below the minConnections watermark', async () => {
       libp2p = new Libp2p({
         ...baseOptions,
-        peerId
+        peerId,
+        connectionManager: {
+          minConnections: 2
+        }
       })
 
       libp2p.peerStore.addressBook.set(remotePeerId, [multiaddr('/ip4/165.1.1.1/tcp/80')])


### PR DESCRIPTION
This PR aims to block large numbers of dials on a peer restart, if this peer already new a large number of peers in the past.

It checks the `minPeers` as the `maybeConnect` function used by the discovery event handlers. This was also using the `minPeers`, but as all the dials were put in parallel, the `connectionManager.size` would not be updated to avoid further dials.

When we work on connectionManager, we should work on better strategies for this, and likely have them as configurable