### PR TITLE
chore: fix multicodec updates

### DIFF
--- a/package.json
+++ b/package.json
@@ -77,7 +77,7 @@
     "merge-options": "^2.0.0",
     "moving-average": "^1.0.0",
     "multiaddr": "^8.1.0",
-    "multicodec": "2.0.4",
+    "multicodec": "^2.0.0",
     "multihashing-async": "^2.0.1",
     "multistream-select": "^1.0.0",
     "mutable-proxy": "^1.0.0",

--- a/package.json
+++ b/package.json
@@ -18,7 +18,6 @@
     "src"
   ],
   "scripts": {
-    "prepare": "aegir ts -p types",
     "lint": "aegir lint",
     "build": "aegir build",
     "test": "npm run test:node && npm run test:browser",

--- a/package.json
+++ b/package.json
@@ -18,6 +18,7 @@
     "src"
   ],
   "scripts": {
+    "prepare": "aegir ts -p types",
     "lint": "aegir lint",
     "build": "aegir build",
     "test": "npm run test:node && npm run test:browser",
@@ -76,7 +77,7 @@
     "merge-options": "^2.0.0",
     "moving-average": "^1.0.0",
     "multiaddr": "^8.1.0",
-    "multicodec": "^2.0.0",
+    "multicodec": "2.0.4",
     "multihashing-async": "^2.0.1",
     "multistream-select": "^1.0.0",
     "mutable-proxy": "^1.0.0",

--- a/src/record/peer-record/consts.js
+++ b/src/record/peer-record/consts.js
@@ -3,9 +3,14 @@
 const multicodec = require('multicodec')
 
 // The domain string used for peer records contained in a Envelope.
-module.exports.ENVELOPE_DOMAIN_PEER_RECORD = multicodec.getName(multicodec.LIBP2P_PEER_RECORD)
+const domain = multicodec.getName(multicodec.LIBP2P_PEER_RECORD) || 'libp2p-peer-record'
 
 // The type hint used to identify peer records in a Envelope.
 // Defined in https://github.com/multiformats/multicodec/blob/master/table.csv
 // with name "libp2p-peer-record"
-module.exports.ENVELOPE_PAYLOAD_TYPE_PEER_RECORD = Uint8Array.from([3, 1])
+const payloadType = Uint8Array.from([3, 1])
+
+module.exports = {
+  ENVELOPE_DOMAIN_PEER_RECORD: domain,
+  ENVELOPE_PAYLOAD_TYPE_PEER_RECORD: payloadType
+}


### PR DESCRIPTION
With multicodec types update, `getName` might return undefined.
This will never happen in this case but types complain that it might be undefined in the PeerRecord, so I added a fallback string value

Needs:
- [ ] remove prepare script