### PR TITLE
Be extra explicit on DHT configuration in CONFIGURATION.md

### DIFF
--- a/doc/CONFIGURATION.md
+++ b/doc/CONFIGURATION.md
@@ -373,7 +373,7 @@ const node = await Libp2p.create({
   config: {
     dht: {                        // The DHT options (and defaults) can be found in its documentation
       kBucketSize: 20,
-      enabled: true,
+      enabled: true,              // This flag is required for DHT to run (disabled by default)
       randomWalk: {
         enabled: true,            // Allows to disable discovery (enabled by default)
         interval: 300e3,


### PR DESCRIPTION
This weekend I hooked up DHT in my js-libp2p app. It did not work, because I had not set dht.enable:true in the configuration on the client side. I [spent an embarrassing amount of time trying to fix this and wound up filing a bug](https://github.com/libp2p/js-libp2p-kad-dht/issues/221). Oops.

However, one thing occurs to me. I remember reading CONFIGURATION.md at some point while setting my app up, and I think I didn't realize the configuration was necessary because of the line "enabled by default"  immediately after. There are two "enabled:true" lines immediately next to each other, one is labeled "enabled by default" (and is), the other is disabled by default. I think I saw "enabled:true // by default" and thought ah! So I don't need to set it! and totally blanked that there was two lines away a second "enabled:true" with no such comment.

The fact I got confused is 100% my fault. But if CONFIGURATION.md confused me, it might confuse other people, so here is a patch that adds a comment to the *other* line to make it clear that the second enabled:true is NOT true by default and in fact is very important.