### PR TITLE
fix: return empty array when no multiaddrs are known

### DIFF
--- a/src/peer-store/address-book.js
+++ b/src/peer-store/address-book.js
@@ -179,7 +179,7 @@ class AddressBook extends Book {
     const record = this.data.get(peerId.toB58String())
 
     if (!record) {
-      return undefined
+      return []
     }
 
     return record.map((address) => {

--- a/test/peer-store/address-book.spec.js
+++ b/test/peer-store/address-book.spec.js
@@ -323,10 +323,10 @@ describe('addressBook', () => {
       throw new Error('invalid peerId should throw error')
     })
 
-    it('returns undefined if no multiaddrs are known for the provided peer', () => {
+    it('returns empty array if no multiaddrs are known for the provided peer', () => {
       const addresses = ab.getMultiaddrsForPeer(peerId)
 
-      expect(addresses).to.not.exist()
+      expect(addresses).to.be.empty()
     })
 
     it('returns the multiaddrs stored', () => {


### PR DESCRIPTION
Returning `undefined` makes the address length check in [dialler/index.js](https://github.com/libp2p/js-libp2p/blob/master/src/dialer/index.js#L73-L75) fail with `cannot read property length of undefined` as it has no null-guard, so the change here is to always return an array, but it might be empty if we don't know any multiaddrs for the given peer.
