### PR TITLE
fix: discovery mechanism examples not working

### DIFF
--- a/examples/discovery-mechanisms/3.js
+++ b/examples/discovery-mechanisms/3.js
@@ -67,7 +67,7 @@ const createNode = async (bootstrappers) => {
     const peer = evt.detail
     console.log(`Peer ${node1.peerId.toString()} discovered: ${peer.id.toString()}`)
   })
-  node2.addEventListener('peer:discovery',(evt) => {
+  node2.addEventListener('peer:discovery', (evt) => {
     const peer = evt.detail
     console.log(`Peer ${node2.peerId.toString()} discovered: ${peer.id.toString()}`)
   })
@@ -77,4 +77,4 @@ const createNode = async (bootstrappers) => {
     node1.start(),
     node2.start()
   ])
-})();
+})()

--- a/examples/discovery-mechanisms/test-2.js
+++ b/examples/discovery-mechanisms/test-2.js
@@ -27,7 +27,7 @@ export async function test () {
     })
   })
 
-  await pWaitFor(() => discoveredNodes > 1)
+  await pWaitFor(() => discoveredNodes > 1, 600000)
 
   proc.kill()
 }

--- a/examples/discovery-mechanisms/test-3.js
+++ b/examples/discovery-mechanisms/test-3.js
@@ -32,7 +32,7 @@ export async function test () {
     })
   })
 
-  await pWaitFor(() => discoveredPeers.length > 3)
+  await pWaitFor(() => discoveredPeers.length > 2, 600000)
 
   proc.kill()
 }

--- a/examples/package.json
+++ b/examples/package.json
@@ -9,7 +9,7 @@
   },
   "license": "MIT",
   "dependencies": {
-    "@libp2p/pubsub-peer-discovery": "^6.0.1",
+    "@libp2p/pubsub-peer-discovery": "^6.0.2",
     "@libp2p/floodsub": "^3.0.3",
     "@nodeutils/defaults-deep": "^1.1.0",
     "execa": "^6.1.0",


### PR DESCRIPTION
- fixed tests that were passing even though the example isn't working
- added timeouts to avoid infinite wait

Depends on:
- https://github.com/libp2p/js-libp2p-pubsub-peer-discovery/pull/49

resolves #1229