### PR TITLE
fix: prepend connection addr to circuit relay address

### DIFF
--- a/src/circuit/transport.ts
+++ b/src/circuit/transport.ts
@@ -132,10 +132,10 @@ export class Circuit implements Transport, Initializable {
       }
 
       if (virtualConnection != null) {
-        // @ts-expect-error dst peer will not be undefined
-        const remoteAddr = new Multiaddr(request.dstPeer.addrs[0])
-        // @ts-expect-error dst peer will not be undefined
-        const localAddr = new Multiaddr(request.srcPeer.addrs[0])
+        const remoteAddr = connection.remoteAddr
+              .encapsulate('/p2p-circuit')
+              .encapsulate(new Multiaddr(request.dstPeer?.addrs[0]))
+        const localAddr = new Multiaddr(request.srcPeer?.addrs[0])
         const maConn = streamToMaConnection({
           stream: virtualConnection,
           remoteAddr,

--- a/src/circuit/transport.ts
+++ b/src/circuit/transport.ts
@@ -133,8 +133,8 @@ export class Circuit implements Transport, Initializable {
 
       if (virtualConnection != null) {
         const remoteAddr = connection.remoteAddr
-              .encapsulate('/p2p-circuit')
-              .encapsulate(new Multiaddr(request.dstPeer?.addrs[0]))
+          .encapsulate('/p2p-circuit')
+          .encapsulate(new Multiaddr(request.dstPeer?.addrs[0]))
         const localAddr = new Multiaddr(request.srcPeer?.addrs[0])
         const maConn = streamToMaConnection({
           stream: virtualConnection,


### PR DESCRIPTION
Otherwise the reported remote addr is not valid