### PR TITLE
fix: add clientMode dht arg and upgrade interface-datastore

### DIFF
--- a/package.json
+++ b/package.json
@@ -90,7 +90,7 @@
     "es6-promisify": "^6.1.1",
     "events": "^3.3.0",
     "hashlru": "^2.3.0",
-    "interface-datastore": "^3.0.3",
+    "interface-datastore": "^4.0.0",
     "ipfs-utils": "^6.0.0",
     "it-all": "^1.0.4",
     "it-buffer": "^0.1.2",

--- a/src/index.js
+++ b/src/index.js
@@ -66,6 +66,7 @@ const { updateSelfPeerRecord } = require('./record/utils')
  * @property {boolean} [enabled = false]
  * @property {number} [kBucketSize = 20]
  * @property {RandomWalkOptions} [randomWalk]
+ * @property {boolean} [clientMode]
  *
  * @typedef {Object} KeychainOptions
  * @property {Datastore} [datastore]


### PR DESCRIPTION
The [clientMode](https://github.com/libp2p/js-libp2p-kad-dht/blob/master/src/index.js#L63) arg was missing from the DhtOptions type and interface-datastore has a new version available.