### PR TITLE
fix: ensure streams are closed on connection close

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -7,7 +7,7 @@ stages:
 
 node_js:
   - 'lts/*'
-  - 'stable'
+  - '14'
 
 os:
   - linux

--- a/package.json
+++ b/package.json
@@ -105,7 +105,7 @@
     "libp2p-gossipsub": "^0.6.0",
     "libp2p-kad-dht": "^0.20.0",
     "libp2p-mdns": "^0.15.0",
-    "libp2p-mplex": "libp2p/js-libp2p-mplex#fix/stream-close",
+    "libp2p-mplex": "^0.10.1",
     "libp2p-noise": "^2.0.0",
     "libp2p-secio": "^0.13.1",
     "libp2p-tcp": "^0.15.1",

--- a/package.json
+++ b/package.json
@@ -105,7 +105,7 @@
     "libp2p-gossipsub": "^0.6.0",
     "libp2p-kad-dht": "^0.20.0",
     "libp2p-mdns": "^0.15.0",
-    "libp2p-mplex": "^0.10.0",
+    "libp2p-mplex": "libp2p/js-libp2p-mplex#fix/stream-close",
     "libp2p-noise": "^2.0.0",
     "libp2p-secio": "^0.13.1",
     "libp2p-tcp": "^0.15.1",

--- a/src/upgrader.js
+++ b/src/upgrader.js
@@ -271,10 +271,15 @@ class Upgrader {
         if (connection && args[1] === 'close' && args[2] && !_timeline.close) {
           // Wait for close to finish before notifying of the closure
           (async () => {
-            if (connection.stat.status === ConnectionStatus.OPEN) {
-              await connection.close()
+            try {
+              if (connection.stat.status === ConnectionStatus.OPEN) {
+                await connection.close()
+              }
+            } catch (err) {
+              log.error(err)
+            } finally {
+              this.onConnectionEnd(connection)
             }
-            this.onConnectionEnd(connection)
           })()
         }
 


### PR DESCRIPTION
This patch ensures that whenever a connection is closed, any remaining streams on the connection are aborted.

- [x] requires https://github.com/libp2p/js-libp2p-mplex/pull/116