### PR TITLE
fix: unref nat manager retries

### DIFF
--- a/src/nat-manager.js
+++ b/src/nat-manager.js
@@ -138,9 +138,9 @@ class NatManager {
 
     this._client = {
       // these are all network operations so add a retry
-      map: (...args) => retry(() => map(...args), { onFailedAttempt: log.error }),
-      destroy: (...args) => retry(() => destroy(...args), { onFailedAttempt: log.error }),
-      externalIp: (...args) => retry(() => externalIp(...args), { onFailedAttempt: log.error })
+      map: (...args) => retry(() => map(...args), { onFailedAttempt: log.error, unref: true }),
+      destroy: (...args) => retry(() => destroy(...args), { onFailedAttempt: log.error, unref: true }),
+      externalIp: (...args) => retry(() => externalIp(...args), { onFailedAttempt: log.error, unref: true })
     }
 
     return this._client


### PR DESCRIPTION
The retry operation in the NAT Manager can prevent node from shutting down, so unref the retries so they don't keep adding work to the event loop.