### PR TITLE
fix: address book guarantees no replicated entries are added

### DIFF
--- a/src/peer-store/address-book.js
+++ b/src/peer-store/address-book.js
@@ -307,10 +307,13 @@ class AddressBook extends Book {
         throw errcode(new Error(`multiaddr ${addr} must be an instance of multiaddr`), ERR_INVALID_PARAMETERS)
       }
 
-      addresses.push({
-        multiaddr: addr,
-        isCertified
-      })
+      // Guarantee no replicates
+      if (!addresses.find((a) => a.multiaddr.equals(addr))) {
+        addresses.push({
+          multiaddr: addr,
+          isCertified
+        })
+      }
     })
 
     return addresses

--- a/test/peer-store/address-book.spec.js
+++ b/test/peer-store/address-book.spec.js
@@ -287,6 +287,14 @@ describe('addressBook', () => {
 
       await defer.promise
     })
+
+    it('does not add replicated content', () => {
+      // set 1
+      ab.set(peerId, [addr1, addr1])
+
+      const addresses = ab.get(peerId)
+      expect(addresses).to.have.lengthOf(1)
+    })
   })
 
   describe('addressBook.get', () => {


### PR DESCRIPTION
Sometimes delegate nodes return replicated addresses and then we will try to dial repeated addresses.

cc @aschmahmann (this happened while finding closest peers to `QmQ73f8hbM4hKwRYBqeUsPtiwfE2x6WPv9WnzaYt4nYcXf`). Not sure if an old node, or wether go DHT guarantees no replicated addresses are returned.