### PR TITLE
chore: update interop version

### DIFF
--- a/package.json
+++ b/package.json
@@ -92,7 +92,7 @@
     "cids": "^1.0.0",
     "delay": "^4.3.0",
     "dirty-chai": "^2.0.1",
-    "interop-libp2p": "libp2p/interop#chore/gossipsub-1.1",
+    "interop-libp2p": "^0.3.0",
     "ipfs-http-client": "^46.0.0",
     "it-concat": "^1.0.0",
     "it-pair": "^1.0.0",


### PR DESCRIPTION
Updates interop with latest `go-libp2p` and `js-libp2p-daemon` updated