### PR TITLE
chore: complement 0.29 migration for pubsub subscribe

### DIFF
--- a/doc/migrations/v0.28-v0.29.md
+++ b/doc/migrations/v0.28-v0.29.md
@@ -90,7 +90,7 @@ libp2p.pubsub.on(topic, handler)
 libp2p.pubsub.subscribe(topic)
 ```
 
-In the latest releases, despite not being documented in `libp2p` the underlying pubsub routers supported subscribing to multiple topics at the same time. We removed that code complexity, since this is easily achieved in the application layer if needed.
+In the latest release, despite not being documented in `libp2p` the underlying pubsub routers supported subscribing to multiple topics at the same time. We removed that code complexity, since this is easily achieved in the application layer if needed.
 
 **Before**
 

--- a/doc/migrations/v0.28-v0.29.md
+++ b/doc/migrations/v0.28-v0.29.md
@@ -90,6 +90,36 @@ libp2p.pubsub.on(topic, handler)
 libp2p.pubsub.subscribe(topic)
 ```
 
+In the latest releases, despite not being documented in `libp2p` the underlying pubsub routers supported subscribing to multiple topics at the same time. We removed that code complexity, since this is easily achieved in the application layer if needed.
+
+**Before**
+
+```js
+const topics = ['a', 'b']
+const handler = (msg) => {
+  // msg.data - pubsub data received
+  const data = msg.data.toString()
+}
+libp2p.pubsub.subscribe(topics, handler)
+```
+
+**After**
+
+```js
+const uint8ArrayToString = require('uint8arrays/to-string')
+
+const topics = ['a', 'b']
+const handler = (msg) => {
+  // msg.data - pubsub data received
+  const data = uint8ArrayToString(msg.data)
+}
+
+topics.forEach((topic) => {
+  libp2p.pubsub.on(topic, handler)
+  libp2p.pubsub.subscribe(topic)
+})
+```
+
 #### Unsubscribe
 
 Handlers should not be directly bound to the subscription anymore.


### PR DESCRIPTION
Added a point in `pubsubs.subscribe` about subscribing to multiple topics.
While we did not have any documentation for it in the past, people can be using it, as it was happening on https://github.com/ipfs/js-ipfs/issues/3282