### PR TITLE
chore: add migration guide template

### DIFF
--- a/MIGRATION_TEMPLATE.md
+++ b/MIGRATION_TEMPLATE.md
@@ -35,7 +35,10 @@ __Describe__
 
 With this release you should update the following libp2p modules if you are relying on them:
 
-<!--Specify module versions in JSON for migration below-->
+<!--Specify module versions in JSON for migration below.
+It's recommended to check package.json changes for this: 
+`git diff <release> <prev> -- package.json`
+-->
 
 ```json
 

--- a/MIGRATION_TEMPLATE.md
+++ b/MIGRATION_TEMPLATE.md
@@ -1,0 +1,42 @@
+<!--Specify versions for migration below-->
+# Migrating to libp2p@__
+
+A migration guide for refactoring your application code from libp2p v__ to v__.
+
+## Table of Contents
+
+- [API](#api)
+- [Module Updates](#module-updates)
+
+## API
+
+<!--Describe breaking APIs with examples for Before and After
+Example:
+
+### Peer Discovery
+
+__Describe__
+
+**Before**
+
+```js
+
+```
+
+**After**
+
+```js
+
+```
+
+-->
+
+## Module Updates
+
+With this release you should update the following libp2p modules if you are relying on them:
+
+<!--Specify module versions in JSON for migration below-->
+
+```json
+
+```


### PR DESCRIPTION
Per suggestion on https://github.com/libp2p/js-libp2p/pull/695#issuecomment-655482342 this PR adds a migration guide template.

Its goal is to create a consistent structure for this document to ease the life of users migrating and also to guarantee that we do not miss important things like the modules to update. Other points might be added in the future