### PR TITLE
feat!: use tag values to choose which connections to close

### DIFF
--- a/doc/API.md
+++ b/doc/API.md
@@ -46,6 +46,9 @@
   * [`peerStore.delete`](#peerstoredelete)
   * [`peerStore.get`](#peerstoreget)
   * [`peerStore.peers`](#peerstorepeers)
+  * [`peerStore.tagPeer`](#peerstoretagpeer)
+  * [`peerStore.unTagPeer`](#peerstoreuntagpeer)
+  * [`peerStore.getTags`](#peerstoregettags)
   * [`pubsub.getSubscribers`](#pubsubgetsubscribers)
   * [`pubsub.getTopics`](#pubsubgettopics)
   * [`pubsub.publish`](#pubsubpublish)
@@ -1396,6 +1399,81 @@ Get all the stored information of every peer.
 for (let [peerIdString, peer] of peerStore.peers.entries()) {
   // peer { id, addresses, metadata, protocols }
 }
+```
+
+### peerStore.tagPeer
+
+Tags a peer with the specified tag and optional value/expiry time
+
+`peerStore.tagPeer(peerId, tag, options)`
+
+#### Parameters
+
+| Name | Type | Description |
+|------|------|-------------|
+| peerId | `PeerId` | The peer to tag |
+| tag | `string` | The name of the tag to add |
+| options | `{ value?: number, ttl?: number }` | An optional value (1-100) and an optional ttl after which the tag will expire (ms) |
+
+#### Returns
+
+| Type | Description |
+|------|-------------|
+| `Promise<void>` | Promise resolves once the tag is stored |
+
+#### Example
+
+```js
+await peerStore.tagPeer(peerId, 'my-tag', { value: 100, ttl: Date.now() + 60000 })
+```
+
+### peerStore.unTagPeer
+
+Remove the tag from the specified peer
+
+`peerStore.unTagPeer(peerId, tag)`
+
+#### Parameters
+
+| Name | Type | Description |
+|------|------|-------------|
+| peerId | `PeerId` | The peer to untag |
+| tag | `string` | The name of the tag to remove |
+
+#### Returns
+
+| Type | Description |
+|------|-------------|
+| `Promise<void>` | Promise resolves once the tag has been removed |
+
+#### Example
+
+```js
+await peerStore.unTagPeer(peerId, 'my-tag')
+```
+
+### peerStore.getTags
+
+Remove the tag from the specified peer
+
+`peerStore.getTags(peerId)`
+
+#### Parameters
+
+| Name | Type | Description |
+|------|------|-------------|
+| peerId | `PeerId` | The peer to get the tags for |
+
+#### Returns
+
+| Type | Description |
+|------|-------------|
+| `Promise<Array<{ name: string, value: number }>>` | The promise resolves to the list of tags for the passed peer |
+
+#### Example
+
+```js
+await peerStore.getTags(peerId)
 ```
 
 ### pubsub.getSubscribers

--- a/doc/API.md
+++ b/doc/API.md
@@ -56,7 +56,6 @@
   * [`pubsub.topicValidators.set`](#pubsubtopicvalidatorsset)
   * [`pubsub.topicValidators.delete`](#pubsubtopicvalidatorsdelete)
   * [`connectionManager.get`](#connectionmanagerget)
-  * [`connectionManager.setPeerValue`](#connectionmanagersetpeervalue)
   * [`connectionManager.size`](#connectionmanagersize)
   * [`keychain.createKey`](#keychaincreatekey)
   * [`keychain.renameKey`](#keychainrenamekey)
@@ -1670,32 +1669,6 @@ Get a connection with a given peer, if it exists.
 
 ```js
 libp2p.connectionManager.get(peerId)
-```
-
-### connectionManager.setPeerValue
-
-Enables users to change the value of certain peers in a range of 0 to 1. Peers with the lowest values will have their Connections pruned first, if any Connection Manager limits are exceeded. See [./CONFIGURATION.md#configuring-connection-manager](./CONFIGURATION.md#configuring-connection-manager) for details on how to configure these limits.
-
-`libp2p.connectionManager.setPeerValue(peerId, value)`
-
-#### Parameters
-
-| Name | Type | Description |
-|------|------|-------------|
-| peerId | [`PeerId`][peer-id] | The peer to set the value for |
-| value | `number` | The value of the peer from 0 to 1 |
-
-#### Returns
-
-| Type | Description |
-|------|-------------|
-| `void` |  |
-
-#### Example
-
-```js
-libp2p.connectionManager.setPeerValue(highPriorityPeerId, 1)
-libp2p.connectionManager.setPeerValue(lowPriorityPeerId, 0)
 ```
 
 ### connectionManager.size

--- a/doc/CONFIGURATION.md
+++ b/doc/CONFIGURATION.md
@@ -556,7 +556,6 @@ const node = await createLibp2p({
     maxConnections: Infinity,
     minConnections: 0,
     pollInterval: 2000,
-    defaultPeerValue: 1,
     // The below values will only be taken into account when Metrics are enabled
     maxData: Infinity,
     maxSentData: Infinity,

--- a/doc/CONNECTION_MANAGER.md
+++ b/doc/CONNECTION_MANAGER.md
@@ -17,4 +17,3 @@ The following is a list of available options for setting limits for the Connecti
 - `maxEventLoopDelay`: sets the maximum event loop delay (measured in milliseconds) this node is willing to endure before it starts disconnecting peers. Defaults to `Infinity`.
 - `pollInterval`: sets the poll interval (in milliseconds) for assessing the current state and determining if this peer needs to force a disconnect. Defaults to `2000` (2 seconds).
 - `movingAverageInterval`: the interval used to calculate moving averages (in milliseconds). Defaults to `60000` (1 minute). This must be an available interval configured in `Metrics`
-- `defaultPeerValue`: number between 0 and 1. Defaults to 1.

--- a/package.json
+++ b/package.json
@@ -86,6 +86,7 @@
     "generate:proto:fetch": "protons ./src/fetch/pb/proto.proto",
     "generate:proto:identify": "protons ./src/identify/pb/message.proto",
     "generate:proto:plaintext": "protons ./src/insecure/pb/proto.proto",
+    "generate:proto:tags": "protons ./src/connection-manager/tags/tags.proto",
     "test": "aegir test",
     "test:node": "aegir test -t node -f \"./dist/test/**/*.{node,spec}.js\" --cov",
     "test:chrome": "aegir test -t browser -f \"./dist/test/**/*.spec.js\" --cov",

--- a/src/connection-manager/index.ts
+++ b/src/connection-manager/index.ts
@@ -31,8 +31,7 @@ const defaultOptions: Partial<ConnectionManagerInit> = {
   maxEventLoopDelay: Infinity,
   pollInterval: 2000,
   autoDialInterval: 10000,
-  movingAverageInterval: 60000,
-  defaultPeerValue: 0.5
+  movingAverageInterval: 60000
 }
 
 const METRICS_COMPONENT = 'connection-manager'
@@ -78,11 +77,6 @@ export interface ConnectionManagerInit {
    * How often, in milliseconds, to compute averages
    */
   movingAverageInterval?: number
-
-  /**
-   * The value of the peer
-   */
-  defaultPeerValue?: number
 
   /**
    * If true, try to connect to all discovered peers up to the connection manager limit

--- a/src/connection-manager/index.ts
+++ b/src/connection-manager/index.ts
@@ -38,10 +38,6 @@ const defaultOptions: Partial<ConnectionManagerInit> = {
 const METRICS_COMPONENT = 'connection-manager'
 const METRICS_PEER_CONNECTIONS = 'peer-connections'
 
-export const TAGS = {
-  KEEP_ALIVE: 'KEEP_ALIVE'
-}
-
 export interface ConnectionManagerInit {
   /**
    * The maximum number of connections to keep open

--- a/test/connection-manager/index.spec.ts
+++ b/test/connection-manager/index.spec.ts
@@ -101,7 +101,7 @@ describe('Connection Manager', () => {
     expect(lowestSpy).to.have.property('callCount', 1)
   })
 
-  it('should close connection when the maximum has been reached even without peer values', async () => {
+  it('should close connection when the maximum has been reached even without tags', async () => {
     const max = 5
     libp2p = await createNode({
       config: createBaseOptions({
@@ -120,11 +120,11 @@ describe('Connection Manager', () => {
 
     // Add 1 too many connections
     const spy = sinon.spy()
-    await Promise.all([...new Array(max + 1)].map(async () => {
+    for (let i = 0; i < max + 1; i++) {
       const connection = mockConnection(mockMultiaddrConnection(mockDuplex(), await createEd25519PeerId()))
       sinon.stub(connection, 'close').callsFake(async () => spy()) // eslint-disable-line
       await connectionManager._onConnect(new CustomEvent('connection', { detail: connection }))
-    }))
+    }
 
     expect(connectionManagerMaybeDisconnectOneSpy.callCount).to.equal(1)
     expect(spy).to.have.property('callCount', 1)


### PR DESCRIPTION
Uses peer tag values to select low-value connections to prune when we have too many connections open.

BREAKING CHANGE: `connectionManager.peerValue` has been removed, use `peerStore.tagPeer` instead