### PR TITLE
fix: look for final peer event instead of peer response

### DIFF
--- a/src/dht/dht-peer-routing.js
+++ b/src/dht/dht-peer-routing.js
@@ -27,12 +27,8 @@ class DHTPeerRouting {
    */
   async findPeer (peerId, options = {}) {
     for await (const event of this._dht.findPeer(peerId, options)) {
-      if (event.name === 'PEER_RESPONSE') {
-        const peer = event.closer.find(peerData => peerData.id.equals(peerId))
-
-        if (peer) {
-          return peer
-        }
+      if (event.name === 'FINAL_PEER') {
+        return event.peer
       }
     }
 


### PR DESCRIPTION
`FINAL_PEER` means we found the peer, `PEER_RESPONSE` means a peer
responded to our query.