### PR TITLE
feat: add autonat support

### DIFF
--- a/package.json
+++ b/package.json
@@ -83,6 +83,7 @@
     "prepublishOnly": "node scripts/update-version.js",
     "build": "aegir build",
     "generate": "run-s generate:proto:*",
+    "generate:proto:autonat": "protons ./src/autonat/pb/index.proto",
     "generate:proto:circuit": "protons ./src/circuit/pb/index.proto",
     "generate:proto:fetch": "protons ./src/fetch/pb/proto.proto",
     "generate:proto:identify": "protons ./src/identify/pb/message.proto",

--- a/src/autonat/constants.ts
+++ b/src/autonat/constants.ts
@@ -1,0 +1,4 @@
+
+export const PROTOCOL = '/libp2p/autonat/1.0.0'
+export const PROTOCOL_VERSION = '1.0.0'
+export const PROTOCOL_NAME = 'autonat'

--- a/src/autonat/index.ts
+++ b/src/autonat/index.ts
@@ -1,0 +1,560 @@
+import { logger } from '@libp2p/logger'
+import {
+  PROTOCOL
+} from './constants.js'
+import type { IncomingStreamData } from '@libp2p/interface-registrar'
+import type { Startable } from '@libp2p/interfaces/startable'
+import type { Components } from '@libp2p/components'
+import { TimeoutController } from 'timeout-abort-controller'
+import { abortableDuplex } from 'abortable-iterator'
+import { Message } from './pb/index.js'
+import { pipe } from 'it-pipe'
+import first from 'it-first'
+import isPrivateIp from 'private-ip'
+import { peerIdFromBytes } from '@libp2p/peer-id'
+import { multiaddr, protocols } from '@multiformats/multiaddr'
+import type { PeerId } from '@libp2p/interface-peer-id'
+import type { DefaultConnectionManager } from '../connection-manager/index.js'
+import type { Connection } from '@libp2p/interface-connection'
+import parallel from 'it-parallel'
+import map from 'it-map'
+import type { PeerInfo } from '@libp2p/interface-peer-info'
+import { createEd25519PeerId } from '@libp2p/peer-id-factory'
+import type { DefaultAddressManager } from '../address-manager/index.js'
+import * as lp from 'it-length-prefixed'
+import { setMaxListeners } from 'events'
+
+const log = logger('libp2p:autonat')
+
+// if more than 3 peers manage to dial us on what we believe to be our external
+// IP then we are convinced that it is, in fact, our external IP
+// https://github.com/libp2p/specs/blob/master/autonat/README.md#autonat-protocol
+const REQUIRED_SUCCESSFUL_DIALS = 4
+
+// Wait this long before we start to query autonat nodes
+const AUTONAT_STARTUP_DELAY = 5000
+
+// Only try to verify our external address this often
+const AUTONAT_REFRESH_INTERVAL = 60000
+
+export interface AutonatServiceInit {
+  /**
+   * Allows overriding the protocol prefix used
+   */
+  protocolPrefix: string
+
+  /**
+   * How long we should wait for a remote peer to verify our external address
+   */
+  timeout: number
+
+  /**
+   * How long to wait after startup before trying to verify our external address
+   */
+  startupDelay: number
+
+  /**
+   * Verify our external addresses this often
+   */
+  refreshInterval: number
+
+  /**
+   * How many parallel inbound autonat streams we allow per-connection
+   */
+  maxInboundStreams: number
+
+  /**
+   * How many parallel outbound autonat streams we allow per-connection
+   */
+  maxOutboundStreams: number
+}
+
+export class AutonatService implements Startable {
+  private readonly components: Components
+  private readonly _init: AutonatServiceInit
+  private readonly startupDelay: number
+  private readonly refreshInterval: number
+  private verifyAddressTimeout?: ReturnType<typeof setTimeout>
+  private started: boolean
+
+  constructor (components: Components, init: AutonatServiceInit) {
+    this.components = components
+    this.started = false
+    this._init = init
+    this.startupDelay = init.startupDelay ?? AUTONAT_STARTUP_DELAY
+    this.refreshInterval = init.refreshInterval ?? AUTONAT_REFRESH_INTERVAL
+
+    this._verifyExternalAddresses = this._verifyExternalAddresses.bind(this)
+  }
+
+  isStarted () {
+    return this.started
+  }
+
+  async start () {
+    if (this.started) {
+      return
+    }
+
+    await this.components.getRegistrar().handle(PROTOCOL, (data) => {
+      void this.handleIncomingAutonatStream(data)
+        .catch(err => {
+          log.error(err)
+        })
+    }, {
+      maxInboundStreams: this._init.maxInboundStreams,
+      maxOutboundStreams: this._init.maxOutboundStreams
+    })
+
+    this.verifyAddressTimeout = setTimeout(this._verifyExternalAddresses, this.startupDelay)
+
+    this.started = true
+  }
+
+  async stop () {
+    await this.components.getRegistrar().unhandle(PROTOCOL)
+    clearTimeout(this.verifyAddressTimeout)
+
+    this.started = false
+  }
+
+  /**
+   * Handle an incoming autonat request
+   */
+  async handleIncomingAutonatStream (data: IncomingStreamData): Promise<void> {
+    const controller = new TimeoutController(this._init.timeout)
+
+    // this controller may be used while dialing lots of peers so prevent MaxListenersExceededWarning
+    // appearing in the console
+    try {
+      // fails on node < 15.4
+      setMaxListeners?.(Infinity, controller.signal)
+    } catch {}
+
+    const ourHosts = this.components.getAddressManager().getAddresses()
+      .map(ma => ma.toOptions().host)
+
+    try {
+      const source = abortableDuplex(data.stream, controller.signal)
+      const self = this
+
+      await pipe(
+        source,
+        lp.decode(),
+        async function * (stream) {
+          const buf = await first(stream)
+
+          if (buf == null) {
+            log('No message received')
+            yield Message.encode({
+              type: Message.MessageType.DIAL_RESPONSE,
+              dialResponse: {
+                status: Message.ResponseStatus.E_BAD_REQUEST,
+                statusText: 'No message was sent'
+              }
+            })
+
+            return
+          }
+
+          let request: Message
+
+          try {
+            request = Message.decode(buf)
+          } catch (err) {
+            log.error('Could not decode message', err)
+
+            yield Message.encode({
+              type: Message.MessageType.DIAL_RESPONSE,
+              dialResponse: {
+                status: Message.ResponseStatus.E_BAD_REQUEST,
+                statusText: 'Could not decode message'
+              }
+            })
+
+            return
+          }
+
+          const dialRequest = request.dial
+
+          if (dialRequest == null) {
+            log.error('Dial was missing from message')
+
+            yield Message.encode({
+              type: Message.MessageType.DIAL_RESPONSE,
+              dialResponse: {
+                status: Message.ResponseStatus.E_BAD_REQUEST,
+                statusText: 'No Dial message found in message'
+              }
+            })
+
+            return
+          }
+
+          let peerId: PeerId
+          const peer = dialRequest.peer
+
+          if (peer == null || peer.id == null) {
+            log.error('PeerId missing from message')
+
+            yield Message.encode({
+              type: Message.MessageType.DIAL_RESPONSE,
+              dialResponse: {
+                status: Message.ResponseStatus.E_BAD_REQUEST,
+                statusText: 'missing peer info'
+              }
+            })
+
+            return
+          }
+
+          try {
+            peerId = peerIdFromBytes(peer.id)
+          } catch (err) {
+            log.error('Invalid PeerId', err)
+
+            yield Message.encode({
+              type: Message.MessageType.DIAL_RESPONSE,
+              dialResponse: {
+                status: Message.ResponseStatus.E_BAD_REQUEST,
+                statusText: 'bad peer id'
+              }
+            })
+
+            return
+          }
+
+          log('Incoming request from %p', peerId)
+
+          // reject any dial requests that arrive via relays
+          if (!data.connection.remotePeer.equals(peerId)) {
+            log('Target peer %p did not equal sending peer %p', peerId, data.connection.remotePeer)
+
+            yield Message.encode({
+              type: Message.MessageType.DIAL_RESPONSE,
+              dialResponse: {
+                status: Message.ResponseStatus.E_BAD_REQUEST,
+                statusText: 'peer id mismatch'
+              }
+            })
+
+            return
+          }
+
+          // get a list of multiaddrs to dial
+          const multiaddrs = peer.addrs
+            .map(buf => multiaddr(buf))
+            .filter(ma => {
+              const isFromSameHost = ma.toOptions().host === data.connection.remoteAddr.toOptions().host
+
+              log.trace('Request to dial %s was sent from %s is same host %s', ma, data.connection.remoteAddr, isFromSameHost)
+              // skip any Multiaddrs where the target node's IP does not match the sending node's IP
+              return isFromSameHost
+            })
+            .filter(ma => {
+              const host = ma.toOptions().host
+              const isPublicIp = !isPrivateIp(host)
+
+              log.trace('Host %s was public %s', host, isPublicIp)
+              // don't try to dial private addresses
+              return isPublicIp
+            })
+            .filter(ma => {
+              const host = ma.toOptions().host
+              const isNotOurHost = !ourHosts.includes(host)
+
+              log.trace('Host %s was not our host %s', host, isNotOurHost)
+              // don't try to dial nodes on the same host as us
+              return isNotOurHost
+            })
+            .filter(ma => {
+              const isSupportedTransport = Boolean(self.components.getTransportManager().transportForMultiaddr(ma))
+
+              log.trace('Transport for %s is supported %s', ma, isSupportedTransport)
+              // skip any Multiaddrs that have transports we do not support
+              return isSupportedTransport
+            })
+            .map(ma => {
+              if (ma.getPeerId() == null) {
+                // make sure we have the PeerId as part of the Multiaddr
+                ma = ma.encapsulate(`/p2p/${peerId.toString()}`)
+              }
+
+              return ma
+            })
+
+          // make sure we have something to dial
+          if (multiaddrs.length === 0) {
+            log('No valid multiaddrs for %p in message', peerId)
+
+            yield Message.encode({
+              type: Message.MessageType.DIAL_RESPONSE,
+              dialResponse: {
+                status: Message.ResponseStatus.E_DIAL_REFUSED,
+                statusText: 'no dialable addresses'
+              }
+            })
+
+            return
+          }
+
+          log('Dial multiaddrs %s for peer %p', multiaddrs.map(ma => ma.toString()).join(', '), peerId)
+
+          let errorMessage = ''
+          let lastMultiaddr = multiaddrs[0]
+
+          for await (const multiaddr of multiaddrs) {
+            let connection: Connection | undefined
+            lastMultiaddr = multiaddr
+
+            try {
+              // use the dialer so we can dial a specific multiaddr instead of every known
+              // multiaddr for the peer
+              const dialer = (self.components.getConnectionManager() as DefaultConnectionManager).dialer
+              connection = await dialer.dial(multiaddr, {
+                signal: controller.signal
+              })
+
+              if (!connection.remoteAddr.equals(multiaddr)) {
+                log.error('Tried to dial %s but dialed %s', multiaddr, connection.remoteAddr)
+                throw new Error('Unexpected remote address')
+              }
+
+              log('Success %p', peerId)
+
+              yield Message.encode({
+                type: Message.MessageType.DIAL_RESPONSE,
+                dialResponse: {
+                  status: Message.ResponseStatus.OK,
+                  addr: connection.remoteAddr.decapsulateCode(protocols('p2p').code).bytes
+                }
+              })
+
+              return
+            } catch (err: any) {
+              log('Could not dial %p', peerId, err)
+              errorMessage = err.message
+            } finally {
+              if (connection != null) {
+                await connection.close()
+              }
+            }
+          }
+
+          yield Message.encode({
+            type: Message.MessageType.DIAL_RESPONSE,
+            dialResponse: {
+              status: Message.ResponseStatus.E_DIAL_ERROR,
+              statusText: errorMessage,
+              addr: lastMultiaddr.bytes
+            }
+          })
+        },
+        lp.encode(),
+        // pipe to the stream, not the abortable source other wise we
+        // can't tell the remote when a dial timed out..
+        data.stream
+      )
+    } finally {
+      controller.clear()
+    }
+  }
+
+  _verifyExternalAddresses () {
+    void this.verifyExternalAddresses()
+      .catch(err => {
+        log.error(err)
+      })
+  }
+
+  /**
+   * Our multicodec topology noticed a new peer that supports autonat
+   */
+  async verifyExternalAddresses () {
+    clearTimeout(this.verifyAddressTimeout)
+
+    // Do not try to push if we are not running
+    if (!this.isStarted()) {
+      return
+    }
+
+    const addressManager = this.components.getAddressManager() as DefaultAddressManager
+
+    const multiaddrs = addressManager.getObservedAddrs()
+      .filter(ma => {
+        const options = ma.toOptions()
+
+        return !isPrivateIp(options.host)
+      })
+
+    if (multiaddrs.length === 0) {
+      log('No public addresses found, not requesting verification')
+      this.verifyAddressTimeout = setTimeout(this._verifyExternalAddresses, this.refreshInterval)
+
+      return
+    }
+
+    const controller = new TimeoutController(this._init.timeout)
+
+    // this controller may be used while dialing lots of peers so prevent MaxListenersExceededWarning
+    // appearing in the console
+    try {
+      // fails on node < 15.4
+      setMaxListeners?.(Infinity, controller.signal)
+    } catch {}
+
+    const self = this
+
+    try {
+      log(`verify multiaddrs %s`, multiaddrs.map(ma => ma.toString()).join(', '))
+
+      const request = Message.encode({
+        type: Message.MessageType.DIAL,
+        dial: {
+          peer: {
+            id: this.components.getPeerId().toBytes(),
+            addrs: multiaddrs.map(map => map.bytes)
+          }
+        }
+      })
+
+      // find some random peers
+      const randomPeer = await createEd25519PeerId()
+      const randomCid = randomPeer.toBytes()
+
+      const results: Record<string, { success: number, failure: number }> = {}
+      const networkSegments: string[] = []
+
+      async function verifyAddress (peer: PeerInfo): Promise<Message.DialResponse | undefined> {
+        try {
+          log('Asking %p to verify multiaddr', peer.id)
+
+          const connection = await self.components.getConnectionManager().openConnection(peer.id, {
+            signal: controller.signal
+          })
+
+          const stream = await connection.newStream(PROTOCOL, {
+            signal: controller.signal
+          })
+          const source = abortableDuplex(stream, controller.signal)
+
+          const buf = await pipe(
+            [request],
+            lp.encode(),
+            source,
+            lp.decode(),
+            async (stream) => await first(stream)
+          )
+
+          if (buf == null) {
+            log('No response received from %s', connection.remotePeer)
+            return undefined
+          }
+
+          const response = Message.decode(buf)
+
+          if (response.type !== Message.MessageType.DIAL_RESPONSE || response.dialResponse == null) {
+            log('Invalid autonat response from %s', connection.remotePeer)
+            return undefined
+          }
+
+          if (response.dialResponse.status === Message.ResponseStatus.OK) {
+            // make sure we use different network segments
+            const options = connection.remoteAddr.toOptions()
+            let segment: string
+
+            if (options.family === 4) {
+              const octets = options.host.split('.')
+              segment = octets[0]
+            } else if (options.family === 6) {
+              const octets = options.host.split(':')
+              segment = octets[0]
+            } else {
+              log('Remote address "%s" was not IP4 or IP6?', options.host)
+              return undefined
+            }
+
+            if (networkSegments.includes(segment)) {
+              log('Already have response from network segment %d - %s', segment, options.host)
+              return undefined
+            }
+
+            networkSegments.push(segment)
+          }
+
+          return response.dialResponse
+        } catch (err) {
+          log.error(err)
+        }
+      }
+
+      for await (const dialResponse of parallel(map(this.components.getPeerRouting().getClosestPeers(randomCid, {
+        signal: controller.signal
+      }), (peer) => async () => await verifyAddress(peer)), {
+        concurrency: REQUIRED_SUCCESSFUL_DIALS
+      })) {
+        try {
+          if (dialResponse == null) {
+            continue
+          }
+
+          // they either told us which address worked/didn't work, or we only sent them one address
+          const addr = dialResponse.addr == null ? multiaddrs[0] : multiaddr(dialResponse.addr)
+
+          log('Autonat response for %s is %s', addr, dialResponse.status)
+
+          if (dialResponse.status === Message.ResponseStatus.E_BAD_REQUEST) {
+            // the remote could not parse our request
+            continue
+          }
+
+          if (dialResponse.status === Message.ResponseStatus.E_DIAL_REFUSED) {
+            // the remote could not honour our request
+            continue
+          }
+
+          if (dialResponse.addr == null && multiaddrs.length > 1) {
+            // we sent the remote multiple addrs but they didn't tell us which ones worked/didn't work
+            continue
+          }
+
+          if (!multiaddrs.some(ma => ma.equals(addr))) {
+            log('Peer reported %s as %s but it was not in our observed address list', addr, dialResponse.status)
+            continue
+          }
+
+          const addrStr = addr.toString()
+
+          if (results[addrStr] == null) {
+            results[addrStr] = { success: 0, failure: 0 }
+          }
+
+          if (dialResponse.status === Message.ResponseStatus.OK) {
+            results[addrStr].success++
+          } else if (dialResponse.status === Message.ResponseStatus.E_DIAL_ERROR) {
+            results[addrStr].failure++
+          }
+
+          if (results[addrStr].success === REQUIRED_SUCCESSFUL_DIALS) {
+            // we are now convinced
+            log('%s is externally dialable', addr)
+            addressManager.confirmObservedAddr(addr)
+            return
+          }
+
+          if (results[addrStr].failure === REQUIRED_SUCCESSFUL_DIALS) {
+            // we are now unconvinced
+            log('%s is not externally dialable', addr)
+            addressManager.removeObservedAddr(addr)
+            return
+          }
+        } catch (err) {
+          log.error('Could not verify external address', err)
+        }
+      }
+    } finally {
+      controller.clear()
+      this.verifyAddressTimeout = setTimeout(this._verifyExternalAddresses, this.refreshInterval)
+    }
+  }
+}

