### PR TITLE
fix: give stats initial values

### DIFF
--- a/src/metrics/stats.js
+++ b/src/metrics/stats.js
@@ -19,7 +19,10 @@ class Stats extends EventEmitter {
 
     this._options = options
     this._queue = []
-    this._stats = {}
+    this._stats = {
+      dataReceived: Big(0),
+      dataSent: Big(0)
+    }
 
     this._frequencyLastTime = Date.now()
     this._frequencyAccumulators = {}

--- a/src/metrics/stats.js
+++ b/src/metrics/stats.js
@@ -2,7 +2,7 @@
 'use strict'
 
 const EventEmitter = require('events')
-const Big = require('bignumber.js')
+const { BigNumber: Big } = require('bignumber.js')
 const MovingAverage = require('moving-average')
 const retimer = require('retimer')
 
@@ -19,6 +19,8 @@ class Stats extends EventEmitter {
 
     this._options = options
     this._queue = []
+
+    /** @type {{ dataReceived: Big, dataSent: Big }} */
     this._stats = {
       dataReceived: Big(0),
       dataSent: Big(0)
@@ -27,6 +29,7 @@ class Stats extends EventEmitter {
     this._frequencyLastTime = Date.now()
     this._frequencyAccumulators = {}
 
+    /** @type {{ dataReceived: MovingAverage[], dataSent: MovingAverage[] }} */
     this._movingAverages = {}
 
     this._update = this._update.bind(this)


### PR DESCRIPTION
Otherwise the compiler cannot derive the type and thinks `stats.snapshot` returns `{}`