### PR TITLE
fix: dialer leaking resources after stopping

### DIFF
--- a/test/dialing/direct.spec.js
+++ b/test/dialing/direct.spec.js
@@ -290,6 +290,34 @@ describe('Dialing (direct, WebSockets)', () => {
     }
   })
 
+  it('should cancel pending dial targets before proceeding', async () => {
+    const dialer = new Dialer({
+      transportManager: localTM,
+      peerStore: {
+        addressBook: {
+          set: () => { }
+        }
+      }
+    })
+
+    sinon.stub(dialer, '_createDialTarget').callsFake(() => {
+      const deferredDial = pDefer()
+      return deferredDial.promise
+    })
+
+    // Perform dial
+    const dialPromise = dialer.connectToPeer(peerId)
+
+    // Let the call stack run
+    await delay(0)
+
+    dialer.destroy()
+
+    await expect(dialPromise)
+      .to.eventually.be.rejected()
+      .and.to.have.property('code', 'ABORT_ERR')
+  })
+
   describe('libp2p.dialer', () => {
     const transportKey = Transport.prototype[Symbol.toStringTag]
     let libp2p
@@ -460,6 +488,41 @@ describe('Dialing (direct, WebSockets)', () => {
       })
 
       await libp2p.hangUp(remoteAddr)
+    })
+
+    it('should cancel pending dial targets and stop', async () => {
+      const [, remotePeerId] = await createPeerId({ number: 2 })
+
+      libp2p = new Libp2p({
+        peerId,
+        modules: {
+          transport: [Transport],
+          streamMuxer: [Muxer],
+          connEncryption: [Crypto]
+        },
+        config: {
+          transport: {
+            [transportKey]: {
+              filter: filters.all
+            }
+          }
+        }
+      })
+
+      sinon.stub(libp2p.dialer, '_createDialTarget').callsFake(() => {
+        const deferredDial = pDefer()
+        return deferredDial.promise
+      })
+
+      // Perform dial
+      const dialPromise = libp2p.dial(remotePeerId)
+
+      // Let the call stack run
+      await delay(0)
+
+      await libp2p.stop()
+      await expect(dialPromise)
+        .to.eventually.be.rejected()
     })
 
     it('should abort pending dials on stop', async () => {

--- a/test/dialing/direct.spec.js
+++ b/test/dialing/direct.spec.js
@@ -523,6 +523,7 @@ describe('Dialing (direct, WebSockets)', () => {
       await libp2p.stop()
       await expect(dialPromise)
         .to.eventually.be.rejected()
+        .and.to.have.property('code', 'ABORT_ERR')
     })
 
     it('should abort pending dials on stop', async () => {


### PR DESCRIPTION
This PR fixes the potential leaking of resources in the dialer on stop.

During the `transport.dial` flow, if libp2p is stopped the on going dials were being aborted. However, situations like https://github.com/libp2p/js-libp2p-tcp/issues/142 were possible when a given resolvable multiaddr (`dnsaddr`) is being resolved before getting into the transport level. This would result in new dial attempts after stop and established connections that prevented the process from properly stop.

Unfortunately, node's dns record resolution does not allow the lookup to be abortable. As a consequence, this PR adds a competing Cancellable promise, which will be rejected in case of `libp2p.stop()` => `dialer.destroy()`. With this, the promise that would resolve the `dialTarget` will be rejected and the current on going dial all together.

Moreover, as described in #779 the latency monitor was not being properly closed. So, I also added `start` and `stop` functions to it (instead of the really odd pattern of starting it in the constructor).

Closes #779 