### PR TITLE
chore: use emittery

### DIFF
--- a/package.json
+++ b/package.json
@@ -58,6 +58,7 @@
     "cids": "^1.0.0",
     "class-is": "^1.1.0",
     "debug": "^4.1.1",
+    "emittery": "^0.8.1",
     "err-code": "^2.0.0",
     "events": "^3.1.0",
     "hashlru": "^2.3.0",

--- a/src/connection-manager/index.js
+++ b/src/connection-manager/index.js
@@ -10,7 +10,7 @@ const mergeOptions = require('merge-options')
 const LatencyMonitor = require('./latency-monitor')
 const retimer = require('retimer')
 
-const { EventEmitter } = require('events')
+const Emittery = require('emittery')
 
 const PeerId = require('peer-id')
 
@@ -56,7 +56,7 @@ const defaultOptions = {
  * @fires ConnectionManager#peer:connect Emitted when a new peer is connected.
  * @fires ConnectionManager#peer:disconnect Emitted when a peer is disconnected.
  */
-class ConnectionManager extends EventEmitter {
+class ConnectionManager extends Emittery {
   /**
    * Responsible for managing known connections.
    *
@@ -137,7 +137,7 @@ class ConnectionManager extends EventEmitter {
   async stop () {
     this._autoDialTimeout && this._autoDialTimeout.clear()
     this._timer && this._timer.clear()
-    this._latencyMonitor && this._latencyMonitor.removeListener('data', this._onLatencyMeasure)
+    this._latencyMonitor && this._latencyMonitor.off('data', this._onLatencyMeasure)
 
     this._started = false
     await this._close()

--- a/src/connection-manager/latency-monitor.js
+++ b/src/connection-manager/latency-monitor.js
@@ -7,7 +7,7 @@
 
 /* global window */
 const globalThis = require('ipfs-utils/src/globalthis')
-const { EventEmitter } = require('events')
+const Emittery = require('emittery')
 const VisibilityChangeEmitter = require('./visibility-change-emitter')
 const debug = require('debug')('latency-monitor:LatencyMonitor')
 
@@ -31,7 +31,7 @@ const debug = require('debug')('latency-monitor:LatencyMonitor')
  * the asyncTestFn and timing how long it takes the callback to be called. It can also periodically emit stats about this.
  * This can be disabled and stats can be pulled via setting dataEmitIntervalMs = 0.
  *
- * @extends {EventEmitter}
+ * @extends {Emittery}
  *
  * The default implementation is an event loop latency monitor. This works by firing periodic events into the event loop
  * and timing how long it takes to get back.
@@ -44,7 +44,7 @@ const debug = require('debug')('latency-monitor:LatencyMonitor')
  * const monitor = new LatencyMonitor({latencyCheckIntervalMs: 1000, dataEmitIntervalMs: 60000, asyncTestFn:ping});
  * monitor.on('data', (summary) => console.log('Ping Pong Latency: %O', summary));
  */
-class LatencyMonitor extends EventEmitter {
+class LatencyMonitor extends Emittery {
   /**
    * @class
    * @param {LatencyMonitorOptions} [options]

--- a/src/connection-manager/visibility-change-emitter.js
+++ b/src/connection-manager/visibility-change-emitter.js
@@ -6,7 +6,7 @@
  */
 'use strict'
 
-const { EventEmitter } = require('events')
+const Emittery = require('emittery')
 
 const debug = require('debug')('latency-monitor:VisibilityChangeEmitter')
 
@@ -32,7 +32,7 @@ const debug = require('debug')('latency-monitor:VisibilityChangeEmitter')
  *     // To access the visibility state directly, call:
  *     console.log('Am I focused now? ' + myVisibilityEmitter.isVisible());
  */
-class VisibilityChangeEmitter extends EventEmitter {
+class VisibilityChangeEmitter extends Emittery {
   /**
    * Creates a VisibilityChangeEmitter
    *

--- a/src/index.js
+++ b/src/index.js
@@ -4,7 +4,7 @@ const debug = require('debug')
 const log = Object.assign(debug('libp2p'), {
   error: debug('libp2p:err')
 })
-const { EventEmitter } = require('events')
+const Emittery = require('emittery')
 const globalThis = require('ipfs-utils/src/globalthis')
 
 const errCode = require('err-code')
@@ -83,11 +83,11 @@ const IDENTIFY_PROTOCOLS = IdentifyService.multicodecs
  * @typedef {Object} CreateOptions
  * @property {PeerId} peerId
  *
- * @extends {EventEmitter}
+ * @extends {Emittery}
  * @fires Libp2p#error Emitted when an error occurs
  * @fires Libp2p#peer:discovery Emitted when a peer is discovered
  */
-class Libp2p extends EventEmitter {
+class Libp2p extends Emittery {
   /**
    * Like `new Libp2p(options)` except it will create a `PeerId`
    * instance if one is not provided in options.
@@ -284,17 +284,19 @@ class Libp2p extends EventEmitter {
    *
    * @param {string} eventName
    * @param  {...any} args
-   * @returns {boolean}
+   * @returns {Promise<void>}
    */
   emit (eventName, ...args) {
-    // TODO: do we still need this?
-    // @ts-ignore _events does not exist in libp2p
-    if (eventName === 'error' && !this._events.error) {
-      log.error(args)
-      return false
-    } else {
-      return super.emit(eventName, ...args)
-    }
+    return new Promise((resolve) => {
+      // TODO: do we still need this?
+      // @ts-ignore _events does not exist in libp2p
+      if (eventName === 'error' && !this._events.error) {
+        log.error(args)
+        resolve()
+      } else {
+        super.emit(eventName, args).then(resolve)
+      }
+    })
   }
 
   /**

--- a/src/metrics/stats.js
+++ b/src/metrics/stats.js
@@ -1,12 +1,12 @@
 // @ts-nocheck
 'use strict'
 
-const { EventEmitter } = require('events')
+const Emittery = require('emittery')
 const Big = require('bignumber.js')
 const MovingAverage = require('moving-average')
 const retimer = require('retimer')
 
-class Stats extends EventEmitter {
+class Stats extends Emittery {
   /**
    * A queue based manager for stat processing
    *

--- a/src/peer-store/index.js
+++ b/src/peer-store/index.js
@@ -2,7 +2,7 @@
 
 const errcode = require('err-code')
 
-const { EventEmitter } = require('events')
+const Emittery = require('emittery')
 const PeerId = require('peer-id')
 
 const AddressBook = require('./address-book')
@@ -19,7 +19,7 @@ const {
  */
 
 /**
- * @extends {EventEmitter}
+ * @extends {Emittery}
  *
  * @fires PeerStore#peer Emitted when a new peer is added.
  * @fires PeerStore#change:protocols Emitted when a known peer supports a different set of protocols.
@@ -27,7 +27,7 @@ const {
  * @fires PeerStore#change:pubkey Emitted emitted when a peer's public key is known.
  * @fires PeerStore#change:metadata Emitted when the known metadata of a peer change.
  */
-class PeerStore extends EventEmitter {
+class PeerStore extends Emittery {
   /**
    * Peer object
    *

--- a/src/peer-store/persistent/index.js
+++ b/src/peer-store/persistent/index.js
@@ -91,7 +91,7 @@ class PersistentPeerStore extends PeerStore {
    */
   async stop () {
     log('PeerStore is stopping')
-    this.removeAllListeners()
+    this.clearListeners()
     await this._commitData()
     log('PeerStore stopped')
   }


### PR DESCRIPTION
EventEmitter is not isomorphic and using this will be problematic with Webpack5. We should consider changing it in favour of emittery or similar. This will be a breaking change as the API is slightly different.