### PR TITLE
chore: examples not using secio

### DIFF
--- a/doc/CONFIGURATION.md
+++ b/doc/CONFIGURATION.md
@@ -223,7 +223,7 @@ Besides the `modules` and `config`, libp2p allows other internal options and con
 // Creating a libp2p node with:
 //   transport: websockets + tcp
 //   stream-muxing: mplex
-//   crypto-channel: secio
+//   crypto-channel: noise
 //   discovery: multicast-dns
 //   dht: kad-dht
 //   pubsub: gossipsub

--- a/examples/chat/src/libp2p-bundle.js
+++ b/examples/chat/src/libp2p-bundle.js
@@ -3,7 +3,6 @@
 const TCP = require('libp2p-tcp')
 const WS = require('libp2p-websockets')
 const mplex = require('libp2p-mplex')
-const SECIO = require('libp2p-secio')
 const { NOISE } = require('libp2p-noise')
 const defaultsDeep = require('@nodeutils/defaults-deep')
 const libp2p = require('../../..')
@@ -17,7 +16,7 @@ class Node extends libp2p {
           WS
         ],
         streamMuxer: [ mplex ],
-        connEncryption: [ NOISE, SECIO ]
+        connEncryption: [ NOISE ]
       }
     }
 

--- a/examples/chat/src/listener.js
+++ b/examples/chat/src/listener.js
@@ -1,7 +1,6 @@
 'use strict'
 /* eslint-disable no-console */
 
-const multaddr = require('multiaddr')
 const PeerId = require('peer-id')
 const Node = require('./libp2p-bundle.js')
 const { stdinToStream, streamToConsole } = require('./stream')

--- a/examples/chat/src/stream.js
+++ b/examples/chat/src/stream.js
@@ -3,7 +3,6 @@
 
 const pipe = require('it-pipe')
 const lp = require('it-length-prefixed')
