### PR TITLE
fix: allow certain keychain operations without a password

### DIFF
--- a/src/index.js
+++ b/src/index.js
@@ -82,7 +82,7 @@ class Libp2p extends EventEmitter {
     }
 
     // Create keychain
-    if (this._options.keychain && this._options.keychain.pass && this._options.keychain.datastore) {
+    if (this._options.keychain && this._options.keychain.datastore) {
       log('creating keychain')
 
       const keychainOpts = Keychain.generateOptions()

--- a/src/keychain/index.js
+++ b/src/keychain/index.js
@@ -110,7 +110,7 @@ class Keychain {
     this.opts = mergeOptions(defaultOptions, options)
 
     // Enforce NIST SP 800-132
-    if (!this.opts.passPhrase || this.opts.passPhrase.length < 20) {
+    if (this.opts.passPhrase && this.opts.passPhrase.length < 20) {
       throw new Error('passPhrase must be least 20 characters')
     }
     if (this.opts.dek.keyLength < NIST.minKeyLength) {
@@ -123,14 +123,22 @@ class Keychain {
       throw new Error(`dek.iterationCount must be least ${NIST.minIterationCount}`)
     }
 
-    // Create the derived encrypting key
-    const dek = crypto.pbkdf2(
-      this.opts.passPhrase,
-      this.opts.dek.salt,
-      this.opts.dek.iterationCount,
-      this.opts.dek.keyLength,
-      this.opts.dek.hash)
-    Object.defineProperty(this, '_', { value: () => dek })
+    // Lazily create the derived encrypting key
+    let dek
+    Object.defineProperty(this, '_', {
+      value: () => {
+        if (!dek) {
+          dek = crypto.pbkdf2(
+            this.opts.passPhrase,
+            this.opts.dek.salt,
+            this.opts.dek.iterationCount,
+            this.opts.dek.keyLength,
+            this.opts.dek.hash)
+        }
+
+        return dek
+      }
+    })
   }
 
   /**

--- a/src/keychain/index.js
+++ b/src/keychain/index.js
@@ -123,22 +123,14 @@ class Keychain {
       throw new Error(`dek.iterationCount must be least ${NIST.minIterationCount}`)
     }
 
-    // Lazily create the derived encrypting key
-    let dek
-    Object.defineProperty(this, '_', {
-      value: () => {
-        if (!dek) {
-          dek = crypto.pbkdf2(
-            this.opts.passPhrase,
-            this.opts.dek.salt,
-            this.opts.dek.iterationCount,
-            this.opts.dek.keyLength,
-            this.opts.dek.hash)
-        }
+    const dek = this.opts.passPhrase ? crypto.pbkdf2(
+      this.opts.passPhrase,
+      this.opts.dek.salt,
+      this.opts.dek.iterationCount,
+      this.opts.dek.keyLength,
+      this.opts.dek.hash) : ''
 
-        return dek
-      }
-    })
+    Object.defineProperty(this, '_', { value: () => dek })
   }
 
   /**

--- a/test/keychain/keychain.spec.js
+++ b/test/keychain/keychain.spec.js
@@ -60,9 +60,7 @@ describe('keychain', () => {
   })
 
   it('does not support unsupported hashing alorithms', () => {
-    const keychain = new Keychain(datastore2, { passPhrase: passPhrase, dek: { hash: 'my-hash' } })
-
-    expect(keychain.createKey('derp')).to.be.rejected()
+    expect(() => new Keychain(datastore2, { passPhrase: passPhrase, dek: { hash: 'my-hash' } })).to.throw()
   })
 
   it('can list keys without a password', async () => {

--- a/test/keychain/keychain.spec.js
+++ b/test/keychain/keychain.spec.js
@@ -509,7 +509,7 @@ describe('libp2p.keychain', () => {
     throw new Error('should throw an error using the keychain if no passphrase provided')
   })
 
-  it('can be used if a passphrase is provided', async () => {
+  it('can be used when a passphrase is provided', async () => {
     const [libp2p] = await peerUtils.createPeer({
       started: false,
       config: {
@@ -523,6 +523,22 @@ describe('libp2p.keychain', () => {
     await libp2p.loadKeychain()
 
     const kInfo = await libp2p.keychain.createKey('keyName', 'rsa', 2048)
+    expect(kInfo).to.exist()
+  })
+
+  it('does not require a keychain passphrase', async () => {
+    const [libp2p] = await peerUtils.createPeer({
+      started: false,
+      config: {
+        keychain: {
+          datastore: new MemoryDatastore()
+        }
+      }
+    })
+
+    await libp2p.loadKeychain()
+
+    const kInfo = await libp2p.keychain.createKey('keyName', 'ed25519')
     expect(kInfo).to.exist()
   })
 


### PR DESCRIPTION
Listing, removing, renaming etc keys do not require a password so
the user should not be required to provide one.

This means we don't have to prompt the user to create a password
when they aren't going to do any operations that require a password.