--- a/src/autonat/pb/index.proto
+++ b/src/autonat/pb/index.proto
@@ -1,0 +1,35 @@
+syntax = "proto3";
+
+message Message {
+  enum MessageType {
+    DIAL          = 0;
+    DIAL_RESPONSE = 1;
+  }
+
+  enum ResponseStatus {
+    OK               = 0;
+    E_DIAL_ERROR     = 100;
+    E_DIAL_REFUSED   = 101;
+    E_BAD_REQUEST    = 200;
+    E_INTERNAL_ERROR = 300;
+  }
+
+  message PeerInfo {
+    optional bytes id = 1;
+    repeated bytes addrs = 2;
+  }
+
+  message Dial {
+    optional PeerInfo peer = 1;
+  }
+
+  message DialResponse {
+    optional ResponseStatus status = 1;
+    optional string statusText = 2;
+    optional bytes addr = 3;
+  }
+
+  optional MessageType type = 1;
+  optional Dial dial = 2;
+  optional DialResponse dialResponse = 3;
+}

--- a/src/autonat/pb/index.ts
+++ b/src/autonat/pb/index.ts
@@ -1,0 +1,133 @@
+/* eslint-disable import/export */
+/* eslint-disable @typescript-eslint/no-namespace */
+
+import { enumeration, encodeMessage, decodeMessage, message, bytes, string } from 'protons-runtime'
+import type { Codec } from 'protons-runtime'
+
+export interface Message {
+  type?: Message.MessageType
+  dial?: Message.Dial
+  dialResponse?: Message.DialResponse
+}
+
+export namespace Message {
+  export enum MessageType {
+    DIAL = 'DIAL',
+    DIAL_RESPONSE = 'DIAL_RESPONSE'
+  }
+
+  enum __MessageTypeValues {
+    DIAL = 0,
+    DIAL_RESPONSE = 1
+  }
+
+  export namespace MessageType {
+    export const codec = () => {
+      return enumeration<typeof MessageType>(__MessageTypeValues)
+    }
+  }
+
+  export enum ResponseStatus {
+    OK = 'OK',
+    E_DIAL_ERROR = 'E_DIAL_ERROR',
+    E_DIAL_REFUSED = 'E_DIAL_REFUSED',
+    E_BAD_REQUEST = 'E_BAD_REQUEST',
+    E_INTERNAL_ERROR = 'E_INTERNAL_ERROR'
+  }
+
+  enum __ResponseStatusValues {
+    OK = 0,
+    E_DIAL_ERROR = 100,
+    E_DIAL_REFUSED = 101,
+    E_BAD_REQUEST = 200,
+    E_INTERNAL_ERROR = 300
+  }
+
+  export namespace ResponseStatus {
+    export const codec = () => {
+      return enumeration<typeof ResponseStatus>(__ResponseStatusValues)
+    }
+  }
+
+  export interface PeerInfo {
+    id?: Uint8Array
+    addrs: Uint8Array[]
+  }
+
+  export namespace PeerInfo {
+    export const codec = (): Codec<PeerInfo> => {
+      return message<PeerInfo>({
+        1: { name: 'id', codec: bytes, optional: true },
+        2: { name: 'addrs', codec: bytes, repeats: true }
+      })
+    }
+
+    export const encode = (obj: PeerInfo): Uint8Array => {
+      return encodeMessage(obj, PeerInfo.codec())
+    }
+
+    export const decode = (buf: Uint8Array): PeerInfo => {
+      return decodeMessage(buf, PeerInfo.codec())
+    }
+  }
+
+  export interface Dial {
+    peer?: Message.PeerInfo
+  }
+
+  export namespace Dial {
+    export const codec = (): Codec<Dial> => {
+      return message<Dial>({
+        1: { name: 'peer', codec: Message.PeerInfo.codec(), optional: true }
+      })
+    }
+
+    export const encode = (obj: Dial): Uint8Array => {
+      return encodeMessage(obj, Dial.codec())
+    }
+
+    export const decode = (buf: Uint8Array): Dial => {
+      return decodeMessage(buf, Dial.codec())
+    }
+  }
+
+  export interface DialResponse {
+    status?: Message.ResponseStatus
+    statusText?: string
+    addr?: Uint8Array
+  }
+
+  export namespace DialResponse {
+    export const codec = (): Codec<DialResponse> => {
+      return message<DialResponse>({
+        1: { name: 'status', codec: Message.ResponseStatus.codec(), optional: true },
+        2: { name: 'statusText', codec: string, optional: true },
+        3: { name: 'addr', codec: bytes, optional: true }
+      })
+    }
+
+    export const encode = (obj: DialResponse): Uint8Array => {
+      return encodeMessage(obj, DialResponse.codec())
+    }
+
+    export const decode = (buf: Uint8Array): DialResponse => {
+      return decodeMessage(buf, DialResponse.codec())
+    }
+  }
+
+  export const codec = (): Codec<Message> => {
+    return message<Message>({
+      1: { name: 'type', codec: Message.MessageType.codec(), optional: true },
+      2: { name: 'dial', codec: Message.Dial.codec(), optional: true },
+      3: { name: 'dialResponse', codec: Message.DialResponse.codec(), optional: true }
+    })
+  }
+
+  export const encode = (obj: Message): Uint8Array => {
+    return encodeMessage(obj, Message.codec())
+  }
+
+  export const decode = (buf: Uint8Array): Message => {
+    return decodeMessage(buf, Message.codec())
+  }
+}

