### PR TITLE
fix: remove abort-controller dep

### DIFF
--- a/package.json
+++ b/package.json
@@ -81,7 +81,6 @@
   },
   "dependencies": {
     "@vascosantos/moving-average": "^1.1.0",
-    "abort-controller": "^3.0.0",
     "abortable-iterator": "^3.0.0",
     "aggregate-error": "^3.1.0",
     "any-signal": "^2.1.1",

--- a/test/dialing/dial-request.spec.js
+++ b/test/dialing/dial-request.spec.js
@@ -5,7 +5,6 @@ const { expect } = require('aegir/utils/chai')
 const sinon = require('sinon')
 
 const { AbortError } = require('libp2p-interfaces/src/transport/errors')
-const AbortController = require('abort-controller')
 const AggregateError = require('aggregate-error')
 const pDefer = require('p-defer')
 const delay = require('delay')

--- a/test/utils/mockMultiaddrConn.js
+++ b/test/utils/mockMultiaddrConn.js
@@ -2,7 +2,6 @@
 
 const duplexPair = require('it-pair/duplex')
 const abortable = require('abortable-iterator')
-const AbortController = require('abort-controller')
 
 /**
  * Returns both sides of a mocked MultiaddrConnection


### PR DESCRIPTION
The `AbortController` class is supported by browsers and node 14+ - we only support node 16+ (e.g. LTS+Current) so the `abort-controller` module isn't needed any more.