### PR TITLE
fix: event emitter types with local types

### DIFF
--- a/src/connection-manager/index.js
+++ b/src/connection-manager/index.js
@@ -10,7 +10,9 @@ const mergeOptions = require('merge-options')
 const LatencyMonitor = require('./latency-monitor')
 const retimer = require('retimer')
 
-const { EventEmitter } = require('events')
+/** @typedef {import('../types').EventEmitterFactory} Events */
+/** @type Events */
+const EventEmitter = require('events')
 
 const PeerId = require('peer-id')
 

--- a/src/connection-manager/latency-monitor.js
+++ b/src/connection-manager/latency-monitor.js
@@ -7,7 +7,9 @@
 
 /* global window */
 const globalThis = require('ipfs-utils/src/globalthis')
-const { EventEmitter } = require('events')
+/** @typedef {import('../types').EventEmitterFactory} Events */
+/** @type Events */
+const EventEmitter = require('events')
 const VisibilityChangeEmitter = require('./visibility-change-emitter')
 const debug = require('debug')('latency-monitor:LatencyMonitor')
 

--- a/src/connection-manager/visibility-change-emitter.js
+++ b/src/connection-manager/visibility-change-emitter.js
@@ -6,7 +6,9 @@
  */
 'use strict'
 
-const { EventEmitter } = require('events')
+/** @typedef {import('../types').EventEmitterFactory} Events */
+/** @type Events */
+const EventEmitter = require('events')
 
 const debug = require('debug')('latency-monitor:VisibilityChangeEmitter')
 

--- a/src/index.js
+++ b/src/index.js
@@ -4,7 +4,9 @@ const debug = require('debug')
 const log = Object.assign(debug('libp2p'), {
   error: debug('libp2p:err')
 })
-const { EventEmitter } = require('events')
+/** @typedef {import('./types').EventEmitterFactory} Events */
+/** @type Events */
+const EventEmitter = require('events')
 const globalThis = require('ipfs-utils/src/globalthis')
 
 const errCode = require('err-code')

--- a/src/metrics/stats.js
+++ b/src/metrics/stats.js
@@ -1,7 +1,9 @@
 // @ts-nocheck
 'use strict'
 
-const { EventEmitter } = require('events')
+/** @typedef {import('../types').EventEmitterFactory} Events */
+/** @type Events */
+const EventEmitter = require('events')
 const Big = require('bignumber.js')
 const MovingAverage = require('moving-average')
 const retimer = require('retimer')

--- a/src/peer-store/index.js
+++ b/src/peer-store/index.js
@@ -2,7 +2,9 @@
 
 const errcode = require('err-code')
 
-const { EventEmitter } = require('events')
+/** @typedef {import('../types').EventEmitterFactory} Events */
+/** @type Events */
+const EventEmitter = require('events')
 const PeerId = require('peer-id')
 
 const AddressBook = require('./address-book')

--- a/src/types.ts
+++ b/src/types.ts
@@ -82,3 +82,22 @@ export type CircuitMessageProto = {
     CAN_HOP: CAN_HOP
   }
 }
+
+export interface EventEmitterFactory {
+  new(): EventEmitter;
+}
+
+export interface EventEmitter {
+  addListener(event: string | symbol, listener: (...args: any[]) => void);
+  on(event: string | symbol, listener: (...args: any[]) => void);
+  once(event: string | symbol, listener: (...args: any[]) => void);
+  removeListener(event: string | symbol, listener: (...args: any[]) => void);
+  off(event: string | symbol, listener: (...args: any[]) => void);
+  removeAllListeners(event?: string | symbol);
+  setMaxListeners(n: number);
+  getMaxListeners(): number;
+  listeners(event: string | symbol): Function[]; // eslint-disable-line @typescript-eslint/ban-types
+  rawListeners(event: string | symbol): Function[]; // eslint-disable-line @typescript-eslint/ban-types
+  emit(event: string | symbol, ...args: any[]): boolean;
+  listenerCount(event: string | symbol): number;
+}


### PR DESCRIPTION
This PR fixes the current broken build job of aegir.

EventEmitter types were broken in https://github.com/DefinitelyTyped/DefinitelyTyped/pull/50266. This was resulting in the following errors:

```
src/connection-manager/latency-monitor.js:2:1 - error TS9006: Declaration emit for this file requires using private name 'EventEmitter' from module '"events"'. An explicit type annotation may unblock declaration emit.

2 'use strict'
  ~~~~~~~~~~~~

src/connection-manager/visibility-change-emitter.js:7:1 - error TS9006: Declaration emit for this file requires using private name 'EventEmitter' from module '"events"'. An explicit type annotation may unblock declaration emit.

7 'use strict'
  ~~~~~~~~~~~~

src/index.js:1:1 - error TS9006: Declaration emit for this file requires using private name 'EventEmitter' from module '"events"'. An explicit type annotation may unblock declaration emit.

1 'use strict'
  ~~~~~~~~~~~~

src/metrics/stats.js:2:1 - error TS9006: Declaration emit for this file requires using private name 'EventEmitter' from module '"events"'. An explicit type annotation may unblock declaration emit.

2 'use strict'
  ~~~~~~~~~~~~

src/peer-store/index.js:1:1 - error TS9006: Declaration emit for this file requires using private name 'EventEmitter' from module '"events"'. An explicit type annotation may unblock declaration emit.

1 'use strict'
  ~~~~~~~~~~~~
```

This is a temporary fix and we should follow up in the next libp2p breaking change with #863 