### PR TITLE
fix: await unhandle of protocols

### DIFF
--- a/src/ping/index.js
+++ b/src/ping/index.js
@@ -22,64 +22,63 @@ const { PROTOCOL_NAME, PING_LENGTH, PROTOCOL_VERSION } = require('./constants')
  * @typedef {import('libp2p-interfaces/src/stream-muxer/types').MuxedStream} MuxedStream
  */
 
-/**
- * Ping a given peer and wait for its response, getting the operation latency.
- *
- * @param {Libp2p} node
- * @param {PeerId|Multiaddr} peer
- * @returns {Promise<number>}
- */
-async function ping (node, peer) {
-  const protocol = `/${node._config.protocolPrefix}/${PROTOCOL_NAME}/${PROTOCOL_VERSION}`
-  // @ts-ignore multiaddr might not have toB58String
-  log('dialing %s to %s', protocol, peer.toB58String ? peer.toB58String() : peer)
-
-  const connection = await node.dial(peer)
-  const { stream } = await connection.newStream(protocol)
-
-  const start = Date.now()
-  const data = crypto.randomBytes(PING_LENGTH)
-
-  const [result] = await pipe(
-    [data],
-    stream,
-    (/** @type {MuxedStream} */ stream) => take(1, stream),
-    toBuffer,
-    collect
-  )
-  const end = Date.now()
-
-  if (!equals(data, result)) {
-    throw errCode(new Error('Received wrong ping ack'), codes.ERR_WRONG_PING_ACK)
+class PingService {
+  /**
+   * @param {import('../')} libp2p
+   */
+  static getProtocolStr (libp2p) {
+    return `/${libp2p._config.protocolPrefix}/${PROTOCOL_NAME}/${PROTOCOL_VERSION}`
   }
 
-  return end - start
+  /**
+   * @param {Libp2p} libp2p
+   */
+  constructor (libp2p) {
+    this._libp2p = libp2p
+  }
+
+  /**
+   * A handler to register with Libp2p to process ping messages
+   *
+   * @param {Object} options
+   * @param {MuxedStream} options.stream
+   */
+  handleMessage ({ stream }) {
+    return pipe(stream, stream)
+  }
+
+  /**
+   * Ping a given peer and wait for its response, getting the operation latency.
+   *
+   * @param {PeerId|Multiaddr} peer
+   * @returns {Promise<number>}
+   */
+  async ping (peer) {
+    const protocol = `/${this._libp2p._config.protocolPrefix}/${PROTOCOL_NAME}/${PROTOCOL_VERSION}`
+    // @ts-ignore multiaddr might not have toB58String
+    log('dialing %s to %s', protocol, peer.toB58String ? peer.toB58String() : peer)
+
+    const connection = await this._libp2p.dial(peer)
+    const { stream } = await connection.newStream(protocol)
+
+    const start = Date.now()
+    const data = crypto.randomBytes(PING_LENGTH)
+
+    const [result] = await pipe(
+      [data],
+      stream,
+      (/** @type {MuxedStream} */ stream) => take(1, stream),
+      toBuffer,
+      collect
+    )
+    const end = Date.now()
+
+    if (!equals(data, result)) {
+      throw errCode(new Error('Received wrong ping ack'), codes.ERR_WRONG_PING_ACK)
+    }
+
+    return end - start
+  }
 }
 
-/**
- * Subscribe ping protocol handler.
- *
- * @param {Libp2p} node
- */
-function mount (node) {
-  node.handle(`/${node._config.protocolPrefix}/${PROTOCOL_NAME}/${PROTOCOL_VERSION}`, ({ stream }) => pipe(stream, stream))
-    .catch(err => {
-      log.error(err)
-    })
-}
-
-/**
- * Unsubscribe ping protocol handler.
- *
- * @param {Libp2p} node
- */
-function unmount (node) {
-  node.unhandle(`/${node._config.protocolPrefix}/${PROTOCOL_NAME}/${PROTOCOL_VERSION}`)
-    .catch(err => {
-      log.error(err)
-    })
-}
-
-exports = module.exports = ping
-exports.mount = mount
-exports.unmount = unmount
+module.exports = PingService

--- a/test/upgrading/upgrader.spec.js
+++ b/test/upgrading/upgrader.spec.js
@@ -371,7 +371,7 @@ describe('libp2p.upgrader', () => {
     expect(libp2p.upgrader).to.equal(libp2p.transportManager.upgrader)
   })
 
-  it('should be able to register and unregister a handler', () => {
+  it('should be able to register and unregister a handler', async () => {
     libp2p = new Libp2p({
       peerId: peers[0],
       modules: {
@@ -384,11 +384,11 @@ describe('libp2p.upgrader', () => {
     expect(libp2p.upgrader.protocols).to.not.have.any.keys(['/echo/1.0.0', '/echo/1.0.1'])
 
     const echoHandler = () => {}
-    libp2p.handle(['/echo/1.0.0', '/echo/1.0.1'], echoHandler)
+    await libp2p.handle(['/echo/1.0.0', '/echo/1.0.1'], echoHandler)
     expect(libp2p.upgrader.protocols.get('/echo/1.0.0')).to.equal(echoHandler)
     expect(libp2p.upgrader.protocols.get('/echo/1.0.1')).to.equal(echoHandler)
 
-    libp2p.unhandle(['/echo/1.0.0'])
+    await libp2p.unhandle(['/echo/1.0.0'])
     expect(libp2p.upgrader.protocols.get('/echo/1.0.0')).to.equal(undefined)
     expect(libp2p.upgrader.protocols.get('/echo/1.0.1')).to.equal(echoHandler)
   })


### PR DESCRIPTION
To allow us to shut down cleanly, we must wait the unhandling of protocols - this is because they write the new list of protocols into the datastore which might also be in the process of shutting down.