### PR TITLE
fix: conn mgr access to moving averages record object

### DIFF
--- a/.aegir.js
+++ b/.aegir.js
@@ -48,7 +48,7 @@ const after = async () => {
 }
 
 module.exports = {
-  bundlesize: { maxSize: '220kB' },
+  bundlesize: { maxSize: '222kB' },
   hooks: {
     pre: before,
     post: after

--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -27,7 +27,7 @@ jobs:
     strategy:
       matrix:
         os: [windows-latest, ubuntu-latest, macos-latest]
-        node: [12, 14]
+        node: [14]
       fail-fast: true
     steps:
       - uses: actions/checkout@v2

--- a/examples/libp2p-in-the-browser/package.json
+++ b/examples/libp2p-in-the-browser/package.json
@@ -15,7 +15,7 @@
   "author": "",
   "license": "ISC",
   "dependencies": {
-    "@babel/preset-env": "^7.8.3",
+    "@babel/preset-env": "^7.13.0",
     "libp2p": "../../",
     "libp2p-bootstrap": "^0.12.1",
     "libp2p-mplex": "^0.10.0",
@@ -24,11 +24,11 @@
     "libp2p-websockets": "^0.14.0"
   },
   "devDependencies": {
-    "@babel/cli": "^7.8.3",
-    "@babel/core": "^7.8.3",
+    "@babel/cli": "^7.13.10",
+    "@babel/core": "^7.13.0",
     "babel-plugin-syntax-async-functions": "^6.13.0",
     "babel-plugin-transform-regenerator": "^6.26.0",
     "babel-polyfill": "^6.26.0",
-    "parcel-bundler": "^1.12.4"
+    "parcel-bundler": "1.12.3"
   }
 }

--- a/examples/webrtc-direct/package.json
+++ b/examples/webrtc-direct/package.json
@@ -10,12 +10,12 @@
   },
   "license": "ISC",
   "devDependencies": {
-    "@babel/cli": "^7.8.3",
-    "@babel/core": "^7.8.3",
+    "@babel/cli": "^7.13.10",
+    "@babel/core": "^7.13.10",
     "babel-plugin-syntax-async-functions": "^6.13.0",
     "babel-plugin-transform-regenerator": "^6.26.0",
     "babel-polyfill": "^6.26.0",
-    "parcel-bundler": "^1.12.4"
+    "parcel-bundler": "1.12.3"
   },
   "dependencies": {
     "libp2p": "../../",

--- a/src/metrics/stats.js
+++ b/src/metrics/stats.js
@@ -82,7 +82,7 @@ class Stats extends EventEmitter {
   /**
    * Returns a clone of the internal movingAverages
    *
-   * @returns {MovingAverage}
+   * @returns {Object}
    */
   get movingAverages () {
     return Object.assign({}, this._movingAverages)


### PR DESCRIPTION
This PR fixes the connection manager access to the `movingAverages` getter. After the module update with types, this broke libp2p's build.

It returns an Object as we can see on:
- https://github.com/libp2p/js-libp2p/blob/master/src/metrics/stats.js#L29
- https://github.com/libp2p/js-libp2p/blob/master/src/metrics/stats.js#L88

This object contains a key for the metric and another object as value to create multiple intervals for computing the move average: `movingAverages[key][interval].movingAverage()` => This is the actual MovingAverage instance.

Metrics is not a public API and is not properly typed for now, the work is being tracked on https://github.com/libp2p/js-libp2p/issues/830 . We should probably change this from an Object to a Map and properly type these moving averages record, but just fixing the bug here.

Per https://github.com/libp2p/js-libp2p/pull/896#issuecomment-793745460

---

- Bundle size was also updated and node CI updated to node 14 only, since node 12 LTS is already in Maintenance LTS and not used in most of our repos
- Parcel version on examples fixed per temporary bug https://github.com/parcel-bundler/parcel/issues/5943