### PR TITLE
fix: add transport manager to exports map and fix docs

### DIFF
--- a/doc/CONFIGURATION.md
+++ b/doc/CONFIGURATION.md
@@ -246,8 +246,8 @@ import { GossipSub } from 'libp2p-gossipsub'
 
 const node = await createLibp2p({
   transports: [
-    TCP,
-    new WS() // It can take instances too!
+    new TCP(),
+    new WS()
   ],
   streamMuxers: [new Mplex()],
   connectionEncryption: [new Noise()],
@@ -697,8 +697,7 @@ import { createLibp2p } from 'libp2p'
 import { TCP } from '@libp2p/tcp'
 import { Mplex } from '@libp2p/mplex'
 import { Noise } from '@chainsafe/libp2p-noise'
-
-const { FaultTolerance } from 'libp2p/src/transport-manager')
+import { FaultTolerance } from 'libp2p/transport-manager'
 
 const node = await createLibp2p({
   transports: [new TCP()],

--- a/doc/STREAMING_ITERABLES.md
+++ b/doc/STREAMING_ITERABLES.md
@@ -22,7 +22,7 @@
 Sometimes you may need to wrap an existing duplex stream in order to perform incoming and outgoing [transforms](#transform) on data. This type of wrapping is commonly used in stream encryption/decryption. Using [it-pair][it-pair] and [it-pipe][it-pipe], we can do this rather easily, given an existing [duplex iterable](#duplex).
 
 ```js
-const duplexPair from 'it-pair/duplex')
+import { duplexPair } from 'it-pair/duplex'
 import { pipe } from 'it-pipe'
 
 // Wrapper is what we will write and read from

--- a/doc/migrations/v0.26-v0.27.md
+++ b/doc/migrations/v0.26-v0.27.md
@@ -49,13 +49,13 @@ Protocol registration is very similar to how it previously was, however, the han
 
 **Before**
 ```js
-const pull from 'pull-stream')
+const pull = require('pull-stream')
 libp2p.handle('/echo/1.0.0', (protocol, conn) => pull(conn, conn))
 ```
 
 **After**
 ```js
-const pipe from 'it-pipe')
+const pipe = require('it-pipe')
 libp2p.handle(['/echo/1.0.0'], ({ protocol, stream }) => pipe(stream, stream))
 ```
 
@@ -65,7 +65,7 @@ libp2p.handle(['/echo/1.0.0'], ({ protocol, stream }) => pipe(stream, stream))
 
 **Before**
 ```js
-const pull from 'pull-stream')
+const pull = require('pull-stream')
 libp2p.dialProtocol(peerInfo, '/echo/1.0.0', (err, conn) => {
   if (err) { throw err }
   pull(
@@ -82,7 +82,7 @@ libp2p.dialProtocol(peerInfo, '/echo/1.0.0', (err, conn) => {
 
 **After**
 ```js
-const pipe from 'it-pipe')
+const pipe = require('it-pipe')
 const { protocol, stream } = await libp2p.dialProtocol(peerInfo, '/echo/1.0.0')
 await pipe(
   ['hey'],

--- a/package.json
+++ b/package.json
@@ -59,6 +59,9 @@
     },
     "./pnet/generate": {
       "import": "./dist/src/pnet/key-generator.js"
+    },
+    "./transport-manager": {
+      "import": "./dist/src/transport-manager.js"
     }
   },
   "eslintConfig": {

--- a/src/config.ts
+++ b/src/config.ts
@@ -4,7 +4,7 @@ import * as Constants from './constants.js'
 import { AGENT_VERSION } from './identify/consts.js'
 import * as RelayConstants from './circuit/constants.js'
 import { publicAddressesFirst } from '@libp2p/utils/address-sort'
-import { FAULT_TOLERANCE } from './transport-manager.js'
+import { FaultTolerance } from './transport-manager.js'
 import type { Multiaddr } from '@multiformats/multiaddr'
 import type { Libp2pInit } from './index.js'
 import { codes, messages } from './errors.js'
@@ -26,7 +26,7 @@ const DefaultConfig: Partial<Libp2pInit> = {
   },
   connectionGater: {},
   transportManager: {
-    faultTolerance: FAULT_TOLERANCE.FATAL_ALL
+    faultTolerance: FaultTolerance.FATAL_ALL
   },
   dialer: {
     maxParallelDials: Constants.MAX_PARALLEL_DIALS,

--- a/src/index.ts
+++ b/src/index.ts
@@ -1,7 +1,7 @@
 import { createLibp2pNode } from './libp2p.js'
 import type { AbortOptions, EventEmitter, RecursivePartial, Startable } from '@libp2p/interfaces'
 import type { Multiaddr } from '@multiformats/multiaddr'
-import type { FAULT_TOLERANCE } from './transport-manager.js'
+import type { FaultTolerance } from './transport-manager.js'
 import type { HostProperties } from './identify/index.js'
 import type { DualDHT } from '@libp2p/interfaces/dht'
 import type { Datastore } from 'interface-datastore'
@@ -95,7 +95,7 @@ export interface ConnectionManagerConfig {
 }
 
 export interface TransportManagerConfig {
-  faultTolerance?: FAULT_TOLERANCE
+  faultTolerance?: FaultTolerance
 }
 
 export interface PeerStoreConfig {

--- a/src/transport-manager.ts
+++ b/src/transport-manager.ts
@@ -12,14 +12,14 @@ import { trackedMap } from '@libp2p/tracked-map'
 const log = logger('libp2p:transports')
 
 export interface TransportManagerInit {
-  faultTolerance?: FAULT_TOLERANCE
+  faultTolerance?: FaultTolerance
 }
 
 export class DefaultTransportManager extends EventEmitter<TransportManagerEvents> implements TransportManager, Startable {
   private readonly components: Components
   private readonly transports: Map<string, Transport>
   private readonly listeners: Map<string, Listener[]>
-  private readonly faultTolerance: FAULT_TOLERANCE
+  private readonly faultTolerance: FaultTolerance
   private started: boolean
 
   constructor (components: Components, init: TransportManagerInit = {}) {
@@ -33,7 +33,7 @@ export class DefaultTransportManager extends EventEmitter<TransportManagerEvents
       metric: 'listeners',
       metrics: this.components.getMetrics()
     })
-    this.faultTolerance = init.faultTolerance ?? FAULT_TOLERANCE.FATAL_ALL
+    this.faultTolerance = init.faultTolerance ?? FaultTolerance.FATAL_ALL
   }
 
   /**
@@ -215,7 +215,7 @@ export class DefaultTransportManager extends EventEmitter<TransportManagerEvents
       // listening on remote addresses as they may be offline. We could then potentially
       // just wait for any (`p-any`) listener to succeed on each transport before returning
       const isListening = results.find(r => r.isFulfilled)
-      if ((isListening == null) && this.faultTolerance !== FAULT_TOLERANCE.NO_FATAL) {
+      if ((isListening == null) && this.faultTolerance !== FaultTolerance.NO_FATAL) {
         throw errCode(new Error(`Transport (${key}) could not listen on any available address`), codes.ERR_NO_VALID_ADDRESSES)
       }
     }
@@ -224,7 +224,7 @@ export class DefaultTransportManager extends EventEmitter<TransportManagerEvents
     // means we were given addresses we do not have transports for
     if (couldNotListen.length === this.transports.size) {
       const message = `no valid addresses were provided for transports [${couldNotListen.join(', ')}]`
-      if (this.faultTolerance === FAULT_TOLERANCE.FATAL_ALL) {
+      if (this.faultTolerance === FaultTolerance.FATAL_ALL) {
         throw errCode(new Error(message), codes.ERR_NO_VALID_ADDRESSES)
       }
       log(`libp2p in dial mode only: ${message}`)
@@ -266,7 +266,7 @@ export class DefaultTransportManager extends EventEmitter<TransportManagerEvents
 /**
  * Enum Transport Manager Fault Tolerance values
  */
-export enum FAULT_TOLERANCE {
+export enum FaultTolerance {
   /**
    * should be used for failing in any listen circumstance
    */

--- a/test/nat-manager/nat-manager.node.ts
+++ b/test/nat-manager/nat-manager.node.ts
@@ -2,7 +2,7 @@
 
 import { expect } from 'aegir/utils/chai.js'
 import { DefaultAddressManager } from '../../src/address-manager/index.js'
-import { DefaultTransportManager, FAULT_TOLERANCE } from '../../src/transport-manager.js'
+import { DefaultTransportManager, FaultTolerance } from '../../src/transport-manager.js'
 import { TCP } from '@libp2p/tcp'
 import { mockUpgrader } from '@libp2p/interface-compliance-tests/mocks'
 import { NatManager } from '../../src/nat-manager.js'
@@ -30,7 +30,7 @@ describe('Nat Manager (TCP)', () => {
     })
     components.setAddressManager(new DefaultAddressManager(components, { listen: addrs }))
     components.setTransportManager(new DefaultTransportManager(components, {
-      faultTolerance: FAULT_TOLERANCE.NO_FATAL
+      faultTolerance: FaultTolerance.NO_FATAL
     }))
 
     const natManager = new NatManager(components, {

--- a/test/transports/transport-manager.spec.ts
+++ b/test/transports/transport-manager.spec.ts
@@ -7,7 +7,7 @@ import { WebSockets } from '@libp2p/websockets'
 import * as filters from '@libp2p/websockets/filters'
 import { NOISE } from '@chainsafe/libp2p-noise'
 import { DefaultAddressManager } from '../../src/address-manager/index.js'
-import { DefaultTransportManager, FAULT_TOLERANCE } from '../../src/transport-manager.js'
+import { DefaultTransportManager, FaultTolerance } from '../../src/transport-manager.js'
 import { mockUpgrader } from '@libp2p/interface-compliance-tests/mocks'
 import { MULTIADDRS_WEBSOCKETS } from '../fixtures/browser.js'
 import { codes as ErrorCodes } from '../../src/errors.js'
@@ -123,7 +123,7 @@ describe('libp2p.transportManager (dial only)', () => {
         listen: ['/ip4/127.0.0.1/tcp/0']
       },
       transportManager: {
-        faultTolerance: FAULT_TOLERANCE.NO_FATAL
+        faultTolerance: FaultTolerance.NO_FATAL
       },
       transports: [
         new WebSockets()
@@ -143,7 +143,7 @@ describe('libp2p.transportManager (dial only)', () => {
         listen: ['/ip4/127.0.0.1/tcp/12345/p2p/QmWDn2LY8nannvSWJzruUYoLZ4vV83vfCBwd8DipvdgQc3/p2p-circuit']
       },
       transportManager: {
-        faultTolerance: FAULT_TOLERANCE.NO_FATAL
+        faultTolerance: FaultTolerance.NO_FATAL
       },
       transports: [
         new WebSockets()


### PR DESCRIPTION
Addresses PR comments from #1172 - fixes syntax of examples in docs, adds the transport manager to the exports map and renames fault tolerance enum for consistency.