### PR TITLE
fix: flakey identify test firefox

### DIFF
--- a/test/identify/index.spec.js
+++ b/test/identify/index.spec.js
@@ -364,7 +364,7 @@ describe('Identify', () => {
       expect(libp2p.identifyService.identify.callCount).to.equal(1)
 
       // The connection should have no open streams
-      expect(connection.streams).to.have.length(0)
+      await pWaitFor(() => connection.streams.length === 0)
       await connection.close()
     })
 


### PR DESCRIPTION
Sometimes firefox is failing the identify test as it takes more time to close the identify stream. This waits for it instead