### PR TITLE
chore: add libp2p-examples repo to release checklist

### DIFF
--- a/RELEASE.md
+++ b/RELEASE.md
@@ -26,6 +26,7 @@
 - Documentation
   - [ ] Ensure that README.md is up to date
   - [ ] Ensure that all the examples run
+  - [ ] Ensure [libp2p/js-libp2p-examples](https://github.com/libp2p/js-libp2p-examples) is updated
   - [ ] Ensure that [libp2p/docs](https://github.com/libp2p/docs) is updated
 - Communication
   - [ ] Create the release issue


### PR DESCRIPTION
We did not update `libp2p-examples` with the uint8array refactor.

I suggest that we add that task in our release process to avoid having inconsistencies between the latest `js-libp2p` and what is in `libp2p-examples#master`. Meanwhile, I will update the `libp2p-examples` with the latest release.