### PR TITLE
fix: create dial target for peer with no known addrs

### DIFF
--- a/src/dialer/index.js
+++ b/src/dialer/index.js
@@ -112,7 +112,7 @@ class Dialer {
       this.peerStore.addressBook.add(id, multiaddrs)
     }
 
-    let addrs = this.peerStore.addressBook.getMultiaddrsForPeer(id)
+    let addrs = this.peerStore.addressBook.getMultiaddrsForPeer(id) || []
 
     // If received a multiaddr to dial, it should be the first to use
     // But, if we know other multiaddrs for the peer, we should try them too.

--- a/test/dialing/direct.node.js
+++ b/test/dialing/direct.node.js
@@ -96,6 +96,15 @@ describe('Dialing (direct, TCP)', () => {
       .and.to.have.nested.property('._errors[0].code', ErrorCodes.ERR_TRANSPORT_UNAVAILABLE)
   })
 
+  it('should fail to connect if peer has no known addresses', async () => {
+    const dialer = new Dialer({ transportManager: localTM, peerStore })
+    const peerId = await PeerId.createFromJSON(Peers[1])
+
+    await expect(dialer.connectToPeer(peerId))
+      .to.eventually.be.rejectedWith(Error)
+      .and.to.have.nested.property('.code', ErrorCodes.ERR_NO_VALID_ADDRESSES)
+  })
+
   it('should be able to connect to a given peer id', async () => {
     const peerStore = new PeerStore()
     const dialer = new Dialer({


### PR DESCRIPTION
This PR fixes `_createDialTarget` dialer function to return an empty array of multiaddrs if there are no known multiaddrs for the target peer.

Closes #673 and #714 