--- a/src/config.ts
+++ b/src/config.ts
@@ -100,6 +100,14 @@ const DefaultConfig: Partial<Libp2pInit> = {
     maxInboundStreams: 1,
     maxOutboundStreams: 1,
     timeout: 10000
+  },
+  autonat: {
+    protocolPrefix: 'libp2p',
+    maxInboundStreams: 1,
+    maxOutboundStreams: 1,
+    timeout: 30000,
+    startupDelay: 5000,
+    refreshInterval: 60000
   }
 }
 

--- a/src/identify/index.ts
+++ b/src/identify/index.ts
@@ -371,10 +371,15 @@ export class IdentifyService implements Startable {
     }
 
     log('identify completed for peer %p and protocols %o', id, protocols)
+    log('our observed address is %s', cleanObservedAddr)
 
-    // TODO: Add and score our observed addr
-    log('received observed address of %s', cleanObservedAddr?.toString())
-    // this.components.getAddressManager().addObservedAddr(observedAddr)
+    /*
+    if (cleanObservedAddr != null) {
+      // TODO: Add and score our observed addr
+      log('received observed address of %s', cleanObservedAddr?.toString())
+      this.components.getAddressManager().addObservedAddr(cleanObservedAddr)
+    }
+    */
   }
 
   /**

--- a/src/index.ts
+++ b/src/index.ts
@@ -26,6 +26,7 @@ import type { KeyChain } from './keychain/index.js'
 import type { ConnectionManagerInit } from './connection-manager/index.js'
 import type { PingServiceInit } from './ping/index.js'
 import type { FetchServiceInit } from './fetch/index.js'
+import type { AutonatServiceInit } from './autonat/index.js'
 
 export interface PersistentPeerStoreOptions {
   threshold?: number
@@ -112,6 +113,7 @@ export interface Libp2pInit {
   identify: IdentifyServiceInit
   ping: PingServiceInit
   fetch: FetchServiceInit
+  autonat: AutonatServiceInit
 
   transports: Transport[]
   streamMuxers?: StreamMuxerFactory[]

--- a/src/libp2p.ts
+++ b/src/libp2p.ts
@@ -28,6 +28,7 @@ import { PersistentPeerStore } from '@libp2p/peer-store'
 import { DHTContentRouting } from './dht/dht-content-routing.js'
 import { AutoDialer } from './connection-manager/dialer/auto-dialer.js'
 import { Initializable, Components, isInitializable } from '@libp2p/components'
+import { AutonatService } from './autonat/index.js'
 import type { PeerId } from '@libp2p/interface-peer-id'
 import type { Connection } from '@libp2p/interface-connection'
 import type { PeerRouting } from '@libp2p/interface-peer-routing'
@@ -59,6 +60,7 @@ export class Libp2pNode extends EventEmitter<Libp2pEvents> implements Libp2p {
   public identifyService?: IdentifyService
   public fetchService: FetchService
   public pingService: PingService
+  public autonatService: AutonatService
   public components: Components
   public peerStore: PeerStore
   public contentRouting: ContentRouting
@@ -232,6 +234,10 @@ export class Libp2pNode extends EventEmitter<Libp2pEvents> implements Libp2p {
 
     this.pingService = this.configureComponent(new PingService(this.components, {
       ...init.ping
+    }))
+
+    this.autonatService = this.configureComponent(new AutonatService(this.components, {
+      ...init.autonat
     }))
 
     const autoDialer = this.configureComponent(new AutoDialer(this.components, {

--- a/src/nat-manager.ts
+++ b/src/nat-manager.ts
@@ -157,11 +157,13 @@ export class NatManager implements Startable {
         protocol: transport.toUpperCase() === 'TCP' ? 'TCP' : 'UDP'
       })
 
-      this.components.getAddressManager().addObservedAddr(Multiaddr.fromNodeAddress({
+      const publicAddr = Multiaddr.fromNodeAddress({
         family: 4,
         address: publicIp,
         port: publicPort
-      }, transport))
+      }, transport)
+
+      this.components.getAddressManager().addObservedAddr(publicAddr)
     }
   }
 

--- a/test/addresses/address-manager.spec.ts
+++ b/test/addresses/address-manager.spec.ts
@@ -1,7 +1,7 @@
 /* eslint-env mocha */
 
 import { expect } from 'aegir/chai'
