### PR TITLE
chore: update websockets

### DIFF
--- a/package.json
+++ b/package.json
@@ -109,7 +109,7 @@
     "libp2p-secio": "^0.13.1",
     "libp2p-tcp": "^0.15.1",
     "libp2p-webrtc-star": "^0.20.0",
-    "libp2p-websockets": "libp2p/js-libp2p-websockets#feat/custom-address-filter-for-transport",
+    "libp2p-websockets": "^0.15.0",
     "multihashes": "^3.0.1",
     "nock": "^13.0.3",
     "p-defer": "^3.0.0",

--- a/package.json
+++ b/package.json
@@ -109,7 +109,7 @@
     "libp2p-secio": "^0.13.1",
     "libp2p-tcp": "^0.15.1",
     "libp2p-webrtc-star": "^0.20.0",
-    "libp2p-websockets": "^0.14.0",
+    "libp2p-websockets": "libp2p/js-libp2p-websockets#feat/custom-address-filter-for-transport",
     "multihashes": "^3.0.1",
     "nock": "^13.0.3",
     "p-defer": "^3.0.0",

--- a/test/dialing/direct.spec.js
+++ b/test/dialing/direct.spec.js
@@ -7,6 +7,7 @@ const pDefer = require('p-defer')
 const pWaitFor = require('p-wait-for')
 const delay = require('delay')
 const Transport = require('libp2p-websockets')
+const filters = require('libp2p-websockets/src/filters')
 const Muxer = require('libp2p-mplex')
 const { NOISE: Crypto } = require('libp2p-noise')
 const multiaddr = require('multiaddr')
@@ -41,7 +42,7 @@ describe('Dialing (direct, WebSockets)', () => {
       upgrader: mockUpgrader,
       onConnection: () => {}
     })
-    localTM.add(Transport.prototype[Symbol.toStringTag], Transport)
+    localTM.add(Transport.prototype[Symbol.toStringTag], Transport, { filter: filters.all })
   })
 
   afterEach(() => {
@@ -292,6 +293,7 @@ describe('Dialing (direct, WebSockets)', () => {
   })
 
   describe('libp2p.dialer', () => {
+    const transportKey = Transport.prototype[Symbol.toStringTag]
     let libp2p
 
     afterEach(async () => {
@@ -307,6 +309,13 @@ describe('Dialing (direct, WebSockets)', () => {
           transport: [Transport],
           streamMuxer: [Muxer],
           connEncryption: [Crypto]
+        },
+        config: {
+          transport: {
+            [transportKey]: {
+              filter: filters.all
+            }
+          }
         }
       })
 
@@ -330,6 +339,13 @@ describe('Dialing (direct, WebSockets)', () => {
           maxParallelDials: 10,
           maxDialsPerPeer: 1,
           dialTimeout: 1e3 // 30 second dial timeout per peer
+        },
+        config: {
+          transport: {
+            [transportKey]: {
+              filter: filters.all
+            }
+          }
         }
       }
       libp2p = await Libp2p.create(config)
@@ -347,6 +363,13 @@ describe('Dialing (direct, WebSockets)', () => {
           transport: [Transport],
           streamMuxer: [Muxer],
           connEncryption: [Crypto]
+        },
+        config: {
+          transport: {
+            [transportKey]: {
+              filter: filters.all
+            }
+          }
         }
       })
 
@@ -370,6 +393,13 @@ describe('Dialing (direct, WebSockets)', () => {
           transport: [Transport],
           streamMuxer: [Muxer],
           connEncryption: [Crypto]
+        },
+        config: {
+          transport: {
+            [transportKey]: {
+              filter: filters.all
+            }
+          }
         }
       })
 
@@ -397,6 +427,13 @@ describe('Dialing (direct, WebSockets)', () => {
           transport: [Transport],
           streamMuxer: [Muxer],
           connEncryption: [Crypto]
+        },
+        config: {
+          transport: {
+            [transportKey]: {
+              filter: filters.all
+            }
+          }
         }
       })
 
@@ -414,6 +451,13 @@ describe('Dialing (direct, WebSockets)', () => {
           transport: [Transport],
           streamMuxer: [Muxer],
           connEncryption: [Crypto]
+        },
+        config: {
+          transport: {
+            [transportKey]: {
+              filter: filters.all
+            }
+          }
         }
       })
 
@@ -427,6 +471,13 @@ describe('Dialing (direct, WebSockets)', () => {
           transport: [Transport],
           streamMuxer: [Muxer],
           connEncryption: [Crypto]
+        },
+        config: {
+          transport: {
+            [transportKey]: {
+              filter: filters.all
+            }
+          }
         }
       })
 

