### PR TITLE
fix: main ci workflow

### DIFF
--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -19,7 +19,7 @@ jobs:
     - run: npx aegir lint
     - run: npx aegir build
     - run: npx aegir dep-check
-    - uses: ipfs/aegir/actions/bundle-size
+    - uses: ipfs/aegir/actions/bundle-size@master
       name: size
       with:
         github_token: ${{ secrets.GITHUB_TOKEN }}


### PR DESCRIPTION
On https://github.com/libp2p/js-libp2p/pull/1061 the bundle size was changed and the main CI workflow has not been running. It must include the branch/version