### PR TITLE
Feat: keychain rotate passphrase

### DIFF
--- a/src/index.js
+++ b/src/index.js
@@ -207,6 +207,7 @@ class Libp2p extends EventEmitter {
     }
 
     // Create keychain
+      // TODO: Decide how to change these options when the keychain password is being changed
     if (this._options.keychain && this._options.keychain.datastore) {
       log('creating keychain')
 

--- a/src/index.js
+++ b/src/index.js
@@ -207,7 +207,6 @@ class Libp2p extends EventEmitter {
     }
 
     // Create keychain
-      // TODO: Decide how to change these options when the keychain password is being changed
     if (this._options.keychain && this._options.keychain.datastore) {
       log('creating keychain')
 

--- a/src/keychain/index.js
+++ b/src/keychain/index.js
@@ -505,16 +505,16 @@ class Keychain {
   }
 
   async rotateKeychainPass (oldPass, newPass){
-    if (typeof oldPassword !== 'string' || typeof newPassword !== 'string') {
-      throw new Error(`Invalid pass type '${typeof oldPassword}'`);
+    if (typeof oldPass !== 'string' || typeof newPass !== 'string') {
+      throw new Error(`Invalid pass type '${typeof oldPass}'`);
     }
-    if (newPassword.length < 20) {
+    if (newPass.length < 20) {
       throw new Error('pass must be least 20 characters')
     }
     // TODO: Need to decide on how to import/generate opts
-    const newDek = newPassword
+    const newDek = newPass
       ? crypto.pbkdf2(
-        newPassword,
+        newPass,
         this.opts.dek.salt,
         this.opts.dek.iterationCount,
         this.opts.dek.keyLength,

--- a/src/keychain/index.js
+++ b/src/keychain/index.js
@@ -557,7 +557,7 @@ class Keychain {
       batch.put(DsName(key.name), uint8ArrayFromString(keyAsPEM))
       batch.put(DsInfoName(key.name), uint8ArrayFromString(JSON.stringify(keyInfo)))
       await batch.commit()
-    })
+    }
     log('keychain reconstructed')
   }
 }

--- a/src/keychain/index.js
+++ b/src/keychain/index.js
@@ -540,7 +540,8 @@ class Keychain {
       const res = await this.store.get(DsName(key.name))
       const pem = uint8ArrayToString(res)
       const privateKey = await crypto.keys.import(pem, oldDek)
-      const keyAsPEM = await privateKey.export(newDek)
+      const password = newDek.toString()
+      const keyAsPEM = await privateKey.export(password)
 
       // Remove key with old pass
       const batch = this.store.batch()

--- a/src/keychain/index.js
+++ b/src/keychain/index.js
@@ -504,7 +504,7 @@ class Keychain {
     }
   }
 
-  async changeKeychainPassword(oldPassword, newPassword){
+  async rotateKeychainPass (oldPass, newPass){
     if (typeof oldPassword !== 'string' || typeof newPassword !== 'string') {
       throw new Error(`Invalid pass type '${typeof oldPassword}'`);
     }

--- a/src/keychain/index.js
+++ b/src/keychain/index.js
@@ -526,7 +526,6 @@ class Keychain {
     log('recreating keychain')
     const oldDek = privates.get(this).dek
     this.opts.pass = newPass
-    // eslint-disable-next-line constant condition
     const newDek = newPass
       ? crypto.pbkdf2(
         newPass,

--- a/src/keychain/index.js
+++ b/src/keychain/index.js
@@ -503,7 +503,13 @@ class Keychain {
       return throwDelayed(errcode(new Error(`Key '${name}' does not exist. ${err.message}`), 'ERR_KEY_NOT_FOUND'))
     }
   }
-
+  
+  /**
+   * Rotate keychain password and re-encrypt all assosciated keys
+   *
+   * @param {string} oldPass - The old local keychain password
+   * @param {string} newPass - The new local keychain password
+   */
   async rotateKeychainPass (oldPass, newPass){
     if (typeof oldPass !== 'string' || typeof newPass !== 'string') {
       throw new Error(`Invalid pass type '${typeof oldPass}'`);
@@ -517,7 +523,6 @@ class Keychain {
       datastore: this.store
     }
 
-    const oldDek = privates.get(this).dek
     const newDek = newPass
       ? crypto.pbkdf2(
         newPass,

--- a/src/keychain/index.js
+++ b/src/keychain/index.js
@@ -536,7 +536,7 @@ class Keychain {
       : ''
     privates.set(this, { dek: newDek })
     const keys = await this.listKeys()
-    await keys.forEach(async key => {
+    for (const key of keys) {
       const res = await this.store.get(DsName(key.name))
       const pem = uint8ArrayToString(res)
       const privateKey = await crypto.keys.import(pem, oldDek)

--- a/src/keychain/index.js
+++ b/src/keychain/index.js
@@ -526,6 +526,7 @@ class Keychain {
     log('recreating keychain')
     const oldDek = privates.get(this).dek
     this.opts.pass = newPass
+    // eslint-disable-next-line constant condition
     const newDek = newPass
       ? crypto.pbkdf2(
         newPass,

--- a/src/keychain/index.js
+++ b/src/keychain/index.js
@@ -543,13 +543,8 @@ class Keychain {
       const password = newDek.toString()
       const keyAsPEM = await privateKey.export(password)
 
-      // Remove key with old pass
+      // Update stored key
       const batch = this.store.batch()
-      batch.delete(DsName(key.name))
-      batch.delete(DsInfoName(key.name))
-      await batch.commit()
-
-      // Import key with new pass
       const keyInfo = {
         name: key.name,
         id: key.id

--- a/src/keychain/index.js
+++ b/src/keychain/index.js
@@ -506,18 +506,18 @@ class Keychain {
       return throwDelayed(errcode(new Error(`Key '${name}' does not exist. ${err.message}`), 'ERR_KEY_NOT_FOUND'))
     }
   }
-  
+
   /**
    * Rotate keychain password and re-encrypt all assosciated keys
    *
    * @param {string} oldPass - The old local keychain password
    * @param {string} newPass - The new local keychain password
    */
-  async rotateKeychainPass (oldPass, newPass){
+  async rotateKeychainPass (oldPass, newPass) {
     if (typeof oldPass !== 'string') {
       return throwDelayed(errcode(new Error(`Invalid old pass type '${typeof oldPass}'`), 'ERR_INVALID_OLD_PASS_TYPE'))
     }
-    if (typeof newPass !== 'string') { 
+    if (typeof newPass !== 'string') {
       return throwDelayed(errcode(new Error(`Invalid new pass type '${typeof newPass}'`), 'ERR_INVALID_NEW_PASS_TYPE'))
     }
     if (newPass.length < 20) {
@@ -538,10 +538,10 @@ class Keychain {
         this.opts.dek.keyLength,
         this.opts.dek.hash)
       : ''
-    privates.set(this, { "dek":newDek })
+    privates.set(this, { dek: newDek })
 
     const keys = await this.listKeys()
-    await keys.forEach(async key =>{
+    await keys.forEach(async key => {
       const res = await this.store.get(DsName(key.name))
       const pem = uint8ArrayToString(res)
       const privateKey = await crypto.keys.import(pem, oldDek)
@@ -551,7 +551,7 @@ class Keychain {
       const batch = this.store.batch()
       batch.delete(DsName(key.name))
       batch.delete(DsInfoName(key.name))
-      await batch.commit()    
+      await batch.commit()
 
       // Import key with new pass
       const keyInfo = {

--- a/test/keychain/keychain.spec.js
+++ b/test/keychain/keychain.spec.js
@@ -492,28 +492,49 @@ describe('keychain', () => {
       expect(key).to.have.property('id', rsaKeyInfo.id)
     })
   })
-})
 
-describe('rotate keychain passphrase', () => {
-  it('should validate newPass is a string', async () => {
-    expect(() => ks.rotateKeychainPass(passPhrase, 1234567890)).to.throw()
-  })
+  describe('rotate keychain passphrase', () => {
+    let oldPass
+    let kc
+    before(async () => {
+      oldPass = `hello-${Date.now()}-${Date.now()}`
+      kc = new Keychain(datastore2, { pass: oldPass })
+    })
 
-  it('should validate oldPass is a string', async () => {
-    expect(() => ks.rotateKeychainPass(1234, "newInsecurePassword1")).to.throw()
-  })
-
-  it('should validate newPass is at least 20 characters', async () => {
-    expect(() => ks.rotateKeychainPass(passPhrase, "new")).to.throw()
-  })
+    it('should validate newPass is a string', async () => {
+      try {
+        await kc.rotateKeychainPass(oldPass, 1234567890)
+      } catch (err) {
+        expect(err).to.exist()
+      }
+    })
   
-  /*
-  TODO:
-  it('can rotate keychain passphrase', async () => {
-
+    it('should validate oldPass is a string', async () => {
+      try {
+        await kc.rotateKeychainPass(1234, "newInsecurePassword1")
+      } catch (err) {
+        expect(err).to.exist()
+      }
+    })
+  
+    it('should validate newPass is at least 20 characters', async () => {
+      try {
+        await kc.rotateKeychainPass(oldPass, "not20Chars")
+      } catch (err) {
+        expect(err).to.exist()
+      }
+    })
+    
+    it('can rotate keychain passphrase', async () => {
+      await kc.rotateKeychainPass(oldPass, "newInsecurePassphrase")
+      setTimeout(async () => {
+        var key = await kc.exportKey("self", "newInsecurePassphrase")
+        // should be able to retrieve key with the new pass if keychain pass has indeed been changed
+        expect(key).to.have.property('name', "self")
+      }, 1000);
+    })
   })
-  */
-});
+})
 
 describe('libp2p.keychain', () => {
   it('needs a passphrase to be used, otherwise throws an error', async () => {

--- a/test/keychain/keychain.spec.js
+++ b/test/keychain/keychain.spec.js
@@ -494,6 +494,27 @@ describe('keychain', () => {
   })
 })
 
+describe('rotate keychain passphrase', () => {
+  it('should validate newPass is a string', async () => {
+    expect(() => ks.rotateKeychainPass(passPhrase, 1234567890)).to.throw()
+  })
+
+  it('should validate oldPass is a string', async () => {
+    expect(() => ks.rotateKeychainPass(1234, "newInsecurePassword1")).to.throw()
+  })
+
+  it('should validate newPass is at least 20 characters', async () => {
+    expect(() => ks.rotateKeychainPass(passPhrase, "new")).to.throw()
+  })
+  
+  /*
+  TODO:
+  it('can rotate keychain passphrase', async () => {
+
+  })
+  */
+});
+
 describe('libp2p.keychain', () => {
   it('needs a passphrase to be used, otherwise throws an error', async () => {
     const [libp2p] = await peerUtils.createPeer({

--- a/test/keychain/keychain.spec.js
+++ b/test/keychain/keychain.spec.js
@@ -573,7 +573,7 @@ describe('keychain', () => {
       // Dek with new password should work:
       await expect(kc.importKey('keyWhosePasswordChanged', pem, newDek))
         .to.eventually.have.property('name', 'keyWhosePasswordChanged')
-    }).timeout(10000);
+    }).timeout(10000)
   })
 })
 

--- a/test/keychain/keychain.spec.js
+++ b/test/keychain/keychain.spec.js
@@ -537,7 +537,7 @@ describe('keychain', () => {
     })
 
     it('can rotate keychain passphrase', async () => {
-      await ks.createKey('keyCreatedWithOldPassword', 'rsa', 2048)
+      await kc.createKey('keyCreatedWithOldPassword', 'rsa', 2048)
       await kc.rotateKeychainPass(oldPass, 'newInsecurePassphrase')
 
       setTimeout(async () => {

--- a/test/keychain/keychain.spec.js
+++ b/test/keychain/keychain.spec.js
@@ -566,7 +566,8 @@ describe('keychain', () => {
           : ''
 
         // Dek with old password should not work:
-        expect(await kc.importKey('keyWhosePassChanged', pem, oldDek)).to.throw()
+        await expect(kc.importKey('keyWhosePassChanged', pem, oldDek))
+          .to.eventually.be.rejected()
         // Dek with new password should work:
         expect(await kc.importKey('keyWhosePasswordChanged', pem, newDek)).to.have.property('name', 'keyWhosePasswordChanged')
       }, 1000)

--- a/test/keychain/keychain.spec.js
+++ b/test/keychain/keychain.spec.js
@@ -573,7 +573,7 @@ describe('keychain', () => {
       // Dek with new password should work:
       await expect(kc.importKey('keyWhosePasswordChanged', pem, newDek))
         .to.eventually.have.property('name', 'keyWhosePasswordChanged')
-    })
+    }).timeout(10000);
   })
 })
 

--- a/test/keychain/keychain.spec.js
+++ b/test/keychain/keychain.spec.js
@@ -569,7 +569,8 @@ describe('keychain', () => {
         await expect(kc.importKey('keyWhosePassChanged', pem, oldDek))
           .to.eventually.be.rejected()
         // Dek with new password should work:
-        expect(await kc.importKey('keyWhosePasswordChanged', pem, newDek)).to.have.property('name', 'keyWhosePasswordChanged')
+        await expect(kc.importKey('keyWhosePasswordChanged', pem, newDek))
+          .to.eventually.have.property('name', 'keyWhosePasswordChanged')
       }, 1000)
     })
   })

--- a/test/keychain/keychain.spec.js
+++ b/test/keychain/keychain.spec.js
@@ -508,30 +508,30 @@ describe('keychain', () => {
         expect(err).to.exist()
       }
     })
-  
+
     it('should validate oldPass is a string', async () => {
       try {
-        await kc.rotateKeychainPass(1234, "newInsecurePassword1")
+        await kc.rotateKeychainPass(1234, 'newInsecurePassword1')
       } catch (err) {
         expect(err).to.exist()
       }
     })
-  
+
     it('should validate newPass is at least 20 characters', async () => {
       try {
-        await kc.rotateKeychainPass(oldPass, "not20Chars")
+        await kc.rotateKeychainPass(oldPass, 'not20Chars')
       } catch (err) {
         expect(err).to.exist()
       }
     })
-    
+
     it('can rotate keychain passphrase', async () => {
-      await kc.rotateKeychainPass(oldPass, "newInsecurePassphrase")
+      await kc.rotateKeychainPass(oldPass, 'newInsecurePassphrase')
       setTimeout(async () => {
-        var key = await kc.exportKey("self", "newInsecurePassphrase")
+        const key = await kc.exportKey('self', 'newInsecurePassphrase')
         // should be able to retrieve key with the new pass if keychain pass has indeed been changed
-        expect(key).to.have.property('name', "self")
-      }, 1000);
+        expect(key).to.have.property('name', 'self')
+      }, 1000)
     })
   })
 })

--- a/test/keychain/keychain.spec.js
+++ b/test/keychain/keychain.spec.js
@@ -555,6 +555,7 @@ describe('keychain', () => {
             options.dek.hash)
           : ''
 
+        // eslint-disable-next-line no-constant-condition
         const newDek = 'newInsecurePassphrase'
           ? crypto.pbkdf2(
             'newInsecurePassphrase',


### PR DESCRIPTION
This is a rough implementation supporting [rotating keychain passphrases](https://github.com/libp2p/js-libp2p/issues/728). I need some suggestions on how to proceed. I haven't received a reply so I've copied the original conversation here for reference:

```js
async changeKeychainPassword(oldPassword, newPassword){
    if (typeof oldPassword !== 'string' || typeof newPassword !== 'string') {
      throw new Error(`Invalid pass type '${typeof oldPassword}'`);
    }
    if (newPassword.length < 20) {
      throw new Error('pass must be least 20 characters')
    }
    // TODO: Need to decide on how to import/generate opts
    const newDek = newPassword
      ? crypto.pbkdf2(
        newPassword,
        this.opts.dek.salt,
        this.opts.dek.iterationCount,
        this.opts.dek.keyLength,
        this.opts.dek.hash)
      : ''
    const oldDek = privates.get(this).dek
    privates.set(this, { "dek":newDek })
    var keys = await this.listKeys()
    await keys.forEach(async key =>{
      // TODO: Decide how to handle deleting and importing the "self" key. 
          // importKey and removeKey throw an error when handling "self"
      if (key.name != "self"){
        var keyAsPEM = await this._getPrivateKey(key.name)
        await this.removeKey(key.name)
        this.importKey(key.name, keyAsPEM, oldDek)
      }
    })
  }

```
[src/keychain/index.js](https://github.com/zeim839/js-libp2p/blob/feat/keychain-change-passphrase/src/keychain/index.js#L507)

What's left is to decide how to handle the "self" key (`this.importKey()` and `this.removeKey()` throw an error on "self") and how to handle changing passwords in the context of src/index.js (see [here](https://github.com/zeim839/js-libp2p/blob/feat/keychain-change-passphrase/src/index.js#L209)). I'm trying to be cautious/minimal with the changes I make so I'd appreciate some suggestions on how to proceed.