### PR TITLE
fix: MaxListenersExceeded warning

### DIFF
--- a/src/circuit/transport.ts
+++ b/src/circuit/transport.ts
@@ -20,6 +20,7 @@ import type { Connection } from '@libp2p/interface-connection'
 import type { RelayConfig } from '../index.js'
 import { abortableDuplex } from 'abortable-iterator'
 import { TimeoutController } from 'timeout-abort-controller'
+import { setMaxListeners } from 'events'
 
 const log = logger('libp2p:circuit')
 
@@ -63,6 +64,11 @@ export class Circuit implements Transport, Initializable {
   async _onProtocol (data: IncomingStreamData) {
     const { connection, stream } = data
     const controller = new TimeoutController(this._init.hop.timeout)
+
+    try {
+      // fails on node < 15.4
+      setMaxListeners?.(Infinity, controller.signal)
+    } catch {}
 
     try {
       const source = abortableDuplex(stream, controller.signal)

--- a/src/connection-manager/dialer/auto-dialer.ts
+++ b/src/connection-manager/dialer/auto-dialer.ts
@@ -2,6 +2,7 @@ import type { PeerInfo } from '@libp2p/interface-peer-info'
 import { logger } from '@libp2p/logger'
 import type { Components } from '@libp2p/components'
 import { TimeoutController } from 'timeout-abort-controller'
+import { setMaxListeners } from 'events'
 
 const log = logger('libp2p:dialer:auto-dialer')
 
@@ -43,6 +44,11 @@ export class AutoDialer {
         log('auto-dialing discovered peer %p with timeout %d', peer.id, this.dialTimeout)
 
         const controller = new TimeoutController(this.dialTimeout)
+
+        try {
+          // fails on node < 15.4
+          setMaxListeners?.(Infinity, controller.signal)
+        } catch {}
 
         void this.components.getConnectionManager().openConnection(peer.id, {
           signal: controller.signal

--- a/src/connection-manager/index.ts
+++ b/src/connection-manager/index.ts
@@ -331,6 +331,11 @@ export class DefaultConnectionManager extends EventEmitter<ConnectionManagerEven
         this.connectOnStartupController?.clear()
         this.connectOnStartupController = new TimeoutController(this.startupReconnectTimeout)
 
+        try {
+          // fails on node < 15.4
+          setMaxListeners?.(Infinity, this.connectOnStartupController.signal)
+        } catch {}
+
         await Promise.all(
           keepAlivePeers.map(async peer => {
             await this.openConnection(peer, {
@@ -510,6 +515,11 @@ export class DefaultConnectionManager extends EventEmitter<ConnectionManagerEven
     if (options?.signal == null) {
       timeoutController = new TimeoutController(this.dialTimeout)
       options.signal = timeoutController.signal
+
+      try {
+        // fails on node < 15.4
+        setMaxListeners?.(Infinity, timeoutController.signal)
+      } catch {}
     }
 
     try {

--- a/src/fetch/index.ts
+++ b/src/fetch/index.ts
@@ -14,6 +14,7 @@ import { abortableDuplex } from 'abortable-iterator'
 import { pipe } from 'it-pipe'
 import first from 'it-first'
 import { TimeoutController } from 'timeout-abort-controller'
+import { setMaxListeners } from 'events'
 
 const log = logger('libp2p:fetch')
 
@@ -99,6 +100,11 @@ export class FetchService implements Startable {
     if (signal == null) {
       timeoutController = new TimeoutController(this.init.timeout)
       signal = timeoutController.signal
+
+      try {
+        // fails on node < 15.4
+        setMaxListeners?.(Infinity, timeoutController.signal)
+      } catch {}
     }
 
     try {

--- a/src/ping/index.ts
+++ b/src/ping/index.ts
@@ -14,6 +14,7 @@ import type { AbortOptions } from '@libp2p/interfaces'
 import { abortableDuplex } from 'abortable-iterator'
 import { TimeoutController } from 'timeout-abort-controller'
 import type { Stream } from '@libp2p/interface-connection'
+import { setMaxListeners } from 'events'
 
 const log = logger('libp2p:ping')
 
@@ -90,6 +91,11 @@ export class PingService implements Startable {
     if (signal == null) {
       timeoutController = new TimeoutController(this.init.timeout)
       signal = timeoutController.signal
+
+      try {
+        // fails on node < 15.4
+        setMaxListeners?.(Infinity, timeoutController.signal)
+      } catch {}
     }
 
     try {


### PR DESCRIPTION
Where we create signals that are passed down the stack, increase the max listeners to prevent warnings in the console.