### PR TITLE
fix: typescript module updates

### DIFF
--- a/.aegir.js
+++ b/.aegir.js
@@ -48,7 +48,7 @@ const after = async () => {
 }
 
 module.exports = {
-  bundlesize: { maxSize: '222kB' },
+  bundlesize: { maxSize: '223kB' },
   hooks: {
     pre: before,
     post: after

--- a/src/keychain/index.js
+++ b/src/keychain/index.js
@@ -14,7 +14,7 @@ require('node-forge/lib/sha512')
 
 /**
  * @typedef {import('peer-id')} PeerId
- * @typedef {import('interface-datastore/src/types').Datastore} Datastore
+ * @typedef {import('interface-datastore').Datastore} Datastore
  */
 
 const keyPrefix = '/pkcs8/'

--- a/src/upgrader.js
+++ b/src/upgrader.js
@@ -201,7 +201,7 @@ class Upgrader {
    * @private
    * @param {object} options
    * @param {string} options.cryptoProtocol - The crypto protocol that was negotiated
-   * @param {string} options.direction - One of ['inbound', 'outbound']
+   * @param {'inbound' | 'outbound'} options.direction - One of ['inbound', 'outbound']
    * @param {MultiaddrConnection} options.maConn - The transport layer connection
    * @param {MuxedStream | MultiaddrConnection} options.upgradedConn - A duplex connection returned from multiplexer and/or crypto selection
    * @param {MuxerFactory} [options.Muxer] - The muxer to be used for muxing


### PR DESCRIPTION
This PR includes 3 commits:
1. Connection direction should be only inbound or outbound per https://github.com/libp2p/js-libp2p-interfaces/pull/86
2. Bundle size needs extra 1kb
3. `interface-datastore` was updated to export `d.ts` file instead