### PR TITLE
chore: auto relay multiaddr update push

### DIFF
--- a/doc/API.md
+++ b/doc/API.md
@@ -71,7 +71,6 @@
   * [`libp2p`](#libp2p)
   * [`libp2p.connectionManager`](#libp2pconnectionmanager)
   * [`libp2p.peerStore`](#libp2ppeerStore)
-  * [`libp2p.transportManager`](#libp2ptransportmanager)
 * [Types](#types)
   * [`Stats`](#stats)
 
@@ -1985,14 +1984,6 @@ This event will be triggered anytime we are disconnected from another peer, rega
 
 - `peerId`: instance of [`PeerId`][peer-id]
 - `protocols`: array of known, supported protocols for the peer (string identifiers)
-
-### libp2p.transportManager
-
-#### Listening addresses change
-
-This event will be triggered anytime the listening addresses change.
-
-`libp2p.transportManager.on('listening', () => {})`
 
 ## Types
 

--- a/doc/API.md
+++ b/doc/API.md
@@ -71,6 +71,7 @@
   * [`libp2p`](#libp2p)
   * [`libp2p.connectionManager`](#libp2pconnectionmanager)
   * [`libp2p.peerStore`](#libp2ppeerStore)
+  * [`libp2p.transportManager`](#libp2ptransportmanager)
 * [Types](#types)
   * [`Stats`](#stats)
 
@@ -1984,6 +1985,14 @@ This event will be triggered anytime we are disconnected from another peer, rega
 
 - `peerId`: instance of [`PeerId`][peer-id]
 - `protocols`: array of known, supported protocols for the peer (string identifiers)
+
+### libp2p.transportManager
+
+#### Listening addresses change
+
+This event will be triggered anytime the listening addresses change.
+
+`libp2p.transportManager.on('listening', () => {})`
 
 ## Types
 

--- a/src/circuit/auto-relay.js
+++ b/src/circuit/auto-relay.js
@@ -143,8 +143,8 @@ class AutoRelay {
 
     try {
       await this._transportManager.listen([multiaddr(listenAddr)])
-      // TODO: push announce multiaddrs update
-      // await this._libp2p.identifyService.pushToPeerStore()
+      // Announce multiaddrs update on listen success
+      await this._libp2p.identifyService.pushToPeerStore()
     } catch (err) {
       log.error(err)
       this._listenRelays.delete(id)

--- a/src/circuit/auto-relay.js
+++ b/src/circuit/auto-relay.js
@@ -143,8 +143,7 @@ class AutoRelay {
 
     try {
       await this._transportManager.listen([multiaddr(listenAddr)])
-      // Announce multiaddrs update on listen success
-      await this._libp2p.identifyService.pushToPeerStore()
+      // Announce multiaddrs will update on listen success by TransportManager event being triggered
     } catch (err) {
       log.error(err)
       this._listenRelays.delete(id)

--- a/src/circuit/listener.js
+++ b/src/circuit/listener.js
@@ -20,8 +20,8 @@ module.exports = (libp2p) => {
     const deleted = listeningAddrs.delete(connection.remotePeer.toB58String())
 
     if (deleted) {
-      // TODO push announce multiaddrs update
-      // libp2p.identifyService.pushToPeerStore()
+      // Announce multiaddrs update on listen success
+      libp2p.identifyService.pushToPeerStore()
     }
   })
 

--- a/src/circuit/listener.js
+++ b/src/circuit/listener.js
@@ -20,8 +20,8 @@ module.exports = (libp2p) => {
     const deleted = listeningAddrs.delete(connection.remotePeer.toB58String())
 
     if (deleted) {
-      // Announce multiaddrs update on listen success
-      libp2p.identifyService.pushToPeerStore()
+      // Announce listen addresses change
+      listener.emit('listening')
     }
   })
 

--- a/src/circuit/listener.js
+++ b/src/circuit/listener.js
@@ -21,7 +21,7 @@ module.exports = (libp2p) => {
 
     if (deleted) {
       // Announce listen addresses change
-      listener.emit('listening')
+      listener.emit('close')
     }
   })
 

--- a/src/identify/index.js
+++ b/src/identify/index.js
@@ -64,11 +64,6 @@ class IdentifyService {
     this.connectionManager = libp2p.connectionManager
 
     /**
-     * @property {TransportManager}
-     */
-    this.transportManager = libp2p.transportManager
-
-    /**
      * @property {PeerId}
      */
     this.peerId = libp2p.peerId
@@ -88,10 +83,11 @@ class IdentifyService {
       this.identify(connection, peerId).catch(log.error)
     })
 
-    // When new addresses are used for listening, update self peer record
-    this.transportManager.on('listening', async () => {
-      await this._createSelfPeerRecord()
-      this.pushToPeerStore()
+    // When self multiaddrs change, trigger identify-push
+    this.peerStore.on('change:multiaddrs', ({ peerId }) => {
+      if (peerId.toString() === this.peerId.toString()) {
+        this.pushToPeerStore()
+      }
     })
   }
 
@@ -101,7 +97,7 @@ class IdentifyService {
    * @returns {Promise<void>}
    */
   async push (connections) {
-    const signedPeerRecord = await this._getSelfPeerRecord()
+    const signedPeerRecord = await this.peerStore.addressBook.getRawEnvelope(this.peerId)
     const listenAddrs = this._libp2p.multiaddrs.map((ma) => ma.bytes)
     const protocols = Array.from(this._protocols.keys())
 
@@ -250,7 +246,7 @@ class IdentifyService {
       publicKey = this.peerId.pubKey.bytes
     }
 
-    const signedPeerRecord = await this._getSelfPeerRecord()
+    const signedPeerRecord = await this.peerStore.addressBook.getRawEnvelope(this.peerId)
 
     const message = Message.encode({
       protocolVersion: PROTOCOL_VERSION,
@@ -318,40 +314,6 @@ class IdentifyService {
 
     // Update the protocols
     this.peerStore.protoBook.set(id, message.protocols)
-  }
-
-  /**
-   * Get self signed peer record raw envelope.
-   * @return {Promise<Uint8Array>}
-   */
-  _getSelfPeerRecord () {
-    const selfSignedPeerRecord = this.peerStore.addressBook.getRawEnvelope(this.peerId)
-
-    if (selfSignedPeerRecord) {
-      return selfSignedPeerRecord
-    }
-
-    return this._createSelfPeerRecord()
-  }
-
-  /**
-   * Create self signed peer record raw envelope.
-   * @return {Uint8Array}
-   */
-  async _createSelfPeerRecord () {
-    try {
-      const peerRecord = new PeerRecord({
-        peerId: this.peerId,
-        multiaddrs: this._libp2p.multiaddrs
-      })
-      const envelope = await Envelope.seal(peerRecord, this.peerId)
-      this.peerStore.addressBook.consumePeerRecord(envelope)
-
-      return this.peerStore.addressBook.getRawEnvelope(this.peerId)
-    } catch (err) {
-      log.error('failed to get self peer record')
-    }
-    return null
   }
 }
 

--- a/src/identify/index.js
+++ b/src/identify/index.js
@@ -63,11 +63,10 @@ class IdentifyService {
      */
     this.connectionManager = libp2p.connectionManager
 
-    this.connectionManager.on('peer:connect', (connection) => {
-      const peerId = connection.remotePeer
-
-      this.identify(connection, peerId).catch(log.error)
-    })
+    /**
+     * @property {TransportManager}
+     */
+    this.transportManager = libp2p.transportManager
 
     /**
      * @property {PeerId}
@@ -82,6 +81,18 @@ class IdentifyService {
     this._protocols = protocols
 
     this.handleMessage = this.handleMessage.bind(this)
+
+    this.connectionManager.on('peer:connect', (connection) => {
+      const peerId = connection.remotePeer
+
+      this.identify(connection, peerId).catch(log.error)
+    })
+
+    // When new addresses are used for listening, update self peer record
+    this.transportManager.on('listening', async () => {
+      await this._createSelfPeerRecord()
+      this.pushToPeerStore()
+    })
   }
 
   /**
@@ -311,33 +322,23 @@ class IdentifyService {
 
   /**
    * Get self signed peer record raw envelope.
-   * @return {Uint8Array}
+   * @return {Promise<Uint8Array>}
    */
-  async _getSelfPeerRecord () {
-    // Update self peer record if needed
-    await this._createOrUpdateSelfPeerRecord()
+  _getSelfPeerRecord () {
+    const selfSignedPeerRecord = this.peerStore.addressBook.getRawEnvelope(this.peerId)
 
-    return this.peerStore.addressBook.getRawEnvelope(this.peerId)
+    if (selfSignedPeerRecord) {
+      return selfSignedPeerRecord
+    }
+
+    return this._createSelfPeerRecord()
   }
 
   /**
-   * Creates or updates the self peer record if it exists and is outdated.
-   * @return {Promise<void>}
+   * Create self signed peer record raw envelope.
+   * @return {Uint8Array}
    */
-  async _createOrUpdateSelfPeerRecord () {
-    const selfPeerRecordEnvelope = await this.peerStore.addressBook.getPeerRecord(this.peerId)
-
-    if (selfPeerRecordEnvelope) {
-      const peerRecord = PeerRecord.createFromProtobuf(selfPeerRecordEnvelope.payload)
-
-      const mIntersection = peerRecord.multiaddrs.filter((m) => this._libp2p.multiaddrs.some((newM) => m.equals(newM)))
-      if (mIntersection.length === this._libp2p.multiaddrs.length) {
-        // Same multiaddrs as already existing in the record, no need to proceed
-        return
-      }
-    }
-
-    // Create / Update Peer record
+  async _createSelfPeerRecord () {
     try {
       const peerRecord = new PeerRecord({
         peerId: this.peerId,
@@ -345,9 +346,12 @@ class IdentifyService {
       })
       const envelope = await Envelope.seal(peerRecord, this.peerId)
       this.peerStore.addressBook.consumePeerRecord(envelope)
+
+      return this.peerStore.addressBook.getRawEnvelope(this.peerId)
     } catch (err) {
-      log.error('failed to create self peer record')
+      log.error('failed to get self peer record')
     }
+    return null
   }
 }
 

--- a/src/index.js
+++ b/src/index.js
@@ -247,6 +247,7 @@ class Libp2p extends EventEmitter {
     log('libp2p is stopping')
 
     try {
+      this._isStarted = false
       for (const service of this._discovery.values()) {
         service.removeListener('peer', this._onDiscoveryPeer)
       }
@@ -258,7 +259,6 @@ class Libp2p extends EventEmitter {
       await this.peerStore.stop()
       await this.connectionManager.stop()
 
-      ping.unmount(this)
       await Promise.all([
         this.pubsub && this.pubsub.stop(),
         this._dht && this._dht.stop(),
@@ -267,6 +267,8 @@ class Libp2p extends EventEmitter {
 
       await this.transportManager.close()
 
+      ping.unmount(this)
+
       this.dialer.destroy()
     } catch (err) {
       if (err) {
@@ -274,7 +276,6 @@ class Libp2p extends EventEmitter {
         this.emit('error', err)
       }
     }
-    this._isStarted = false
     log('libp2p has stopped')
   }
 

--- a/src/index.js
+++ b/src/index.js
@@ -268,7 +268,6 @@ class Libp2p extends EventEmitter {
       await this.transportManager.close()
 
       ping.unmount(this)
-
       this.dialer.destroy()
     } catch (err) {
       if (err) {

--- a/src/index.js
+++ b/src/index.js
@@ -258,6 +258,7 @@ class Libp2p extends EventEmitter {
       await this.peerStore.stop()
       await this.connectionManager.stop()
 
+      ping.unmount(this)
       await Promise.all([
         this.pubsub && this.pubsub.stop(),
         this._dht && this._dht.stop(),
@@ -266,7 +267,6 @@ class Libp2p extends EventEmitter {
 
       await this.transportManager.close()
 
-      ping.unmount(this)
       this.dialer.destroy()
     } catch (err) {
       if (err) {

--- a/src/record/utils.js
+++ b/src/record/utils.js
@@ -1,0 +1,20 @@
+'use strict'
+
+const Envelope = require('./envelope')
+const PeerRecord = require('./peer-record')
+
+/**
+ * Create (or update if existing) self peer record and store it in the AddressBook.
+ * @param {libp2p} libp2p
+ * @returns {Promise<void>}
+ */
+async function updateSelfPeerRecord (libp2p) {
+  const peerRecord = new PeerRecord({
+    peerId: libp2p.peerId,
+    multiaddrs: libp2p.multiaddrs
+  })
+  const envelope = await Envelope.seal(peerRecord, libp2p.peerId)
+  libp2p.peerStore.addressBook.consumePeerRecord(envelope)
+}
+
+module.exports.updateSelfPeerRecord = updateSelfPeerRecord

--- a/src/transport-manager.js
+++ b/src/transport-manager.js
@@ -1,5 +1,6 @@
 'use strict'
 
+const { EventEmitter } = require('events')
 const pSettle = require('p-settle')
 const { codes } = require('./errors')
 const errCode = require('err-code')
@@ -7,7 +8,11 @@ const debug = require('debug')
 const log = debug('libp2p:transports')
 log.error = debug('libp2p:transports:error')
 
-class TransportManager {
+/**
+ * Responsible for managing the transports and their listeners.
+ * @fires TransportManager#listening Emitted when listening addresses change.
+ */
+class TransportManager extends EventEmitter {
   /**
    * @constructor
    * @param {object} options
@@ -16,6 +21,8 @@ class TransportManager {
    * @param {boolean} [options.faultTolerance = FAULT_TOLERANCE.FATAL_ALL] Address listen error tolerance.
    */
   constructor ({ libp2p, upgrader, faultTolerance = FAULT_TOLERANCE.FATAL_ALL }) {
+    super()
+
     this.libp2p = libp2p
     this.upgrader = upgrader
     this._transports = new Map()
@@ -62,6 +69,7 @@ class TransportManager {
       log('closing listeners for %s', key)
       while (listeners.length) {
         const listener = listeners.pop()
+        listener.removeAllListeners('listening')
         tasks.push(listener.close())
       }
     }
@@ -150,6 +158,9 @@ class TransportManager {
         const listener = transport.createListener({}, this.onConnection)
         this._listeners.get(key).push(listener)
 
+        // Track listen events
+        listener.on('listening', () => this.emit('listening'))
+
         // We need to attempt to listen on everything
         tasks.push(listener.listen(addr))
       }
@@ -194,6 +205,7 @@ class TransportManager {
     if (this._listeners.has(key)) {
       // Close any running listeners
       for (const listener of this._listeners.get(key)) {
+        listener.removeAllListeners('listening')
         await listener.close()
       }
     }

--- a/src/transport-manager.js
+++ b/src/transport-manager.js
@@ -7,8 +7,7 @@ const debug = require('debug')
 const log = debug('libp2p:transports')
 log.error = debug('libp2p:transports:error')
 
-const Envelope = require('./record/envelope')
-const PeerRecord = require('./record/peer-record')
+const { updateSelfPeerRecord } = require('./record/utils')
 
 class TransportManager {
   /**
@@ -156,8 +155,8 @@ class TransportManager {
         this._listeners.get(key).push(listener)
 
         // Track listen/close events
-        listener.on('listening', () => this._createSelfPeerRecord())
-        listener.on('close', () => this._createSelfPeerRecord())
+        listener.on('listening', () => updateSelfPeerRecord(this.libp2p))
+        listener.on('close', () => updateSelfPeerRecord(this.libp2p))
 
         // We need to attempt to listen on everything
         tasks.push(listener.listen(addr))
@@ -225,26 +224,6 @@ class TransportManager {
     }
 
     await Promise.all(tasks)
-  }
-
-  /**
-   * Create self signed peer record raw envelope.
-   * @return {Uint8Array}
-   */
-  async _createSelfPeerRecord () {
-    try {
-      const peerRecord = new PeerRecord({
-        peerId: this.libp2p.peerId,
-        multiaddrs: this.libp2p.multiaddrs
-      })
-      const envelope = await Envelope.seal(peerRecord, this.libp2p.peerId)
-      this.libp2p.peerStore.addressBook.consumePeerRecord(envelope)
-
-      return this.libp2p.peerStore.addressBook.getRawEnvelope(this.libp2p.peerId)
-    } catch (err) {
-      log.error('failed to get self peer record')
-    }
-    return null
   }
 }
 

--- a/test/dialing/direct.node.js
+++ b/test/dialing/direct.node.js
@@ -40,21 +40,28 @@ describe('Dialing (direct, TCP)', () => {
   let peerStore
   let remoteAddr
 
-  before(async () => {
-    const [remotePeerId] = await Promise.all([
-      PeerId.createFromJSON(Peers[0])
+  beforeEach(async () => {
+    const [localPeerId, remotePeerId] = await Promise.all([
+      PeerId.createFromJSON(Peers[0]),
+      PeerId.createFromJSON(Peers[1])
     ])
+
+    peerStore = new PeerStore({ peerId: remotePeerId })
     remoteTM = new TransportManager({
       libp2p: {
-        addressManager: new AddressManager({ listen: [listenAddr] })
+        addressManager: new AddressManager({ listen: [listenAddr] }),
+        peerId: remotePeerId,
+        peerStore
       },
       upgrader: mockUpgrader
     })
     remoteTM.add(Transport.prototype[Symbol.toStringTag], Transport)
 
-    peerStore = new PeerStore({ peerId: remotePeerId })
     localTM = new TransportManager({
-      libp2p: {},
+      libp2p: {
+        peerId: localPeerId,
+        peerStore: new PeerStore({ peerId: localPeerId })
+      },
       upgrader: mockUpgrader
     })
     localTM.add(Transport.prototype[Symbol.toStringTag], Transport)
@@ -64,7 +71,7 @@ describe('Dialing (direct, TCP)', () => {
     remoteAddr = remoteTM.getAddrs()[0].encapsulate(`/p2p/${remotePeerId.toB58String()}`)
   })
 
-  after(() => remoteTM.close())
+  afterEach(() => remoteTM.close())
 
   afterEach(() => {
     sinon.restore()
@@ -110,7 +117,7 @@ describe('Dialing (direct, TCP)', () => {
       peerStore
     })
 
-    peerStore.addressBook.set(peerId, [remoteAddr])
+    peerStore.addressBook.set(peerId, remoteTM.getAddrs())
 
     const connection = await dialer.connectToPeer(peerId)
     expect(connection).to.exist()

--- a/test/dialing/direct.spec.js
+++ b/test/dialing/direct.spec.js
@@ -354,7 +354,6 @@ describe('Dialing (direct, WebSockets)', () => {
       const connection = await libp2p.dial(remoteAddr)
       expect(connection).to.exist()
 
-      sinon.spy(libp2p.peerStore.addressBook, 'consumePeerRecord')
       sinon.spy(libp2p.peerStore.protoBook, 'set')
 
       // Wait for onConnection to be called
@@ -363,8 +362,6 @@ describe('Dialing (direct, WebSockets)', () => {
       expect(libp2p.identifyService.identify.callCount).to.equal(1)
       await libp2p.identifyService.identify.firstCall.returnValue
 
-      // Self + New peer
-      expect(libp2p.peerStore.addressBook.consumePeerRecord.callCount).to.equal(2)
       expect(libp2p.peerStore.protoBook.set.callCount).to.equal(1)
     })
 

--- a/test/identify/index.spec.js
+++ b/test/identify/index.spec.js
@@ -412,6 +412,42 @@ describe('Identify', () => {
       // Verify the streams close
       await pWaitFor(() => connection.streams.length === 0)
     })
+
+    it('should push multiaddr updates to an already connected peer', async () => {
+      libp2p = new Libp2p({
+        ...baseOptions,
+        peerId
+      })
+
+      await libp2p.start()
+
+      sinon.spy(libp2p.identifyService, 'identify')
+      sinon.spy(libp2p.identifyService, 'push')
+
+      const connection = await libp2p.dialer.connectToPeer(remoteAddr)
+      expect(connection).to.exist()
+      // Wait for nextTick to trigger the identify call
+      await delay(1)
+
+      // Wait for identify to finish
+      await libp2p.identifyService.identify.firstCall.returnValue
+      sinon.stub(libp2p, 'isStarted').returns(true)
+
+      libp2p.peerStore.addressBook.add(libp2p.peerId, [multiaddr('/ip4/180.0.0.1/tcp/15001/ws')])
+
+      // Verify the remote peer is notified of change
+      expect(libp2p.identifyService.push.callCount).to.equal(1)
+      for (const call of libp2p.identifyService.push.getCalls()) {
+        const [connections] = call.args
+        expect(connections.length).to.equal(1)
+        expect(connections[0].remotePeer.toB58String()).to.equal(remoteAddr.getPeerId())
+        const results = await call.returnValue
+        expect(results.length).to.equal(1)
+      }
+
+      // Verify the streams close
+      await pWaitFor(() => connection.streams.length === 0)
+    })
   })
 })
 
@@ -424,8 +460,5 @@ const _createSelfPeerRecord = async (libp2p) => {
     })
     const envelope = await Envelope.seal(peerRecord, libp2p.peerId)
     libp2p.peerStore.addressBook.consumePeerRecord(envelope)
-
-    return libp2p.peerStore.addressBook.getRawEnvelope(libp2p.peerId)
   } catch (_) {}
-  return null
 }

--- a/test/identify/index.spec.js
+++ b/test/identify/index.spec.js
@@ -52,6 +52,7 @@ describe('Identify', () => {
       libp2p: {
         peerId: localPeer,
         connectionManager: new EventEmitter(),
+        transportManager: new EventEmitter(),
         peerStore: new PeerStore({ peerId: localPeer }),
         multiaddrs: listenMaddrs
       },
@@ -62,6 +63,7 @@ describe('Identify', () => {
       libp2p: {
         peerId: remotePeer,
         connectionManager: new EventEmitter(),
+        transportManager: new EventEmitter(),
         peerStore: new PeerStore({ peerId: remotePeer }),
         multiaddrs: listenMaddrs
       },
@@ -105,6 +107,7 @@ describe('Identify', () => {
       libp2p: {
         peerId: localPeer,
         connectionManager: new EventEmitter(),
+        transportManager: new EventEmitter(),
         peerStore: new PeerStore({ peerId: localPeer }),
         multiaddrs: listenMaddrs
       },
@@ -115,6 +118,7 @@ describe('Identify', () => {
       libp2p: {
         peerId: remotePeer,
         connectionManager: new EventEmitter(),
+        transportManager: new EventEmitter(),
         peerStore: new PeerStore({ peerId: remotePeer }),
         multiaddrs: listenMaddrs
       },
@@ -164,6 +168,7 @@ describe('Identify', () => {
       libp2p: {
         peerId: localPeer,
         connectionManager: new EventEmitter(),
+        transportManager: new EventEmitter(),
         peerStore: new PeerStore({ peerId: localPeer }),
         multiaddrs: []
       },
@@ -173,6 +178,7 @@ describe('Identify', () => {
       libp2p: {
         peerId: remotePeer,
         connectionManager: new EventEmitter(),
+        transportManager: new EventEmitter(),
         peerStore: new PeerStore({ peerId: remotePeer }),
         multiaddrs: []
       },
@@ -210,6 +216,7 @@ describe('Identify', () => {
         libp2p: {
           peerId: localPeer,
           connectionManager: new EventEmitter(),
+          transportManager: new EventEmitter(),
           peerStore: new PeerStore({ peerId: localPeer }),
           multiaddrs: listenMaddrs
         },
@@ -223,6 +230,7 @@ describe('Identify', () => {
         libp2p: {
           peerId: remotePeer,
           connectionManager,
+          transportManager: new EventEmitter(),
           peerStore: new PeerStore({ peerId: remotePeer }),
           multiaddrs: []
         }
@@ -271,6 +279,7 @@ describe('Identify', () => {
         libp2p: {
           peerId: localPeer,
           connectionManager: new EventEmitter(),
+          transportManager: new EventEmitter(),
           peerStore: new PeerStore({ peerId: localPeer }),
           multiaddrs: listenMaddrs
         },
@@ -284,6 +293,7 @@ describe('Identify', () => {
         libp2p: {
           peerId: remotePeer,
           connectionManager,
+          transportManager: new EventEmitter(),
           peerStore: new PeerStore({ peerId: remotePeer }),
           multiaddrs: []
         }

--- a/test/transports/transport-manager.node.js
+++ b/test/transports/transport-manager.node.js
@@ -4,12 +4,16 @@
 const chai = require('chai')
 chai.use(require('dirty-chai'))
 const { expect } = chai
+const sinon = require('sinon')
 
 const AddressManager = require('../../src/address-manager')
 const TransportManager = require('../../src/transport-manager')
+const PeerStore = require('../../src/peer-store')
 const Transport = require('libp2p-tcp')
+const PeerId = require('peer-id')
 const multiaddr = require('multiaddr')
 const mockUpgrader = require('../utils/mockUpgrader')
+const Peers = require('../fixtures/peers')
 const addrs = [
   multiaddr('/ip4/127.0.0.1/tcp/0'),
   multiaddr('/ip4/127.0.0.1/tcp/0')
@@ -17,11 +21,17 @@ const addrs = [
 
 describe('Transport Manager (TCP)', () => {
   let tm
+  let localPeer
+
+  before(async () => {
+    localPeer = await PeerId.createFromJSON(Peers[0])
+  })
 
   before(() => {
     tm = new TransportManager({
       libp2p: {
-        addressManager: new AddressManager({ listen: addrs })
+        addressManager: new AddressManager({ listen: addrs }),
+        PeerStore: new PeerStore({ peerId: localPeer })
       },
       upgrader: mockUpgrader,
       onConnection: () => {}
@@ -40,10 +50,16 @@ describe('Transport Manager (TCP)', () => {
   })
 
   it('should be able to listen', async () => {
+    sinon.spy(tm, '_createSelfPeerRecord')
+
     tm.add(Transport.prototype[Symbol.toStringTag], Transport)
     await tm.listen(addrs)
     expect(tm._listeners).to.have.key(Transport.prototype[Symbol.toStringTag])
     expect(tm._listeners.get(Transport.prototype[Symbol.toStringTag])).to.have.length(addrs.length)
+
+    // Created Self Peer record on new listen address
+    expect(tm._createSelfPeerRecord.callCount).to.equal(addrs.length)
+
     // Ephemeral ip addresses may result in multiple listeners
     expect(tm.getAddrs().length).to.equal(addrs.length)
     await tm.close()


### PR DESCRIPTION
This PR is a follow up of the [main implementation](https://github.com/libp2p/js-libp2p/pull/723) of auto relay to inform the connected peers of the new addresses to announce, by sending the new signed peer record via `identify-push`.

The self peer record update logic was added to create the new record, when the multiaddr changes. Ping unmount needed to be modified to before the transports close, otherwise when the ping unhandle protocol is triggered, the `identify-push` will try to access the addresses when they do not exist, causing unhandled exceptions, such as https://github.com/libp2p/js-libp2p-tcp/blob/v0.15.1/src/listener.js#L97

When we support dynamic transport updates, we should automate the self peer record update based on events for updated addresses. This will enable us to not verify if the addresses are outdated each time we want to send the self peer record envelope.

Needs:

- [x] #723 