### PR TITLE
fix: back port #678 to catch pipe errors

### DIFF
--- a/src/identify/index.js
+++ b/src/identify/index.js
@@ -227,7 +227,7 @@ class IdentifyService {
    * @param {*} options.stream
    * @param {Connection} options.connection
    */
-  _handleIdentify ({ connection, stream }) {
+  async _handleIdentify ({ connection, stream }) {
     let publicKey = Buffer.alloc(0)
     if (this.peerInfo.id.pubKey) {
       publicKey = this.peerInfo.id.pubKey.bytes
@@ -242,12 +242,16 @@ class IdentifyService {
       protocols: Array.from(this._protocols.keys())
     })
 
-    pipe(
-      [message],
-      lp.encode(),
-      stream,
-      consume
-    )
+    try {
+      await pipe(
+        [message],
+        lp.encode(),
+        stream,
+        consume
+      )
+    } catch (err) {
+      log.error('could not respond to identify request', err)
+    }
   }
 
   /**
@@ -258,17 +262,16 @@ class IdentifyService {
    * @param {Connection} options.connection
    */
   async _handlePush ({ connection, stream }) {
-    const [data] = await pipe(
-      [],
-      stream,
-      lp.decode(),
-      take(1),
-      toBuffer,
-      collect
-    )
-
     let message
     try {
+      const [data] = await pipe(
+        [],
+        stream,
+        lp.decode(),
+        take(1),
+        toBuffer,
+        collect
+      )
       message = Message.decode(data)
     } catch (err) {
       return log.error('received invalid message', err)

--- a/src/metrics/index.js
+++ b/src/metrics/index.js
@@ -210,7 +210,7 @@ class Metrics {
 
     const _sink = stream.sink
     stream.sink = source => {
-      pipe(
+      return pipe(
         source,
         tap(chunk => metrics._onMessage({
           remotePeer,

--- a/src/pnet/index.js
+++ b/src/pnet/index.js
@@ -17,7 +17,7 @@ const handshake = require('it-handshake')
 const { NONCE_LENGTH } = require('./key-generator')
 const debug = require('debug')
 const log = debug('libp2p:pnet')
-log.err = debug('libp2p:pnet:err')
+log.error = debug('libp2p:pnet:err')
 
 /**
  * Takes a Private Shared Key (psk) and provides a `protect` method
@@ -69,7 +69,7 @@ class Protector {
       // Decrypt all inbound traffic
       createUnboxStream(remoteNonce, this.psk),
       external
-    )
+    ).catch(log.error)
 
     return internal
   }

--- a/src/upgrader.js
+++ b/src/upgrader.js
@@ -258,7 +258,7 @@ class Upgrader {
       }
 
       // Pipe all data through the muxer
-      pipe(upgradedConn, muxer, upgradedConn)
+      pipe(upgradedConn, muxer, upgradedConn).catch(log.error)
     }
 
     const _timeline = maConn.timeline


### PR DESCRIPTION
This is a port of fixed in https://github.com/libp2p/js-libp2p/pull/678 for 0.27.x.

The metrics sink wrapper was not returning the wrapper which causes `sink()` to be undefined instead of a promise.

fixes: https://github.com/libp2p/js-libp2p/issues/694