### PR TITLE
chore: connection encryption example test

### DIFF
--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -72,6 +72,13 @@ jobs:
       - uses: actions/checkout@v2
       - run: yarn
       - run: cd examples && yarn && npm run test -- chat
+  test-connection-encryption-example:
+    needs: check
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v2
+      - run: yarn
+      - run: cd examples && yarn && npm run test -- connection-encryption
   test-echo-example:
     needs: check
     runs-on: ubuntu-latest

--- a/examples/connection-encryption/1.js
+++ b/examples/connection-encryption/1.js
@@ -1,6 +1,6 @@
 'use strict'
 
-const Libp2p = require('../../')
+const Libp2p = require('../..')
 const TCP = require('libp2p-tcp')
 const Mplex = require('libp2p-mplex')
 const { NOISE } = require('libp2p-noise')

--- a/examples/connection-encryption/README.md
+++ b/examples/connection-encryption/README.md
@@ -1,4 +1,4 @@
-# Encrypted Communications
+# Connection Encryption
 
 libp2p can leverage the encrypted communications from the transports it uses (i.e WebRTC). To ensure that every connection is encrypted, independently of how it was set up, libp2p also supports a set of modules that encrypt every communication established.
 

--- a/examples/connection-encryption/test.js
+++ b/examples/connection-encryption/test.js
@@ -1,0 +1,30 @@
+'use strict'
+
+const path = require('path')
+const execa = require('execa')
+const pDefer = require('p-defer')
+const uint8ArrayToString = require('uint8arrays/to-string')
+
+async function test () {
+  const messageReceived = pDefer()
+  process.stdout.write('1.js\n')
+
+  const proc = execa('node', [path.join(__dirname, '1.js')], {
+    cwd: path.resolve(__dirname),
+    all: true
+  })
+
+  proc.all.on('data', async (data) => {
+    process.stdout.write(data)
+
+    const s = uint8ArrayToString(data)
+    if (s.includes('This information is sent out encrypted to the other peer')) {
+      messageReceived.resolve()
+    }
+  })
+
+  await messageReceived.promise
+  proc.kill()
+}
+
+module.exports = test


### PR DESCRIPTION
This PR adds a test for the connection encryption example. The example folder name was changed to connection encryption to better match the connEncryption module name in libp2p configuration.