-const uint8ArrayToString = require('uint8arrays/to-string')
 
 function stdinToStream(stream) {
   // Read utf-8 from stdin

--- a/examples/discovery-mechanisms/1.js
+++ b/examples/discovery-mechanisms/1.js
@@ -4,7 +4,6 @@
 const Libp2p = require('../../')
 const TCP = require('libp2p-tcp')
 const Mplex = require('libp2p-mplex')
-const SECIO = require('libp2p-secio')
 const { NOISE } = require('libp2p-noise')
 const Bootstrap = require('libp2p-bootstrap')
 
@@ -29,7 +28,7 @@ const bootstrapers = [
     modules: {
       transport: [TCP],
       streamMuxer: [Mplex],
-      connEncryption: [NOISE, SECIO],
+      connEncryption: [NOISE],
       peerDiscovery: [Bootstrap]
     },
     config: {

--- a/examples/discovery-mechanisms/2.js
+++ b/examples/discovery-mechanisms/2.js
@@ -4,7 +4,6 @@
 const Libp2p = require('../../')
 const TCP = require('libp2p-tcp')
 const Mplex = require('libp2p-mplex')
-const SECIO = require('libp2p-secio')
 const { NOISE } = require('libp2p-noise')
 const MulticastDNS = require('libp2p-mdns')
 
@@ -16,7 +15,7 @@ const createNode = async () => {
     modules: {
       transport: [TCP],
       streamMuxer: [Mplex],
-      connEncryption: [NOISE, SECIO],
+      connEncryption: [NOISE],
       peerDiscovery: [MulticastDNS]
     },
     config: {

--- a/examples/discovery-mechanisms/README.md
+++ b/examples/discovery-mechanisms/README.md
@@ -8,7 +8,7 @@ These mechanisms save configuration and enable a node to operate without any exp
 
 ## 1. Bootstrap list of Peers when booting a node
 
-For this demo, we will connect to IPFS default bootstrapper nodes and so, we will need to support the same set of features those nodes have, that are: TCP, mplex and SECIO. You can see the complete example at [1.js](./1.js).
+For this demo, we will connect to IPFS default bootstrapper nodes and so, we will need to support the same set of features those nodes have, that are: TCP, mplex and NOISE. You can see the complete example at [1.js](./1.js).
 
 First, we create our libp2p node.
 
@@ -20,7 +20,7 @@ const node = Libp2p.create({
   modules: {
     transport: [ TCP ],
     streamMuxer: [ Mplex ],
-    connEncryption: [ NOISE, SECIO ],
+    connEncryption: [ NOISE ],
     peerDiscovery: [ Bootstrap ]
   },
   config: {
@@ -62,7 +62,7 @@ const node = await Libp2p.create({
   modules: {
     transport: [ TCP ],
     streamMuxer: [ Mplex ],
-    connEncryption: [ NOISE, SECIO ],
+    connEncryption: [ NOISE ],
     peerDiscovery: [ Bootstrap ]
   },
   config: {
@@ -130,7 +130,7 @@ const createNode = () => {
     modules: {
       transport: [ TCP ],
       streamMuxer: [ Mplex ],
-      connEncryption: [ NOISE, SECIO ],
+      connEncryption: [ NOISE ],
       peerDiscovery: [ MulticastDNS ]
     },
     config: {

--- a/examples/echo/src/libp2p-bundle.js
+++ b/examples/echo/src/libp2p-bundle.js
@@ -3,7 +3,6 @@
 const TCP = require('libp2p-tcp')
 const WS = require('libp2p-websockets')
 const mplex = require('libp2p-mplex')
-const SECIO = require('libp2p-secio')
 const { NOISE } = require('libp2p-noise')
 
 const defaultsDeep = require('@nodeutils/defaults-deep')
@@ -18,7 +17,7 @@ class Node extends libp2p {
           WS
         ],
         streamMuxer: [ mplex ],
-        connEncryption: [ NOISE, SECIO ]
+        connEncryption: [ NOISE ]
       }
     }
 

--- a/examples/encrypted-communications/1.js
+++ b/examples/encrypted-communications/1.js
@@ -4,7 +4,6 @@ const Libp2p = require('../../')
 const TCP = require('libp2p-tcp')
 const Mplex = require('libp2p-mplex')
 const { NOISE } = require('libp2p-noise')
-const SECIO = require('libp2p-secio')
 
 const pipe = require('it-pipe')
 
@@ -16,7 +15,7 @@ const createNode = async () => {
     modules: {
       transport: [TCP],
       streamMuxer: [Mplex],
-      connEncryption: [NOISE, SECIO]
+      connEncryption: [NOISE]
     }
   })
 

--- a/examples/encrypted-communications/README.md
+++ b/examples/encrypted-communications/README.md
@@ -8,31 +8,24 @@ A byproduct of having these encrypted communications modules is that we can auth
 
 # 1. Set up encrypted communications
 
-We will build this example on top of example for [Protocol and Stream Multiplexing](../protocol-and-stream-multiplexing). You will need the modules `libp2p-secio`<sup>*</sup> and `libp2p-noise` to complete it, go ahead and `npm install libp2p-secio libp2p-noise`.
+We will build this example on top of example for [Protocol and Stream Multiplexing](../protocol-and-stream-multiplexing). You will need the `libp2p-noise` module to complete it, go ahead and `npm install libp2p-noise`.
 
 To add them to your libp2p configuration, all you have to do is:
 
 ```JavaScript
 const Libp2p = require('libp2p')
 const { NOISE } = require('libp2p-noise')
-const SECIO = require('libp2p-secio')
 
 const createNode = () => {
   return Libp2p.create({
     modules: {
       transport: [ TCP ],
       streamMuxer: [ Mplex ],
-      // Attach secio as the crypto channel to use
-      connEncryption: [ NOISE, SECIO ]
+      // Attach noise as the crypto channel to use
+      connEncryption: [ NOISE ]
     }
   })
 }
 ```
 
 And that's it, from now on, all your libp2p communications are encrypted. Try running the example [1.js](./1.js) to see it working.
-
-_<sup>*</sup> SECIO is the crypto channel developed for IPFS, it is a TLS 1.3 like crypto channel that established an encrypted communication channel between two peers._
-
-If you want to want to learn more about how SECIO works, you can read the [great write up done by Dominic Tarr](https://github.com/auditdrivencrypto/secure-channel/blob/master/prior-art.md#ipfss-secure-channel).
-
-Important note: SECIO hasn't been audited and so, we do not recommend to trust its security. We intent to move to TLS 1.3 once the specification is finalized and an implementation exists that we can use.

--- a/examples/libp2p-in-the-browser/index.js
+++ b/examples/libp2p-in-the-browser/index.js
@@ -3,7 +3,6 @@ import Libp2p from 'libp2p'
 import Websockets from 'libp2p-websockets'
 import WebRTCStar from 'libp2p-webrtc-star'
 import { NOISE } from 'libp2p-noise'
-import Secio from 'libp2p-secio'
 import Mplex from 'libp2p-mplex'
 import Bootstrap from 'libp2p-bootstrap'
 
@@ -21,7 +20,7 @@ document.addEventListener('DOMContentLoaded', async () => {
     },
     modules: {
       transport: [Websockets, WebRTCStar],
-      connEncryption: [NOISE, Secio],
+      connEncryption: [NOISE],
       streamMuxer: [Mplex],
       peerDiscovery: [Bootstrap]
     },

--- a/examples/libp2p-in-the-browser/package.json
+++ b/examples/libp2p-in-the-browser/package.json
@@ -19,7 +19,6 @@
     "libp2p-bootstrap": "^0.12.1",
     "libp2p-mplex": "^0.10.0",
     "libp2p-noise": "^2.0.0",
-    "libp2p-secio": "^0.13.1",
     "libp2p-webrtc-star": "^0.20.0",
     "libp2p-websockets": "^0.14.0"
   },

--- a/examples/peer-and-content-routing/1.js
+++ b/examples/peer-and-content-routing/1.js
@@ -5,7 +5,6 @@ const Libp2p = require('../../')
 const TCP = require('libp2p-tcp')
 const Mplex = require('libp2p-mplex')
 const { NOISE } = require('libp2p-noise')
-const SECIO = require('libp2p-secio')
 const KadDHT = require('libp2p-kad-dht')
 
 const delay = require('delay')
@@ -18,7 +17,7 @@ const createNode = async () => {
     modules: {
       transport: [TCP],
       streamMuxer: [Mplex],
-      connEncryption: [NOISE, SECIO],
+      connEncryption: [NOISE],
       dht: KadDHT
     },
     config: {

--- a/examples/peer-and-content-routing/2.js
+++ b/examples/peer-and-content-routing/2.js
@@ -4,7 +4,6 @@
 const Libp2p = require('../../')
 const TCP = require('libp2p-tcp')
 const Mplex = require('libp2p-mplex')
-const SECIO = require('libp2p-secio')
 const { NOISE } = require('libp2p-noise')
 const CID = require('cids')
 const KadDHT = require('libp2p-kad-dht')
@@ -20,7 +19,7 @@ const createNode = async () => {
     modules: {
       transport: [TCP],
       streamMuxer: [Mplex],
-      connEncryption: [NOISE, SECIO],
+      connEncryption: [NOISE],
       dht: KadDHT
     },
     config: {

--- a/examples/peer-and-content-routing/README.md
+++ b/examples/peer-and-content-routing/README.md
@@ -23,7 +23,7 @@ const node = await Libp2p.create({
   modules: {
     transport: [ TCP ],
     streamMuxer: [ Mplex ],
-    connEncryption: [ NOISE, SECIO ],
+    connEncryption: [ NOISE ],
     // we add the DHT module that will enable Peer and Content Routing
     dht: KadDHT
   },

--- a/examples/pnet/libp2p-node.js
+++ b/examples/pnet/libp2p-node.js
@@ -3,7 +3,6 @@
 const Libp2p = require('libp2p')
 const TCP = require('libp2p-tcp')
 const MPLEX = require('libp2p-mplex')
-const SECIO = require('libp2p-secio')
 const { NOISE } = require('libp2p-noise')
 const Protector = require('libp2p/src/pnet')
 
@@ -24,7 +23,7 @@ const privateLibp2pNode = async (swarmKey) => {
       streamMuxer: [MPLEX], // We're only using mplex muxing
       // Let's make sure to use identifying crypto in our pnet since the protector doesn't
       // care about node identity, and only the presence of private keys
-      connEncryption: [NOISE, SECIO],
+      connEncryption: [NOISE],
       // Leave peer discovery empty, we don't want to find peers. We could omit the property, but it's
       // being left in for explicit readability.
       // We should explicitly dial pnet peers, or use a custom discovery service for finding nodes in our pnet

--- a/examples/protocol-and-stream-muxing/1.js
+++ b/examples/protocol-and-stream-muxing/1.js
@@ -4,7 +4,6 @@ const Libp2p = require('../../')
 const TCP = require('libp2p-tcp')
 const MPLEX = require('libp2p-mplex')
 const { NOISE } = require('libp2p-noise')
-const SECIO = require('libp2p-secio')
 
 const pipe = require('it-pipe')
 
@@ -16,7 +15,7 @@ const createNode = async () => {
     modules: {
       transport: [TCP],
       streamMuxer: [MPLEX],
-      connEncryption: [NOISE, SECIO]
+      connEncryption: [NOISE]
     }
   })
 

--- a/examples/protocol-and-stream-muxing/2.js
+++ b/examples/protocol-and-stream-muxing/2.js
@@ -4,7 +4,6 @@ const Libp2p = require('../../')
 const TCP = require('libp2p-tcp')
 const MPLEX = require('libp2p-mplex')
 const { NOISE } = require('libp2p-noise')
-const SECIO = require('libp2p-secio')
 
 const pipe = require('it-pipe')
 
@@ -16,7 +15,7 @@ const createNode = async () => {
     modules: {
       transport: [TCP],
       streamMuxer: [MPLEX],
-      connEncryption: [NOISE, SECIO]
+      connEncryption: [NOISE]
     }
   })
 

--- a/examples/protocol-and-stream-muxing/3.js
+++ b/examples/protocol-and-stream-muxing/3.js
@@ -5,7 +5,6 @@ const Libp2p = require('../../')
 const TCP = require('libp2p-tcp')
 const MPLEX = require('libp2p-mplex')
 const { NOISE } = require('libp2p-noise')
-const SECIO = require('libp2p-secio')
 
 const pipe = require('it-pipe')
 
@@ -17,7 +16,7 @@ const createNode = async () => {
     modules: {
       transport: [TCP],
       streamMuxer: [MPLEX],
-      connEncryption: [NOISE, SECIO]
+      connEncryption: [NOISE]
     }
   })
 

--- a/examples/pubsub/1.js
+++ b/examples/pubsub/1.js
@@ -5,7 +5,6 @@ const Libp2p = require('../../')
 const TCP = require('libp2p-tcp')
 const Mplex = require('libp2p-mplex')
 const { NOISE } = require('libp2p-noise')
-const SECIO = require('libp2p-secio')
 const Gossipsub = require('libp2p-gossipsub')
 const uint8ArrayFromString = require('uint8arrays/from-string')
 const uint8ArrayToString = require('uint8arrays/to-string')
@@ -18,7 +17,7 @@ const createNode = async () => {
     modules: {
       transport: [TCP],
       streamMuxer: [Mplex],
-      connEncryption: [NOISE, SECIO],
+      connEncryption: [NOISE],
       pubsub: Gossipsub
     }
   })

--- a/examples/pubsub/README.md
+++ b/examples/pubsub/README.md
@@ -27,7 +27,7 @@ const node = await Libp2p.create({
   modules: {
     transport: [ TCP ],
     streamMuxer: [ Mplex ],
-    connEncryption: [ NOISE, SECIO ],
+    connEncryption: [ NOISE ],
     // we add the Pubsub module we want
     pubsub: Gossipsub
   }

--- a/examples/pubsub/message-filtering/1.js
+++ b/examples/pubsub/message-filtering/1.js
@@ -5,7 +5,6 @@ const Libp2p = require('../../../')
 const TCP = require('libp2p-tcp')
 const Mplex = require('libp2p-mplex')
 const { NOISE } = require('libp2p-noise')
-const SECIO = require('libp2p-secio')
 const Gossipsub = require('libp2p-gossipsub')
 const uint8ArrayFromString = require('uint8arrays/from-string')
 const uint8ArrayToString = require('uint8arrays/to-string')
@@ -18,7 +17,7 @@ const createNode = async () => {
     modules: {
       transport: [TCP],
       streamMuxer: [Mplex],
-      connEncryption: [NOISE, SECIO],
+      connEncryption: [NOISE],
       pubsub: Gossipsub
     }
   })

--- a/examples/pubsub/message-filtering/README.md
+++ b/examples/pubsub/message-filtering/README.md
@@ -17,7 +17,7 @@ const node = await Libp2p.create({
   modules: {
     transport: [ TCP ],
     streamMuxer: [ Mplex ],
-    connEncryption: [ NOISE, SECIO ],
+    connEncryption: [ NOISE ],
     pubsub: Gossipsub
   }
 })

--- a/examples/transports/1.js
+++ b/examples/transports/1.js
@@ -4,7 +4,6 @@
 const Libp2p = require('../..')
 const TCP = require('libp2p-tcp')
 const { NOISE } = require('libp2p-noise')
-const SECIO = require('libp2p-secio')
 
 const createNode = async () => {
   const node = await Libp2p.create({
@@ -15,7 +14,7 @@ const createNode = async () => {
     },
     modules: {
       transport: [TCP],
-      connEncryption: [NOISE, SECIO]
+      connEncryption: [NOISE]
     }
   })
 

--- a/examples/transports/2.js
+++ b/examples/transports/2.js
@@ -4,7 +4,6 @@
 const Libp2p = require('../..')
 const TCP = require('libp2p-tcp')
 const { NOISE } = require('libp2p-noise')
-const SECIO = require('libp2p-secio')
 const MPLEX = require('libp2p-mplex')
 
 const pipe = require('it-pipe')
@@ -19,7 +18,7 @@ const createNode = async () => {
     },
     modules: {
       transport: [TCP],
-      connEncryption: [NOISE, SECIO],
+      connEncryption: [NOISE],
       streamMuxer: [MPLEX]
     }
   })

--- a/examples/transports/3.js
+++ b/examples/transports/3.js
@@ -5,7 +5,6 @@ const Libp2p = require('../..')
 const TCP = require('libp2p-tcp')
 const WebSockets = require('libp2p-websockets')
 const { NOISE } = require('libp2p-noise')
-const SECIO = require('libp2p-secio')
 const MPLEX = require('libp2p-mplex')
 
 const pipe = require('it-pipe')
@@ -21,7 +20,7 @@ const createNode = async (transports, addresses = []) => {
     },
     modules: {
       transport: transports,
-      connEncryption: [NOISE, SECIO],
+      connEncryption: [NOISE],
       streamMuxer: [MPLEX]
     }
   })

--- a/examples/transports/README.md
+++ b/examples/transports/README.md
@@ -13,7 +13,7 @@ When using libp2p, you need properly configure it, that is, pick your set of mod
 You will need 4 dependencies total, so go ahead and install all of them with:
 
 ```bash
-> npm install libp2p libp2p-tcp libp2p-secio peer-info
+> npm install libp2p libp2p-tcp libp2p-noise peer-info
 ```
 
 Then, on your favorite text editor create a file with the `.js` extension. I've called mine `1.js`.
@@ -26,7 +26,6 @@ First thing is to create our own libp2p node! Insert:
 const Libp2p = require('libp2p')
 const TCP = require('libp2p-tcp')
 const { NOISE } = require('libp2p-noise')
-const SECIO = require('libp2p-secio')
 
 const createNode = async () => {
   const node = await Libp2p.create({
@@ -37,7 +36,7 @@ const createNode = async () => {
     },
     modules: {
       transport: [ TCP ],
-      connEncryption: [ NOISE, SECIO ]
+      connEncryption: [ NOISE ]
     }
   })
 
@@ -174,7 +173,7 @@ const createNode = async (transports, multiaddrs = []) => {
     },
     modules: {
       transport: transports,
-      connEncryption: [SECIO],
+      connEncryption: [NOISE],
       streamMuxer: [MPLEX]
     }
   })

--- a/src/circuit/README.md
+++ b/src/circuit/README.md
@@ -41,7 +41,7 @@ const multiaddr = require('multiaddr')
 const Libp2p = require('libp2p')
 const TCP = require('libp2p-tcp')
 const MPLEX = require('libp2p-mplex')
-const SECIO = require('libp2p-secio')
+const { NOISE } = require('libp2p-noise')
 
 const relayAddr = ...
 
@@ -52,7 +52,7 @@ const node = await Libp2p.create({
   modules: {
     transport: [TCP],
     streamMuxer: [MPLEX],
-    connEncryption: [SECIO]
+    connEncryption: [NOISE]
   },
   config: {
     relay: {                   // Circuit Relay options (this config is part of libp2p core configurations)


### PR DESCRIPTION
As we announced that we're removing support for the SECIO security transport, this PR removes its usages from the examples per https://github.com/libp2p/js-libp2p/pull/745#pullrequestreview-484066297