### PR TITLE
fix: store remote agent and protocol version during identify

### DIFF
--- a/src/identify/index.js
+++ b/src/identify/index.js
@@ -189,6 +189,8 @@ class IdentifyService {
       const envelope = await Envelope.openAndCertify(signedPeerRecord, PeerRecord.DOMAIN)
       if (this.peerStore.addressBook.consumePeerRecord(envelope)) {
         this.peerStore.protoBook.set(id, protocols)
+        this.peerStore.metadataBook.set(id, 'AgentVersion', uint8ArrayFromString(message.agentVersion))
+        this.peerStore.metadataBook.set(id, 'ProtocolVersion', uint8ArrayFromString(message.protocolVersion))
         return
       }
     } catch (err) {
@@ -204,6 +206,7 @@ class IdentifyService {
 
     this.peerStore.protoBook.set(id, protocols)
     this.peerStore.metadataBook.set(id, 'AgentVersion', uint8ArrayFromString(message.agentVersion))
+    this.peerStore.metadataBook.set(id, 'ProtocolVersion', uint8ArrayFromString(message.protocolVersion))
 
     // TODO: Add and score our observed addr
     log('received observed address of %s', cleanObservedAddr)

--- a/test/identify/index.spec.js
+++ b/test/identify/index.spec.js
@@ -454,7 +454,7 @@ describe('Identify', () => {
       await pWaitFor(() => connection.streams.length === 0)
       await connection.close()
 
-      const remotePeer = PeerId.createFromB58String('12D3KooWHFKTMzwerBtsVmtz4ZZEQy2heafxzWw6wNn5PPYkBxJ5')
+      const remotePeer = PeerId.createFromB58String(remoteAddr.getPeerId())
 
       const storedAgentVersion = libp2p.peerStore.metadataBook.getValue(remotePeer, 'AgentVersion')
       const storedProtocolVersion = libp2p.peerStore.metadataBook.getValue(remotePeer, 'ProtocolVersion')

--- a/test/identify/index.spec.js
+++ b/test/identify/index.spec.js
@@ -430,6 +430,39 @@ describe('Identify', () => {
       await connection.close()
     })
 
+    it('should store remote agent and protocol versions in metadataBook after connecting', async () => {
+      libp2p = new Libp2p({
+        ...baseOptions,
+        peerId
+      })
+
+      await libp2p.start()
+
+      sinon.spy(libp2p.identifyService, 'identify')
+      const peerStoreSpyConsumeRecord = sinon.spy(libp2p.peerStore.addressBook, 'consumePeerRecord')
+      const peerStoreSpyAdd = sinon.spy(libp2p.peerStore.addressBook, 'add')
+
+      const connection = await libp2p.dialer.connectToPeer(remoteAddr)
+      expect(connection).to.exist()
+
+      // Wait for peer store to be updated
+      // Dialer._createDialTarget (add), Identify (consume)
+      await pWaitFor(() => peerStoreSpyConsumeRecord.callCount === 1 && peerStoreSpyAdd.callCount === 1)
+      expect(libp2p.identifyService.identify.callCount).to.equal(1)
+
+      // The connection should have no open streams
+      await pWaitFor(() => connection.streams.length === 0)
+      await connection.close()
+
+      const remotePeer = PeerId.createFromB58String('12D3KooWHFKTMzwerBtsVmtz4ZZEQy2heafxzWw6wNn5PPYkBxJ5')
+
+      const storedAgentVersion = libp2p.peerStore.metadataBook.getValue(remotePeer, 'AgentVersion')
+      const storedProtocolVersion = libp2p.peerStore.metadataBook.getValue(remotePeer, 'ProtocolVersion')
+
+      expect(storedAgentVersion).to.exist()
+      expect(storedProtocolVersion).to.exist()
+    })
+
     it('should push protocol updates to an already connected peer', async () => {
       libp2p = new Libp2p({
         ...baseOptions,


### PR DESCRIPTION
These values were not being stored during identify.