### PR TITLE
chore: add GitHub issue templates

### DIFF
--- a/.github/ISSUE_TEMPLATE/config.yml
+++ b/.github/ISSUE_TEMPLATE/config.yml
@@ -1,0 +1,5 @@
+blank_issues_enabled: false
+contact_links:
+ - name: libp2p Official Forum
+   url: https://discuss.libp2p.io
+   about: For general questions, support requests and discussions

--- a/.github/ISSUE_TEMPLATE/open_an_issue.md
+++ b/.github/ISSUE_TEMPLATE/open_an_issue.md
@@ -1,0 +1,55 @@
+---
+name: Open an issue
+about: For reporting bugs or errors in the JavaScript libp2p implementation
+title: ''
+labels: need/triage
+assignees: ''
+---
+
+<!--
+Thank you for reporting an issue.
+
+This issue tracker is for bugs found within the JavaScript implementation of libp2p.
+
+If you are asking a question about how to use libp2p, please ask on https://discuss.libp2p.io
+
+Otherwise please fill in as much of the template below as possible.
+-->
+
+- **Version**:
+<!--
+Check package.json version
+-->
+
+- **Platform**:
+<!--
+Output of `uname -a` (UNIX), or version and 32 or 64-bit (Windows). If using in a Browser, please share the browser version as well
+-->
+
+- **Subsystem**:
+<!--
+If known, please specify affected core module name (e.g Dialer, Pubsub, Relay etc)
+-->
+
+#### Severity:
+<!--
+One of following:
+  Critical - System crash, application panic.
+  High - The main functionality of the application does not work, API breakage, repo format breakage, etc.
+  Medium - A non-essential functionality does not work, performance issues, etc.
+  Low - An optional functionality does not work.
+  Very Low - Translation or documentation mistake. Something that won't give anyone a bad day.
+-->
+
+#### Description:
+<!--
+- What you did
+- What happened
+- What you expected to happen
+-->
+
+#### Steps to reproduce the error:
+<!--
+If possible, please provide code that demonstrates the problem, keeping it as simple and free of external dependencies as you are able
+-->
+

--- a/.github/ISSUE_TEMPLATE/release.md
+++ b/.github/ISSUE_TEMPLATE/release.md
@@ -25,7 +25,6 @@
     - [ ] [js-ipfs](https://github.com/ipfs/js-ipfs)
 - Documentation
   - [ ] Ensure that README.md is up to date
-  - [ ] Ensure [libp2p/js-libp2p-examples](https://github.com/libp2p/js-libp2p-examples) is updated
   - [ ] Ensure that [libp2p/docs](https://github.com/libp2p/docs) is updated
 - Communication
   - [ ] Create the release issue


### PR DESCRIPTION
This PR moves the Release Template to an Issue Template.

Other changes:
- Release template does not track libp2p-examples
- Generic Issue template update: currently we have one (defined In Project settings?), but it mentions discuss.ipfs.io

Needs current issue template to be removed (I do not have permissions to access Settings)