### PR TITLE
fix: peerRouting.findPeer() trying to find self

### DIFF
--- a/src/peer-routing.js
+++ b/src/peer-routing.js
@@ -104,6 +104,8 @@ class PeerRouting {
       throw errCode(new Error('No peer routers available'), 'NO_ROUTERS_AVAILABLE')
     }
 
+    if (id._idB58String == this._peerId._idB58String) throw errCode(new Error('Cannot search for self'), 'ERR_DIALED_SELF')
+
     const output = await pipe(
       merge(
         ...this._routers.map(router => [router.findPeer(id, options)])

--- a/src/peer-routing.js
+++ b/src/peer-routing.js
@@ -104,7 +104,7 @@ class PeerRouting {
       throw errCode(new Error('No peer routers available'), 'NO_ROUTERS_AVAILABLE')
     }
 
-    if (id.toB58String()== this._peerId.toB58String()) {
+    if (id.toB58String() === this._peerId.toB58String()) {
       throw errCode(new Error('Should not try to find self'), 'ERR_FIND_SELF')
     }
 

--- a/src/peer-routing.js
+++ b/src/peer-routing.js
@@ -104,7 +104,9 @@ class PeerRouting {
       throw errCode(new Error('No peer routers available'), 'NO_ROUTERS_AVAILABLE')
     }
 
-    if (id._idB58String == this._peerId._idB58String) throw errCode(new Error('Cannot search for self'), 'ERR_DIALED_SELF')
+    if (id.toB58String()== this._peerId.toB58String()) {
+      throw errCode(new Error('Should not try to find self'), 'ERR_FIND_SELF')
+    }
 
     const output = await pipe(
       merge(

--- a/test/peer-routing/peer-routing.node.js
+++ b/test/peer-routing/peer-routing.node.js
@@ -101,7 +101,7 @@ describe('peer-routing', () => {
       return deferred.promise
     })
 
-    it('should error when peer tries to find itself', async () =>{
+    it('should error when peer tries to find itself', async () => {
       await expect(nodes[0].peerRouting.findPeer(nodes[0].peerId))
         .to.eventually.be.rejected()
         .and.to.have.property('code', 'ERR_FIND_SELF')
@@ -193,7 +193,7 @@ describe('peer-routing', () => {
       expect(mockApi.isDone()).to.equal(true)
     })
 
-    it('should error when peer tries to find itself', async () =>{
+    it('should error when peer tries to find itself', async () => {
       await expect(node.peerRouting.findPeer(node.peerId))
         .to.eventually.be.rejected()
         .and.to.have.property('code', 'ERR_FIND_SELF')

--- a/test/peer-routing/peer-routing.node.js
+++ b/test/peer-routing/peer-routing.node.js
@@ -100,6 +100,12 @@ describe('peer-routing', () => {
 
       return deferred.promise
     })
+
+    it('should error when peer tries to find itself', async () =>{
+      await expect(nodes[0].peerRouting.findPeer(nodes[0].peerId))
+        .to.eventually.be.rejected()
+        .and.to.have.property('code', 'ERR_FIND_SELF')
+    })
   })
 
   describe('via delegate router', () => {
@@ -185,6 +191,12 @@ describe('peer-routing', () => {
 
       expect(peer.id).to.equal(peerKey)
       expect(mockApi.isDone()).to.equal(true)
+    })
+
+    it('should error when peer tries to find itself', async () =>{
+      await expect(node.peerRouting.findPeer(node.peerId))
+        .to.eventually.be.rejected()
+        .and.to.have.property('code', 'ERR_FIND_SELF')
     })
 
     it('should error when a peer cannot be found', async () => {


### PR DESCRIPTION
Resolves an issue where nodes running findPeer() on themselves return abstract aggregateErrors instead of something "more suitable" like ERR_DIALED_SELF. Original issue can be found [here](https://github.com/libp2p/js-libp2p/issues/827).

This is accomplished by comparing the _idB58String of the ID parameter to this._peerId._idB58String at [peer-routing.js](https://github.com/libp2p/js-libp2p/blob/master/src/peer-routing.js#L102). if the two values are equal, an error is thrown alerting the user of the mistake. For example:

```javascript
async findPeer (id, options) { // eslint-disable-line require-await
    ...

    if (id._idB58String == this._peerId._idB58String) throw errCode(new Error('Cannot search for self'), 'ERR_DIALED_SELF')
    
   ...
}
```