### PR TITLE
Edited transport example

### DIFF
--- a/examples/transports/1.js
+++ b/examples/transports/1.js
@@ -8,7 +8,7 @@ const { NOISE } = require('libp2p-noise')
 const createNode = async () => {
   const node = await Libp2p.create({
     addresses: {
-      // To signall the addresses we want to be available, we use
+      // To signal the addresses we want to be available, we use
       // the multiaddr format, a self describable address
       listen: ['/ip4/0.0.0.0/tcp/0']
     },

--- a/examples/transports/2.js
+++ b/examples/transports/2.js
@@ -12,7 +12,7 @@ const concat = require('it-concat')
 const createNode = async () => {
   const node = await Libp2p.create({
     addresses: {
-      // To signall the addresses we want to be available, we use
+      // To signal the addresses we want to be available, we use
       // the multiaddr format, a self describable address
       listen: ['/ip4/0.0.0.0/tcp/0']
     },

--- a/examples/transports/3.js
+++ b/examples/transports/3.js
@@ -16,7 +16,7 @@ const createNode = async (transports, addresses = []) => {
 
   const node = await Libp2p.create({
     addresses: {
-      listen: addresses.map((a) => a)
+      listen: addresses
     },
     modules: {
       transport: transports,


### PR DESCRIPTION
The transport example said to install `peer-info`but `npm` ended up complaining about the [package being deprecated](https://www.npmjs.com/package/peer-info). It turns out that the example never used this dependency and instead opted in to using the PeerStore. Thus this PR removes the instruction to install `peer-info`. Additionally, some of the code snippets in the document did not match the full solution. In particular, section 2 had code that printed the stream data in a way that causes the output to not match the final output given. For the sake of consistency, this PR updated the snippets to match the code in the corresponding solution files. The desynchronization also led to issues where I would follow the example but not have the code work properly. Notably, I had an issue in section 2 where the stream multiplexer was not available. The document never mentioned that `libp2p-mplex` should be installed, but `2.js` showed that this package was required. Therefore, this PR updates the code blocks, telling the reader to install more dependencies, by adding dependencies not mentioned but used in the solution files and removing those that are never used in the solution files. This PR also added some complementary text in section 2 that explains the code snippet and links to additional documentation.