### PR TITLE
chore: update delegates config docs to use http client

### DIFF
--- a/doc/CONFIGURATION.md
+++ b/doc/CONFIGURATION.md
@@ -391,6 +391,7 @@ const Libp2p = require('libp2p')
 const TCP = require('libp2p-tcp')
 const MPLEX = require('libp2p-mplex')
 const { NOISE } = require('libp2p-noise')
+const ipfsHttpClient = require('ipfs-http-client')
 const DelegatedPeerRouter = require('libp2p-delegated-peer-routing')
 const DelegatedContentRouter = require('libp2p-delegated-content-routing')
 const PeerId = require('peer-id')
@@ -398,17 +399,25 @@ const PeerId = require('peer-id')
 // create a peerId
 const peerId = await PeerId.create()
 
+const delegatedPeerRouting = new DelegatedPeerRouter(ipfsHttpClient({
+  host: 'node0.delegate.ipfs.io' // In production you should setup your own delegates
+  protocol: 'https',
+  port: 443
+}))
+
+const delegatedContentRouting = new DelegatedContentRouter(peerId, ipfsHttpClient({
+  host: 'node0.delegate.ipfs.io' // In production you should setup your own delegates
+  protocol: 'https',
+  port: 443
+}))
+
 const node = await Libp2p.create({
   modules: {
     transport: [TCP],
     streamMuxer: [MPLEX],
     connEncryption: [NOISE],
-    contentRouting: [
-      new DelegatedContentRouter(peerId)
-    ],
-    peerRouting: [
-      new DelegatedPeerRouter()
-    ],
+    contentRouting: [delegatedContentRouting],
+    peerRouting: [delegatedPeerRouting],
   },
   peerId,
   peerRouting: { // Peer routing configuration

--- a/test/content-routing/content-routing.node.js
+++ b/test/content-routing/content-routing.node.js
@@ -107,9 +107,7 @@ describe('content-routing', () => {
         host: '0.0.0.0',
         protocol: 'http',
         port: 60197
-      }), [
-        multiaddr('/ip4/0.0.0.0/tcp/60197')
-      ])
+      }))
 
       ;[node] = await peerUtils.createPeer({
         config: mergeOptions(baseOptions, {
@@ -253,9 +251,7 @@ describe('content-routing', () => {
         host: '0.0.0.0',
         protocol: 'http',
         port: 60197
-      }), [
-        multiaddr('/ip4/0.0.0.0/tcp/60197')
-      ])
+      }))
 
       ;[node] = await peerUtils.createPeer({
         config: mergeOptions(routingOptions, {


### PR DESCRIPTION
Updates configuration docs for delegate config using the http-client per newer versions