### PR TITLE
docs: add build step to docs

### DIFF
--- a/README.md
+++ b/README.md
@@ -105,6 +105,7 @@ You can find multiple examples on the [examples folder](./examples) that will gu
 > git clone https://github.com/libp2p/js-libp2p.git
 > cd js-libp2p
 > npm install
+> npm run build
 ```
 
 ### Tests

--- a/examples/auto-relay/README.md
+++ b/examples/auto-relay/README.md
@@ -5,7 +5,7 @@ While direct connections to nodes are preferable, it's not always possible to do
 
 ## 0. Setup the example
 
-Before moving into the examples, you should run `npm install` on the top level `js-libp2p` folder, in order to install all the dependencies needed for this example. Once the install finishes, you should move into the example folder with `cd examples/auto-relay`.
+Before moving into the examples, you should run `npm install` and `npm run build` on the top level `js-libp2p` folder, in order to install all the dependencies needed for this example. Once the install finishes, you should move into the example folder with `cd examples/auto-relay`.
 
 This example comes with 3 main files. A `relay.js` file to be used in the first step, a `listener.js` file to be used in the second step and a `dialer.js` file to be used on the third step. All of these scripts will run their own libp2p node, which will interact with the previous ones. All nodes must be running in order for you to proceed.
 

--- a/examples/chat/README.md
+++ b/examples/chat/README.md
@@ -3,7 +3,7 @@
 This example creates a simple chat app in your terminal.
 
 ## Setup
-1. Install the modules in the libp2p root directory, `npm install`.
+1. Install the modules in the libp2p root directory, `npm install` and `npm run build`.
 2. Open 2 terminal windows in the `./examples/chat/src` directory.
 
 ## Running

--- a/examples/echo/README.md
+++ b/examples/echo/README.md
@@ -3,7 +3,7 @@
 This example performs a simple echo from the listener to the dialer.
 
 ## Setup
-1. Install the modules from libp2p root, `npm install`.
+1. Install the modules from libp2p root, `npm install` and `npm run build`.
 2. Open 2 terminal windows in the `./src` directory.
 
 ## Running

--- a/examples/libp2p-in-the-browser/README.md
+++ b/examples/libp2p-in-the-browser/README.md
@@ -6,11 +6,12 @@ This example leverages the [Parcel.js bundler](https://parceljs.org/) to compile
 
 In order to run the example:
 
-- Install dependencey at the root of the js-libp2p repository (if not already done), 
+- Install dependencey at the root of the js-libp2p repository (if not already done),
 - then, install the dependencies from same directory as this README:
 
 ```
 npm install
+npm run build
 cd ./examples/libp2p-in-the-browser
 npm install
 ```

--- a/examples/peer-and-content-routing/README.md
+++ b/examples/peer-and-content-routing/README.md
@@ -8,7 +8,7 @@ Content Routing is the category of modules that offer a way to find where conten
 
 # 1. Using Peer Routing to find other peers
 
-This example builds on top of the [Protocol and Stream Muxing](../protocol-and-stream-muxing). We need to install `libp2p-kad-dht`, go ahead and `npm install libp2p-kad-dht`. If you want to see the final version, open [1.js](./1.js).
+This example builds on top of the [Protocol and Stream Muxing](../protocol-and-stream-muxing). We need to install `@libp2p/kad-dht`, go ahead and `npm install @libp2p/kad-dht`. If you want to see the final version, open [1.js](./1.js).
 
 First, let's update our config to support Peer Routing and Content Routing.
 

--- a/examples/pnet/README.md
+++ b/examples/pnet/README.md
@@ -2,7 +2,7 @@
 This example shows how to set up a private network of libp2p nodes.
 
 ## Setup
-1. Install the modules in the libp2p root directory, `npm install`.
+1. Install the modules in the libp2p root directory, `npm install` and `npm run build`.
 
 ## Run
 Running the example will cause two nodes with the same swarm key to be started and exchange basic information.

--- a/examples/pubsub/README.md
+++ b/examples/pubsub/README.md
@@ -10,7 +10,7 @@ We've seen many interesting use cases appear with this, here are some highlights
 
 ## 0. Set up the example
 
-Before moving into the examples, you should run `npm install` on the top level `js-libp2p` folder, in order to install all the dependencies needed for this example. In addition, you will need to install the example related dependencies by doing `cd examples && npm install`. Once the install finishes, you should move into the example folder with `cd pubsub`.
+Before moving into the examples, you should run `npm install` and `npm run build` on the top level `js-libp2p` folder, in order to install all the dependencies needed for this example. In addition, you will need to install the example related dependencies by doing `cd examples && npm install`. Once the install finishes, you should move into the example folder with `cd pubsub`.
 
 ## 1. Setting up a simple PubSub network on top of libp2p
 


### PR DESCRIPTION
Now that we need to build ts to js a build step is necessary.

Add it to the instructions where we are telling people to clone the repo first.

Refs: #1273