### PR TITLE
chore: remove ipfs-utils dep

### DIFF
--- a/doc/CONFIGURATION.md
+++ b/doc/CONFIGURATION.md
@@ -399,13 +399,13 @@ const PeerId = require('peer-id')
 // create a peerId
 const peerId = await PeerId.create()
 
-const delegatedPeerRouting = new DelegatedPeerRouter(ipfsHttpClient({
+const delegatedPeerRouting = new DelegatedPeerRouter(ipfsHttpClient.create({
   host: 'node0.delegate.ipfs.io', // In production you should setup your own delegates
   protocol: 'https',
   port: 443
 }))
 
-const delegatedContentRouting = new DelegatedContentRouter(peerId, ipfsHttpClient({
+const delegatedContentRouting = new DelegatedContentRouter(peerId, ipfsHttpClient.create({
   host: 'node0.delegate.ipfs.io', // In production you should setup your own delegates
   protocol: 'https',
   port: 443

--- a/package.json
+++ b/package.json
@@ -91,7 +91,6 @@
     "events": "^3.3.0",
     "hashlru": "^2.3.0",
     "interface-datastore": "^4.0.0",
-    "ipfs-utils": "^7.0.0",
     "it-all": "^1.0.4",
     "it-buffer": "^0.1.2",
     "it-drain": "^1.0.3",
@@ -128,6 +127,7 @@
     "streaming-iterables": "^5.0.2",
     "timeout-abort-controller": "^1.1.1",
     "varint": "^6.0.0",
+    "wherearewe": "^1.0.0",
     "xsalsa20": "^1.1.0"
   },
   "devDependencies": {

--- a/package.json
+++ b/package.json
@@ -141,7 +141,7 @@
     "delay": "^5.0.0",
     "interop-libp2p": "^0.4.0",
     "into-stream": "^6.0.0",
-    "ipfs-http-client": "^49.0.4",
+    "ipfs-http-client": "^50.1.1",
     "it-concat": "^1.0.0",
     "it-pair": "^1.0.0",
     "it-pushable": "^1.4.0",

--- a/src/circuit/utils.js
+++ b/src/circuit/utils.js
@@ -3,8 +3,6 @@
 const CID = require('cids')
 const multihashing = require('multihashing-async')
 
-const TextEncoder = require('ipfs-utils/src/text-encoder')
-
 /**
  * Convert a namespace string into a cid.
  *

--- a/src/nat-manager.js
+++ b/src/nat-manager.js
@@ -8,7 +8,7 @@ const { Multiaddr } = require('multiaddr')
 const log = Object.assign(debug('libp2p:nat'), {
   error: debug('libp2p:nat:err')
 })
-const { isBrowser } = require('ipfs-utils/src/env')
+const { isBrowser } = require('wherearewe')
 const retry = require('p-retry')
 // @ts-ignore private-api does not export types
 const isPrivateIp = require('private-ip')

--- a/test/content-routing/content-routing.node.js
+++ b/test/content-routing/content-routing.node.js
@@ -105,7 +105,7 @@ describe('content-routing', () => {
     beforeEach(async () => {
       const [peerId] = await peerUtils.createPeerId({ fixture: true })
 
-      delegate = new DelegatedContentRouter(peerId, ipfsHttpClient({
+      delegate = new DelegatedContentRouter(peerId, ipfsHttpClient.create({
         host: '0.0.0.0',
         protocol: 'http',
         port: 60197
@@ -253,7 +253,7 @@ describe('content-routing', () => {
     beforeEach(async () => {
       const [peerId] = await peerUtils.createPeerId({ fixture: true })
 
-      delegate = new DelegatedContentRouter(peerId, ipfsHttpClient({
+      delegate = new DelegatedContentRouter(peerId, ipfsHttpClient.create({
         host: '0.0.0.0',
         protocol: 'http',
         port: 60197

--- a/test/peer-routing/peer-routing.node.js
+++ b/test/peer-routing/peer-routing.node.js
@@ -113,7 +113,7 @@ describe('peer-routing', () => {
     let delegate
 
     beforeEach(async () => {
-      delegate = new DelegatedPeerRouter(ipfsHttpClient({
+      delegate = new DelegatedPeerRouter(ipfsHttpClient.create({
         host: '0.0.0.0',
         protocol: 'http',
         port: 60197
@@ -288,7 +288,7 @@ describe('peer-routing', () => {
     let delegate
 
     beforeEach(async () => {
-      delegate = new DelegatedPeerRouter(ipfsHttpClient({
+      delegate = new DelegatedPeerRouter(ipfsHttpClient.create({
         host: '0.0.0.0',
         protocol: 'http',
         port: 60197

--- a/test/relay/auto-relay.node.js
+++ b/test/relay/auto-relay.node.js
@@ -515,7 +515,7 @@ describe('auto-relay', () => {
 
       // Create 2 nodes, and turn HOP on for the relay
       ;[local, remote, relayLibp2p] = peerIds.map((peerId, index) => {
-        const delegate = new DelegatedContentRouter(peerId, ipfsHttpClient({
+        const delegate = new DelegatedContentRouter(peerId, ipfsHttpClient.create({
           host: '0.0.0.0',
           protocol: 'http',
           port: 60197

--- a/test/ts-use/src/main.ts
+++ b/test/ts-use/src/main.ts
@@ -35,13 +35,13 @@ async function main() {
   // create a peerId
   const peerId = await PeerId.create()
 
-  const delegatedPeerRouting = new DelegatedPeerRouter(ipfsHttpClient({
+  const delegatedPeerRouting = new DelegatedPeerRouter(ipfsHttpClient.create({
     host: 'node0.delegate.ipfs.io', // In production you should setup your own delegates
     protocol: 'https',
     port: 443
   }))
 
-  const delegatedContentRouting = new DelegatedContentRouter(peerId, ipfsHttpClient({
+  const delegatedContentRouting = new DelegatedContentRouter(peerId, ipfsHttpClient.create({
     host: 'node0.delegate.ipfs.io', // In production you should setup your own delegates
     protocol: 'https',
     port: 443


### PR DESCRIPTION
We only use it for the env detection, so use [wherearewe](https://www.npmjs.com/package/wherearewe) instead which is that, but pulled out into a tiny module.

The `TextDecoder` class is global everywhere we support so we don't need to pull it in from `ipfs-utils` and it's been removed from v8 of that module anyway.

Also updates ipfs-http-client to the latest version.