### PR TITLE
fix: do not add abort signals to "useless" addresses

### DIFF
--- a/src/dialer/index.js
+++ b/src/dialer/index.js
@@ -110,7 +110,7 @@ class Dialer {
     const dialTarget = await this._createDialTarget(peer)
 
     if (!dialTarget.addrs.length) {
-      throw errCode(new Error('The dial request has no addresses'), codes.ERR_NO_VALID_ADDRESSES)
+      throw errCode(new Error('The dial request has no valid addresses'), codes.ERR_NO_VALID_ADDRESSES)
     }
     const pendingDial = this._pendingDials.get(dialTarget.id) || this._createPendingDial(dialTarget, options)
 
@@ -134,6 +134,7 @@ class Dialer {
    * Creates a DialTarget. The DialTarget is used to create and track
    * the DialRequest to a given peer.
    * If a multiaddr is received it should be the first address attempted.
+   * Multiaddrs not supported by the available transports will be filtered out.
    *
    * @private
    * @param {PeerId|Multiaddr|string} peer - A PeerId or Multiaddr
@@ -162,9 +163,12 @@ class Dialer {
       resolvedAddrs.forEach(ra => addrs.push(ra))
     }
 
+    // Multiaddrs not supported by the available transports will be filtered out.
+    const supportedAddrs = addrs.filter(a => this.transportManager.transportForMultiaddr(a))
+
     return {
       id: id.toB58String(),
-      addrs
+      addrs: supportedAddrs
     }
   }
 

--- a/test/core/listening.node.js
+++ b/test/core/listening.node.js
@@ -45,7 +45,7 @@ describe('Listening', () => {
     expect(addrs.length).to.be.at.least(2)
     for (const addr of addrs) {
       const opts = addr.toOptions()
-      expect(opts.family).to.equal('ipv4')
+      expect(opts.family).to.equal(4)
       expect(opts.transport).to.equal('tcp')
       expect(opts.host).to.match(/[0-9]+\.[0-9]+\.[0-9]+\.[0-9]+/)
       expect(opts.port).to.be.gt(0)


### PR DESCRIPTION
Node warns of a possible memory leak thanks o added event listeners on abortSignal:

```
(node:52434) MaxListenersExceededWarning: Possible EventTarget memory leak detected. 11 abort listeners added to [AbortSignal]. Use events.setMaxListeners() to increase limit
at EventTarget.[kNewListener] (node:internal/event_target:256:17)
at EventTarget.addEventListener (node:internal/event_target:335:23)
at anySignal (node_modules/any-signal/index.js:27:12)
at node_modules/libp2p/src/dialer/dial-request.js:70:85
at runMicrotasks ()
at processTicksAndRejections (node:internal/process/task_queues:94:5)
```

This started to happen when we start supporting `dnsaddr` resolution and `js-ipfs` started using bootstrap nodes with such addresses. Once these `dnsaddr` records are resolved, we get a large list of multiaddrs for the given peer, where several addresses are not relevant for JS libp2p dialer as we do not support transports for them (quic).

Despite having several useless addresses, during the dial flow we only checked if we have any transport to dial a peer on the `transport-manager` layer, which essentially means we are adding  unnecessary event listeneres and creating  unnecessary promises to be resolved for each of the addresses that will simply be rejected further on the stack.

This PR fixes the above issue by simply filtering out in the beginning of the dial flow the addresses that will not be useful.

Closes #900 