### PR TITLE
fix: pass libp2p to the dht

### DIFF
--- a/src/index.js
+++ b/src/index.js
@@ -166,6 +166,7 @@ class Libp2p extends EventEmitter {
     if (this._modules.dht) {
       const DHT = this._modules.dht
       this._dht = new DHT({
+        libp2p: this,
         dialer: this.dialer,
         peerId: this.peerId,
         peerStore: this.peerStore,


### PR DESCRIPTION
The DHT needs to be able to get its addresses for provide calls. This change passes libp2p itself to the DHT which is ideal, as we can get rid of all the subcomponents. To avoid the breaking change I am not removing the other components right now, but we should do this in 0.29.