### PR TITLE
fix: pubsub intermittent test

### DIFF
--- a/test/pubsub/operation.node.js
+++ b/test/pubsub/operation.node.js
@@ -311,7 +311,11 @@ describe('Pubsub subsystem operates correctly', () => {
       expect(handlerSpy.args.map(([message]) => uint8ArrayToString(message.data))).to.include.members(['message1', 'message2'])
 
       // Disconnect the first connection (this acts as a delayed reconnect)
+      const libp2pConnUpdateSpy = sinon.spy(libp2p.connectionManager.connections, 'set')
+      const remoteLibp2pConnUpdateSpy = sinon.spy(remoteLibp2p.connectionManager.connections, 'set')
+
       await originalConnection.close()
+      await pWaitFor(() => libp2pConnUpdateSpy.callCount === 1 && remoteLibp2pConnUpdateSpy.callCount === 1)
 
       // Verify messages go both ways after the disconnect
       handlerSpy.resetHistory()


### PR DESCRIPTION
The pubsub test `should handle quick reconnects with a delayed disconnect` was failing sometimes, mostly in linux. The test would timeout waiting for `await pWaitFor(() => handlerSpy.callCount === 2)`. In these cases, the `handlerSpy.callCount` was 1 and only `libp2p` (who triggered the connection close) would receive the message.

I added to the test a validation that waits for the other party to be notified of the connection close before publishing more pubsub messages. It checks if the connections map was updated by the connection manager as a result of the disconnect

Closes #709 