### PR TITLE
fix: emit peer:connect after all

### DIFF
--- a/package.json
+++ b/package.json
@@ -135,6 +135,8 @@
     "it-stream-types": "^1.0.4",
     "it-take": "^1.0.2",
     "it-to-buffer": "^2.0.2",
+    "@libp2p/tracked-map": "^1.0.4",
+    "it-pair": "^2.0.2",
     "merge-options": "^3.0.4",
     "mortice": "^3.0.0",
     "multiformats": "^9.6.3",

--- a/src/connection-manager/index.ts
+++ b/src/connection-manager/index.ts
@@ -267,8 +267,6 @@ export class DefaultConnectionManager extends EventEmitter<ConnectionManagerEven
     const peerIdStr = peerId.toString()
     const storedConns = this.connections.get(peerIdStr)
 
-    this.dispatchEvent(new CustomEvent<Connection>('peer:connect', { detail: connection }))
-
     if (storedConns != null) {
       storedConns.push(connection)
     } else {
@@ -284,6 +282,7 @@ export class DefaultConnectionManager extends EventEmitter<ConnectionManagerEven
     }
 
     await this._checkMaxLimit('maxConnections', this.getConnectionList().length)
+    this.dispatchEvent(new CustomEvent<Connection>('peer:connect', { detail: connection }))
   }
 
   /**

--- a/test/dialing/direct.spec.ts
+++ b/test/dialing/direct.spec.ts
@@ -434,11 +434,9 @@ describe('libp2p.dialer (direct, WebSockets)', () => {
 
     await libp2p.start()
 
-    libp2p.components.getUpgrader().addEventListener('connection', () => {
+    libp2p.connectionManager.addEventListener('peer:connect', () => {
       connectionPromise.resolve()
-    }, {
-      once: true
-    })
+    }, { once: true })
 
     const connection = await libp2p.dial(MULTIADDRS_WEBSOCKETS[0])
     expect(connection).to.exist()

--- a/test/identify/index.spec.ts
+++ b/test/identify/index.spec.ts
@@ -34,7 +34,6 @@ import { peerIdFromString } from '@libp2p/peer-id'
 import type { PeerId } from '@libp2p/interfaces/peer-id'
 import type { Libp2pNode } from '../../src/libp2p.js'
 import { pEvent } from 'p-event'
-import pDefer from 'p-defer'
 
 const listenMaddrs = [new Multiaddr('/ip4/127.0.0.1/tcp/15002/ws')]
 
@@ -527,15 +526,12 @@ describe('Identify', () => {
 
       const identityServiceIdentifySpy = sinon.spy(libp2p.identifyService, 'identify')
       const identityServicePushSpy = sinon.spy(libp2p.identifyService, 'push')
-      const connectionPromise = pDefer()
-      libp2p.connectionManager.addEventListener('peer:connect', () => {
-        connectionPromise.resolve()
-      }, { once: true })
+      const connectionPromise = pEvent(libp2p.connectionManager, 'peer:connect')
       const connection = await libp2p.dial(remoteAddr)
 
       expect(connection).to.exist()
       // Wait for connection event to be emitted
-      await connectionPromise.promise
+      await connectionPromise
 
       // Wait for identify to finish
       await identityServiceIdentifySpy.firstCall.returnValue
@@ -597,15 +593,12 @@ describe('Identify', () => {
 
       const identityServiceIdentifySpy = sinon.spy(libp2p.identifyService, 'identify')
       const identityServicePushSpy = sinon.spy(libp2p.identifyService, 'push')
-      const connectionPromise = pDefer()
-      libp2p.connectionManager.addEventListener('peer:connect', () => {
-        connectionPromise.resolve()
-      }, { once: true })
+      const connectionPromise = pEvent(libp2p.connectionManager, 'peer:connect')
       const connection = await libp2p.dial(remoteAddr)
 
       expect(connection).to.exist()
       // Wait for connection event to be emitted
-      await connectionPromise.promise
+      await connectionPromise
 
       // Wait for identify to finish
       await identityServiceIdentifySpy.firstCall.returnValue

--- a/test/identify/index.spec.ts
+++ b/test/identify/index.spec.ts
@@ -34,6 +34,7 @@ import { peerIdFromString } from '@libp2p/peer-id'
 import type { PeerId } from '@libp2p/interfaces/peer-id'
 import type { Libp2pNode } from '../../src/libp2p.js'
 import { pEvent } from 'p-event'
+import pDefer from 'p-defer'
 
 const listenMaddrs = [new Multiaddr('/ip4/127.0.0.1/tcp/15002/ws')]
 
@@ -526,9 +527,15 @@ describe('Identify', () => {
 
       const identityServiceIdentifySpy = sinon.spy(libp2p.identifyService, 'identify')
       const identityServicePushSpy = sinon.spy(libp2p.identifyService, 'push')
-
+      const connectionPromise = pDefer()
+      libp2p.connectionManager.addEventListener('peer:connect', () => {
+        connectionPromise.resolve()
+      }, { once: true })
       const connection = await libp2p.dial(remoteAddr)
+
       expect(connection).to.exist()
+      // Wait for connection event to be emitted
+      await connectionPromise.promise
 
       // Wait for identify to finish
       await identityServiceIdentifySpy.firstCall.returnValue
@@ -590,9 +597,15 @@ describe('Identify', () => {
 
       const identityServiceIdentifySpy = sinon.spy(libp2p.identifyService, 'identify')
       const identityServicePushSpy = sinon.spy(libp2p.identifyService, 'push')
-
+      const connectionPromise = pDefer()
+      libp2p.connectionManager.addEventListener('peer:connect', () => {
+        connectionPromise.resolve()
+      }, { once: true })
       const connection = await libp2p.dial(remoteAddr)
+
       expect(connection).to.exist()
+      // Wait for connection event to be emitted
+      await connectionPromise.promise
 
       // Wait for identify to finish
       await identityServiceIdentifySpy.firstCall.returnValue

--- a/test/upgrading/upgrader.spec.ts
+++ b/test/upgrading/upgrader.spec.ts
@@ -499,6 +499,13 @@ describe('libp2p.upgrader', () => {
       libp2p.components.getUpgrader().upgradeOutbound(outbound),
       remoteLibp2p.components.getUpgrader().upgradeInbound(inbound)
     ])
+    await new Promise<void>((resolve, reject) => {
+      const t = setTimeout(reject, 1000)
+      libp2p.connectionManager.addEventListener('peer:connect', () => {
+        clearTimeout(t)
+        resolve()
+      }, { once: true })
+    })
     expect(connectionManagerDispatchEventSpy.callCount).to.equal(1)
 
     let [event] = connectionManagerDispatchEventSpy.getCall(0).args


### PR DESCRIPTION
**Motivation**

In lodestar, when we handle "peer:connect" event, we dial the peer which gives another "peer:connect" event and it causes other issues

**Motivation**

In `onConnect` function, "peer:connect" event should be emitted after we add connection to the `connections` map so that when app dial the peer in "peer:connect" event handler, it uses the same/existing connection