### PR TITLE
Fix: Update comment in bootstrapers.js

### DIFF
--- a/examples/discovery-mechanisms/bootstrapers.js
+++ b/examples/discovery-mechanisms/bootstrapers.js
@@ -1,6 +1,6 @@
 'use strict'
 
-// Find this list at: https://github.com/ipfs/js-ipfs/blob/master/src/core/runtime/config-nodejs.json
+// Find this list at: https://github.com/ipfs/js-ipfs/blob/master/packages/ipfs-core/src/runtime/config-nodejs.js
 const bootstrapers = [
   '/ip4/104.131.131.82/tcp/4001/p2p/QmaCpDMGvV2BGHeYERUEnRQAwe3N8SzbUtfsmvsqQLuvuJ',
   '/dnsaddr/bootstrap.libp2p.io/p2p/QmNnooDu7bfjPFoTZYxMNLWUQJyrVwtbZg5gBMjTezGAJN',


### PR DESCRIPTION
It looks like the location of this file changed upstream. This change just fixes the URL in a comment