### PR TITLE
fix: transport manager fault tolerance should include tolerance to transport listen fail

### DIFF
--- a/src/transport-manager.js
+++ b/src/transport-manager.js
@@ -196,7 +196,7 @@ class TransportManager {
       // listening on remote addresses as they may be offline. We could then potentially
       // just wait for any (`p-any`) listener to succeed on each transport before returning
       const isListening = results.find(r => r.isFulfilled === true)
-      if (!isListening) {
+      if (!isListening && this.faultTolerance !== FAULT_TOLERANCE.NO_FATAL) {
         throw errCode(new Error(`Transport (${key}) could not listen on any available address`), codes.ERR_NO_VALID_ADDRESSES)
       }
     }

--- a/test/transports/transport-manager.spec.js
+++ b/test/transports/transport-manager.spec.js
@@ -209,11 +209,29 @@ describe('libp2p.transportManager (dial only)', () => {
     throw new Error('it should fail to start if multiaddr fails to listen')
   })
 
-  it('does not fail to start if multiaddr fails to listen when supporting dial only mode', async () => {
+  it('does not fail to start if provided listen multiaddr are not compatible to configured transports (when supporting dial only mode)', async () => {
     libp2p = new Libp2p({
       peerId,
       addresses: {
         listen: [multiaddr('/ip4/127.0.0.1/tcp/0')]
+      },
+      transportManager: {
+        faultTolerance: FaultTolerance.NO_FATAL
+      },
+      modules: {
+        transport: [Transport],
+        connEncryption: [Crypto]
+      }
+    })
+
+    await libp2p.start()
+  })
+
+  it('does not fail to start if provided listen multiaddr fail to listen on configured transports (when supporting dial only mode)', async () => {
+    libp2p = new Libp2p({
+      peerId,
+      addresses: {
+        listen: [multiaddr('/ip4/127.0.0.1/tcp/12345/p2p/QmWDn2LY8nannvSWJzruUYoLZ4vV83vfCBwd8DipvdgQc3/p2p-circuit')]
       },
       transportManager: {
         faultTolerance: FaultTolerance.NO_FATAL


### PR DESCRIPTION
When we added a fault tolerance option to libp2p's transport manager, this only included a scenario where the provided multiaddrs were not compatible to the configured transport resulting in no listen multiaddrs used to create listeners in the transports.

This fault tolerance should also include tolerance for failure on trying to listen on multiaddrs that are compatible with the configured transport but the listen fails. This is specially important for remote listeners like relays and webrtc signal servers.

Context: https://github.com/ipfs-shipyard/ipfs-share-files/pull/121