-import { Multiaddr, protocols } from '@multiformats/multiaddr'
+import { multiaddr, Multiaddr, protocols } from '@multiformats/multiaddr'
 import { AddressFilter, DefaultAddressManager } from '../../src/address-manager/index.js'
 import { createNode } from '../utils/creators/peer.js'
 import { createFromJSON } from '@libp2p/peer-id-factory'
@@ -80,13 +80,13 @@ describe('Address Manager', () => {
 
     expect(am.getObservedAddrs()).to.be.empty()
 
-    am.addObservedAddr('/ip4/123.123.123.123/tcp/39201')
+    am.addObservedAddr(multiaddr('/ip4/123.123.123.123/tcp/39201'))
 
     expect(am.getObservedAddrs()).to.have.lengthOf(1)
   })
 
   it('should dedupe added observed addresses', () => {
-    const ma = '/ip4/123.123.123.123/tcp/39201'
+    const ma = multiaddr('/ip4/123.123.123.123/tcp/39201')
     const am = new DefaultAddressManager(new Components({
       peerId,
       transportManager: stubInterface<TransportManager>()
@@ -101,11 +101,11 @@ describe('Address Manager', () => {
     am.addObservedAddr(ma)
 
     expect(am.getObservedAddrs()).to.have.lengthOf(1)
-    expect(am.getObservedAddrs().map(ma => ma.toString())).to.include(ma)
+    expect(am.getObservedAddrs().map(ma => ma.toString())).to.include(ma.toString())
   })
 
   it('should only emit one change:addresses event', () => {
-    const ma = '/ip4/123.123.123.123/tcp/39201'
+    const ma = multiaddr('/ip4/123.123.123.123/tcp/39201')
     const am = new DefaultAddressManager(new Components({
       peerId,
       transportManager: stubInterface<TransportManager>()
@@ -118,16 +118,16 @@ describe('Address Manager', () => {
       eventCount++
     })
 
-    am.addObservedAddr(ma)
-    am.addObservedAddr(ma)
-    am.addObservedAddr(ma)
-    am.addObservedAddr(`${ma}/p2p/${peerId.toString()}`)
+    am.confirmObservedAddr(ma)
+    am.confirmObservedAddr(ma)
+    am.confirmObservedAddr(ma)
+    am.confirmObservedAddr(multiaddr(`${ma}/p2p/${peerId.toString()}`))
 
     expect(eventCount).to.equal(1)
   })
 
   it('should strip our peer address from added observed addresses', () => {
-    const ma = '/ip4/123.123.123.123/tcp/39201'
+    const ma = multiaddr('/ip4/123.123.123.123/tcp/39201')
     const am = new DefaultAddressManager(new Components({
       peerId,
       transportManager: stubInterface<TransportManager>()
@@ -138,14 +138,14 @@ describe('Address Manager', () => {
     expect(am.getObservedAddrs()).to.be.empty()
 
     am.addObservedAddr(ma)
-    am.addObservedAddr(`${ma}/p2p/${peerId.toString()}`)
+    am.addObservedAddr(multiaddr(`${ma}/p2p/${peerId.toString()}`))
 
     expect(am.getObservedAddrs()).to.have.lengthOf(1)
-    expect(am.getObservedAddrs().map(ma => ma.toString())).to.include(ma)
+    expect(am.getObservedAddrs().map(ma => ma.toString())).to.include(ma.toString())
   })
 
   it('should strip our peer address from added observed addresses in difference formats', () => {
-    const ma = '/ip4/123.123.123.123/tcp/39201'
+    const ma = multiaddr('/ip4/123.123.123.123/tcp/39201')
     const am = new DefaultAddressManager(new Components({
       peerId,
       transportManager: stubInterface<TransportManager>()
@@ -156,10 +156,10 @@ describe('Address Manager', () => {
     expect(am.getObservedAddrs()).to.be.empty()
 
     am.addObservedAddr(ma)
-    am.addObservedAddr(`${ma}/p2p/${peerId.toString()}`)
+    am.addObservedAddr(multiaddr(`${ma}/p2p/${peerId.toString()}`))
 
     expect(am.getObservedAddrs()).to.have.lengthOf(1)
-    expect(am.getObservedAddrs().map(ma => ma.toString())).to.include(ma)
+    expect(am.getObservedAddrs().map(ma => ma.toString())).to.include(ma.toString())
   })
 })
 

--- a/test/addresses/addresses.node.ts
+++ b/test/addresses/addresses.node.ts
@@ -165,7 +165,7 @@ describe('libp2p.multiaddrs', () => {
 
     expect(libp2p.components.getAddressManager().getAddresses()).to.have.lengthOf(listenAddresses.length)
 
-    libp2p.components.getAddressManager().addObservedAddr(new Multiaddr(ma))
+    libp2p.components.getAddressManager().confirmObservedAddr(new Multiaddr(ma))
 
     expect(libp2p.components.getAddressManager().getAddresses()).to.have.lengthOf(listenAddresses.length + 1)
     expect(libp2p.components.getAddressManager().getAddresses().map(ma => ma.decapsulateCode(protocols('p2p').code).toString())).to.include(ma)

--- a/test/autonat/index.spec.ts
+++ b/test/autonat/index.spec.ts
@@ -1,0 +1,669 @@
+/* eslint-env mocha */
+/* eslint max-nested-callbacks: ["error", 5] */
+
+import { expect } from 'aegir/chai'
+import sinon from 'sinon'
+import { createEd25519PeerId } from '@libp2p/peer-id-factory'
+import { Components } from '@libp2p/components'
+import { start, stop } from '@libp2p/interfaces/startable'
+import { AutonatService, AutonatServiceInit } from '../../src/autonat/index.js'
+import { StubbedInstance, stubInterface } from 'ts-sinon'
+import type { PeerRouting } from '@libp2p/interface-peer-routing'
+import { Multiaddr, multiaddr } from '@multiformats/multiaddr'
+import type { Registrar } from '@libp2p/interface-registrar'
+import type { AddressManager } from '@libp2p/interface-address-manager'
+import type { Connection, Stream } from '@libp2p/interface-connection'
+import { PROTOCOL } from '../../src/autonat/constants.js'
+import { Message } from '../../src/autonat/pb/index.js'
+import type { PeerId } from '@libp2p/interface-peer-id'
+import { pushable } from 'it-pushable'
+import type { Transport, TransportManager } from '@libp2p/interface-transport'
+import type { AddressBook, PeerStore } from '@libp2p/interface-peer-store'
+import type { DefaultConnectionManager } from '../../src/connection-manager/index.js'
+import type { Dialer } from '../../src/connection-manager/dialer/index.js'
+import * as lp from 'it-length-prefixed'
+import all from 'it-all'
+import { pipe } from 'it-pipe'
+
+const defaultInit: AutonatServiceInit = {
+  protocolPrefix: 'libp2p',
+  maxInboundStreams: 1,
+  maxOutboundStreams: 1,
+  timeout: 100,
+  startupDelay: 120000,
+  refreshInterval: 120000
+}
+
+describe('autonat', () => {
+  let service: AutonatService
+  let components: Components
+  let peerRouting: StubbedInstance<PeerRouting>
+  let registrar: StubbedInstance<Registrar>
+  let addressManager: StubbedInstance<AddressManager>
+  let connectionManager: StubbedInstance<DefaultConnectionManager>
+  let dialer: StubbedInstance<Dialer>
+  let transportManager: StubbedInstance<TransportManager>
+  let peerStore: StubbedInstance<PeerStore>
+
+  beforeEach(async () => {
+    peerRouting = stubInterface<PeerRouting>()
+    registrar = stubInterface<Registrar>()
+    addressManager = stubInterface<AddressManager>()
+    addressManager.getAddresses.returns([])
+
+    dialer = stubInterface<Dialer>()
+    connectionManager = stubInterface<DefaultConnectionManager>()
+    // @ts-expect-error read-only property
+    connectionManager.dialer = dialer
+    transportManager = stubInterface<TransportManager>()
+    peerStore = stubInterface<PeerStore>()
+    peerStore.addressBook = stubInterface<AddressBook>()
+
+    components = new Components({
+      peerId: await createEd25519PeerId(),
+      peerRouting,
+      registrar,
+      addressManager,
+      connectionManager,
+      transportManager,
+      peerStore
+    })
+
+    service = new AutonatService(components, defaultInit)
+
+    await start(components)
+    await start(service)
+  })
+
+  afterEach(async () => {
+    sinon.restore()
+
+    await stop(service)
+    await stop(components)
+  })
+
+  describe('verify our observed addresses', () => {
+    async function stubPeerResponse (host: string, dialResponse: Message.DialResponse, peerId?: PeerId) {
+      // stub random peer lookup
+      const peer = {
+        id: peerId ?? await createEd25519PeerId(),
+        multiaddrs: [],
+        protocols: []
+      }
+
+      // stub connection to remote peer
+      const connection = stubInterface<Connection>()
+      connection.remoteAddr = multiaddr(`/ip4/${host}/tcp/28319/p2p/${peer.id.toString()}`)
+      connectionManager.openConnection.withArgs(peer.id).resolves(connection)
+
+      // stub autonat protocol stream
+      const stream = stubInterface<Stream>()
+      connection.newStream.withArgs(PROTOCOL).resolves(stream)
+
+      // stub autonat response
+      const response = Message.encode({
+        type: Message.MessageType.DIAL_RESPONSE,
+        dialResponse
+      })
+      stream.source = (async function * () {
+        yield lp.varintEncode(response.length)
+        yield response
+      }())
+      stream.sink.returns(Promise.resolve())
+
+      return peer
+    }
+
+    it('should request peers verify our observed address', async () => {
+      const observedAddress = multiaddr('/ip4/123.123.123.123/tcp/28319')
+      addressManager.getObservedAddrs.returns([observedAddress])
+
+      // The network says OK
+      const peers = [
+        await stubPeerResponse('124.124.124.124', {
+          status: Message.ResponseStatus.OK
+        }),
+        await stubPeerResponse('125.124.124.124', {
+          status: Message.ResponseStatus.OK
+        }),
+        await stubPeerResponse('126.124.124.124', {
+          status: Message.ResponseStatus.OK
+        }),
+        await stubPeerResponse('127.124.124.124', {
+          status: Message.ResponseStatus.OK
+        })
+      ]
+
+      peerRouting.getClosestPeers.returns(async function * () {
+        yield * peers
+      }())
+
+      await service.verifyExternalAddresses()
+
+      expect(addressManager.confirmObservedAddr.calledWith(observedAddress))
+        .to.be.true('Did not confirm observed multiaddr')
+    })
+
+    it('should mark observed address as low confidence when dialing fails', async () => {
+      const observedAddress = multiaddr('/ip4/123.123.123.123/tcp/28319')
+      addressManager.getObservedAddrs.returns([observedAddress])
+
+      // The network says ERROR
+      const peers = [
+        await stubPeerResponse('124.124.124.124', {
+          status: Message.ResponseStatus.E_DIAL_ERROR
+        }),
+        await stubPeerResponse('125.124.124.124', {
+          status: Message.ResponseStatus.E_DIAL_ERROR
+        }),
+        await stubPeerResponse('126.124.124.124', {
+          status: Message.ResponseStatus.E_DIAL_ERROR
+        }),
+        await stubPeerResponse('127.124.124.124', {
+          status: Message.ResponseStatus.E_DIAL_ERROR
+        })
+      ]
+
+      peerRouting.getClosestPeers.returns(async function * () {
+        yield * peers
+      }())
+
+      await service.verifyExternalAddresses()
+
+      expect(addressManager.removeObservedAddr.calledWith(observedAddress))
+        .to.be.true('Did not verify external multiaddr')
+    })
+
+    it('should ignore non error or success statuses', async () => {
+      const observedAddress = multiaddr('/ip4/123.123.123.123/tcp/28319')
+      addressManager.getObservedAddrs.returns([observedAddress])
+
+      // Mix of responses, mostly OK
+      const peers = [
+        await stubPeerResponse('124.124.124.124', {
+          status: Message.ResponseStatus.OK
+        }),
+        await stubPeerResponse('125.124.124.124', {
+          status: Message.ResponseStatus.OK
+        }),
+        await stubPeerResponse('126.124.124.124', {
+          status: Message.ResponseStatus.OK
+        }),
+        await stubPeerResponse('127.124.124.124', {
+          status: Message.ResponseStatus.E_DIAL_ERROR
+        }),
+        await stubPeerResponse('128.124.124.124', {
+          status: Message.ResponseStatus.E_DIAL_REFUSED
+        }),
+        await stubPeerResponse('129.124.124.124', {
+          status: Message.ResponseStatus.E_INTERNAL_ERROR
+        }),
+        await stubPeerResponse('139.124.124.124', {
+          status: Message.ResponseStatus.OK
+        })
+      ]
+
+      peerRouting.getClosestPeers.returns(async function * () {
+        yield * peers
+      }())
+
+      await service.verifyExternalAddresses()
+
+      expect(addressManager.confirmObservedAddr.calledWith(observedAddress))
+        .to.be.true('Did not confirm external multiaddr')
+
+      expect(connectionManager.openConnection.callCount)
+        .to.equal(peers.length, 'Did not open connections to all peers')
+    })
+
+    it('should require confirmation from diverse networks', async () => {
+      const observedAddress = multiaddr('/ip4/123.123.123.123/tcp/28319')
+      addressManager.getObservedAddrs.returns([observedAddress])
+
+      // an attacker says OK, the rest of the network says ERROR
+      const peers = [
+        await stubPeerResponse('124.124.124.124', {
+          status: Message.ResponseStatus.OK
+        }),
+        await stubPeerResponse('124.124.124.125', {
+          status: Message.ResponseStatus.OK
+        }),
+        await stubPeerResponse('124.124.124.126', {
+          status: Message.ResponseStatus.OK
+        }),
+        await stubPeerResponse('124.124.124.127', {
+          status: Message.ResponseStatus.OK
+        }),
+        await stubPeerResponse('127.124.124.124', {
+          status: Message.ResponseStatus.E_DIAL_ERROR
+        }),
+        await stubPeerResponse('128.124.124.124', {
+          status: Message.ResponseStatus.E_DIAL_ERROR
+        }),
+        await stubPeerResponse('129.124.124.124', {
+          status: Message.ResponseStatus.E_DIAL_ERROR
+        }),
+        await stubPeerResponse('130.124.124.124', {
+          status: Message.ResponseStatus.E_DIAL_ERROR
+        })
+      ]
+
+      peerRouting.getClosestPeers.returns(async function * () {
+        yield * peers
+      }())
+
+      await service.verifyExternalAddresses()
+
+      expect(addressManager.removeObservedAddr.calledWith(observedAddress))
+        .to.be.true('Did not verify external multiaddr')
+
+      expect(connectionManager.openConnection.callCount)
+        .to.equal(peers.length, 'Did not open connections to all peers')
+    })
+
+    it('should require confirmation from diverse peers', async () => {
+      const observedAddress = multiaddr('/ip4/123.123.123.123/tcp/28319')
+      addressManager.getObservedAddrs.returns([observedAddress])
+
+      const peerId = await createEd25519PeerId()
+
+      // an attacker says OK, the rest of the network says ERROR
+      const peers = [
+        await stubPeerResponse('124.124.124.124', {
+          status: Message.ResponseStatus.OK
+        }, peerId),
+        await stubPeerResponse('125.124.124.125', {
+          status: Message.ResponseStatus.OK
+        }, peerId),
+        await stubPeerResponse('126.124.124.126', {
+          status: Message.ResponseStatus.OK
+        }, peerId),
+        await stubPeerResponse('127.124.124.127', {
+          status: Message.ResponseStatus.OK
+        }, peerId),
+        await stubPeerResponse('128.124.124.124', {
+          status: Message.ResponseStatus.E_DIAL_ERROR
+        }),
+        await stubPeerResponse('129.124.124.124', {
+          status: Message.ResponseStatus.E_DIAL_ERROR
+        }),
+        await stubPeerResponse('130.124.124.124', {
+          status: Message.ResponseStatus.E_DIAL_ERROR
+        }),
+        await stubPeerResponse('131.124.124.124', {
+          status: Message.ResponseStatus.E_DIAL_ERROR
+        })
+      ]
+
+      peerRouting.getClosestPeers.returns(async function * () {
+        yield * peers
+      }())
+
+      await service.verifyExternalAddresses()
+
+      expect(addressManager.removeObservedAddr.calledWith(observedAddress))
+        .to.be.true('Did not verify external multiaddr')
+
+      expect(connectionManager.openConnection.callCount)
+        .to.equal(peers.length, 'Did not open connections to all peers')
+    })
+
+    it('should only accept observed addresses', async () => {
+      const observedAddress = multiaddr('/ip4/123.123.123.123/tcp/28319')
+      const reportedAddress = multiaddr('/ip4/100.100.100.100/tcp/28319')
+
+      // our observed addresses
+      addressManager.getObservedAddrs.returns([observedAddress])
+
+      // an attacker says OK, the rest of the network says ERROR
+      const peers = [
+        await stubPeerResponse('124.124.124.124', {
+          status: Message.ResponseStatus.OK,
+          addr: reportedAddress.bytes
+        }),
+        await stubPeerResponse('125.124.124.125', {
+          status: Message.ResponseStatus.OK,
+          addr: reportedAddress.bytes
+        }),
+        await stubPeerResponse('126.124.124.126', {
+          status: Message.ResponseStatus.OK,
+          addr: reportedAddress.bytes
+        }),
+        await stubPeerResponse('127.124.124.127', {
+          status: Message.ResponseStatus.OK,
+          addr: reportedAddress.bytes
+        }),
+        await stubPeerResponse('128.124.124.124', {
+          status: Message.ResponseStatus.E_DIAL_ERROR
+        }),
+        await stubPeerResponse('129.124.124.124', {
+          status: Message.ResponseStatus.E_DIAL_ERROR
+        }),
+        await stubPeerResponse('130.124.124.124', {
+          status: Message.ResponseStatus.E_DIAL_ERROR
+        }),
+        await stubPeerResponse('131.124.124.124', {
+          status: Message.ResponseStatus.E_DIAL_ERROR
+        })
+      ]
+
+      peerRouting.getClosestPeers.returns(async function * () {
+        yield * peers
+      }())
+
+      await service.verifyExternalAddresses()
+
+      expect(addressManager.removeObservedAddr.calledWith(observedAddress))
+        .to.be.true('Did not verify external multiaddr')
+
+      expect(connectionManager.openConnection.callCount)
+        .to.equal(peers.length, 'Did not open connections to all peers')
+    })
+
+    it('should time out when verifying an observed address', async () => {
+      const observedAddress = multiaddr('/ip4/123.123.123.123/tcp/28319')
+      addressManager.getObservedAddrs.returns([observedAddress])
+
+      // The network says OK
+      const peers = [
+        await stubPeerResponse('124.124.124.124', {
+          status: Message.ResponseStatus.OK
+        }),
+        await stubPeerResponse('125.124.124.124', {
+          status: Message.ResponseStatus.OK
+        }),
+        await stubPeerResponse('126.124.124.124', {
+          status: Message.ResponseStatus.OK
+        }),
+        await stubPeerResponse('127.124.124.124', {
+          status: Message.ResponseStatus.OK
+        })
+      ]
+
+      peerRouting.getClosestPeers.returns(async function * () {
+        yield * peers
+      }())
+
+      connectionManager.openConnection.reset()
+      connectionManager.openConnection.callsFake(async (peer, options = {}) => {
+        return await Promise<Connection>.race([
+          new Promise<Connection>((resolve, reject) => {
+            options.signal?.addEventListener('abort', () => {
+              reject(new Error('Dial aborted!'))
+            })
+          }),
+          new Promise<Connection>((resolve, reject) => {
+            // longer than the timeout
+            setTimeout(() => {
+              reject(new Error('Dial Timeout!'))
+            }, 1000)
+          })
+        ])
+      })
+
+      await service.verifyExternalAddresses()
+
+      expect(addressManager.addObservedAddr.called)
+        .to.be.false('Verify external multiaddr when we should have timed out')
+    })
+  })
+
+  describe('verify others observed addresses', () => {
+    async function stubIncomingStream (opts: {
+      requestingPeer?: PeerId
+      remotePeer?: PeerId
+      observedAddress?: Multiaddr
+      remoteAddr?: Multiaddr
+      message?: Message | Uint8Array | boolean
+      transportSupported?: boolean
+      canDial?: boolean
+    } = {}) {
+      const requestingPeer = opts.requestingPeer ?? await createEd25519PeerId()
+      const remotePeer = opts.remotePeer ?? requestingPeer
+      const observedAddress = opts.observedAddress ?? multiaddr('/ip4/124.124.124.124/tcp/28319')
+      const remoteAddr = opts.remoteAddr ?? observedAddress.encapsulate(`/p2p/${remotePeer.toString()}`)
+      const source = pushable()
+      const sink = pushable()
+      const stream: Stream = {
+        ...stubInterface<Stream>(),
+        source,
+        sink: async (stream) => {
+          for await (const buf of stream) {
+            sink.push(buf)
+          }
+
+          sink.end()
+        }
+      }
+      const connection = {
+        ...stubInterface<Connection>(),
+        remotePeer,
+        remoteAddr
+      }
+
+      // we might support this transport
+      transportManager.transportForMultiaddr.withArgs(observedAddress)
+        .returns(opts.transportSupported === false ? undefined : stubInterface<Transport>())
+
+      // we might open a new connection
+      const newConnection = stubInterface<Connection>()
+      newConnection.remotePeer = remotePeer
+      newConnection.remoteAddr = remoteAddr
+
+      if (opts.canDial === false) {
+        dialer.dial.rejects(new Error('Could not dial'))
+      } else if (opts.canDial === true) {
+        dialer.dial.resolves(newConnection)
+      }
+
+      let buf: Uint8Array | undefined
+
+      if (opts.message instanceof Uint8Array) {
+        buf = opts.message
+      } else if (opts.message == null) {
+        buf = Message.encode({
+          type: Message.MessageType.DIAL,
+          dial: {
+            peer: {
+              id: requestingPeer.toBytes(),
+              addrs: [
+                observedAddress.bytes
+              ]
+            }
+          }
+        })
+      } else if (opts.message !== false && opts.message !== true) {
+        buf = Message.encode(opts.message)
+      }
+
+      if (buf != null) {
+        source.push(lp.varintEncode(buf.byteLength))
+        source.push(buf)
+      }
+
+      source.end()
+
+      await service.handleIncomingAutonatStream({
+        stream,
+        connection
+      })
+
+      const slice = await pipe(
+        sink,
+        lp.decode(),
+        source => all(source)
+      )
+
+      if (slice.length !== 1) {
+        throw new Error('Response was not length encoded')
+      }
+
+      const message = Message.decode(slice[0])
+
+      if (message.dialResponse?.status === Message.ResponseStatus.OK) {
+        expect(newConnection.close.called).to.be.true('Did not close connection after dial')
+      }
+
+      return message
+    }
+
+    it('should dial a requested address', async () => {
+      const message = await stubIncomingStream({
+        canDial: true
+      })
+
+      expect(message).to.have.property('type', Message.MessageType.DIAL_RESPONSE)
+      expect(message).to.have.nested.property('dialResponse.status', Message.ResponseStatus.OK)
+    })
+
+    it('should expect a message', async () => {
+      const message = await stubIncomingStream({
+        message: false
+      })
+
+      expect(message).to.have.property('type', Message.MessageType.DIAL_RESPONSE)
+      expect(message).to.have.nested.property('dialResponse.status', Message.ResponseStatus.E_BAD_REQUEST)
+      expect(message).to.have.nested.property('dialResponse.statusText', 'No message was sent')
+    })
+
+    it('should expect a valid message', async () => {
+      const message = await stubIncomingStream({
+        message: Uint8Array.from([3, 2, 1, 0])
+      })
+
+      expect(message).to.have.property('type', Message.MessageType.DIAL_RESPONSE)
+      expect(message).to.have.nested.property('dialResponse.status', Message.ResponseStatus.E_BAD_REQUEST)
+      expect(message).to.have.nested.property('dialResponse.statusText', 'Could not decode message')
+    })
+
+    it('should expect a dial message', async () => {
+      const message = await stubIncomingStream({
+        message: {}
+      })
+
+      expect(message).to.have.property('type', Message.MessageType.DIAL_RESPONSE)
+      expect(message).to.have.nested.property('dialResponse.status', Message.ResponseStatus.E_BAD_REQUEST)
+      expect(message).to.have.nested.property('dialResponse.statusText', 'No Dial message found in message')
+    })
+
+    it('should expect a message with a peer id', async () => {
+      const observedAddress = multiaddr('/ip4/124.124.124.124/tcp/28319')
+      const message = await stubIncomingStream({
+        observedAddress,
+        message: {
+          type: Message.MessageType.DIAL,
+          dial: {
+            peer: {
+              addrs: [
+                observedAddress.bytes
+              ]
+            }
+          }
+        }
+      })
+
+      expect(message).to.have.property('type', Message.MessageType.DIAL_RESPONSE)
+      expect(message).to.have.nested.property('dialResponse.status', Message.ResponseStatus.E_BAD_REQUEST)
+      expect(message).to.have.nested.property('dialResponse.statusText', 'missing peer info')
+    })
+
+    it('should expect a message with a valid peer id', async () => {
+      const observedAddress = multiaddr('/ip4/124.124.124.124/tcp/28319')
+      const message = await stubIncomingStream({
+        observedAddress,
+        message: {
+          type: Message.MessageType.DIAL,
+          dial: {
+            peer: {
+              id: Uint8Array.from([0, 1, 2, 3]),
+              addrs: [
+                observedAddress.bytes
+              ]
+            }
+          }
+        }
+      })
+
+      expect(message).to.have.property('type', Message.MessageType.DIAL_RESPONSE)
+      expect(message).to.have.nested.property('dialResponse.status', Message.ResponseStatus.E_BAD_REQUEST)
+      expect(message).to.have.nested.property('dialResponse.statusText', 'bad peer id')
+    })
+
+    it('should fail to dial a requested address when it arrives via a relay', async () => {
+      const remotePeer = await createEd25519PeerId()
+      const requestingPeer = await createEd25519PeerId()
+
+      const message = await stubIncomingStream({
+        remotePeer,
+        remoteAddr: multiaddr(`/ip4/223.223.223.223/tcp/27132/p2p/${remotePeer.toString()}/p2p-circuit/p2p/${requestingPeer.toString()}`),
+        requestingPeer
+      })
+
+      expect(message).to.have.property('type', Message.MessageType.DIAL_RESPONSE)
+      expect(message).to.have.nested.property('dialResponse.status', Message.ResponseStatus.E_BAD_REQUEST)
+      expect(message).to.have.nested.property('dialResponse.statusText', 'peer id mismatch')
+    })
+
+    it('should refuse to dial a requested address when it is from a different host', async () => {
+      const requestingPeer = await createEd25519PeerId()
+      const observedAddress = multiaddr('/ip4/10.10.10.10/tcp/27132')
+      const remoteAddr = multiaddr(`/ip4/129.129.129.129/tcp/27132/p2p/${requestingPeer.toString()}`)
+
+      const message = await stubIncomingStream({
+        requestingPeer,
+        remoteAddr,
+        observedAddress
+      })
+
+      expect(message).to.have.property('type', Message.MessageType.DIAL_RESPONSE)
+      expect(message).to.have.nested.property('dialResponse.status', Message.ResponseStatus.E_DIAL_REFUSED)
+      expect(message).to.have.nested.property('dialResponse.statusText', 'no dialable addresses')
+    })
+
+    it('should refuse to dial a requested address when it is on an unsupported transport', async () => {
+      const message = await stubIncomingStream({
+        transportSupported: false
+      })
+
+      expect(message).to.have.property('type', Message.MessageType.DIAL_RESPONSE)
+      expect(message).to.have.nested.property('dialResponse.status', Message.ResponseStatus.E_DIAL_REFUSED)
+      expect(message).to.have.nested.property('dialResponse.statusText', 'no dialable addresses')
+    })
+
+    it('should error when to dialing a requested address', async () => {
+      const message = await stubIncomingStream({
+        canDial: false
+      })
+
+      expect(message).to.have.property('type', Message.MessageType.DIAL_RESPONSE)
+      expect(message).to.have.nested.property('dialResponse.status', Message.ResponseStatus.E_DIAL_ERROR)
+      expect(message).to.have.nested.property('dialResponse.statusText', 'Could not dial')
+    })
+
+    it('should time out when dialing a requested address', async () => {
+      dialer.dial.callsFake(async function (ma, options = {}) {
+        return await Promise<Connection>.race([
+          new Promise<Connection>((resolve, reject) => {
+            options.signal?.addEventListener('abort', () => {
+              reject(new Error('Dial aborted!'))
+            })
+          }),
+          new Promise<Connection>((resolve, reject) => {
+            // longer than the timeout
+            setTimeout(() => {
+              reject(new Error('Dial Timeout!'))
+            }, 1000)
+          })
+        ])
+      })
+
+      const message = await stubIncomingStream({
+        canDial: undefined
+      })
+
+      expect(message).to.have.property('type', Message.MessageType.DIAL_RESPONSE)
+      expect(message).to.have.nested.property('dialResponse.status', Message.ResponseStatus.E_DIAL_ERROR)
+      expect(message).to.have.nested.property('dialResponse.statusText', 'Dial aborted!')
+    })
+  })
+})

--- a/test/core/consume-peer-record.spec.ts
+++ b/test/core/consume-peer-record.spec.ts
@@ -28,7 +28,7 @@ describe('Consume peer record', () => {
     await libp2p.stop()
   })
 
-  it('should consume peer record when observed addrs are added', async () => {
+  it('should consume peer record when observed addrs are confirmed', async () => {
     let done: () => void
 
     libp2p.components.getPeerStore().addressBook.consumePeerRecord = async () => {
@@ -42,7 +42,7 @@ describe('Consume peer record', () => {
 
     await libp2p.start()
 
-    libp2p.components.getAddressManager().addObservedAddr(new Multiaddr('/ip4/123.123.123.123/tcp/3983'))
+    libp2p.components.getAddressManager().confirmObservedAddr(new Multiaddr('/ip4/123.123.123.123/tcp/3983'))
 
     await p
 


### PR DESCRIPTION
Implements the [autonat](https://github.com/libp2p/specs/blob/master/autonat/README.md)
spec to give us confidence in our external addresses and to open the
door to things like switching DHT server mode on automatically, hole
punching, v2 circuit relay etc.

Depends on:

- [ ] https://github.com/libp2p/js-libp2p-interfaces/pull/269