### PR TITLE
Libp2p.pubsub.subscribe returns void, remove await

### DIFF
--- a/examples/pubsub/1.js
+++ b/examples/pubsub/1.js
@@ -41,13 +41,13 @@ const createNode = async () => {
   node1.pubsub.on(topic, (msg) => {
     console.log(`node1 received: ${uint8ArrayToString(msg.data)}`)
   })
-  await node1.pubsub.subscribe(topic)
+  node1.pubsub.subscribe(topic)
 
   // Will not receive own published messages by default
   node2.pubsub.on(topic, (msg) => {
     console.log(`node2 received: ${uint8ArrayToString(msg.data)}`)
   })
-  await node2.pubsub.subscribe(topic)
+  node2.pubsub.subscribe(topic)
 
   // node2 publishes "news" every second
   setInterval(() => {


### PR DESCRIPTION
Seems like the correct return type of `Libp2p.pubsub.subscribe` is `void`, so the `await` can be removed: https://github.com/libp2p/js-libp2p/blob/ae21299ade9bcb2cf3fd00150c4389fbe3b24267/src/pubsub-adapter.js#L29