### PR TITLE
feat: resolve multiaddrs before dial

### DIFF
--- a/doc/CONFIGURATION.md
+++ b/doc/CONFIGURATION.md
@@ -465,6 +465,7 @@ Dialing in libp2p can be configured to limit the rate of dialing, and how long d
 | maxParallelDials | `number` | How many multiaddrs we can dial in parallel. |
 | maxDialsPerPeer | `number` | How many multiaddrs we can dial per peer, in parallel. |
 | dialTimeout | `number` | Second dial timeout per peer in ms. |
+| resolvers | `object` | Dial [Resolvers](https://github.com/multiformats/js-multiaddr/blob/master/src/resolvers/index.js) for resolving multiaddrs |
 
 The below configuration example shows how the dialer should be configured, with the current defaults:
 
@@ -473,6 +474,8 @@ const Libp2p = require('libp2p')
 const TCP = require('libp2p-tcp')
 const MPLEX = require('libp2p-mplex')
 const { NOISE } = require('libp2p-noise')
+
+const { dnsaddrResolver } = require('multiaddr/src/resolvers')
 
 const node = await Libp2p.create({
   modules: {
@@ -483,7 +486,10 @@ const node = await Libp2p.create({
   dialer: {
     maxParallelDials: 100,
     maxDialsPerPeer: 4,
-    dialTimeout: 30e3
+    dialTimeout: 30e3,
+    resolvers: {
+      dnsaddr: dnsaddrResolver
+    }
   }
 ```
 

--- a/doc/GETTING_STARTED.md
+++ b/doc/GETTING_STARTED.md
@@ -204,8 +204,8 @@ const Bootstrap = require('libp2p-bootstrap')
 
 // Known peers addresses
 const bootstrapMultiaddrs = [
-  '/dns4/ams-1.bootstrap.libp2p.io/tcp/443/wss/p2p/QmSoLer265NRgSp2LA3dPaeykiS1J6DifTC88f5uVQKNAd',
-  '/dns4/lon-1.bootstrap.libp2p.io/tcp/443/wss/p2p/QmSoLMeWqB7YGVLJN3pNLQpmmEk35v6wYtsMGLzSr5QBU3'
+  '/dnsaddr/bootstrap.libp2p.io/p2p/QmbLHAnMoJPWSCR5Zhtx6BHJX9KiKNN6tpvbUcqanj75Nb',
+  '/dnsaddr/bootstrap.libp2p.io/p2p/QmNnooDu7bfjPFoTZYxMNLWUQJyrVwtbZg5gBMjTezGAJN'
 ]
 
 const node = await Libp2p.create({

--- a/examples/libp2p-in-the-browser/index.js
+++ b/examples/libp2p-in-the-browser/index.js
@@ -31,12 +31,11 @@ document.addEventListener('DOMContentLoaded', async () => {
         [Bootstrap.tag]: {
           enabled: true,
           list: [
-            '/dns4/ams-1.bootstrap.libp2p.io/tcp/443/wss/p2p/QmSoLer265NRgSp2LA3dPaeykiS1J6DifTC88f5uVQKNAd',
-            '/dns4/lon-1.bootstrap.libp2p.io/tcp/443/wss/p2p/QmSoLMeWqB7YGVLJN3pNLQpmmEk35v6wYtsMGLzSr5QBU3',
-            '/dns4/sfo-3.bootstrap.libp2p.io/tcp/443/wss/p2p/QmSoLPppuBtQSGwKDZT2M73ULpjvfd3aZ6ha4oFGL1KrGM',
-            '/dns4/sgp-1.bootstrap.libp2p.io/tcp/443/wss/p2p/QmSoLSafTMBsPKadTEgaXctDQVcqN88CNLHXMkTNwMKPnu',
-            '/dns4/nyc-1.bootstrap.libp2p.io/tcp/443/wss/p2p/QmSoLueR4xBeUbY9WZ9xGUUxunbKWcrNFTDAadQJmocnWm',
-            '/dns4/nyc-2.bootstrap.libp2p.io/tcp/443/wss/p2p/QmSoLV4Bbm51jM9C4gDYZQ9Cy3U6aXMJDAbzgu2fzaDs64'
+            '/dnsaddr/bootstrap.libp2p.io/p2p/QmNnooDu7bfjPFoTZYxMNLWUQJyrVwtbZg5gBMjTezGAJN',
+            '/dnsaddr/bootstrap.libp2p.io/p2p/QmbLHAnMoJPWSCR5Zhtx6BHJX9KiKNN6tpvbUcqanj75Nb',
+            '/dnsaddr/bootstrap.libp2p.io/p2p/QmZa1sAxajnQjVM8WjWXoMbmPd7NsWhfKsPkErzpm9wGkp',
+            '/dnsaddr/bootstrap.libp2p.io/p2p/QmQCU2EcMqAqQPR2i9bChDtGNJchTbq5TbXJJ16u19uLTa',
+            '/dnsaddr/bootstrap.libp2p.io/p2p/QmcZf59bWwK5XFi76CZX8cbJ4BhTzzA3gU1ZjYZcYW3dwt'
           ]
         }
       }

--- a/package.json
+++ b/package.json
@@ -64,7 +64,7 @@
     "mafmt": "^8.0.0",
     "merge-options": "^2.0.0",
     "moving-average": "^1.0.0",
-    "multiaddr": "^8.0.0",
+    "multiaddr": "multiformats/js-multiaddr#feat/resolve-multiaddrs",
     "multicodec": "^2.0.0",
     "multistream-select": "^1.0.0",
     "mutable-proxy": "^1.0.0",

--- a/package.json
+++ b/package.json
@@ -64,7 +64,7 @@
     "mafmt": "^8.0.0",
     "merge-options": "^2.0.0",
     "moving-average": "^1.0.0",
-    "multiaddr": "multiformats/js-multiaddr#feat/resolve-multiaddrs",
+    "multiaddr": "^8.1.0",
     "multicodec": "^2.0.0",
     "multistream-select": "^1.0.0",
     "mutable-proxy": "^1.0.0",

--- a/src/config.js
+++ b/src/config.js
@@ -1,6 +1,8 @@
 'use strict'
 
 const mergeOptions = require('merge-options')
+const { dnsaddrResolver } = require('multiaddr/src/resolvers')
+
 const Constants = require('./constants')
 
 const { FaultTolerance } = require('./transport-manager')
@@ -20,7 +22,10 @@ const DefaultConfig = {
   dialer: {
     maxParallelDials: Constants.MAX_PARALLEL_DIALS,
     maxDialsPerPeer: Constants.MAX_PER_PEER_DIALS,
-    dialTimeout: Constants.DIAL_TIMEOUT
+    dialTimeout: Constants.DIAL_TIMEOUT,
+    resolvers: {
+      dnsaddr: dnsaddrResolver
+    }
   },
   metrics: {
     enabled: false

--- a/src/dialer/index.js
+++ b/src/dialer/index.js
@@ -27,7 +27,7 @@ class Dialer {
    * @param {number} [options.concurrency = MAX_PARALLEL_DIALS] - Number of max concurrent dials.
    * @param {number} [options.perPeerLimit = MAX_PER_PEER_DIALS] - Number of max concurrent dials per peer.
    * @param {number} [options.timeout = DIAL_TIMEOUT] - How long a dial attempt is allowed to take.
-   * @param {object} [options.resolvers = {}]
+   * @param {object} [options.resolvers = {}] - multiaddr resolvers to use when dialing
    */
   constructor ({
     transportManager,

--- a/src/dialer/index.js
+++ b/src/dialer/index.js
@@ -240,6 +240,7 @@ class Dialer {
    */
   async _resolveRecord (ma) {
     try {
+      ma = multiaddr(ma.toString()) // Use current multiaddr module
       const multiaddrs = await ma.resolve()
       return multiaddrs
     } catch (_) {

--- a/src/index.js
+++ b/src/index.js
@@ -134,7 +134,8 @@ class Libp2p extends EventEmitter {
       peerStore: this.peerStore,
       concurrency: this._options.dialer.maxParallelDials,
       perPeerLimit: this._options.dialer.maxDialsPerPeer,
-      timeout: this._options.dialer.dialTimeout
+      timeout: this._options.dialer.dialTimeout,
+      resolvers: this._options.dialer.resolvers
     })
 
     this._modules.transport.forEach((Transport) => {

--- a/test/dialing/direct.node.js
+++ b/test/dialing/direct.node.js
@@ -158,9 +158,9 @@ describe('Dialing (direct, TCP)', () => {
 
   it('should dial to the max concurrency', async () => {
     const addrs = [
-      '/ip4/0.0.0.0/tcp/8000',
-      '/ip4/0.0.0.0/tcp/8001',
-      '/ip4/0.0.0.0/tcp/8002'
+      multiaddr('/ip4/0.0.0.0/tcp/8000'),
+      multiaddr('/ip4/0.0.0.0/tcp/8001'),
+      multiaddr('/ip4/0.0.0.0/tcp/8002')
     ]
     const dialer = new Dialer({
       transportManager: localTM,

--- a/test/dialing/direct.spec.js
+++ b/test/dialing/direct.spec.js
@@ -263,16 +263,11 @@ describe('Dialing (direct, WebSockets)', () => {
 
   describe('libp2p.dialer', () => {
     let libp2p
-    let remoteLibp2p
 
     afterEach(async () => {
       sinon.restore()
       libp2p && await libp2p.stop()
       libp2p = null
-    })
-
-    after(async () => {
-      remoteLibp2p && await remoteLibp2p.stop()
     })
 
     it('should create a dialer', () => {

--- a/test/dialing/resolver.spec.js
+++ b/test/dialing/resolver.spec.js
@@ -142,22 +142,10 @@ describe('Dialing (resolvable addresses)', () => {
     sinon.spy(transport, 'dial')
 
     // Resolver stub
-    let firstCall = false
-    let secondCall = false
-
     const stub = sinon.stub(Resolver.prototype, 'resolveTxt')
-    stub.callsFake(() => {
-      if (!firstCall) {
-        firstCall = true
-        // Return an array of dnsaddr
-        return Promise.resolve(getDnsaddrStub(remoteId))
-      } else if (!secondCall) {
-        secondCall = true
-        // Address failed to resolve
-        return Promise.reject(new Error())
-      }
-      return Promise.resolve(getDnsRelayedAddrStub(remoteId))
-    })
+    stub.onCall(0).callsFake(() => Promise.resolve(getDnsaddrStub(remoteId)))
+    stub.onCall(1).callsFake(() => Promise.reject(new Error()))
+    stub.callsFake(() => Promise.resolve(getDnsRelayedAddrStub(remoteId)))
 
     // Dial with address resolve
     const connection = await libp2p.dial(dialAddr)

--- a/test/dialing/resolver.spec.js
+++ b/test/dialing/resolver.spec.js
@@ -1,0 +1,131 @@
+'use strict'
+/* eslint-env mocha */
+
+const { expect } = require('aegir/utils/chai')
+const sinon = require('sinon')
+
+const multiaddr = require('multiaddr')
+const { Resolver } = require('multiaddr/src/resolvers/dns')
+
+const peerUtils = require('../utils/creators/peer')
+const baseOptions = require('../utils/base-options.browser')
+
+const { MULTIADDRS_WEBSOCKETS } = require('../fixtures/browser')
+const relayAddr = MULTIADDRS_WEBSOCKETS[0]
+
+const getDnsaddrStub = (peerId) => [
+  [`dnsaddr=/dnsaddr/ams-1.bootstrap.libp2p.io/p2p/${peerId}`],
+  [`dnsaddr=/dnsaddr/ams-2.bootstrap.libp2p.io/p2p/${peerId}`],
+  [`dnsaddr=/dnsaddr/lon-1.bootstrap.libp2p.io/p2p/${peerId}`],
+  [`dnsaddr=/dnsaddr/nrt-1.bootstrap.libp2p.io/p2p/${peerId}`],
+  [`dnsaddr=/dnsaddr/nyc-1.bootstrap.libp2p.io/p2p/${peerId}`],
+  [`dnsaddr=/dnsaddr/sfo-2.bootstrap.libp2p.io/p2p/${peerId}`]
+]
+
+const relayedAddr = (peerId) => `${relayAddr}/p2p-circuit/p2p/${peerId}`
+
+const getDnsRelayedAddrStub = (peerId) => [
+  [`dnsaddr=${relayedAddr(peerId)}`]
+]
+
+describe('Dialing (resolvable addresses)', () => {
+  let libp2p, remoteLibp2p
+
+  beforeEach(async () => {
+    [libp2p, remoteLibp2p] = await peerUtils.createPeer({
+      number: 2,
+      config: {
+        modules: baseOptions.modules,
+        addresses: {
+          listen: [multiaddr(`${relayAddr}/p2p-circuit`)]
+        },
+        config: {
+          peerDiscovery: {
+            autoDial: false
+          }
+        }
+      },
+      started: true,
+      populateAddressBooks: false
+    })
+  })
+
+  afterEach(async () => {
+    sinon.restore()
+    await Promise.all([libp2p, remoteLibp2p].map(n => n.stop()))
+  })
+
+  it('resolves dnsaddr to ws local address', async () => {
+    const remoteId = remoteLibp2p.peerId.toB58String()
+    const dialAddr = multiaddr(`/dnsaddr/remote.libp2p.io/p2p/${remoteId}`)
+    const relayedAddrFetched = multiaddr(relayedAddr(remoteId))
+
+    // Transport spy
+    const transport = libp2p.transportManager._transports.get('Circuit')
+    sinon.spy(transport, 'dial')
+
+    // Resolver stub
+    const stub = sinon.stub(Resolver.prototype, 'resolveTxt')
+    stub.onCall(0).returns(Promise.resolve(getDnsRelayedAddrStub(remoteId)))
+
+    // Dial with address resolve
+    const connection = await libp2p.dial(dialAddr)
+    expect(connection).to.exist()
+    expect(connection.remoteAddr.equals(relayedAddrFetched))
+
+    const dialArgs = transport.dial.firstCall.args
+    expect(dialArgs[0].equals(relayedAddrFetched)).to.eql(true)
+  })
+
+  it('resolves a dnsaddr recursively', async () => {
+    const remoteId = remoteLibp2p.peerId.toB58String()
+    const dialAddr = multiaddr(`/dnsaddr/remote.libp2p.io/p2p/${remoteId}`)
+    const relayedAddrFetched = multiaddr(relayedAddr(remoteId))
+
+    // Transport spy
+    const transport = libp2p.transportManager._transports.get('Circuit')
+    sinon.spy(transport, 'dial')
+
+    // Resolver stub
+    const stub = sinon.stub(Resolver.prototype, 'resolveTxt')
+    let alreadyCalled = false
+    stub.callsFake(() => {
+      if (!alreadyCalled) {
+        alreadyCalled = true
+        // Return an array of dnsaddr
+        return Promise.resolve(getDnsaddrStub(remoteId))
+      }
+      return Promise.resolve(getDnsRelayedAddrStub(remoteId))
+    })
+
+    // Dial with address resolve
+    const connection = await libp2p.dial(dialAddr)
+    expect(connection).to.exist()
+    expect(connection.remoteAddr.equals(relayedAddrFetched))
+
+    const dialArgs = transport.dial.firstCall.args
+    expect(dialArgs[0].equals(relayedAddrFetched)).to.eql(true)
+  })
+
+  // TODO: Temporary solution does not resolve dns4/dns6
+  it('stops recursive resolve if finds dns4/dns6 and dials it', async () => {
+    const remoteId = remoteLibp2p.peerId.toB58String()
+    const dialAddr = multiaddr(`/dnsaddr/remote.libp2p.io/p2p/${remoteId}`)
+
+    // Stub resolver
+    const dnsMa = multiaddr(`/dns4/ams-1.remote.libp2p.io/tcp/443/wss/p2p/${remoteId}`)
+    const stubResolve = sinon.stub(Resolver.prototype, 'resolveTxt')
+    stubResolve.returns(Promise.resolve([
+      [`dnsaddr=${dnsMa}`]
+    ]))
+
+    // Stub transport
+    const transport = libp2p.transportManager._transports.get('WebSockets')
+    const stubTransport = sinon.stub(transport, 'dial')
+    stubTransport.callsFake((multiaddr) => {
+      expect(multiaddr.equals(dnsMa)).to.eql(true)
+    })
+
+    await libp2p.dial(dialAddr)
+  })
+})


### PR DESCRIPTION
This PR adds the ability to resolve multiaddrs before dialling. The multiaddr resolvers are customizable within the dialer configuration and come with a default for `dnsaddr`. At this moment, we do not resolve `dns4` and `dns6` per https://github.com/libp2p/js-libp2p/pull/772#issuecomment-707164483 . I will make sure to create an issue to track this.

Needs:

- [x] https://github.com/vasco-santos/dns-over-http-resolver/pull/1
- [x] https://github.com/multiformats/js-multiaddr/pull/149