### PR TITLE
fix: remove inline arg types from function definitions

### DIFF
--- a/package.json
+++ b/package.json
@@ -104,7 +104,7 @@
     "it-pipe": "^1.1.0",
     "it-take": "1.0.0",
     "libp2p-crypto": "^0.19.0",
-    "libp2p-interfaces": "libp2p/js-libp2p-interfaces#feat/export-new-stream-muxer-function",
+    "libp2p-interfaces": "^0.10.1",
     "libp2p-utils": "^0.3.1",
     "mafmt": "^9.0.0",
     "merge-options": "^3.0.4",

--- a/package.json
+++ b/package.json
@@ -104,7 +104,7 @@
     "it-pipe": "^1.1.0",
     "it-take": "1.0.0",
     "libp2p-crypto": "^0.19.0",
-    "libp2p-interfaces": "^0.10.0",
+    "libp2p-interfaces": "libp2p/js-libp2p-interfaces#feat/export-new-stream-muxer-function",
     "libp2p-utils": "^0.3.1",
     "mafmt": "^9.0.0",
     "merge-options": "^3.0.4",

--- a/src/upgrader.js
+++ b/src/upgrader.js
@@ -222,6 +222,7 @@ class Upgrader {
   }) {
     /** @type {import("libp2p-interfaces/src/stream-muxer/types").Muxer} */
     let muxer
+    /** @type {import("libp2p-interfaces/src/connection/connection").CreatedMuxedStream | undefined} */
     let newStream
     /** @type {Connection} */
     let connection // eslint-disable-line prefer-const
@@ -249,7 +250,7 @@ class Upgrader {
         }
       })
 
-      newStream = async (/** @type {string | string[]} */ protocols) => {
+      newStream = async (protocols) => {
         log('%s: starting new stream on %s', direction, protocols)
         const muxedStream = muxer.newStream()
         const mss = new Multistream.Dialer(muxedStream)
@@ -309,8 +310,8 @@ class Upgrader {
       },
       newStream: newStream || errConnectionNotMultiplexed,
       getStreams: () => muxer ? muxer.streams : errConnectionNotMultiplexed(),
-      close: async (/** @type {Error | undefined} */ err) => {
-        await maConn.close(err)
+      close: async () => {
+        await maConn.close()
         // Ensure remaining streams are aborted
         if (muxer) {
           muxer.streams.map(stream => stream.abort())

--- a/test/ts-use/package.json
+++ b/test/ts-use/package.json
@@ -9,7 +9,7 @@
     "libp2p-delegated-content-routing": "^0.9.0",
     "libp2p-delegated-peer-routing": "^0.8.2",
     "libp2p-gossipsub": "^0.8.0",
-    "libp2p-interfaces": "^0.8.4",
+    "libp2p-interfaces": "libp2p/js-libp2p-interfaces#feat/export-new-stream-muxer-function",
     "libp2p-kad-dht": "^0.21.0",
     "libp2p-mplex": "^0.10.2",
     "libp2p-noise": "^2.0.5",

--- a/test/ts-use/package.json
+++ b/test/ts-use/package.json
@@ -9,7 +9,7 @@
     "libp2p-delegated-content-routing": "^0.9.0",
     "libp2p-delegated-peer-routing": "^0.8.2",
     "libp2p-gossipsub": "^0.8.0",
-    "libp2p-interfaces": "libp2p/js-libp2p-interfaces#feat/export-new-stream-muxer-function",
+    "libp2p-interfaces": "^0.10.1",
     "libp2p-kad-dht": "^0.21.0",
     "libp2p-mplex": "^0.10.2",
     "libp2p-noise": "^2.0.5",


### PR DESCRIPTION
Fixes problem with create-react-app's default webpack config that
transpiles the functions to non-async methods.

Depends on:

- [x] https://github.com/libp2p/js-libp2p-interfaces/pull/91