### PR TITLE
fix: peer discovery type in config to object

### DIFF
--- a/src/index.js
+++ b/src/index.js
@@ -51,9 +51,6 @@ const { updateSelfPeerRecord } = require('./record/utils')
  * @typedef {Object} PeerStoreOptions
  * @property {boolean} persistence
  *
- * @typedef {Object} PeerDiscoveryOptions
- * @property {boolean} autoDial
- *
  * @typedef {Object} RelayOptions
  * @property {boolean} enabled
  * @property {import('./circuit').RelayAdvertiseOptions} advertise
@@ -62,7 +59,7 @@ const { updateSelfPeerRecord } = require('./record/utils')
  *
  * @typedef {Object} Libp2pConfig
  * @property {Object} [dht] dht module options
- * @property {PeerDiscoveryOptions} [peerDiscovery]
+ * @property {Object} [peerDiscovery]
  * @property {Pubsub} [pubsub] pubsub module options
  * @property {RelayOptions} [relay]
  * @property {Record<string, Object>} [transport] transport options indexed by transport key


### PR DESCRIPTION
Making PeerDiscovery options to `Object` by now. Otherwise, ts projects will fail to build as they will need to add discovery modules configuration. This should only be done when we type the modules

Closes #876 