### PR TITLE
fix: catch errors when reconnecting old peers

### DIFF
--- a/src/connection-manager/index.ts
+++ b/src/connection-manager/index.ts
@@ -347,6 +347,9 @@ export class DefaultConnectionManager extends EventEmitter<ConnectionManagerEven
           })
         )
       })
+      .catch(err => {
+        log.error(err)
+      })
       .finally(() => {
         this.connectOnStartupController?.clear()
       })


### PR DESCRIPTION
Since we don't wait for successful reconnection to existing peers,
the peerstore can be closed while we're accessing it since we might
be shut down right after we've started up, e.g. during test runs so
just log any reconnect errors instead of throwing.