### PR TITLE
chore: fix examples

### DIFF
--- a/.github/workflows/examples.yml
+++ b/.github/workflows/examples.yml
@@ -12,6 +12,9 @@ jobs:
     runs-on: ubuntu-latest
     steps:
     - uses: actions/checkout@v2
+    - uses: actions/setup-node@v2
+      with:
+        node-version: 16
     - run: npm install
     - run: npx aegir lint
     - run: npx aegir ts -p check
@@ -21,82 +24,118 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@v2
+      - uses: actions/setup-node@v2
+        with:
+          node-version: 16
       - run: npm install
-      - run: cd examples && yarn && npm run test -- auto-relay
+      - run: cd examples && npm i && npm run test -- auto-relay
   test-chat-example:
     needs: check
     runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@v2
+      - uses: actions/setup-node@v2
+        with:
+          node-version: 16
       - run: npm install
-      - run: cd examples && yarn && npm run test -- chat
+      - run: cd examples && npm i && npm run test -- chat
   test-connection-encryption-example:
     needs: check
     runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@v2
+      - uses: actions/setup-node@v2
+        with:
+          node-version: 16
       - run: npm install
-      - run: cd examples && yarn && npm run test -- connection-encryption
+      - run: cd examples && npm i && npm run test -- connection-encryption
   test-discovery-mechanisms-example:
     needs: check
     runs-on: macos-latest
     steps:
       - uses: actions/checkout@v2
+      - uses: actions/setup-node@v2
+        with:
+          node-version: 16
       - run: npm install
-      - run: cd examples && yarn && npm run test -- discovery-mechanisms
+      - run: cd examples && npm i && npm run test -- discovery-mechanisms
   test-echo-example:
     needs: check
     runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@v2
+      - uses: actions/setup-node@v2
+        with:
+          node-version: 16
       - run: npm install
-      - run: cd examples && yarn && npm run test -- echo
+      - run: cd examples && npm i && npm run test -- echo
   test-libp2p-in-the-browser-example:
     needs: check
     runs-on: macos-latest
     steps:
       - uses: actions/checkout@v2
+      - uses: actions/setup-node@v2
+        with:
+          node-version: 16
       - run: npm install
-      - run: cd examples && yarn && npm run test -- libp2p-in-the-browser
+      - run: cd examples && npm i && npm run test -- libp2p-in-the-browser
   test-peer-and-content-routing-example:
     needs: check
     runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@v2
+      - uses: actions/setup-node@v2
+        with:
+            node-version: 16
       - run: npm install
-      - run: cd examples && yarn && npm run test -- peer-and-content-routing
+      - run: cd examples && npm i && npm run test -- peer-and-content-routing
   test-pnet-example:
     needs: check
     runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@v2
+      - uses: actions/setup-node@v2
+        with:
+            node-version: 16
       - run: npm install
-      - run: cd examples && yarn && npm run test -- pnet
+      - run: cd examples && npm i && npm run test -- pnet
   test-protocol-and-stream-muxing-example:
     needs: check
     runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@v2
+      - uses: actions/setup-node@v2
+        with:
+            node-version: 16
       - run: npm install
-      - run: cd examples && yarn && npm run test -- protocol-and-stream-muxing
+      - run: cd examples && npm i && npm run test -- protocol-and-stream-muxing
   test-pubsub-example:
     needs: check
     runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@v2
+      - uses: actions/setup-node@v2
+        with:
+            node-version: 16
       - run: npm install
-      - run: cd examples && yarn && npm run test -- pubsub
+      - run: cd examples && npm i && npm run test -- pubsub
   test-transports-example:
     needs: check
     runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@v2
+      - uses: actions/setup-node@v2
+        with:
+            node-version: 16
       - run: npm install
-      - run: cd examples && yarn && npm run test -- transports
+      - run: cd examples && npm i && npm run test -- transports
   test-webrtc-direct-example:
     needs: check
     runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@v2
-      - run: npm install
-      - run: cd examples && yarn && npm run test -- webrtc-direct
+      - uses: actions/setup-node@v2
+        with:
+            node-version: 16
+      - run: npm install -g @mapbox/node-pre-gyp && npm install
+      - run: cd examples && npm i && npm run test -- webrtc-direct


### PR DESCRIPTION
Uses npm to install deps for examples.

We can put yarn back when we remove `node-fetch@2.x` from ipfs-utils, or when
yarn can download tarball dependencies reliably.

This either needs:

1. https://github.com/node-fetch/node-fetch/pull/1172 merging
2. Swap node-fetch for undici
3. Drop CJS support (node-fetch 3 has the above fix but is ESM-only)