### PR TITLE
doc(pubsub): add topicValidators links in API.md table of contents

### DIFF
--- a/doc/API.md
+++ b/doc/API.md
@@ -48,6 +48,8 @@
   * [`pubsub.unsubscribe`](#pubsubunsubscribe)
   * [`pubsub.on`](#pubsubon)
   * [`pubsub.removeListener`](#pubsubremovelistener)
+  * [`pubsub.topicValidators.set`](#pubsubtopicvalidatorsset)
+  * [`pubsub.topicValidators.delete`](#pubsubtopicvalidatorsdelete)
   * [`connectionManager.get`](#connectionmanagerget)
   * [`connectionManager.setPeerValue`](#connectionmanagersetpeervalue)
   * [`connectionManager.size`](#connectionmanagersize)


### PR DESCRIPTION
Adds missing links in the table of contents to the `pubsub.topicValidators.set` and `pubsub.topicValidators.delete` properties within API.md