### PR TITLE
feat: allow user to pass in multistream implementation

### DIFF
--- a/src/index.js
+++ b/src/index.js
@@ -105,6 +105,8 @@ const { updateSelfPeerRecord } = require('./record/utils')
  * @property {Object} [dht]
  * @property {{new(...args: any[]): Pubsub}} [pubsub]
  * @property {Protector} [connProtector]
+ * @property {import('./upgrader').MultistreamOption} [multistream]
+
  *
  * @typedef {Object} Libp2pOptions
  * @property {Libp2pModules} modules libp2p modules to use
@@ -221,6 +223,7 @@ class Libp2p extends EventEmitter {
 
     // Setup the Upgrader
     this.upgrader = new Upgrader({
+      multistream: this._options.modules.multistream,
       localPeer: this.peerId,
       metrics: this.metrics,
       onConnection: (connection) => this.connectionManager.onConnect(connection),


### PR DESCRIPTION
Hi! Just wanted to allow users to easily pass in a multistream implementation. Useful if wanting a custom match function based on RegExp rather than strings.

If not merged, some advice would be helpful the best way to pass in custom modules for multistream / upgrader / protobook / etc.