### PR TITLE
fix: remove peer routing search-for-self

### DIFF
--- a/doc/CONFIGURATION.md
+++ b/doc/CONFIGURATION.md
@@ -415,14 +415,7 @@ const node = await Libp2p.create({
     contentRouting: [delegatedContentRouting],
     peerRouting: [delegatedPeerRouting],
   },
-  peerId,
-  peerRouting: { // Peer routing configuration
-    refreshManager: { // Refresh known and connected closest peers
-      enabled: true, // Should find the closest peers.
-      interval: 6e5, // Interval for getting the new for closest peers of 10min
-      bootDelay: 10e3 // Delay for the initial query for closest peers
-    }
-  }
+  peerId
 })
 ```
 

--- a/package.json
+++ b/package.json
@@ -82,7 +82,6 @@
   "dependencies": {
     "@motrix/nat-api": "^0.3.1",
     "@vascosantos/moving-average": "^1.1.0",
-    "abort-controller": "^3.0.0",
     "abortable-iterator": "^3.0.0",
     "aggregate-error": "^3.1.0",
     "any-signal": "^2.1.1",
@@ -136,7 +135,6 @@
     "@chainsafe/libp2p-noise": "^4.0.0",
     "@nodeutils/defaults-deep": "^1.1.0",
     "@types/es6-promisify": "^6.0.0",
-    "@types/node": "^16.0.1",
     "@types/node-forge": "^0.10.1",
     "@types/varint": "^6.0.0",
     "aegir": "^36.0.0",

--- a/src/config.js
+++ b/src/config.js
@@ -49,24 +49,11 @@ const DefaultConfig = {
     persistence: false,
     threshold: 5
   },
-  peerRouting: {
-    refreshManager: {
-      enabled: true,
-      interval: 6e5,
-      bootDelay: 10e3
-    }
-  },
   config: {
     protocolPrefix: 'ipfs',
     dht: {
       enabled: false,
-      kBucketSize: 20,
-      randomWalk: {
-        enabled: false, // disabled waiting for https://github.com/libp2p/js-libp2p-kad-dht/issues/86
-        queriesPerPeriod: 1,
-        interval: 300e3,
-        timeout: 10e3
-      }
+      kBucketSize: 20
     },
     nat: {
       enabled: true,

--- a/src/dialer/dial-request.js
+++ b/src/dialer/dial-request.js
@@ -1,7 +1,6 @@
 'use strict'
 
 const errCode = require('err-code')
-const AbortController = require('abort-controller').default
 const { anySignal } = require('any-signal')
 // @ts-ignore p-fifo does not export types
 const FIFO = require('p-fifo')

--- a/src/index.js
+++ b/src/index.js
@@ -384,7 +384,6 @@ class Libp2p extends EventEmitter {
       this._isStarted = false
 
       this.relay && this.relay.stop()
-      this.peerRouting.stop()
       this._autodialler.stop()
       await (this._dht && this._dht.stop())
 
@@ -663,8 +662,6 @@ class Libp2p extends EventEmitter {
 
     // Relay
     this.relay && this.relay.start()
-
-    this.peerRouting.start()
   }
 
   /**

--- a/test/dialing/dial-request.spec.js
+++ b/test/dialing/dial-request.spec.js
@@ -5,7 +5,6 @@ const { expect } = require('aegir/utils/chai')
 const sinon = require('sinon')
 
 const { AbortError } = require('libp2p-interfaces/src/transport/errors')
-const AbortController = require('abort-controller')
 const AggregateError = require('aggregate-error')
 const pDefer = require('p-defer')
 const delay = require('delay')

--- a/test/ts-use/src/main.ts
+++ b/test/ts-use/src/main.ts
@@ -62,13 +62,6 @@ async function main() {
       contentRouting: [delegatedContentRouting],
       peerRouting: [delegatedPeerRouting]
     },
-    peerRouting: {
-      refreshManager: {
-        enabled: true,
-        interval: 1000,
-        bootDelay: 11111
-      }
-    },
     dialer: {
       maxParallelDials: 100,
       maxDialsPerPeer: 4,

--- a/test/utils/mockMultiaddrConn.js
+++ b/test/utils/mockMultiaddrConn.js
@@ -2,7 +2,6 @@
 
 const duplexPair = require('it-pair/duplex')
 const abortable = require('abortable-iterator')
-const AbortController = require('abort-controller')
 
 /**
  * Returns both sides of a mocked MultiaddrConnection


### PR DESCRIPTION
The peer routing module starts a recurring process that searches for
peers close to our peer id.

This makes the DHT module query the network for peers.  Thing is the
DHT module is already doing this because periodically searching for
peers close to us is in the DHT spec so this ends up making redundant
queries.

This PR removes the recurring task configured by the peer routing module.