### PR TITLE
chore: autopublish next version

### DIFF
--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -114,7 +114,6 @@ jobs:
       - uses: actions/setup-node@v2
         with:
           node-version: lts/*
-          registry-url: 'https://registry.npmjs.org'
         if: ${{ steps.release.outputs.release_created }}
       - uses: ipfs/aegir/actions/cache-node-modules@master
         if: ${{ steps.release.outputs.release_created }}
@@ -122,3 +121,9 @@ jobs:
         env:
           NODE_AUTH_TOKEN: ${{secrets.NPM_TOKEN}}
         if: ${{ steps.release.outputs.release_created }}
+      - run: |
+            npm version `node -p -e "require('./package.json').version"`-`git rev-parse --short HEAD` --no-git-tag-version
+            npm publish --tag next
+        env:
+          NODE_AUTH_TOKEN: ${{secrets.NPM_TOKEN}}
+        if: ${{ !steps.release.outputs.release_created }}


### PR DESCRIPTION
If we aren't releasing a version on a given release run, publish an rc under the `next` tag instead.