### PR TITLE
fix(identify): make agentversion dynamic and add it to the peerstore

### DIFF
--- a/src/identify/consts.js
+++ b/src/identify/consts.js
@@ -1,6 +1,8 @@
 'use strict'
 
+const libp2pVersion = require('../../package.json').version
+
 module.exports.PROTOCOL_VERSION = 'ipfs/0.1.0'
-module.exports.AGENT_VERSION = 'js-libp2p/0.1.0'
+module.exports.AGENT_VERSION = `js-libp2p/${libp2pVersion}`
 module.exports.MULTICODEC_IDENTIFY = '/ipfs/id/1.0.0'
 module.exports.MULTICODEC_IDENTIFY_PUSH = '/ipfs/id/push/1.0.0'

--- a/src/identify/index.js
+++ b/src/identify/index.js
@@ -175,6 +175,7 @@ class IdentifyService {
     // Update peers data in PeerStore
     this.peerStore.addressBook.set(id, listenAddrs.map((addr) => multiaddr(addr)))
     this.peerStore.protoBook.set(id, protocols)
+    this.peerStore.metadataBook.set(id, 'AgentVersion', Buffer.from(message.agentVersion))
 
     // TODO: Track our observed address so that we can score it
     log('received observed address of %s', observedAddr)

--- a/test/identify/index.spec.js
+++ b/test/identify/index.spec.js
@@ -19,6 +19,7 @@ const { IdentifyService, multicodecs } = require('../../src/identify')
 const Peers = require('../fixtures/peers')
 const Libp2p = require('../../src')
 const baseOptions = require('../utils/base-options.browser')
+const pkg = require('../../package.json')
 
 const { MULTIADDRS_WEBSOCKETS } = require('../fixtures/browser')
 const remoteAddr = MULTIADDRS_WEBSOCKETS[0]
@@ -53,6 +54,9 @@ describe('Identify', () => {
           },
           protoBook: {
             set: () => { }
+          },
+          metadataBook: {
+            set: () => { }
           }
         },
         multiaddrs: []
@@ -77,6 +81,7 @@ describe('Identify', () => {
 
     sinon.spy(localIdentify.peerStore.addressBook, 'set')
     sinon.spy(localIdentify.peerStore.protoBook, 'set')
+    sinon.spy(localIdentify.peerStore.metadataBook, 'set')
 
     // Run identify
     await Promise.all([
@@ -90,6 +95,12 @@ describe('Identify', () => {
 
     expect(localIdentify.peerStore.addressBook.set.callCount).to.equal(1)
     expect(localIdentify.peerStore.protoBook.set.callCount).to.equal(1)
+
+    const metadataArgs = localIdentify.peerStore.metadataBook.set.firstCall.args
+    expect(metadataArgs[0].id.bytes).to.equal(remotePeer.bytes)
+    expect(metadataArgs[1]).to.equal('AgentVersion')
+    expect(metadataArgs[2].toString()).to.equal(`js-libp2p/${pkg.version}`)
+
     // Validate the remote peer gets updated in the peer store
     const call = localIdentify.peerStore.addressBook.set.firstCall
     expect(call.args[0].id.bytes).to.equal(remotePeer.bytes)


### PR DESCRIPTION
The AgentVersion in identify shouldn't be static. In go-libp2p the AgentVersion is generated by the application name and version, so for go-ipfs this looks like `go-ipfs/<version>`. Ideally we would replicate this, however this is a trickier to handle in JS as we need to account for browser usage. At the very least we need to default to the js-libp2p version, so this adds that basic level of support.

This is extremely helpful for understanding what versions are being used on the network, which helps us when determining upgrade strategies and change rollouts on the network.

go-libp2p also tracks the AgentVersion of peers in the metadata book, so I added that here as well, which is necessary for actually checking this data (we were previously ignoring this).