### PR TITLE
fix: record tracked map clears

### DIFF
--- a/src/metrics/tracked-map.js
+++ b/src/metrics/tracked-map.js
@@ -38,6 +38,12 @@ class TrackedMap extends Map {
     this._metrics.updateComponentMetric(this._component, this._name, this.size)
     return deleted
   }
+
+  clear () {
+    super.clear()
+
+    this._metrics.updateComponentMetric(this._component, this._name, this.size)
+  }
 }
 
 /**


### PR DESCRIPTION
Record the size of a map after we `.clear()` it.