### PR TITLE
feat: add config option to expose raw connections

### DIFF
--- a/doc/CONFIGURATION.md
+++ b/doc/CONFIGURATION.md
@@ -28,6 +28,7 @@
       - [Configuring Metrics](#configuring-metrics)
       - [Configuring PeerStore](#configuring-peerstore)
       - [Customizing Transports](#customizing-transports)
+      - [Exposing Raw Connections](#exposing-raw-connections)
   - [Configuration examples](#configuration-examples)
 
 ## Overview
@@ -719,6 +720,24 @@ const node = await Libp2p.create({
         }
       }
     }
+  }
+})
+```
+
+#### Exposing Raw Connections
+
+By default, libp2p abstracts away the underlying raw connections to other peers to provide replicable and expected functionality. However, the underlying connections may have functionality valuable to the developer that lies outside the scope of libp2p. The configuration option `exposeRawConn` can be used to expose the underlying connections. This will also expose a `transportTag` property so the type of transport can be identified at the application level.
+
+```js
+const transportKey = WebRTCStar.prototype[Symbol.toStringTag]
+const node = await Libp2p.create({
+  modules: {
+    transport: [WebRTCStar],
+    streamMuxer: [MPLEX],
+    connEncryption: [NOISE]
+  },
+  config: {
+    exposeRawConn: true
   }
 })
 ```

--- a/src/config.js
+++ b/src/config.js
@@ -81,7 +81,8 @@ const DefaultConfig = {
         maxListeners: 2
       }
     },
-    transport: {}
+    transport: {},
+    exposeRawConn: false
   }
 }
 

--- a/src/dialer/index.js
+++ b/src/dialer/index.js
@@ -112,7 +112,6 @@ class Dialer {
     if (!dialTarget.addrs.length) {
       throw errCode(new Error('The dial request has no addresses'), codes.ERR_NO_VALID_ADDRESSES)
     }
-
     const pendingDial = this._pendingDials.get(dialTarget.id) || this._createPendingDial(dialTarget, options)
 
     try {

--- a/src/dialer/index.js
+++ b/src/dialer/index.js
@@ -112,6 +112,7 @@ class Dialer {
     if (!dialTarget.addrs.length) {
       throw errCode(new Error('The dial request has no addresses'), codes.ERR_NO_VALID_ADDRESSES)
     }
+
     const pendingDial = this._pendingDials.get(dialTarget.id) || this._createPendingDial(dialTarget, options)
 
     try {

--- a/src/index.js
+++ b/src/index.js
@@ -176,7 +176,8 @@ class Libp2p extends EventEmitter {
       localPeer: this.peerId,
       metrics: this.metrics,
       onConnection: (connection) => this.connectionManager.onConnect(connection),
-      onConnectionEnd: (connection) => this.connectionManager.onDisconnect(connection)
+      onConnectionEnd: (connection) => this.connectionManager.onDisconnect(connection),
+      exposeRawConn: this._config.exposeRawConn
     })
 
     // Setup the transport manager

--- a/src/upgrader.js
+++ b/src/upgrader.js
@@ -305,6 +305,7 @@ class Upgrader {
         multiplexer: Muxer && Muxer.multicodec,
         encryption: cryptoProtocol
       },
+      transportTag: maConn.transportTag,
       newStream: newStream || errConnectionNotMultiplexed,
       getStreams: () => muxer ? muxer.streams : errConnectionNotMultiplexed,
       close: async (err) => {

--- a/src/upgrader.js
+++ b/src/upgrader.js
@@ -38,6 +38,7 @@ class Upgrader {
    * @param {Map<string, MuxerFactory>} [options.muxers]
    * @param {(Connection) => void} options.onConnection - Called when a connection is upgraded
    * @param {(Connection) => void} options.onConnectionEnd
+   * @param {boolean} [options.exposeRawConn = false]
    */
   constructor ({
     localPeer,
@@ -45,7 +46,8 @@ class Upgrader {
     cryptos = new Map(),
     muxers = new Map(),
     onConnectionEnd = () => {},
-    onConnection = () => {}
+    onConnection = () => {},
+    exposeRawConn = false
   }) {
     this.localPeer = localPeer
     this.metrics = metrics
@@ -55,6 +57,7 @@ class Upgrader {
     this.protocols = new Map()
     this.onConnection = onConnection
     this.onConnectionEnd = onConnectionEnd
+    this.exposeRawConn = exposeRawConn
   }
 
   /**
@@ -290,6 +293,7 @@ class Upgrader {
 
     // Create the connection
     connection = new Connection({
+      rawConn: this.exposeRawConn ? maConn.conn : undefined,
       localAddr: maConn.localAddr,
       remoteAddr: maConn.remoteAddr,
       localPeer: this.localPeer,


### PR DESCRIPTION
Adds an option to the libp2p configuration `config.exposeRawConn` (default: false)

This option is then used by the upgrader to expose the raw connection and transport tag from a `MultiaddrConnection` to the `Connection`

Requires https://github.com/libp2p/js-libp2p-interfaces/pull/79

Solves https://github.com/libp2p/js-libp2p/issues/838