### PR TITLE
do not trigger attack protection when loading self

### DIFF
--- a/src/libp2p.ts
+++ b/src/libp2p.ts
@@ -361,11 +361,14 @@ export class Libp2pNode extends EventEmitter<Libp2pEvents> implements Libp2p {
       return
     }
 
-    try {
-      await this.keychain.findKeyByName('self')
-    } catch (err: any) {
-      await this.keychain.importPeer('self', this.peerId)
+    const keyInfos = await this.keychain.listKeys()
+    for (const keyInfo of keyInfos){
+      if (keyInfo.name === 'self'){
+        await this.keychain.findKeyByName('self')
+        return
+      }
     }
+    await this.keychain.importPeer('self', this.peerId)
   }
 
   isStarted () {


### PR DESCRIPTION
If the repo is empty, then calling `await this.keychain.findKeyByName('self')` will trigger [`await randomDelay()`](https://github.com/libp2p/js-libp2p/blob/05e8e7ead96d494bdd7dfa5d6430155670066767/src/keychain/index.ts#L305) which attempts to slow down some kinds of attacks.  We are not attacking ourselves, and so we should check for the `self` key gracefully.

Further, there appears no purpose for the try/catch block since its original use was to catch the error thrown by `findKeyByName('self')`