### PR TITLE
fixed unhandled promise rejection in case peer lookup fails

### DIFF
--- a/src/peer-routing.js
+++ b/src/peer-routing.js
@@ -110,7 +110,7 @@ class PeerRouting {
 
     const output = await pipe(
       merge(
-        ...this._routers.map(router => [router.findPeer(id, options)])
+        Promise.all(this._routers.map(async router => [await router.findPeer(id, options)]))
       ),
       (source) => filter(source, Boolean),
       // @ts-ignore findPeer resolves a Promise
@@ -140,7 +140,7 @@ class PeerRouting {
 
     yield * pipe(
       merge(
-        ...this._routers.map(router => router.getClosestPeers(key, options))
+        Promise.all(this._routers.map(router => router.getClosestPeers(key, options)))
       ),
       (source) => storeAddresses(source, this._peerStore),
       (source) => uniquePeers(source),


### PR DESCRIPTION
We noticed that in rare cases libp2p leaves unhandled rejected promises in the `findPeer` group of methods. This PR tries to fix them. It's not easily reproduced.