### PR TITLE
fix: routers should only use dht if enabled

### DIFF
--- a/src/content-routing/index.js
+++ b/src/content-routing/index.js
@@ -35,7 +35,7 @@ class ContentRouting {
     this.dht = libp2p._dht
 
     // If we have the dht, add it to the available content routers
-    if (this.dht) {
+    if (this.dht && libp2p._config.dht.enabled) {
       this.routers.push(this.dht)
     }
   }

--- a/src/peer-routing.js
+++ b/src/peer-routing.js
@@ -36,7 +36,7 @@ class PeerRouting {
     this._routers = libp2p._modules.peerRouting || []
 
     // If we have the dht, add it to the available peer routers
-    if (libp2p._dht) {
+    if (libp2p._dht && libp2p._config.dht.enabled) {
       this._routers.push(libp2p._dht)
     }
 

--- a/test/content-routing/content-routing.node.js
+++ b/test/content-routing/content-routing.node.js
@@ -131,6 +131,10 @@ describe('content-routing', () => {
 
     afterEach(() => node.stop())
 
+    it('should only have one router', () => {
+      expect(node.contentRouting.routers).to.have.lengthOf(1)
+    })
+
     it('should use the delegate router to provide', () => {
       const deferred = pDefer()
 

--- a/test/peer-routing/peer-routing.node.js
+++ b/test/peer-routing/peer-routing.node.js
@@ -132,6 +132,10 @@ describe('peer-routing', () => {
 
     afterEach(() => node.stop())
 
+    it('should only have one router', () => {
+      expect(node.peerRouting._routers).to.have.lengthOf(1)
+    })
+
     it('should use the delegate router to find peers', async () => {
       const deferred = pDefer()
       const [remotePeerId] = await peerUtils.createPeerId({ fixture: false })


### PR DESCRIPTION
When used from IPFS (and other projects where the DHT module is added to the libp2p config), but the enabled option was turned to false (default), the DHT was being used for content/peer routing queries.