### PR TITLE
fix: add tracked map

### DIFF
--- a/src/index.js
+++ b/src/index.js
@@ -161,6 +161,15 @@ class Libp2p extends EventEmitter {
     this.peerId = this._options.peerId
     this.datastore = this._options.datastore
 
+    // Create Metrics
+    if (this._options.metrics.enabled) {
+      const metrics = new Metrics({
+        ...this._options.metrics
+      })
+
+      this.metrics = metrics
+    }
+
     this.peerStore = (this.datastore && this._options.peerStore.persistence)
       ? new PersistentPeerStore({
         peerId: this.peerId,
@@ -194,15 +203,6 @@ class Libp2p extends EventEmitter {
       minConnections: this._options.connectionManager.minConnections,
       autoDialInterval: this._options.connectionManager.autoDialInterval
     })
-
-    // Create Metrics
-    if (this._options.metrics.enabled) {
-      const metrics = new Metrics({
-        ...this._options.metrics
-      })
-
-      this.metrics = metrics
-    }
 
     // Create keychain
     if (this._options.keychain && this._options.keychain.datastore) {

--- a/src/metrics/tracked-map.js
+++ b/src/metrics/tracked-map.js
@@ -1,0 +1,65 @@
+
+/**
+ * @template K
+ * @template V
+ */
+class TrackedMap extends Map {
+  /**
+   * @param {string} component
+   * @param {string} name
+   * @param {import('.')} metrics
+   */
+  constructor (component, name, metrics) {
+    super()
+
+    this._component = component
+    this._name = name
+    this._metrics = metrics
+
+    this._metrics.updateComponentMetric(this._component, this._name, this.size)
+  }
+
+  get size () {
+    return super.size
+  }
+
+  /**
+   * @param {K} key
+   * @param {V} value
+   */
+  set (key, value) {
+    super.set(key, value)
+    this._metrics.updateComponentMetric(this._component, this._name, this.size)
+    return this
+  }
+
+  /**
+   * @param {K} key
+   */
+  delete (key) {
+    const deleted = super.delete(key)
+    this._metrics.updateComponentMetric(this._component, this._name, this.size)
+    return deleted
+  }
+}
+
+/**
+  * @template K
+  * @template V
+  * @param {string} component
+  * @param {string} name
+  * @param {import('.')} [metrics]
+  * @returns {Map<K, V>}
+  */
+module.exports = (component, name, metrics) => {
+  /** @type {Map<K, V>} */
+  let map
+
+  if (metrics) {
+    map = new TrackedMap(component, name, metrics)
+  } else {
+    map = new Map()
+  }
+
+  return map
+}

--- a/src/metrics/tracked-map.js
+++ b/src/metrics/tracked-map.js
@@ -1,3 +1,4 @@
+'use strict'
 
 /**
  * @template K
@@ -40,13 +41,13 @@ class TrackedMap extends Map {
 }
 
 /**
-  * @template K
-  * @template V
-  * @param {string} component
-  * @param {string} name
-  * @param {import('.')} [metrics]
-  * @returns {Map<K, V>}
-  */
+ * @template K
+ * @template V
+ * @param {string} component
+ * @param {string} name
+ * @param {import('.')} [metrics]
+ * @returns {Map<K, V>}
+ */
 module.exports = (component, name, metrics) => {
   /** @type {Map<K, V>} */
   let map

--- a/src/metrics/tracked-map.js
+++ b/src/metrics/tracked-map.js
@@ -19,10 +19,6 @@ class TrackedMap extends Map {
     this._metrics.updateComponentMetric(this._component, this._name, this.size)
   }
 
-  get size () {
-    return super.size
-  }
-
   /**
    * @param {K} key
    * @param {V} value


### PR DESCRIPTION
Small refactor of the component stats - adds a `TrackedMap` which encapsulates updating the metrics and means we don't need to null guard on `this._metrics` everywhere.

If metrics are not enabled a regular `Map` is used.