### PR TITLE
fix: event handlers error

### DIFF
--- a/package.json
+++ b/package.json
@@ -73,6 +73,7 @@
     "p-fifo": "^1.0.0",
     "p-settle": "^4.0.1",
     "peer-id": "^0.14.2",
+    "proper-event-emitter": "^1.0.0",
     "protons": "^2.0.0",
     "retimer": "^2.0.0",
     "sanitize-filename": "^1.6.3",

--- a/src/circuit/listener.js
+++ b/src/circuit/listener.js
@@ -1,6 +1,6 @@
 'use strict'
 
-const EventEmitter = require('events')
+const EventEmitter = require('proper-event-emitter')
 const multiaddr = require('multiaddr')
 
 const debug = require('debug')

--- a/src/connection-manager/index.js
+++ b/src/connection-manager/index.js
@@ -9,7 +9,7 @@ const mergeOptions = require('merge-options')
 const LatencyMonitor = require('./latency-monitor')
 const retimer = require('retimer')
 
-const { EventEmitter } = require('events')
+const EventEmitter = require('proper-event-emitter')
 
 const PeerId = require('peer-id')
 
@@ -199,6 +199,7 @@ class ConnectionManager extends EventEmitter {
     const storedConn = this.connections.get(peerIdStr)
 
     this.emit('peer:connect', connection)
+
     if (storedConn) {
       storedConn.push(connection)
     } else {

--- a/src/index.js
+++ b/src/index.js
@@ -1,6 +1,6 @@
 'use strict'
 
-const { EventEmitter } = require('events')
+const EventEmitter = require('proper-event-emitter')
 const debug = require('debug')
 const globalThis = require('ipfs-utils/src/globalthis')
 const log = debug('libp2p')

--- a/src/peer-store/index.js
+++ b/src/peer-store/index.js
@@ -5,7 +5,7 @@ const debug = require('debug')
 const log = debug('libp2p:peer-store')
 log.error = debug('libp2p:peer-store:error')
 
-const { EventEmitter } = require('events')
+const EventEmitter = require('proper-event-emitter')
 const PeerId = require('peer-id')
 
 const AddressBook = require('./address-book')

--- a/test/core/event-handling-error.spec.js
+++ b/test/core/event-handling-error.spec.js
@@ -1,0 +1,98 @@
+'use strict'
+/* eslint-env mocha */
+
+const chai = require('chai')
+chai.use(require('dirty-chai'))
+const { expect } = chai
+
+const errCode = require('err-code')
+const { isNode, isWebWorker } = require('ipfs-utils/src/env')
+
+const multiaddr = require('multiaddr')
+const PeerId = require('peer-id')
+
+const peerUtils = require('../utils/creators/peer')
+const mockConnection = require('../utils/mockConnection')
+const baseOptions = require('../utils/base-options.browser')
+const { MULTIADDRS_WEBSOCKETS } = require('../fixtures/browser')
+
+const relayAddr = MULTIADDRS_WEBSOCKETS[0]
+const code = 'HANDLER_ERROR'
+const errorMsg = 'handle error'
+
+describe('event handlers error', () => {
+  // TODO: Need a way of catching the error in the process and absorb it
+  if (isWebWorker) {
+    return
+  }
+
+  let libp2p
+  let peerId
+
+  before(async () => {
+    peerId = await PeerId.create()
+  })
+
+  beforeEach(async () => {
+    [libp2p] = await peerUtils.createPeer({
+      config: {
+        modules: baseOptions.modules,
+        addresses: {
+          listen: [multiaddr(`${relayAddr}/p2p-circuit`)]
+        }
+      },
+      started: true
+    })
+  })
+
+  afterEach(async () => {
+    libp2p && await libp2p.stop()
+  })
+
+  it('should throw on "peer:connect" event handler error', async () => {
+    const p = catchGlobalError()
+
+    libp2p.connectionManager.on('peer:connect', () => {
+      throw errCode(new Error(errorMsg), code)
+    })
+
+    const connection = await mockConnection()
+    libp2p.connectionManager.onConnect(connection)
+
+    await p
+  })
+
+  it('should throw on "peer:discovery" event handler error', async () => {
+    const p = catchGlobalError()
+
+    libp2p.on('peer:discovery', () => {
+      throw errCode(new Error(errorMsg), code)
+    })
+
+    const ma = multiaddr('/ip4/127.0.0.1/tcp/0')
+    libp2p.peerStore.addressBook.add(peerId, [ma])
+
+    await p
+  })
+})
+
+const catchGlobalError = () => {
+  return new Promise((resolve) => {
+    if (isNode) {
+      const originalException = process.listeners('uncaughtException').pop()
+
+      originalException && process.removeListener('uncaughtException', originalException)
+      process.once('uncaughtException', (err) => {
+        expect(err).to.exist()
+        expect(err.code).to.eql(code)
+
+        originalException && process.listeners('uncaughtException').push(originalException)
+        resolve()
+      })
+    } else {
+      window.onerror = () => {
+        resolve()
+      }
+    }
+  })
+}


### PR DESCRIPTION
For some scenarios, if a user error in a libp2p event handler is thrown, the handler execution fails silently and the user has no way of knowing about the error.

The best solution according to the EventEmitter docs is to throw all the side effects of the `emit` in the global context, as it happens in [node.js](https://github.com/nodejs/node/blob/e36ffb72bebae55091304da51837ca204367dc16/lib/events.js#L177-L179) out of the box. Several browser shims for the EventEmitter I looked into leave this to the user and do not throw in the global context. Examples:

- https://github.com/protobufjs/protobuf.js/blob/master/lib/eventemitter/index.js#L81
- https://github.com/browserify/events/blob/master/events.js#L158
 
As JS has a variety of shims for each building tool, it is not feasible to fix this upstream.  I created [proper-event-emitter](https://github.com/vasco-santos/proper-event-emitter) that extends Event Emitter and wraps the `super.emit` with a try catch and throw it in the global context using `setTimeout`

Closes #751 