### PR TITLE
docs: update connection link in API docs

### DIFF
--- a/doc/API.md
+++ b/doc/API.md
@@ -2086,7 +2086,7 @@ the NatManager performing NAT hole punching.
 
 [address]: https://github.com/libp2p/js-libp2p/tree/master/src/peer-store/address-book.js
 [cid]: https://github.com/multiformats/js-cid
-[connection]: https://github.com/libp2p/js-interfaces/tree/master/src/connection
+[connection]: https://github.com/libp2p/js-libp2p-interfaces/tree/master/packages/interfaces/src/connection
 [multiaddr]: https://github.com/multiformats/js-multiaddr
 [peer-id]: https://github.com/libp2p/js-peer-id
 [keys]: https://github.com/libp2p/js-libp2p-crypto/tree/master/src/keys


### PR DESCRIPTION
Fixes #1018

The issue was caused when the repo [js-libp2p-interfaces](https://github.com/libp2p/js-libp2p-interfaces) was renamed and refactored in this [commit](https://github.com/libp2p/js-libp2p-interfaces/commit/946348f7f8acc1ff7bc9cd0ab4c2602d41106f76) 