--- a/test/dialing/resolver.spec.js
+++ b/test/dialing/resolver.spec.js
@@ -37,11 +37,12 @@ describe('Dialing (resolvable addresses)', () => {
     [libp2p, remoteLibp2p] = await peerUtils.createPeer({
       number: 2,
       config: {
-        modules: baseOptions.modules,
+        ...baseOptions,
         addresses: {
           listen: [multiaddr(`${relayAddr}/p2p-circuit`)]
         },
         config: {
+          ...baseOptions.config,
           peerDiscovery: {
             autoDial: false
           }

--- a/test/transports/transport-manager.spec.js
+++ b/test/transports/transport-manager.spec.js
@@ -6,6 +6,7 @@ const sinon = require('sinon')
 
 const multiaddr = require('multiaddr')
 const Transport = require('libp2p-websockets')
+const filters = require('libp2p-websockets/src/filters')
 const { NOISE: Crypto } = require('libp2p-noise')
 const AddressManager = require('../../src/address-manager')
 const TransportManager = require('../../src/transport-manager')
@@ -39,7 +40,7 @@ describe('Transport Manager (WebSockets)', () => {
   })
 
   it('should be able to add and remove a transport', async () => {
-    tm.add(Transport.prototype[Symbol.toStringTag], Transport)
+    tm.add(Transport.prototype[Symbol.toStringTag], Transport, { filter: filters.all })
     expect(tm._transports.size).to.equal(1)
     await tm.remove(Transport.prototype[Symbol.toStringTag])
   })
@@ -66,7 +67,7 @@ describe('Transport Manager (WebSockets)', () => {
   })
 
   it('should be able to dial', async () => {
-    tm.add(Transport.prototype[Symbol.toStringTag], Transport)
+    tm.add(Transport.prototype[Symbol.toStringTag], Transport, { filter: filters.all })
     const addr = MULTIADDRS_WEBSOCKETS[0]
     const connection = await tm.dial(addr)
     expect(connection).to.exist()
@@ -74,7 +75,7 @@ describe('Transport Manager (WebSockets)', () => {
   })
 
   it('should fail to dial an unsupported address', async () => {
-    tm.add(Transport.prototype[Symbol.toStringTag], Transport)
+    tm.add(Transport.prototype[Symbol.toStringTag], Transport, { filter: filters.all })
     const addr = multiaddr('/ip4/127.0.0.1/tcp/0')
     await expect(tm.dial(addr))
       .to.eventually.be.rejected()
@@ -82,7 +83,7 @@ describe('Transport Manager (WebSockets)', () => {
   })
 
   it('should fail to listen with no valid address', async () => {
-    tm.add(Transport.prototype[Symbol.toStringTag], Transport)
+    tm.add(Transport.prototype[Symbol.toStringTag], Transport, { filter: filters.all })
 
     await expect(tm.listen([listenAddr]))
       .to.eventually.be.rejected()

--- a/test/utils/base-options.browser.js
+++ b/test/utils/base-options.browser.js
@@ -1,8 +1,11 @@
 'use strict'
 
 const Transport = require('libp2p-websockets')
+const filters = require('libp2p-websockets/src/filters')
 const Muxer = require('libp2p-mplex')
 const { NOISE: Crypto } = require('libp2p-noise')
+
+const transportKey = Transport.prototype[Symbol.toStringTag]
 
 module.exports = {
   modules: {
@@ -15,6 +18,11 @@ module.exports = {
       enabled: true,
       hop: {
         enabled: false
+      }
+    },
+    transport: {
+      [transportKey]: {
+        filter: filters.all
       }
     }
   }


### PR DESCRIPTION
This PR updates websockets version, which comes with a BREAKING CHANGE on the filter. Only DNS+WSS addresses are now returned on filter by default in the browser. The tests were update to pass a custom filter so that we can test this locally with loopback websocket addresses

Needs:
- [x] https://github.com/libp2p/js-libp2p-websockets/pull/116