### PR TITLE
chore: switch to nat api

### DIFF
--- a/package.json
+++ b/package.json
@@ -69,7 +69,7 @@
     "node": ">=15.0.0"
   },
   "browser": {
-    "@motrix/nat-api": false
+    "nat-api": false
   },
   "eslintConfig": {
     "extends": "ipfs",
@@ -80,7 +80,6 @@
     ]
   },
   "dependencies": {
-    "@motrix/nat-api": "^0.3.1",
     "@vascosantos/moving-average": "^1.1.0",
     "abort-controller": "^3.0.0",
     "abortable-iterator": "^3.0.0",
@@ -114,6 +113,7 @@
     "multiformats": "^9.0.0",
     "multistream-select": "^2.0.0",
     "mutable-proxy": "^1.0.0",
+    "nat-api": "^0.3.1",
     "node-forge": "^0.10.0",
     "p-any": "^3.0.0",
     "p-fifo": "^1.0.0",

--- a/src/nat-manager.js
+++ b/src/nat-manager.js
@@ -1,7 +1,7 @@
 'use strict'
 
 // @ts-ignore nat-api does not export types
-const NatAPI = require('@motrix/nat-api')
+const NatAPI = require('nat-api')
 const debug = require('debug')
 const { promisify } = require('es6-promisify')
 const { Multiaddr } = require('multiaddr')


### PR DESCRIPTION
@motrix/nat-api is a fork, nat-api has the fix from https://github.com/alxhotel/nat-api/pull/25