### PR TITLE
fix: do not wait for autodial start

### DIFF
--- a/src/connection-manager/auto-dialler.js
+++ b/src/connection-manager/auto-dialler.js
@@ -57,7 +57,9 @@ class AutoDialler {
     }
 
     this._running = true
-    this._autoDial()
+    this._autoDial().catch(err => {
+      log.error('could start autodial', err)
+    })
     log('started')
   }
 


### PR DESCRIPTION
When we've previously seen loads of peers and stored them in the
datastore we'll try to dial them as part of starting the autodial
component.

If we or our peers have bad network connections this can make
starting a libp2p node take ages so don't wait for a round of auto
dialing before considering the component started.