### PR TITLE
fix: add timeout for circuit relay

### DIFF
--- a/src/circuit/circuit/hop.ts
+++ b/src/circuit/circuit/hop.ts
@@ -12,6 +12,7 @@ import { peerIdFromBytes } from '@libp2p/peer-id'
 import type { Duplex } from 'it-stream-types'
 import type { Circuit } from '../transport.js'
 import type { ConnectionManager } from '@libp2p/interface-connection-manager'
+import type { AbortOptions } from '@libp2p/interfaces'
 
 const log = logger('libp2p:circuit:hop')
 
@@ -118,7 +119,7 @@ export async function handleHop (hopRequest: HopRequest) {
   )
 }
 
-export interface HopConfig {
+export interface HopConfig extends AbortOptions {
   connection: Connection
   request: CircuitPB
 }
@@ -130,11 +131,14 @@ export interface HopConfig {
 export async function hop (options: HopConfig): Promise<Duplex<Uint8Array>> {
   const {
     connection,
-    request
+    request,
+    signal
   } = options
 
   // Create a new stream to the relay
-  const stream = await connection.newStream(RELAY_CODEC)
+  const stream = await connection.newStream(RELAY_CODEC, {
+    signal
+  })
   // Send the HOP request
   const streamHandler = new StreamHandler({ stream })
   streamHandler.write(request)
@@ -156,7 +160,7 @@ export async function hop (options: HopConfig): Promise<Duplex<Uint8Array>> {
   throw errCode(new Error(`HOP request failed with code "${response.code ?? 'unknown'}"`), Errors.ERR_HOP_REQUEST_FAILED)
 }
 
-export interface CanHopOptions {
+export interface CanHopOptions extends AbortOptions {
   connection: Connection
 }
 
@@ -165,11 +169,14 @@ export interface CanHopOptions {
  */
 export async function canHop (options: CanHopOptions) {
   const {
-    connection
+    connection,
+    signal
   } = options
 
   // Create a new stream to the relay
-  const stream = await connection.newStream(RELAY_CODEC)
+  const stream = await connection.newStream(RELAY_CODEC, {
+    signal
+  })
 
   // Send the HOP request
   const streamHandler = new StreamHandler({ stream })

--- a/src/circuit/circuit/stop.ts
+++ b/src/circuit/circuit/stop.ts
@@ -5,6 +5,7 @@ import { StreamHandler } from './stream-handler.js'
 import { validateAddrs } from './utils.js'
 import type { Connection } from '@libp2p/interface-connection'
 import type { Duplex } from 'it-stream-types'
+import type { AbortOptions } from '@libp2p/interfaces'
 
 const log = logger('libp2p:circuit:stop')
 
@@ -42,7 +43,7 @@ export function handleStop (options: HandleStopOptions): Duplex<Uint8Array> | un
   return streamHandler.rest()
 }
 
-export interface StopOptions {
+export interface StopOptions extends AbortOptions {
   connection: Connection
   request: CircuitPB
 }
@@ -53,10 +54,13 @@ export interface StopOptions {
 export async function stop (options: StopOptions) {
   const {
     connection,
-    request
+    request,
+    signal
   } = options
 
-  const stream = await connection.newStream([RELAY_CODEC])
+  const stream = await connection.newStream(RELAY_CODEC, {
+    signal
+  })
   log('starting stop request to %p', connection.remotePeer)
   const streamHandler = new StreamHandler({ stream })
 

--- a/src/circuit/transport.ts
+++ b/src/circuit/transport.ts
@@ -160,6 +160,7 @@ export class Circuit implements Transport, Initializable {
 
     try {
       const virtualConnection = await hop({
+        ...options,
         connection: relayConnection,
         request: {
           type: CircuitPB.Type.HOP,

--- a/src/config.ts
+++ b/src/config.ts
@@ -67,7 +67,8 @@ const DefaultConfig: Partial<Libp2pInit> = {
     },
     hop: {
       enabled: false,
-      active: false
+      active: false,
+      timeout: 30000
     },
     autoRelay: {
       enabled: false,

--- a/src/index.ts
+++ b/src/index.ts
@@ -50,6 +50,7 @@ export interface MetricsConfig {
 export interface HopConfig {
   enabled?: boolean
   active?: boolean
+  timeout: number
 }
 
 export interface RelayConfig {


### PR DESCRIPTION
Make sure we don't potentially wait forever during the initial
circuit relay handshake.