### PR TITLE
docs: use Libp2p.create() in examples (#811)

### DIFF
--- a/doc/API.md
+++ b/doc/API.md
@@ -114,12 +114,25 @@ For Libp2p configurations and modules details read the [Configuration Document](
 
 ```js
 const Libp2p = require('libp2p')
+const TCP = require('libp2p-tcp')
+const MPLEX = require('libp2p-mplex')
+const { NOISE } = require('libp2p-noise')
 
-// specify options
-const options = {}
+async function main () {
+  // specify options
+  const options = {
+    modules: {
+      transport: [TCP],
+      streamMuxer: [MPLEX],
+      connEncryption: [NOISE]
+    }
+  }
 
-// create libp2p
-const libp2p = await Libp2p.create(options)
+  // create libp2p
+  const libp2p = await Libp2p.create(options)
+}
+
+main()
 ```
 
 Note: The [`PeerId`][peer-id] option is not required and will be generated if it is not provided.
@@ -131,20 +144,30 @@ As an alternative, it is possible to create a Libp2p instance with the construct
 
 ```js
 const Libp2p = require('libp2p')
+const TCP = require('libp2p-tcp')
+const MPLEX = require('libp2p-mplex')
+const { NOISE } = require('libp2p-noise')
 const PeerId = require('peer-id')
 
-;(async () => {
+async function main () {
   const peerId = await PeerId.create();
 
   // specify options
   // peerId is required when Libp2p is instantiated via the constructor
   const options = {
-    peerId
+    peerId,
+    modules: {
+      transport: [TCP],
+      streamMuxer: [MPLEX],
+      connEncryption: [NOISE]
+    }
   }
 
   // create libp2p
   const libp2p = new Libp2p(options)
-})()
+}
+
+main()
 ```
 
 Required keys in the `options` object:

--- a/doc/API.md
+++ b/doc/API.md
@@ -131,12 +131,20 @@ As an alternative, it is possible to create a Libp2p instance with the construct
 
 ```js
 const Libp2p = require('libp2p')
+const PeerId = require('peer-id')
 
-// specify options
-const options = {}
+;(async () => {
+  const peerId = await PeerId.create();
 
-// create libp2p
-const libp2p = new Libp2p(options)
+  // specify options
+  // peerId is required when Libp2p is instantiated via the constructor
+  const options = {
+    peerId
+  }
+
+  // create libp2p
+  const libp2p = new Libp2p(options)
+})()
 ```
 
 Required keys in the `options` object:

--- a/examples/chat/src/dialer.js
+++ b/examples/chat/src/dialer.js
@@ -3,7 +3,7 @@
 
 const PeerId = require('peer-id')
 const multiaddr = require('multiaddr')
-const Node = require('./libp2p-bundle')
+const createLibp2p = require('./libp2p-bundle')
 const { stdinToStream, streamToConsole } = require('./stream')
 
 async function run() {
@@ -13,7 +13,7 @@ async function run() {
   ])
 
   // Create a new libp2p node on localhost with a randomly chosen port
-  const nodeDialer = new Node({
+  const nodeDialer = await createLibp2p({
     peerId: idDialer,
     addresses: {
       listen: ['/ip4/0.0.0.0/tcp/0']

--- a/examples/chat/src/libp2p-bundle.js
+++ b/examples/chat/src/libp2p-bundle.js
@@ -7,21 +7,16 @@ const { NOISE } = require('libp2p-noise')
 const defaultsDeep = require('@nodeutils/defaults-deep')
 const libp2p = require('../../..')
 
-class Node extends libp2p {
-  constructor (_options) {
-    const defaults = {
-      modules: {
-        transport: [
-          TCP,
-          WS
-        ],
-        streamMuxer: [ mplex ],
-        connEncryption: [ NOISE ]
-      }
-    }
-
-    super(defaultsDeep(_options, defaults))
+async function createLibp2p(_options) {
+  const defaults = {
+    modules: {
+      transport: [TCP, WS],
+      streamMuxer: [mplex],
+      connEncryption: [NOISE],
+    },
   }
+
+  return libp2p.create(defaultsDeep(_options, defaults))
 }
 
-module.exports = Node
+module.exports = createLibp2p

--- a/examples/chat/src/listener.js
+++ b/examples/chat/src/listener.js
@@ -2,13 +2,13 @@
 /* eslint-disable no-console */
 
 const PeerId = require('peer-id')
-const Node = require('./libp2p-bundle.js')
+const createLibp2p = require('./libp2p-bundle.js')
 const { stdinToStream, streamToConsole } = require('./stream')
 
 async function run() {
   // Create a new libp2p node with the given multi-address
   const idListener = await PeerId.createFromJSON(require('./peer-id-listener'))
-  const nodeListener = new Node({
+  const nodeListener = await createLibp2p({
     peerId: idListener,
     addresses: {
       listen: ['/ip4/0.0.0.0/tcp/10333']

--- a/examples/echo/src/dialer.js
+++ b/examples/echo/src/dialer.js
@@ -5,9 +5,8 @@
  * Dialer Node
  */
 
-const multiaddr = require('multiaddr')
 const PeerId = require('peer-id')
-const Node = require('./libp2p-bundle')
+const createLibp2p = require('./libp2p-bundle')
 const pipe = require('it-pipe')
 
 async function run() {
@@ -17,7 +16,7 @@ async function run() {
   ])
 
   // Dialer
-  const dialerNode = new Node({
+  const dialerNode = await createLibp2p({
     addresses: {
       listen: ['/ip4/0.0.0.0/tcp/0']
     },

--- a/examples/echo/src/libp2p-bundle.js
+++ b/examples/echo/src/libp2p-bundle.js
@@ -8,21 +8,16 @@ const { NOISE } = require('libp2p-noise')
 const defaultsDeep = require('@nodeutils/defaults-deep')
 const libp2p = require('../../..')
 
-class Node extends libp2p {
-  constructor (_options) {
-    const defaults = {
-      modules: {
-        transport: [
-          TCP,
-          WS
-        ],
-        streamMuxer: [ mplex ],
-        connEncryption: [ NOISE ]
-      }
-    }
-
-    super(defaultsDeep(_options, defaults))
+async function createLibp2p(_options) {
+  const defaults = {
+    modules: {
+      transport: [TCP, WS],
+      streamMuxer: [mplex],
+      connEncryption: [NOISE],
+    },
   }
+
+  return libp2p.create(defaultsDeep(_options, defaults))
 }
 
-module.exports = Node
+module.exports = createLibp2p

--- a/examples/echo/src/listener.js
+++ b/examples/echo/src/listener.js
@@ -6,14 +6,14 @@
  */
 
 const PeerId = require('peer-id')
-const Node = require('./libp2p-bundle')
+const createLibp2p = require('./libp2p-bundle')
 const pipe = require('it-pipe')
 
 async function run() {
   const listenerId = await PeerId.createFromJSON(require('./id-l'))
 
   // Listener libp2p node
-  const listenerNode = new Node({
+  const listenerNode = await createLibp2p({
     addresses: {
       listen: ['/ip4/0.0.0.0/tcp/10333']
     },


### PR DESCRIPTION
I didn't changed the use of `new Libp2p()` in the `examples/delegated-routing` directory because this is already in progress in PR #507

https://github.com/libp2p/js-libp2p/blob/d0a9fada32677ee3b810d5c2fb8d5e2c4f5a9fef/examples/delegated-routing/src/libp2p-bundle.js#L23-L30