### PR TITLE
fix: retimer reschedule does not work as interval

### DIFF
--- a/src/connection-manager/index.js
+++ b/src/connection-manager/index.js
@@ -178,7 +178,7 @@ class ConnectionManager extends EventEmitter {
     const total = received + sent
     this._checkMaxLimit('maxData', total)
     log('metrics update', total)
-    this._timer.reschedule(this._options.pollInterval)
+    retimer(this._checkMetrics, this._options.pollInterval)
   }
 
   /**
@@ -291,17 +291,9 @@ class ConnectionManager extends EventEmitter {
   async _autoDial () {
     const minConnections = this._options.minConnections
 
-    const recursiveTimeoutTrigger = () => {
-      if (this._autoDialTimeout) {
-        this._autoDialTimeout.reschedule(this._options.autoDialInterval)
-      } else {
-        this._autoDialTimeout = retimer(this._autoDial, this._options.autoDialInterval)
-      }
-    }
-
     // Already has enough connections
     if (this.size >= minConnections) {
-      recursiveTimeoutTrigger()
+      this._autoDialTimeout = retimer(this._autoDial, this._options.autoDialInterval)
       return
     }
 
@@ -332,7 +324,7 @@ class ConnectionManager extends EventEmitter {
       }
     }
 
-    recursiveTimeoutTrigger()
+    this._autoDialTimeout = retimer(this._autoDial, this._options.autoDialInterval)
   }
 
   /**

--- a/src/connection-manager/index.js
+++ b/src/connection-manager/index.js
@@ -178,7 +178,7 @@ class ConnectionManager extends EventEmitter {
     const total = received + sent
     this._checkMaxLimit('maxData', total)
     log('metrics update', total)
-    retimer(this._checkMetrics, this._options.pollInterval)
+    this._timer = retimer(this._checkMetrics, this._options.pollInterval)
   }
 
   /**

--- a/src/metrics/stats.js
+++ b/src/metrics/stats.js
@@ -128,11 +128,7 @@ class Stats extends EventEmitter {
    * @returns {void}
    */
   _resetComputeTimeout () {
-    if (this._timeout) {
-      this._timeout.reschedule(this._nextTimeout())
-    } else {
-      this._timeout = retimer(this._update, this._nextTimeout())
-    }
+    this._timeout = retimer(this._update, this._nextTimeout())
   }
 
   /**


### PR DESCRIPTION
`retimer` reschedule is not an `interval` feature but a "delay" of a previously defined interval. This PR fixes it