### PR TITLE
fix: Behavior of LIBP2P_FORCE_PNET

### DIFF
--- a/src/index.js
+++ b/src/index.js
@@ -312,7 +312,7 @@ class Libp2p extends EventEmitter {
     // Attach private network protector
     if (this._modules.connProtector) {
       this.upgrader.protector = this._modules.connProtector
-    } else if (globalThis.process !== undefined && globalThis.process.env && globalThis.process.env.LIBP2P_FORCE_PNET) { // eslint-disable-line no-undef
+    } else if (globalThis.process !== undefined && globalThis.process.env && globalThis.process.env.LIBP2P_FORCE_PNET==='1') { // eslint-disable-line no-undef
       throw new Error('Private network is enforced, but no protector was provided')
     }
 

--- a/src/index.js
+++ b/src/index.js
@@ -312,7 +312,7 @@ class Libp2p extends EventEmitter {
     // Attach private network protector
     if (this._modules.connProtector) {
       this.upgrader.protector = this._modules.connProtector
-    } else if (globalThis.process !== undefined && globalThis.process.env && globalThis.process.env.LIBP2P_FORCE_PNET==='1') { // eslint-disable-line no-undef
+    } else if (globalThis.process !== undefined && globalThis.process.env && globalThis.process.env.LIBP2P_FORCE_PNET === '1') { // eslint-disable-line no-undef
       throw new Error('Private network is enforced, but no protector was provided')
     }
 


### PR DESCRIPTION
js-libp2p throw error when `LIBP2P_FORCE_PNET` is `0` and don't use Protector. Because, `0` (string) is `true` and js-libp2p enforce to use private network. However, go-libp2p don't throw an error when `LIBP2P_FORCE_PNET` is `0`.

This PR changes js-libp2p not to throw an error when the environment variable `LIBP2P_FORCE_PNET` is `0` (and any value other than `1`) and don't use Protector.