### PR TITLE
chore: remove pubsub dev deps

### DIFF
--- a/package.json
+++ b/package.json
@@ -152,8 +152,6 @@
     "libp2p-bootstrap": "^0.14.0",
     "libp2p-delegated-content-routing": "^0.11.0",
     "libp2p-delegated-peer-routing": "^0.11.1",
-    "libp2p-floodsub": "^0.28.0",
-    "libp2p-gossipsub": "^0.12.1",
     "libp2p-interfaces-compliance-tests": "^2.0.1",
     "libp2p-interop": "^0.6.0",
     "libp2p-kad-dht": "^0.27.1",


### PR DESCRIPTION
We don't need them anymore as we changed testing setup per https://github.com/libp2p/js-libp2p/issues/857