### PR TITLE
Fix: CONFIGURATION.md keychain typo

### DIFF
--- a/doc/CONFIGURATION.md
+++ b/doc/CONFIGURATION.md
@@ -515,7 +515,7 @@ const node = await Libp2p.create({
   }
 })
 
-await libp2p.loadKeychain()
+await node.loadKeychain()
 ```
 
 #### Configuring Dialing


### PR DESCRIPTION
Fixed a typo at [setup keychain](https://github.com/libp2p/js-libp2p/blob/master/doc/CONFIGURATION.md#setup-with-keychain) that was referencing "libp2p"  instead of "node." See below:

```javascript
const node = await Libp2p.create({...})

//Typo:
await libp2p.loadKeychain()
//Correction:
await node.loadKeychain()
```
