### PR TITLE
chore: add discovery example with relay and pubsub discovery

### DIFF
--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -79,6 +79,13 @@ jobs:
       - uses: actions/checkout@v2
       - run: yarn
       - run: cd examples && yarn && npm run test -- connection-encryption
+  test-discovery-mechanisms-example:
+    needs: check
+    runs-on: macos-latest
+    steps:
+      - uses: actions/checkout@v2
+      - run: yarn
+      - run: cd examples && yarn && npm run test -- discovery-mechanisms
   test-echo-example:
     needs: check
     runs-on: ubuntu-latest
@@ -93,13 +100,6 @@ jobs:
       - uses: actions/checkout@v2
       - run: yarn
       - run: cd examples && yarn && npm run test -- libp2p-in-the-browser
-  test-discovery-mechanisms-example:
-    needs: check
-    runs-on: macos-latest
-    steps:
-      - uses: actions/checkout@v2
-      - run: yarn
-      - run: cd examples && yarn && npm run test -- discovery-mechanisms
   test-peer-and-content-routing-example:
     needs: check
     runs-on: ubuntu-latest

--- a/examples/discovery-mechanisms/3.js
+++ b/examples/discovery-mechanisms/3.js
@@ -1,0 +1,68 @@
+/* eslint-disable no-console */
+'use strict'
+
+const Libp2p = require('../../')
+const TCP = require('libp2p-tcp')
+const Mplex = require('libp2p-mplex')
+const { NOISE } = require('libp2p-noise')
+const Gossipsub = require('libp2p-gossipsub')
+const Bootstrap = require('libp2p-bootstrap')
+const PubsubPeerDiscovery = require('libp2p-pubsub-peer-discovery')
+
+const createRelayServer = require('libp2p-relay-server')
+
+const createNode = async (bootstrapers) => {
+  const node = await Libp2p.create({
+    addresses: {
+      listen: ['/ip4/0.0.0.0/tcp/0']
+    },
+    modules: {
+      transport: [TCP],
+      streamMuxer: [Mplex],
+      connEncryption: [NOISE],
+      pubsub: Gossipsub,
+      peerDiscovery: [Bootstrap, PubsubPeerDiscovery]
+    },
+    config: {
+      peerDiscovery: {
+        [PubsubPeerDiscovery.tag]: {
+          interval: 1000,
+          enabled: true
+        },
+        [Bootstrap.tag]: {
+          enabled: true,
+          list: bootstrapers
+        }
+      }
+    }
+  })
+
+  return node
+}
+
+;(async () => {
+  const relay = await createRelayServer({
+    listenAddresses: ['/ip4/0.0.0.0/tcp/0']
+  })
+  console.log(`libp2p relay starting with id: ${relay.peerId.toB58String()}`)
+  await relay.start()
+  const relayMultiaddrs = relay.multiaddrs.map((m) => `${m.toString()}/p2p/${relay.peerId.toB58String()}`)
+
+  const [node1, node2] = await Promise.all([
+    createNode(relayMultiaddrs),
+    createNode(relayMultiaddrs)
+  ])
+
+  node1.on('peer:discovery', (peerId) => {
+    console.log(`Peer ${node1.peerId.toB58String()} discovered: ${peerId.toB58String()}`)
+  })
+  node2.on('peer:discovery', (peerId) => {
+    console.log(`Peer ${node2.peerId.toB58String()} discovered: ${peerId.toB58String()}`)
+  })
+
+  ;[node1, node2].forEach((node, index) => console.log(`Node ${index} starting with id: ${node.peerId.toB58String()}`))
+  await Promise.all([
+    node1.start(),
+    node2.start()
+  ])
+})();

--- a/examples/discovery-mechanisms/test-3.js
+++ b/examples/discovery-mechanisms/test-3.js
@@ -1,0 +1,35 @@
+'use strict'
+
+const path = require('path')
+const execa = require('execa')
+const pWaitFor = require('p-wait-for')
+const uint8ArrayToString = require('uint8arrays/to-string')
+
+const discoveredCopy = 'discovered:'
+
+async function test() {
+  let discoverCount = 0
+
+  process.stdout.write('3.js\n')
+
+  const proc = execa('node', [path.join(__dirname, '3.js')], {
+    cwd: path.resolve(__dirname),
+    all: true
+  })
+
+  proc.all.on('data', async (data) => {
+    process.stdout.write(data)
+    const line = uint8ArrayToString(data)
+
+    // Discovered or Connected
+    if (line.includes(discoveredCopy)) {
+      discoverCount++
+    }
+  })
+
+  await pWaitFor(() => discoverCount === 4)
+
+  proc.kill()
+}
+
+module.exports = test

--- a/examples/discovery-mechanisms/test.js
+++ b/examples/discovery-mechanisms/test.js
@@ -2,10 +2,12 @@
 
 const test1 = require('./test-1')
 const test2 = require('./test-2')
+const test3 = require('./test-3')
 
 async function test () {
   await test1()
   await test2()
+  await test3()
 }
 
 module.exports = test

--- a/examples/package.json
+++ b/examples/package.json
@@ -10,6 +10,8 @@
   "dependencies": {
     "execa": "^2.1.0",
     "fs-extra": "^8.1.0",
+    "libp2p-pubsub-peer-discovery": "^3.0.0",
+    "libp2p-relay-server": "^0.1.2",
     "p-defer": "^3.0.0",
     "which": "^2.0.1"
   },


### PR DESCRIPTION
This PR adds a new discovery example leveraging [libp2p/js-libp2p-relay-server](https://github.com/libp2p/js-libp2p-relay-server) with pubsub discovery.

Needs:
- [x] #841 