### PR TITLE
fix: chat example with new multiaddr

### DIFF
--- a/examples/chat/src/dialer.js
+++ b/examples/chat/src/dialer.js
@@ -2,11 +2,11 @@
 /* eslint-disable no-console */
 
 const PeerId = require('peer-id')
-const multiaddr = require('multiaddr')
+const { Multiaddr } = require('multiaddr')
 const createLibp2p = require('./libp2p')
 const { stdinToStream, streamToConsole } = require('./stream')
 
-async function run() {
+async function run () {
   const [idDialer, idListener] = await Promise.all([
     PeerId.createFromJSON(require('./peer-id-dialer')),
     PeerId.createFromJSON(require('./peer-id-listener'))
@@ -30,7 +30,7 @@ async function run() {
   })
 
   // Dial to the remote peer (the "listener")
-  const listenerMa = multiaddr(`/ip4/127.0.0.1/tcp/10333/p2p/${idListener.toB58String()}`)
+  const listenerMa = new Multiaddr(`/ip4/127.0.0.1/tcp/10333/p2p/${idListener.toB58String()}`)
   const { stream } = await nodeDialer.dialProtocol(listenerMa, '/chat/1.0.0')
 
   console.log('Dialer dialed to listener on protocol: /chat/1.0.0')

--- a/examples/chat/src/listener.js
+++ b/examples/chat/src/listener.js
@@ -5,7 +5,7 @@ const PeerId = require('peer-id')
 const createLibp2p = require('./libp2p.js')
 const { stdinToStream, streamToConsole } = require('./stream')
 
-async function run() {
+async function run () {
   // Create a new libp2p node with the given multi-address
   const idListener = await PeerId.createFromJSON(require('./peer-id-listener'))
   const nodeListener = await createLibp2p({

--- a/examples/package.json
+++ b/examples/package.json
@@ -10,8 +10,8 @@
   "dependencies": {
     "execa": "^2.1.0",
     "fs-extra": "^8.1.0",
-    "libp2p-pubsub-peer-discovery": "libp2p/js-libp2p-pubsub-peer-discovery#chore/update-deps-25_05_2021",
-    "libp2p-relay-server": "libp2p/js-libp2p-relay-server#chore/update-deps-25_05_2021",
+    "libp2p-pubsub-peer-discovery": "^4.0.0",
+    "libp2p-relay-server": "^0.2.0",
     "p-defer": "^3.0.0",
     "which": "^2.0.1"
   },

--- a/examples/package.json
+++ b/examples/package.json
@@ -10,8 +10,8 @@
   "dependencies": {
     "execa": "^2.1.0",
     "fs-extra": "^8.1.0",
-    "libp2p-pubsub-peer-discovery": "^3.0.0",
-    "libp2p-relay-server": "^0.1.2",
+    "libp2p-pubsub-peer-discovery": "libp2p/js-libp2p-pubsub-peer-discovery#chore/update-deps-25_05_2021",
+    "libp2p-relay-server": "libp2p/js-libp2p-relay-server#chore/update-deps-25_05_2021",
     "p-defer": "^3.0.0",
     "which": "^2.0.1"
   },


### PR DESCRIPTION
The Multiaddr update did not bubble up to the chat example 😱 Thanks @mobeiqingkong for pointing this out

The chat example test has been running fine in the CI (last commit: https://github.com/libp2p/js-libp2p/runs/2637518502), but it is using the old multiaddr. After looking into how it is getting the dependencies, I noticed that libp2p examples have some dependencies (`libp2p-pubsub-peer-discovery` and `libp2p-relay-server`) that use the older multiaddr and that ends up being the one used in the examples.

Needs:

- [x] https://github.com/libp2p/js-libp2p-pubsub-peer-discovery/pull/10
- [x] https://github.com/libp2p/js-libp2p-relay-server/pull/6
