### PR TITLE
fix!: load self key into keychain on startup if not present

### DIFF
--- a/doc/API.md
+++ b/doc/API.md
@@ -185,36 +185,6 @@ Required keys in the `options` object:
 
 ## Libp2p Instance Methods
 
-### loadKeychain
-
-Load keychain keys from the datastore, importing the private key as 'self', if needed.
-
-`libp2p.loadKeychain()`
-
-#### Returns
-
-| Type | Description |
-|------|-------------|
-| `Promise` | Promise resolves when the keychain is ready |
-
-#### Example
-
-```js
-import { createLibp2p } from 'libp2p'
-
-// ...
-
-const libp2p = await createLibp2p({
-  // ...
-  keychain: {
-    pass: '0123456789pass1234567890'
-  }
-})
-
-// load keychain
-await libp2p.loadKeychain()
-```
-
 ### start
 
 Starts the libp2p node.

--- a/doc/CONFIGURATION.md
+++ b/doc/CONFIGURATION.md
@@ -494,8 +494,6 @@ const node = await createLibp2p({
     datastore: dsInstant,
   }
 })
-
-await node.loadKeychain()
 ```
 
 #### Configuring Dialing

--- a/src/index.ts
+++ b/src/index.ts
@@ -141,12 +141,6 @@ export interface Libp2p extends Startable, EventEmitter<Libp2pEvents> {
   dht: DualDHT
 
   /**
-   * Load keychain keys from the datastore.
-   * Imports the private key as 'self', if needed.
-   */
-  loadKeychain: () => Promise<void>
-
-  /**
    * Get a deduplicated list of peer advertising multiaddrs by concatenating
    * the listen addresses used by transports with any configured
    * announce addresses as well as observed addresses reported by peers.

--- a/src/libp2p.ts
+++ b/src/libp2p.ts
@@ -352,22 +352,6 @@ export class Libp2pNode extends EventEmitter<Libp2pEvents> implements Libp2p {
     log('libp2p has stopped')
   }
 
-  /**
-   * Load keychain keys from the datastore.
-   * Imports the private key as 'self', if needed.
-   */
-  async loadKeychain () {
-    if (this.keychain == null) {
-      return
-    }
-
-    try {
-      await this.keychain.findKeyByName('self')
-    } catch (err: any) {
-      await this.keychain.importPeer('self', this.peerId)
-    }
-  }
-
   isStarted () {
     return this.started
   }

--- a/test/configuration/utils.ts
+++ b/test/configuration/utils.ts
@@ -9,12 +9,10 @@ import type { Message, PublishResult, PubSubInit, PubSubRPC, PubSubRPCMessage } 
 import type { Libp2pInit, Libp2pOptions } from '../../src/index.js'
 import type { PeerId } from '@libp2p/interface-peer-id'
 import * as cborg from 'cborg'
-import { peerIdFromString } from '@libp2p/peer-id'
 
 const relayAddr = MULTIADDRS_WEBSOCKETS[0]
 
 export const baseOptions: Partial<Libp2pInit> = {
-  peerId: peerIdFromString('12D3KooWJKCJW8Y26pRFNv78TCMGLNTfyN8oKaFswMRYXTzSbSst'),
   transports: [new WebSockets()],
   streamMuxers: [new Mplex()],
   connectionEncryption: [new Plaintext()]

--- a/test/keychain/keychain.spec.ts
+++ b/test/keychain/keychain.spec.ts
@@ -512,8 +512,6 @@ describe('libp2p.keychain', () => {
       }
     })
 
-    await libp2p.loadKeychain()
-
     const kInfo = await libp2p.keychain.createKey('keyName', 'Ed25519')
     expect(kInfo).to.exist()
   })
@@ -525,8 +523,6 @@ describe('libp2p.keychain', () => {
         datastore: new MemoryDatastore()
       }
     })
-
-    await libp2p.loadKeychain()
 
     const kInfo = await libp2p.keychain.createKey('keyName', 'Ed25519')
     expect(kInfo).to.exist()
@@ -543,7 +539,6 @@ describe('libp2p.keychain', () => {
         }
       }
     })
-    await libp2p.loadKeychain()
 
     const kInfo = await libp2p.keychain.createKey('keyName', 'Ed25519')
     expect(kInfo).to.exist()
@@ -558,7 +553,6 @@ describe('libp2p.keychain', () => {
       }
     })
 
-    await libp2p2.loadKeychain()
     const key = await libp2p2.keychain.findKeyByName('keyName')
 
     expect(key).to.exist()


### PR DESCRIPTION
To prevent triggering keychain attack prevention on startup, refactor the `KeyChain` class to load the current PeerId as the `'self'` key on startup.

Fixes #1315

BREAKING CHANGE: the `loadKeychain` method has been removed as it is no longer necessary