### PR TITLE
fix: address book should not emit peer event if no addresses are known

### DIFF
--- a/src/circuit/auto-relay.js
+++ b/src/circuit/auto-relay.js
@@ -262,6 +262,9 @@ class AutoRelay {
     }
   }
 
+  /**
+   * @param {PeerId} peerId
+   */
   async _tryToListenOnRelay (peerId) {
     try {
       const connection = await this._libp2p.dial(peerId)

--- a/src/circuit/auto-relay.js
+++ b/src/circuit/auto-relay.js
@@ -231,8 +231,7 @@ class AutoRelay {
 
     // Try to listen on known peers that are not connected
     for (const peerId of knownHopsToDial) {
-      const connection = await this._libp2p.dial(peerId)
-      await this._addListenRelay(connection, peerId.toB58String())
+      await this._tryToListenOnRelay(peerId)
 
       // Check if already listening on enough relays
       if (this._listenRelays.size >= this.maxListeners) {
@@ -247,12 +246,11 @@ class AutoRelay {
         if (!provider.multiaddrs.length) {
           continue
         }
+
         const peerId = provider.id
-
         this._peerStore.addressBook.add(peerId, provider.multiaddrs)
-        const connection = await this._libp2p.dial(peerId)
 
-        await this._addListenRelay(connection, peerId.toB58String())
+        await this._tryToListenOnRelay(peerId)
 
         // Check if already listening on enough relays
         if (this._listenRelays.size >= this.maxListeners) {
@@ -261,6 +259,15 @@ class AutoRelay {
       }
     } catch (err) {
       log.error(err)
+    }
+  }
+
+  async _tryToListenOnRelay (peerId) {
+    try {
+      const connection = await this._libp2p.dial(peerId)
+      await this._addListenRelay(connection, peerId.toB58String())
+    } catch (err) {
+      log.error(`could not connect and listen on known hop relay ${peerId.toB58String()}`)
     }
   }
 }

--- a/src/index.js
+++ b/src/index.js
@@ -700,7 +700,7 @@ class Libp2p extends EventEmitter {
         try {
           await this.dialer.connectToPeer(peerId)
         } catch (err) {
-          log.error('could not connect to discovered peer', err)
+          log.error(`could not connect to discovered peer ${peerId.toB58String()} with ${err}`)
         }
       }
     }

--- a/src/peer-store/address-book.js
+++ b/src/peer-store/address-book.js
@@ -229,7 +229,7 @@ class AddressBook extends Book {
     const addresses = this._toAddresses(multiaddrs)
     const id = peerId.toB58String()
 
-    // Not add unavailable addresses
+    // No addresses to be added
     if (!addresses.length) {
       return this
     }

--- a/src/peer-store/address-book.js
+++ b/src/peer-store/address-book.js
@@ -229,6 +229,11 @@ class AddressBook extends Book {
     const addresses = this._toAddresses(multiaddrs)
     const id = peerId.toB58String()
 
+    // Not add unavailable addresses
+    if (!addresses.length) {
+      return this
+    }
+
     const entry = this.data.get(id)
 
     if (entry && entry.addresses) {

--- a/test/peer-store/address-book.spec.js
+++ b/test/peer-store/address-book.spec.js
@@ -186,6 +186,23 @@ describe('addressBook', () => {
       throw new Error('invalid multiaddr should throw error')
     })
 
+    it('does not emit event if no addresses are added', async () => {
+      const defer = pDefer()
+
+      peerStore.on('peer', () => {
+        defer.reject()
+      })
+
+      ab.add(peerId, [])
+
+      // Wait 50ms for incorrect second event
+      setTimeout(() => {
+        defer.resolve()
+      }, 50)
+
+      await defer.promise
+    })
+
     it('adds the new content and emits change event', () => {
       const defer = pDefer()
 

--- a/test/relay/auto-relay.node.js
+++ b/test/relay/auto-relay.node.js
@@ -359,6 +359,7 @@ describe('auto-relay', () => {
       expect(relayLibp2p1.connectionManager.size).to.equal(1)
 
       // Spy on dial
+      sinon.spy(autoRelay1, '_tryToListenOnRelay')
       sinon.spy(relayLibp2p1, 'dial')
 
       // Remove peer used as relay from peerStore and disconnect it
@@ -369,6 +370,7 @@ describe('auto-relay', () => {
 
       // Wait for other peer connected to be added as listen addr
       await pWaitFor(() => relayLibp2p1.transportManager.listen.callCount === 2)
+      expect(autoRelay1._tryToListenOnRelay.callCount).to.equal(1)
       expect(autoRelay1._listenRelays.size).to.equal(1)
       expect(relayLibp2p1.connectionManager.size).to.eql(1)
     })


### PR DESCRIPTION
The AddressBook.add has a bug where if a libp2p module does `addressBook.add(peerId, [])` the peer event will be emitted. This leads into two consequences:
- (with autoDial enabled) a dial will be attempted to the discovered peer, even though we can't really dial it
  - dial on discovery is wrapped with a `try ... catch` and it will just fail and life goes on  
- when we really discover addresses for the peer and do a new `addressBook.add`, the event will not be emitted and the peer will not be dialled (if autoDial enabled)

Other than this bug and related to #886 , the `libp2p.dial` / `libp2p.dialProtocol` should be wrapped by a `try ... catch` as a dial fail should not make libp2p protocols fail to properly work. This PR also wraps the `autoRelay` dial to avoid a unhandled promise rejection. Moreover, the dials to found providers would be stopped if one dial fails, now it will continue iterating on the providers if dials fail.

