### PR TITLE
♻️  Additional notes on production guides

### DIFF
--- a/doc/production/DELEGATE_NODES.md
+++ b/doc/production/DELEGATE_NODES.md
@@ -65,6 +65,13 @@ Bear in mind that this allows access to any origin. You might want to control th
 
 6. Start the example and retry its flows.
 
+<details>
+<summary>Troubleshooting</summary>
+
+<p><b>Error: no IPFS repo found in <code>$INSTALLATION_PATH/ipfs/common</code></b></p>
+Bear in mind that in some distributions you might need to run <code>ipfs init</code> before starting the <code>go-ipfs</code> daemon. If you are running the <code>go-ipfs</code> node in a server you might prefer using the <code>server</code> profile and running <code>ipfs init --profile server</code> instead. For more detailed instructions, please refer to the canonical documentation for <a target="_blank" href="https://docs.ipfs.io/how-to/command-line-quick-start/#initialize-the-repository">initializing the repository</a>
+</details>
+
 ## Setup a remote go-ipfs node as a Delegate Node for js-ipfs
 
 You should follow all the steps mentioned for the setup of a remote go-ipfs for the libp2p example, except for the integration with the example.

--- a/examples/delegated-routing/README.md
+++ b/examples/delegated-routing/README.md
@@ -13,7 +13,7 @@ This example uses a publicly known delegated routing node. This aims to ease exp
 2. Run the IPFS daemon: `ipfs daemon`
 3. In another window output the addresses of the node: `ipfs id`. Make note of the websocket address, it will contain `/ws/` in the address.
   - If there is no websocket address, you will need to add it in the ipfs config file (`~/.ipfs/config`)
-  - Add to Swarm Addresses something like: `"/ip4/127.0.0.1/tcp/4010/ws"`
+  - Add to Swarm Addresses something like: `"/ip4/127.0.0.1/tcp/4001/ws"`. Make sure to restart your IPFS node afterwards to ensure the new settings had been applied.
 4. In `./src/App.js` replace `BootstrapNode` with your nodes Websocket address from the step above.
 5. Start this example:
 


### PR DESCRIPTION
Patch for https://github.com/libp2p/js-libp2p/pull/718, aiming to cover SSL setup for `go-ipfs`, et.al `libp2p` nodes.