### PR TITLE
fix: transport-manager test, dummy-dht interface compliance

### DIFF
--- a/src/dht/dummy-dht.ts
+++ b/src/dht/dummy-dht.ts
@@ -3,8 +3,17 @@ import type { PeerDiscoveryEvents } from '@libp2p/interfaces/peer-discovery'
 import errCode from 'err-code'
 import { messages, codes } from '../errors.js'
 import { EventEmitter } from '@libp2p/interfaces/events'
+import { symbol } from '@libp2p/interfaces/peer-discovery'
 
 export class DummyDHT extends EventEmitter<PeerDiscoveryEvents> implements DualDHT {
+  get [symbol] (): true {
+    return true
+  }
+
+  get [Symbol.toStringTag] () {
+    return '@libp2p/dummy-dht'
+  }
+
   get wan (): SingleDHT {
     throw errCode(new Error(messages.DHT_DISABLED), codes.DHT_DISABLED)
   }

--- a/test/transports/transport-manager.spec.ts
+++ b/test/transports/transport-manager.spec.ts
@@ -47,7 +47,7 @@ describe('Transport Manager (WebSockets)', () => {
     tm.add(transport)
 
     expect(tm.getTransports()).to.have.lengthOf(1)
-    await tm.remove(transport.constructor.name)
+    await tm.remove(transport[Symbol.toStringTag])
     expect(tm.getTransports()).to.have.lengthOf(0)
   })
 


### PR DESCRIPTION
not sure if this might be needed, but it fixes tests and build scripts

should i just wait until 0.37.0 release?

btw, i am just trying to run it in browser, but keep finding dependencies on nodejs APIs (so far: ~~mortice~~, thunky, clean-stack)