### PR TITLE
fix: do not add observed address received from peers

### DIFF
--- a/src/identify/index.js
+++ b/src/identify/index.js
@@ -204,7 +204,7 @@ class IdentifyService {
 
     // TODO: Add and score our observed addr
     log('received observed address of %s', observedAddr)
-    //this.addressManager.addObservedAddr(observedAddr)
+    // this.addressManager.addObservedAddr(observedAddr)
   }
 
   /**

--- a/src/identify/index.js
+++ b/src/identify/index.js
@@ -202,9 +202,9 @@ class IdentifyService {
     this.peerStore.protoBook.set(id, protocols)
     this.peerStore.metadataBook.set(id, 'AgentVersion', uint8ArrayFromString(message.agentVersion))
 
-    // TODO: Score our observed addr
+    // TODO: Add and score our observed addr
     log('received observed address of %s', observedAddr)
-    this.addressManager.addObservedAddr(observedAddr)
+    //this.addressManager.addObservedAddr(observedAddr)
   }
 
   /**


### PR DESCRIPTION
We have no way of verifying them so don't add them just yet.