### PR TITLE
fix: demand pubsub class instead of pubsub instance

### DIFF
--- a/src/index.js
+++ b/src/index.js
@@ -102,7 +102,7 @@ const { updateSelfPeerRecord } = require('./record/utils')
  * @property {PeerRoutingModule[]} [peerRouting]
  * @property {ContentRoutingModule[]} [contentRouting]
  * @property {Object} [dht]
- * @property {Pubsub} [pubsub]
+ * @property {{new(...args: any[]): Pubsub}} [pubsub]
  * @property {Protector} [connProtector]
  *
  * @typedef {Object} Libp2pOptions

--- a/src/pubsub-adapter.js
+++ b/src/pubsub-adapter.js
@@ -7,12 +7,13 @@
  */
 
 /**
- * @param {import("libp2p-interfaces/src/pubsub")} PubsubRouter
+ * @param {{new(...args: any[]): PubsubRouter}} PubsubRouter
  * @param {import('.')} libp2p
  * @param {{ enabled: boolean; } & import(".").PubsubLocalOptions & import("libp2p-interfaces/src/pubsub").PubsubOptions} options
  */
 function pubsubAdapter (PubsubRouter, libp2p, options) {
-  // @ts-ignore Pubsub constructor type not defined
+  /** @type {PubsubRouter & { _subscribeAdapter: PubsubRouter['subscribe'], _unsubscribeAdapter: PubsubRouter['unsubscribe'] }} */
+  // @ts-ignore we set the extra _subscribeAdapter and _unsubscribeAdapter properties afterwards
   const pubsub = new PubsubRouter(libp2p, options)
   pubsub._subscribeAdapter = pubsub.subscribe
   pubsub._unsubscribeAdapter = pubsub.unsubscribe


### PR DESCRIPTION
Changes the `Libp2pModules.pubsub` property to be a class that maybe
extends `PubsubBaseProtocol` instead of an instance of that class.

The `.dht` property could use the same treatment but that can be
done in a follow up as the current `object` type doesn't cause an error.