### PR TITLE
fix: clean up pending dial targets

### DIFF
--- a/src/dialer/index.js
+++ b/src/dialer/index.js
@@ -155,14 +155,16 @@ class Dialer {
       this._pendingDialTargets.set(id, { resolve, reject })
     })
 
-    const dialTarget = await Promise.race([
-      this._createDialTarget(peer),
-      cancellablePromise
-    ])
+    try {
+      const dialTarget = await Promise.race([
+        this._createDialTarget(peer),
+        cancellablePromise
+      ])
 
-    this._pendingDialTargets.delete(id)
-
-    return dialTarget
+      return dialTarget
+    } finally {
+      this._pendingDialTargets.delete(id)
+    }
   }
 
   /**


### PR DESCRIPTION
If the `Promise.race` throws, execution of the function is terminated so the pending dial target is never removed from the map and we leak memory.

This can happen when there are invalid multiaddrs or when a peer reports more dialable addresses than the threshold.

Instead wrap the `Promise.race` in a `try/finally` which will always remove the pending dial target in the event of success or failure.