### PR TITLE
fix: remove mplex prefix from muxer errors

### DIFF
--- a/examples/delegated-routing/package.json
+++ b/examples/delegated-routing/package.json
@@ -9,7 +9,7 @@
     "@libp2p/delegated-content-routing": "^2.0.1",
     "@libp2p/delegated-peer-routing": "^2.0.1",
     "@libp2p/kad-dht": "^3.0.0",
-    "@libp2p/mplex": "^4.0.1",
+    "@libp2p/mplex": "^4.0.2",
     "@libp2p/webrtc-star": "^3.0.0",
     "@libp2p/websockets": "^3.0.0",
     "react": "^17.0.2",

--- a/examples/libp2p-in-the-browser/package.json
+++ b/examples/libp2p-in-the-browser/package.json
@@ -11,7 +11,7 @@
   "dependencies": {
     "@chainsafe/libp2p-noise": "^7.0.1",
     "@libp2p/bootstrap": "^2.0.0",
-    "@libp2p/mplex": "^4.0.1",
+    "@libp2p/mplex": "^4.0.2",
     "@libp2p/webrtc-star": "^3.0.0",
     "@libp2p/websockets": "^3.0.0",
     "libp2p": "../../"

--- a/examples/webrtc-direct/package.json
+++ b/examples/webrtc-direct/package.json
@@ -12,7 +12,7 @@
     "@libp2p/webrtc-direct": "^2.0.0",
     "@chainsafe/libp2p-noise": "^7.0.1",
     "@libp2p/bootstrap": "^2.0.0",
-    "@libp2p/mplex": "^4.0.1",
+    "@libp2p/mplex": "^4.0.2",
     "libp2p": "../../",
     "wrtc": "^0.4.7"
   },

--- a/package.json
+++ b/package.json
@@ -180,7 +180,7 @@
     "@libp2p/interop": "^2.0.0",
     "@libp2p/kad-dht": "^3.0.0",
     "@libp2p/mdns": "^3.0.0",
-    "@libp2p/mplex": "^4.0.1",
+    "@libp2p/mplex": "^4.0.2",
     "@libp2p/pubsub": "^3.0.1",
     "@libp2p/tcp": "^3.0.0",
     "@libp2p/topology": "^3.0.0",

--- a/test/relay/relay.node.ts
+++ b/test/relay/relay.node.ts
@@ -202,6 +202,6 @@ describe('Dialing (via relay, TCP)', () => {
 
     // because we timed out, the remote should have reset the stream
     await expect(all(stream.source)).to.eventually.be.rejected
-      .with.property('code', 'ERR_MPLEX_STREAM_RESET')
+      .with.property('code', 'ERR_STREAM_RESET')
   })
 })

--- a/test/upgrading/upgrader.spec.ts
+++ b/test/upgrading/upgrader.spec.ts
@@ -654,7 +654,7 @@ describe('libp2p.upgrader', () => {
     expect(streamCount).to.equal(1)
 
     await expect(localToRemote.newStream(protocol)).to.eventually.be.rejected()
-      .with.property('code', 'ERR_MPLEX_STREAM_RESET')
+      .with.property('code', 'ERR_STREAM_RESET')
   })
 
   it('should limit the number of outgoing streams that can be opened using a protocol', async () => {


### PR DESCRIPTION
Muxer errors are now standard across implementations so do not depend on the `"MPLEX_"` prefix