### PR TITLE
fix: cleanup open streams on conn close

### DIFF
--- a/src/upgrader.js
+++ b/src/upgrader.js
@@ -306,7 +306,13 @@ class Upgrader {
       },
       newStream: newStream || errConnectionNotMultiplexed,
       getStreams: () => muxer ? muxer.streams : errConnectionNotMultiplexed,
-      close: (err) => maConn.close(err)
+      close: async (err) => {
+        await maConn.close(err)
+        // Ensure remaining streams are aborted
+        if (muxer) {
+          muxer.streams.map(stream => stream.abort(err))
+        }
+      }
     })
 
     this.onConnection(connection)


### PR DESCRIPTION
Ensures any remaining streams are closed when the connection shuts down. This was discovered during testing of https://github.com/ChainSafe/lodestar.

Shouldn't be needed when https://github.com/libp2p/js-libp2p-interfaces/pull/67 is completed, but that won't land until 0.30.