### PR TITLE
chore: libp2p interop job needs exit for aegir

### DIFF
--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -67,4 +67,4 @@ jobs:
     steps:
       - uses: actions/checkout@v2
       - run: npm install
-      - run: cd node_modules/interop-libp2p && yarn && LIBP2P_JS=${GITHUB_WORKSPACE}/src/index.js npx aegir test -t node --bail
+      - run: cd node_modules/interop-libp2p && yarn && LIBP2P_JS=${GITHUB_WORKSPACE}/src/index.js npx aegir test -t node --bail -- --exit


### PR DESCRIPTION
We have some issue closing everything to end the process and previously `aegir` was always closing the process, which does not happen with the newer version. This makes interop test flaky. So, as https://github.com/libp2p/interop/blob/v0.4.1/.travis.yml#L28 let's add the exit flag for now