### PR TITLE
docs: re-add talks section

### DIFF
--- a/README.md
+++ b/README.md
@@ -66,6 +66,8 @@ We are in the process of writing better documentation, blog posts, tutorials and
 - [docs.libp2p.io](https://docs.libp2p.io)
 - [Specification (WIP)](https://github.com/libp2p/specs)
 - [Discussion Forums](https://discuss.libp2p.io)
+- Talks
+  - [`libp2p <3 ethereum` at DEVCON2](https://archive.devcon.org/archive/watch/2/libp2p-devp2p-ipfs-and-ethereum-networking/)
 - Articles
   - [The overview of libp2p](https://github.com/libp2p/libp2p#description)
 


### PR DESCRIPTION
The libp2p <3 ethereum video seems to have been moved to https://archive.devcon.org/archive/watch/2/libp2p-devp2p-ipfs-and-ethereum-networking/
unfortunately couldnt find the slides and demos previously linked

Related:
https://github.com/libp2p/js-libp2p/issues/1299
https://github.com/libp2p/js-libp2p/pull/1300