### PR TITLE
docs: use tag for webrtc-star discovery config

### DIFF
--- a/doc/CONFIGURATION.md
+++ b/doc/CONFIGURATION.md
@@ -304,7 +304,7 @@ const node = await Libp2p.create({
   },
   config: {
     peerDiscovery: {
-      webRTCStar: {
+      [WebRTCStar.tag]: {
         enabled: true
       }
     }


### PR DESCRIPTION
To avoid confusions like we previously had. This was not fixed at the time