### PR TITLE
fix: do not emit peers on startup

### DIFF
--- a/src/libp2p.ts
+++ b/src/libp2p.ts
@@ -309,18 +309,6 @@ export class Libp2pNode extends EventEmitter<Libp2pEvents> implements Libp2p {
       )
 
       log('libp2p has started')
-
-      // Once we start, emit any peers we may have already discovered
-      // TODO: this should be removed, as we already discovered these peers in the past
-      await this.components.getPeerStore().forEach(peer => {
-        this.dispatchEvent(new CustomEvent<PeerInfo>('peer:discovery', {
-          detail: {
-            id: peer.id,
-            multiaddrs: peer.addresses.map(addr => addr.multiaddr),
-            protocols: peer.protocols
-          }
-        }))
-      })
     } catch (err: any) {
       log.error('An error occurred starting libp2p', err)
       await this.stop()


### PR DESCRIPTION
When starting we emit every peer in the peer store as if they were a new peer.  This makes auto-dial try to dial every peer in the peer store which is very wasteful when there are hundreds if not thousands of peers in the peer store.

Instead any component that thinks it needs a connection certain peers should have tagged those peers with something memorable and should try to connect to them on startup.