### PR TITLE
fix: ping multiaddr from peer not previously stored in peerstore

### DIFF
--- a/src/index.js
+++ b/src/index.js
@@ -324,7 +324,7 @@ class Libp2p extends EventEmitter {
    * @returns {Promise<Connection|*>}
    */
   async dialProtocol (peer, protocols, options) {
-    const { id, multiaddrs } = getPeer(peer, this.peerStore)
+    const { id, multiaddrs } = getPeer(peer)
     let connection = this.connectionManager.get(id)
 
     if (!connection) {
@@ -396,7 +396,12 @@ class Libp2p extends EventEmitter {
    * @returns {Promise<number>}
    */
   ping (peer) {
-    const { id } = getPeer(peer)
+    const { id, multiaddrs } = getPeer(peer)
+
+    // If received multiaddr, ping it
+    if (multiaddrs) {
+      return ping(this, multiaddrs[0])
+    }
 
     return ping(this, id)
   }

--- a/src/ping/index.js
+++ b/src/ping/index.js
@@ -15,11 +15,11 @@ const { PROTOCOL, PING_LENGTH } = require('./constants')
 /**
  * Ping a given peer and wait for its response, getting the operation latency.
  * @param {Libp2p} node
- * @param {PeerId} peer
+ * @param {PeerId|multiaddr} peer
  * @returns {Promise<Number>}
  */
 async function ping (node, peer) {
-  log('dialing %s to %s', PROTOCOL, peer.toB58String())
+  log('dialing %s to %s', PROTOCOL, peer.toB58String ? peer.toB58String() : peer)
 
   const { stream } = await node.dialProtocol(peer, PROTOCOL)
 

--- a/test/core/ping.node.js
+++ b/test/core/ping.node.js
@@ -17,7 +17,7 @@ describe('ping', () => {
 
   beforeEach(async () => {
     nodes = await peerUtils.createPeer({
-      number: 2,
+      number: 3,
       config: baseOptions
     })
 
@@ -25,7 +25,14 @@ describe('ping', () => {
     nodes[1].peerStore.addressBook.set(nodes[0].peerId, nodes[0].multiaddrs)
   })
 
-  it('ping once from peer0 to peer1', async () => {
+  it('ping once from peer0 to peer1 using a multiaddr', async () => {
+    const ma = `${nodes[2].multiaddrs[0]}/p2p/${nodes[2].peerId.toB58String()}`
+    const latency = await nodes[0].ping(ma)
+
+    expect(latency).to.be.a('Number')
+  })
+
+  it('ping once from peer0 to peer1 using a peerId', async () => {
     const latency = await nodes[0].ping(nodes[1].peerId)
 
     expect(latency).to.be.a('Number')


### PR DESCRIPTION
When we try to ping using a multiaddr, under the hood we were trying to ping using the peer id but the address was not stored.

I added support for pinging using the multiaddr instead of adding the multiaddr to the addressBook because otherwise the ping could be done to a different multiaddr as a consequence of the parallel dials.

Context: https://discuss.libp2p.io/t/examples-failing-help-new-to-libp2p/620