### PR TITLE
feat: support delegated value store in content-routing module

### DIFF
--- a/package.json
+++ b/package.json
@@ -78,10 +78,10 @@
     ]
   },
   "dependencies": {
-    "abortable-iterator": "^3.0.0",
     "@motrix/nat-api": "^0.3.1",
     "@vascosantos/moving-average": "^1.1.0",
     "abort-controller": "^3.0.0",
+    "abortable-iterator": "^3.0.0",
     "aggregate-error": "^3.1.0",
     "any-signal": "^2.1.1",
     "bignumber.js": "^9.0.1",
@@ -104,7 +104,6 @@
     "it-pipe": "^1.1.0",
     "it-take": "^1.0.0",
     "libp2p-crypto": "^0.19.4",
-    "libp2p-interfaces": "^1.0.0",
     "libp2p-utils": "^0.4.0",
     "mafmt": "^10.0.0",
     "merge-options": "^3.0.4",
@@ -149,7 +148,7 @@
     "it-pushable": "^1.4.0",
     "libp2p": ".",
     "libp2p-bootstrap": "^0.13.0",
-    "libp2p-delegated-content-routing": "^0.11.0",
+    "libp2p-delegated-content-routing": "git+ssh://git@github.com/libp2p/js-libp2p-delegated-content-routing#362cd00988e717f6fc49b0a1f2fa7bbaabbfcc53",
     "libp2p-delegated-peer-routing": "^0.10.0",
     "libp2p-floodsub": "^0.27.0",
     "libp2p-gossipsub": "^0.11.0",

--- a/src/errors.js
+++ b/src/errors.js
@@ -3,7 +3,8 @@
 exports.messages = {
   NOT_STARTED_YET: 'The libp2p node is not started yet',
   DHT_DISABLED: 'DHT is not available',
-  CONN_ENCRYPTION_REQUIRED: 'At least one connection encryption module is required'
+  CONN_ENCRYPTION_REQUIRED: 'At least one connection encryption module is required',
+  VALUE_STORE_REQUIRED: 'At least one value storage module is required for this operation if the DHT is not enabled.'
 }
 
 exports.codes = {
@@ -34,5 +35,6 @@ exports.codes = {
   ERR_TRANSPORT_DIAL_FAILED: 'ERR_TRANSPORT_DIAL_FAILED',
   ERR_UNSUPPORTED_PROTOCOL: 'ERR_UNSUPPORTED_PROTOCOL',
   ERR_INVALID_MULTIADDR: 'ERR_INVALID_MULTIADDR',
-  ERR_SIGNATURE_NOT_VALID: 'ERR_SIGNATURE_NOT_VALID'
+  ERR_SIGNATURE_NOT_VALID: 'ERR_SIGNATURE_NOT_VALID',
+  ERR_VALUE_STORE_UNAVAILABLE: 'ERR_VALUE_STORE_UNAVAILABLE'
 }

--- a/src/index.js
+++ b/src/index.js
@@ -40,6 +40,7 @@ const { updateSelfPeerRecord } = require('./record/utils')
  * @typedef {import('libp2p-interfaces/src/transport/types').TransportFactory<any, any>} TransportFactory
  * @typedef {import('libp2p-interfaces/src/stream-muxer/types').MuxerFactory} MuxerFactory
  * @typedef {import('libp2p-interfaces/src/content-routing/types').ContentRouting} ContentRoutingModule
+ * @typedef {import('libp2p-interfaces/src/value-store/types').ValueStore} ValueStoreModule
  * @typedef {import('libp2p-interfaces/src/peer-discovery/types').PeerDiscoveryFactory} PeerDiscoveryFactory
  * @typedef {import('libp2p-interfaces/src/peer-routing/types').PeerRouting} PeerRoutingModule
  * @typedef {import('libp2p-interfaces/src/crypto/types').Crypto} Crypto
@@ -102,6 +103,7 @@ const { updateSelfPeerRecord } = require('./record/utils')
  * @property {PeerDiscoveryFactory[]} [peerDiscovery]
  * @property {PeerRoutingModule[]} [peerRouting]
  * @property {ContentRoutingModule[]} [contentRouting]
+ * @property {ValueStoreModule[]} [valueStorage]
  * @property {Object} [dht]
  * @property {{new(...args: any[]): Pubsub}} [pubsub]
  * @property {Protector} [connProtector]


### PR DESCRIPTION
This adds support for delegated `put` / `get` operations in the `content-routing` module instead of always using the DHT. It depends on some in-progress PRs, so CI is currently failing.

Dependencies:

- [ ] https://github.com/libp2p/js-libp2p-interfaces/pull/108
- [ ] https://github.com/libp2p/js-libp2p-delegated-content-routing/pull/54

To run the tests locally, you can checkout the PR branch of `js-libp2p-interfaces` and `npm link` it into js-libp2p. For now, I'm depending on a commit hash for the delegated-content-routing PR, but that doesn't work for libp2p-interfaces since it's a multi-module repo.

This adds a new entry to the config `modules` object called `valueStorage` which can contain `ValueStore` implementations. Currently the only non-DHT implementation is in the delegated-content-routing PR above.

I don't think the config change is technically a breaking API change since it's additive - if you don't add the new valueStorage module in your config you just won't get delegated put/get operations, but the DHT will still work if you've enabled it.