### PR TITLE
chore: update getting started connect event

### DIFF
--- a/doc/GETTING_STARTED.md
+++ b/doc/GETTING_STARTED.md
@@ -232,9 +232,9 @@ node.on('peer:discovery', (peer) => {
   console.log('Discovered %s', peer.id.toB58String()) // Log discovered peer
 })
 
-node.on('peer:connect', (peer) => {
-    console.log('Connected to %s', peer.id.toB58String()) // Log connected peer
-  })
+node.connectionManager.on('peer:connect', (connection) => {
+  console.log('Connected to %s', connection.remotePeer.toB58String()) // Log connected peer
+})
 
 // start libp2p
 await node.start()

--- a/examples/libp2p-in-the-browser/index.js
+++ b/examples/libp2p-in-the-browser/index.js
@@ -5,7 +5,7 @@ import WebRTCStar from 'libp2p-webrtc-star'
 import { NOISE } from 'libp2p-noise'
 import Secio from 'libp2p-secio'
 import Mplex from 'libp2p-mplex'
-import Boostrap from 'libp2p-bootstrap'
+import Bootstrap from 'libp2p-bootstrap'
 
 document.addEventListener('DOMContentLoaded', async () => {
   // Create our libp2p node
@@ -23,11 +23,13 @@ document.addEventListener('DOMContentLoaded', async () => {
       transport: [Websockets, WebRTCStar],
       connEncryption: [NOISE, Secio],
       streamMuxer: [Mplex],
-      peerDiscovery: [Boostrap]
+      peerDiscovery: [Bootstrap]
     },
     config: {
       peerDiscovery: {
-        bootstrap: {
+        // The `tag` property will be searched when creating the instance of your Peer Discovery service.
+        // The associated object, will be passed to the service when it is instantiated.
+        [Bootstrap.tag]: {
           enabled: true,
           list: [
             '/dns4/ams-1.bootstrap.libp2p.io/tcp/443/wss/p2p/QmSoLer265NRgSp2LA3dPaeykiS1J6DifTC88f5uVQKNAd',


### PR DESCRIPTION
The getting started document was not totally updated when we released `0.28` and the connect event was not changed per https://github.com/libp2p/js-libp2p/blob/master/doc/migrations/v0.27-v0.28.md#events

Morever, `[Bootstrap.tag]` is now used in the browser example to be consistent and avoid confusions.

Closes #750 