### PR TITLE
feat: allow per-component metrics to be collected

### DIFF
--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -19,7 +19,7 @@ jobs:
     - run: npx aegir lint
     - run: npx aegir build
     - run: npx aegir dep-check
-    - uses: ipfs/aegir/actions/bundle-size@fix/use-node-16-for-bundle-size
+    - uses: ipfs/aegir/actions/bundle-size
       name: size
       with:
         github_token: ${{ secrets.GITHUB_TOKEN }}

--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -19,7 +19,7 @@ jobs:
     - run: npx aegir lint
     - run: npx aegir build
     - run: npx aegir dep-check
-    - uses: ipfs/aegir/actions/bundle-size@v32.1.0
+    - uses: ipfs/aegir/actions/bundle-size@fix/use-node-16-for-bundle-size
       name: size
       with:
         github_token: ${{ secrets.GITHUB_TOKEN }}

--- a/src/connection-manager/index.js
+++ b/src/connection-manager/index.js
@@ -166,8 +166,8 @@ class ConnectionManager extends EventEmitter {
 
     await Promise.all(tasks)
     this.connections.clear()
-    this._metrics && this._metrics.updateMetric(METRICS_COMPONENT, METRICS_PEER_CONNECTIONS, 0)
-    this._metrics && this._metrics.updateMetric(METRICS_COMPONENT, METRICS_ALL_CONNECTIONS, 0)
+    this._metrics && this._metrics.updateComponentMetric(METRICS_COMPONENT, METRICS_PEER_CONNECTIONS, 0)
+    this._metrics && this._metrics.updateComponentMetric(METRICS_COMPONENT, METRICS_ALL_CONNECTIONS, 0)
   }
 
   /**
@@ -223,8 +223,8 @@ class ConnectionManager extends EventEmitter {
       storedConn.push(connection)
     } else {
       this.connections.set(peerIdStr, [connection])
-      this._metrics && this._metrics.updateMetric(METRICS_COMPONENT, METRICS_PEER_CONNECTIONS, this.connections.size)
-      this._metrics && this._metrics.updateMetric(METRICS_COMPONENT, METRICS_ALL_CONNECTIONS, this.size)
+      this._metrics && this._metrics.updateComponentMetric(METRICS_COMPONENT, METRICS_PEER_CONNECTIONS, this.connections.size)
+      this._metrics && this._metrics.updateComponentMetric(METRICS_COMPONENT, METRICS_ALL_CONNECTIONS, this.size)
     }
 
     this._libp2p.peerStore.keyBook.set(peerId, peerId.pubKey)
@@ -255,8 +255,8 @@ class ConnectionManager extends EventEmitter {
       this.emit('peer:disconnect', connection)
     }
 
-    this._metrics && this._metrics.updateMetric(METRICS_COMPONENT, METRICS_PEER_CONNECTIONS, this.connections.size)
-    this._metrics && this._metrics.updateMetric(METRICS_COMPONENT, METRICS_ALL_CONNECTIONS, this.size)
+    this._metrics && this._metrics.updateComponentMetric(METRICS_COMPONENT, METRICS_PEER_CONNECTIONS, this.connections.size)
+    this._metrics && this._metrics.updateComponentMetric(METRICS_COMPONENT, METRICS_ALL_CONNECTIONS, this.size)
   }
 
   /**

--- a/src/dialer/index.js
+++ b/src/dialer/index.js
@@ -112,8 +112,8 @@ class Dialer {
     }
     this._pendingDialTargets.clear()
 
-    this._metrics && this._metrics.updateMetric(METRICS_COMPONENT, METRICS_PENDING_DIALS, 0)
-    this._metrics && this._metrics.updateMetric(METRICS_COMPONENT, METRICS_PENDING_DIAL_TARGETS, 0)
+    this._metrics && this._metrics.updateComponentMetric(METRICS_COMPONENT, METRICS_PENDING_DIALS, 0)
+    this._metrics && this._metrics.updateComponentMetric(METRICS_COMPONENT, METRICS_PENDING_DIAL_TARGETS, 0)
   }
 
   /**
@@ -163,7 +163,7 @@ class Dialer {
     const id = `${(parseInt(String(Math.random() * 1e9), 10)).toString() + Date.now()}`
     const cancellablePromise = new Promise((resolve, reject) => {
       this._pendingDialTargets.set(id, { resolve, reject })
-      this._metrics && this._metrics.updateMetric(METRICS_COMPONENT, METRICS_PENDING_DIAL_TARGETS, this._pendingDialTargets.size)
+      this._metrics && this._metrics.updateComponentMetric(METRICS_COMPONENT, METRICS_PENDING_DIAL_TARGETS, this._pendingDialTargets.size)
     })
 
     try {
@@ -175,7 +175,7 @@ class Dialer {
       return dialTarget
     } finally {
       this._pendingDialTargets.delete(id)
-      this._metrics && this._metrics.updateMetric(METRICS_COMPONENT, METRICS_PENDING_DIAL_TARGETS, this._pendingDialTargets.size)
+      this._metrics && this._metrics.updateComponentMetric(METRICS_COMPONENT, METRICS_PENDING_DIAL_TARGETS, this._pendingDialTargets.size)
     }
   }
 
@@ -264,12 +264,12 @@ class Dialer {
       destroy: () => {
         timeoutController.clear()
         this._pendingDials.delete(dialTarget.id)
-        this._metrics && this._metrics.updateMetric(METRICS_COMPONENT, METRICS_PENDING_DIALS, this._pendingDials.size)
+        this._metrics && this._metrics.updateComponentMetric(METRICS_COMPONENT, METRICS_PENDING_DIALS, this._pendingDials.size)
       }
     }
     this._pendingDials.set(dialTarget.id, pendingDial)
 
-    this._metrics && this._metrics.updateMetric(METRICS_COMPONENT, METRICS_PENDING_DIALS, this._pendingDials.size)
+    this._metrics && this._metrics.updateComponentMetric(METRICS_COMPONENT, METRICS_PENDING_DIALS, this._pendingDials.size)
 
     return pendingDial
   }

--- a/src/index.js
+++ b/src/index.js
@@ -197,10 +197,16 @@ class Libp2p extends EventEmitter {
 
     // Create Metrics
     if (this._options.metrics.enabled) {
-      this.metrics = new Metrics({
-        ...this._options.metrics,
-        connectionManager: this.connectionManager
+      const metrics = new Metrics({
+        ...this._options.metrics
       })
+
+      // listen for peer disconnect events
+      this.connectionManager.on('peer:disconnect', (connection) => {
+        metrics.onPeerDisconnected(connection.remotePeer)
+      })
+
+      this.metrics = metrics
     }
 
     // Create keychain
@@ -262,6 +268,7 @@ class Libp2p extends EventEmitter {
     this.dialer = new Dialer({
       transportManager: this.transportManager,
       peerStore: this.peerStore,
+      metrics: this.metrics,
       ...this._options.dialer
     })
 

--- a/src/index.js
+++ b/src/index.js
@@ -201,11 +201,6 @@ class Libp2p extends EventEmitter {
         ...this._options.metrics
       })
 
-      // listen for peer disconnect events
-      this.connectionManager.on('peer:disconnect', (connection) => {
-        metrics.onPeerDisconnected(connection.remotePeer)
-      })
-
       this.metrics = metrics
     }
 

--- a/src/metrics/index.js
+++ b/src/metrics/index.js
@@ -95,7 +95,7 @@ class Metrics {
     return this._componentMetrics
   }
 
-  updateMetric (component, metric, value) {
+  updateComponentMetric (component, metric, value) {
     if (!this._componentMetrics.has(component)) {
       this._componentMetrics.set(component, new Map())
     }

--- a/src/metrics/index.js
+++ b/src/metrics/index.js
@@ -24,9 +24,6 @@ const directionToEvent = {
  */
 
 /**
- * @typedef MetricsProperties
- * @property {import('../connection-manager')} connectionManager
- *
  * @typedef MetricsOptions
  * @property {number} [computeThrottleMaxQueueSize = defaultOptions.computeThrottleMaxQueueSize]
  * @property {number} [computeThrottleTimeout = defaultOptions.computeThrottleTimeout]
@@ -37,7 +34,7 @@ const directionToEvent = {
 class Metrics {
   /**
    * @class
-   * @param {MetricsProperties & MetricsOptions} options
+   * @param {MetricsOptions} options
    */
   constructor (options) {
     this._options = mergeOptions(defaultOptions, options)
@@ -47,10 +44,7 @@ class Metrics {
     this._oldPeers = oldPeerLRU(this._options.maxOldPeersRetention)
     this._running = false
     this._onMessage = this._onMessage.bind(this)
-    this._connectionManager = options.connectionManager
-    this._connectionManager.on('peer:disconnect', (connection) => {
-      this.onPeerDisconnected(connection.remotePeer)
-    })
+    this._componentMetrics = new Map()
   }
 
   /**
@@ -92,6 +86,22 @@ class Metrics {
    */
   get peers () {
     return Array.from(this._peerStats.keys())
+  }
+
+  /**
+   * @returns {Map}
+   */
+  getComponentMetrics () {
+    return this._componentMetrics
+  }
+
+  updateMetric (component, metric, value) {
+    if (!this._componentMetrics.has(component)) {
+      this._componentMetrics.set(component, new Map())
+    }
+
+    const map = this._componentMetrics.get(component)
+    map.set(metric, value)
   }
 
   /**

--- a/test/metrics/index.spec.js
+++ b/test/metrics/index.spec.js
@@ -3,9 +3,6 @@
 
 const { expect } = require('aegir/utils/chai')
 const sinon = require('sinon')
-
-const { EventEmitter } = require('events')
-
 const { randomBytes } = require('libp2p-crypto')
 const duplexPair = require('it-pair/duplex')
 const pipe = require('it-pipe')
@@ -34,8 +31,7 @@ describe('Metrics', () => {
     const [local, remote] = duplexPair()
     const metrics = new Metrics({
       computeThrottleMaxQueueSize: 1, // compute after every message
-      movingAverageIntervals: [10, 100, 1000],
-      connectionManager: new EventEmitter()
+      movingAverageIntervals: [10, 100, 1000]
     })
 
     metrics.trackStream({
@@ -70,8 +66,7 @@ describe('Metrics', () => {
     const [local, remote] = duplexPair()
     const metrics = new Metrics({
       computeThrottleMaxQueueSize: 1, // compute after every message
-      movingAverageIntervals: [10, 100, 1000],
-      connectionManager: new EventEmitter()
+      movingAverageIntervals: [10, 100, 1000]
     })
 
     metrics.trackStream({
@@ -119,8 +114,7 @@ describe('Metrics', () => {
     const [local2, remote2] = duplexPair()
     const metrics = new Metrics({
       computeThrottleMaxQueueSize: 1, // compute after every message
-      movingAverageIntervals: [10, 100, 1000],
-      connectionManager: new EventEmitter()
+      movingAverageIntervals: [10, 100, 1000]
     })
     const protocol = '/echo/1.0.0'
     metrics.start()
@@ -175,8 +169,7 @@ describe('Metrics', () => {
     const [local, remote] = duplexPair()
     const metrics = new Metrics({
       computeThrottleMaxQueueSize: 1, // compute after every message
-      movingAverageIntervals: [10, 100, 1000],
-      connectionManager: new EventEmitter()
+      movingAverageIntervals: [10, 100, 1000]
     })
     metrics.start()
 
@@ -231,8 +224,7 @@ describe('Metrics', () => {
     }))
 
     const metrics = new Metrics({
-      maxOldPeersRetention: 5, // Only keep track of 5
-      connectionManager: new EventEmitter()
+      maxOldPeersRetention: 5 // Only keep track of 5
     })
 
     // Clone so trackedPeers isn't modified
@@ -261,5 +253,23 @@ describe('Metrics', () => {
     for (const spy of spies) {
       expect(spy).to.have.property('callCount', 1)
     }
+  })
+
+  it('should allow components to track metrics', () => {
+    const metrics = new Metrics({
+      maxOldPeersRetention: 5 // Only keep track of 5
+    })
+
+    expect(metrics.getComponentMetrics()).to.be.empty()
+
+    const component = 'my-component'
+    const metric = 'some-metric'
+    const value = 1
+
+    metrics.updateMetric(component, metric, value)
+
+    expect(metrics.getComponentMetrics()).to.have.lengthOf(1)
+    expect(metrics.getComponentMetrics().get(component)).to.have.lengthOf(1)
+    expect(metrics.getComponentMetrics().get(component).get(metric)).to.equal(value)
   })
 })

--- a/test/metrics/index.spec.js
+++ b/test/metrics/index.spec.js
@@ -266,7 +266,7 @@ describe('Metrics', () => {
     const metric = 'some-metric'
     const value = 1
 
-    metrics.updateMetric(component, metric, value)
+    metrics.updateComponentMetric(component, metric, value)
 
     expect(metrics.getComponentMetrics()).to.have.lengthOf(1)
     expect(metrics.getComponentMetrics().get(component)).to.have.lengthOf(1)


### PR DESCRIPTION
Implements the idea from #1060 - allows us to get some insight into what's happening in a libp2p node out side of just bandwidth stats.

Configures a few default metrics if metrics are enabled - current connections, the state of the dial queue, etc.

Also makes the `Metrics` class not depend on the `ConnectionManager` class, otherwise we can't collect simple metrics from the connection manager class due to the circular dependency.