### PR TITLE
fix: update muxer behavior

### DIFF
--- a/src/upgrader.ts
+++ b/src/upgrader.ts
@@ -315,6 +315,7 @@ export class DefaultUpgrader extends EventEmitter<UpgraderEvents> implements Upg
     if (muxerFactory != null) {
       // Create the muxer
       muxer = muxerFactory.createStreamMuxer({
+        direction,
         // Run anytime a remote stream is created
         onIncomingStream: muxedStream => {
           if (connection == null) {
@@ -469,7 +470,7 @@ export class DefaultUpgrader extends EventEmitter<UpgraderEvents> implements Upg
         await maConn.close()
         // Ensure remaining streams are closed
         if (muxer != null) {
-          muxer.streams.forEach(s => s.close())
+          muxer.close()
         }
       }
     })

--- a/test/relay/auto-relay.node.ts
+++ b/test/relay/auto-relay.node.ts
@@ -1,6 +1,7 @@
 /* eslint-env mocha */
 
 import { expect } from 'aegir/chai'
+import { pEvent } from 'p-event'
 import defer from 'p-defer'
 import pWaitFor from 'p-wait-for'
 import sinon from 'sinon'
@@ -205,6 +206,7 @@ describe('auto-relay', () => {
 
       // Disconnect from peer used for relay
       await relayLibp2p2.stop()
+      await pEvent(relayLibp2p1.connectionManager, 'peer:disconnect', { timeout: 500 })
 
       // Should not be using the relay any more
       await expect(usingAsRelay(relayLibp2p1, relayLibp2p2, {


### PR DESCRIPTION
- use `direction` in `muxerFactory.createStreamMuxer`
- use `muxer.close` instead of `muxer.streams.forEach(s => s.close())`