### PR TITLE
feat: custom and store self agent version + store self protocol version

### DIFF
--- a/doc/API.md
+++ b/doc/API.md
@@ -92,7 +92,7 @@ Creates an instance of Libp2p.
 | options.modules | [`Array<object>`](./CONFIGURATION.md#modules) | libp2p [modules](./CONFIGURATION.md#modules) to use |
 | [options.addresses] | `{ listen: Array<string>, announce: Array<string>, noAnnounce: Array<string> }` | Addresses for transport listening and to advertise to the network |
 | [options.config] | `object` | libp2p modules configuration and core configuration |
-| [options.host] | `{agentVersion: string, protocolVersion: string}` | libp2p host options |
+| [options.host] | `{ agentVersion: string }` | libp2p host options |
 | [options.connectionManager] | [`object`](./CONFIGURATION.md#configuring-connection-manager) | libp2p Connection Manager [configuration](./CONFIGURATION.md#configuring-connection-manager) |
 | [options.transportManager] | [`object`](./CONFIGURATION.md#configuring-transport-manager) | libp2p transport manager [configuration](./CONFIGURATION.md#configuring-transport-manager) |
 | [options.datastore] | `object` | must implement [ipfs/interface-datastore](https://github.com/ipfs/interface-datastore) (in memory datastore will be used if not provided) |

--- a/doc/API.md
+++ b/doc/API.md
@@ -92,6 +92,7 @@ Creates an instance of Libp2p.
 | options.modules | [`Array<object>`](./CONFIGURATION.md#modules) | libp2p [modules](./CONFIGURATION.md#modules) to use |
 | [options.addresses] | `{ listen: Array<string>, announce: Array<string>, noAnnounce: Array<string> }` | Addresses for transport listening and to advertise to the network |
 | [options.config] | `object` | libp2p modules configuration and core configuration |
+| [options.host] | `{agentVersion: string, protocolVersion: string}` | libp2p host options |
 | [options.connectionManager] | [`object`](./CONFIGURATION.md#configuring-connection-manager) | libp2p Connection Manager [configuration](./CONFIGURATION.md#configuring-connection-manager) |
 | [options.transportManager] | [`object`](./CONFIGURATION.md#configuring-transport-manager) | libp2p transport manager [configuration](./CONFIGURATION.md#configuring-transport-manager) |
 | [options.datastore] | `object` | must implement [ipfs/interface-datastore](https://github.com/ipfs/interface-datastore) (in memory datastore will be used if not provided) |

--- a/src/config.js
+++ b/src/config.js
@@ -4,10 +4,7 @@ const mergeOptions = require('merge-options')
 const { dnsaddrResolver } = require('multiaddr/src/resolvers')
 
 const Constants = require('./constants')
-const {
-  AGENT_VERSION,
-  PROTOCOL_VERSION
-} = require('./identify/consts')
+const { AGENT_VERSION } = require('./identify/consts')
 
 const { FaultTolerance } = require('./transport-manager')
 
@@ -32,8 +29,7 @@ const DefaultConfig = {
     }
   },
   host: {
-    agentVersion: AGENT_VERSION,
-    protocolVersion: PROTOCOL_VERSION
+    agentVersion: AGENT_VERSION
   },
   metrics: {
     enabled: false

--- a/src/config.js
+++ b/src/config.js
@@ -4,6 +4,10 @@ const mergeOptions = require('merge-options')
 const { dnsaddrResolver } = require('multiaddr/src/resolvers')
 
 const Constants = require('./constants')
+const {
+  AGENT_VERSION,
+  PROTOCOL_VERSION
+} = require('./identify/consts')
 
 const { FaultTolerance } = require('./transport-manager')
 
@@ -26,6 +30,10 @@ const DefaultConfig = {
     resolvers: {
       dnsaddr: dnsaddrResolver
     }
+  },
+  host: {
+    agentVersion: AGENT_VERSION,
+    protocolVersion: PROTOCOL_VERSION
   },
   metrics: {
     enabled: false

--- a/src/identify/index.js
+++ b/src/identify/index.js
@@ -83,6 +83,16 @@ class IdentifyService {
     this._protocols = protocols
 
     this.handleMessage = this.handleMessage.bind(this)
+
+    // Store self host metadata
+    this._host = {
+      agentVersion: AGENT_VERSION,
+      protocolVersion: PROTOCOL_VERSION,
+      ...libp2p._options.host
+    }
+
+    this.peerStore.metadataBook.set(this.peerId, 'AgentVersion', uint8ArrayFromString(this._host.agentVersion))
+    this.peerStore.metadataBook.set(this.peerId, 'ProtocolVersion', uint8ArrayFromString(this._host.protocolVersion))
   }
 
   /**
@@ -246,8 +256,8 @@ class IdentifyService {
     const signedPeerRecord = await this._getSelfPeerRecord()
 
     const message = Message.encode({
-      protocolVersion: PROTOCOL_VERSION,
-      agentVersion: AGENT_VERSION,
+      protocolVersion: this._host.protocolVersion,
+      agentVersion: this._host.agentVersion,
       publicKey,
       listenAddrs: this._libp2p.multiaddrs.map((ma) => ma.bytes),
       signedPeerRecord,

--- a/test/identify/index.spec.js
+++ b/test/identify/index.spec.js
@@ -207,9 +207,8 @@ describe('Identify', () => {
       .and.to.have.property('code', Errors.ERR_INVALID_PEER)
   })
 
-  it('should store host data into metadataBook', () => {
+  it('should store host data and protocol version into metadataBook', () => {
     const agentVersion = 'js-project/1.0.0'
-    const protocolVersion = '1000'
     const peerStore = new PeerStore({ peerId: localPeer })
 
     sinon.spy(peerStore.metadataBook, 'set')
@@ -222,8 +221,7 @@ describe('Identify', () => {
         multiaddrs: listenMaddrs,
         _options: {
           host: {
-            agentVersion,
-            protocolVersion
+            agentVersion
           }
         }
       },
@@ -236,7 +234,7 @@ describe('Identify', () => {
     const storedProtocolVersion = peerStore.metadataBook.getValue(localPeer, 'ProtocolVersion')
 
     expect(agentVersion).to.eql(unit8ArrayToString(storedAgentVersion))
-    expect(protocolVersion).to.eql(unit8ArrayToString(storedProtocolVersion))
+    expect(storedProtocolVersion).to.exist()
   })
 
   describe('push', () => {
@@ -447,16 +445,14 @@ describe('Identify', () => {
       await pWaitFor(() => connection.streams.length === 0)
     })
 
-    it('should store host data into metadataBook', () => {
+    it('should store host data and protocol version into metadataBook', () => {
       const agentVersion = 'js-project/1.0.0'
-      const protocolVersion = '1000'
 
       libp2p = new Libp2p({
         ...baseOptions,
         peerId,
         host: {
-          agentVersion,
-          protocolVersion
+          agentVersion
         }
       })
 
@@ -464,7 +460,7 @@ describe('Identify', () => {
       const storedProtocolVersion = libp2p.peerStore.metadataBook.getValue(localPeer, 'ProtocolVersion')
 
       expect(agentVersion).to.eql(unit8ArrayToString(storedAgentVersion))
-      expect(protocolVersion).to.eql(unit8ArrayToString(storedProtocolVersion))
+      expect(storedProtocolVersion).to.exist()
     })
   })
 })


### PR DESCRIPTION
This PR adds the ability to custom the agentVersion of libp2p, as well as to store it and the protocol version self values in the metadataBook.

I added a host property to track this custom options. `go-libp2p` also has the concept of host and it seems a good naming. When we work on the configuration improvements, we should probably think about moving other options inside the host, such as the AddressBook options.

I followed the same logic of signedPeerRecords being created in the IdentifyService and added this into the Identify subsystem.

Closes #799