### PR TITLE
fix: increase the maxlisteners for timeout controllers

### DIFF
--- a/src/dialer/index.js
+++ b/src/dialer/index.js
@@ -9,7 +9,8 @@ const { Multiaddr } = require('multiaddr')
 const { TimeoutController } = require('timeout-abort-controller')
 const { AbortError } = require('abortable-iterator')
 const { anySignal } = require('any-signal')
-
+// @ts-expect-error setMaxListeners is missing from the types
+const { setMaxListeners } = require('events')
 const DialRequest = require('./dial-request')
 const { publicAddressesFirst } = require('libp2p-utils/src/address-sort')
 const getPeer = require('../get-peer')
@@ -253,6 +254,10 @@ class Dialer {
 
     // Combine the timeout signal and options.signal, if provided
     const timeoutController = new TimeoutController(this.timeout)
+    // this controller will potentially be used while dialing lots of
+    // peers so prevent MaxListenersExceededWarning appearing in the console
+    setMaxListeners && setMaxListeners(Infinity, timeoutController.signal)
+
     const signals = [timeoutController.signal]
     options.signal && signals.push(options.signal)
     const signal = anySignal(signals)

--- a/src/peer-routing.js
+++ b/src/peer-routing.js
@@ -151,7 +151,7 @@ class PeerRouting {
     }
 
     if (options.timeout) {
-      const controller = new TimeoutController(options.timeout).signal
+      const controller = new TimeoutController(options.timeout)
       // this controller will potentially be used while dialing lots of
       // peers so prevent MaxListenersExceededWarning appearing in the console
       setMaxListeners && setMaxListeners(Infinity, controller.signal)


### PR DESCRIPTION
We use timeout controllers to ensure we're not dialling peers forever but we can end up registering lots of listeners for the `abort` event when peers have a lot of addresses.

In node this means we see an unhelpful `MaxListenersExceededWarning` in the console warning of a potential memory leak.

Increase the max number of listeners on the signal to silence the warning.