### PR TITLE
chore: do not look up external IP during test

### DIFF
--- a/test/nat-manager/nat-manager.node.js
+++ b/test/nat-manager/nat-manager.node.js
@@ -268,7 +268,10 @@ describe('Nat Manager (TCP)', () => {
       natManager
     } = await createNatManager([
       `/ip4/${addr}/tcp/0`
-    ])
+    ], {
+      // so we don't try to look up the current computer's external address
+      externalIp: '184.12.31.4'
+    })
 
     // use the actual nat manager client not the stub
     delete natManager._client


### PR DESCRIPTION
The NAT manager test will throw if the current computer is behind a
double NAT as at runtime it won't be possible to map external ports.

We don't care about that during the test so configure a fake external
IP so the test will still test the shut-down functionality on a computer
that is behind a double NAT.