### PR TITLE
docs: fix examples in documentation

### DIFF
--- a/doc/GETTING_STARTED.md
+++ b/doc/GETTING_STARTED.md
@@ -34,12 +34,12 @@ Now that we have libp2p installed, let's configure the minimum needed to get you
 
 Libp2p uses Transports to establish connections between peers over the network. Transports are the components responsible for performing the actual exchange of data between libp2p nodes. You can configure any number of Transports, but you only need 1 to start with. Supporting more Transports will improve the ability of your node to speak to a larger number of nodes on the network, as matching Transports are required for two nodes to communicate with one another.
 
-You should select Transports according to the runtime of your application; Node.js or the browser. You can see a list of some of the available Transports in the [configuration readme](./CONFIGURATION.md#transport). For this guide let's install `libp2p-websockets`, as it can be used in both Node.js and the browser.
+You should select Transports according to the runtime of your application; Node.js or the browser. You can see a list of some of the available Transports in the [configuration readme](./CONFIGURATION.md#transport). For this guide let's install `@libp2p/websockets`, as it can be used in both Node.js and the browser.
 
-Start by installing `libp2p-websockets`:
+Start by installing `@libp2p/websockets`:
 
 ```sh
-npm install libp2p-websockets
+npm install @libp2p/websockets
 ```
 
 Now that we have the module installed, let's configure libp2p to use the Transport. We'll use the [`Libp2p.create`](./API.md#create) method, which takes a single configuration object as its only parameter. We can add the Transport by passing it into the `modules.transport` array:
@@ -66,13 +66,13 @@ If you want to know more about libp2p transports, you should read the following 
 
 Encryption is an important part of communicating on the libp2p network. Every connection must be encrypted to help ensure security for everyone. As such, Connection Encryption (Crypto) is a required component of libp2p.
 
-There are a growing number of Crypto modules being developed for libp2p. As those are released they will be tracked in the [Connection Encryption section of the configuration readme](./CONFIGURATION.md#connection-encryption). For now, we are going to configure our node to use the `libp2p-noise` module.
+There are a growing number of Crypto modules being developed for libp2p. As those are released they will be tracked in the [Connection Encryption section of the configuration readme](./CONFIGURATION.md#connection-encryption). For now, we are going to configure our node to use the `@chainsafe/libp2p-noise` module.
 
 ```sh
-npm install libp2p-noise
+npm install @chainsafe/libp2p-noise
 ```
 
-With `libp2p-noise` installed, we can add it to our existing configuration by importing it and adding it to the `modules.connEncryption` array:
+With `@chainsafe/libp2p-noise` installed, we can add it to our existing configuration by importing it and adding it to the `modules.connEncryption` array:
 
 ```js
 import { createLibp2p } from 'libp2p'
@@ -96,12 +96,12 @@ If you want to know more about libp2p connection encryption, you should read the
 
 While multiplexers are not strictly required, they are highly recommended as they improve the effectiveness and efficiency of connections for the various protocols libp2p runs. Adding a multiplexer to your configuration will allow libp2p to run several of its internal protocols, like Identify, as well as allow your application to easily run any number of protocols over a single connection.
 
-Looking at the [available stream multiplexing](./CONFIGURATION.md#stream-multiplexing) modules, js-libp2p currently only supports `libp2p-mplex`, so we will use that here. Bear in mind that future libp2p Transports might have `multiplexing` capabilities already built-in (such as `QUIC`).
+Looking at the [available stream multiplexing](./CONFIGURATION.md#stream-multiplexing) modules, js-libp2p currently only supports `@libp2p/mplex`, so we will use that here. Bear in mind that future libp2p Transports might have `multiplexing` capabilities already built-in (such as `QUIC`).
 
-You can install `libp2p-mplex` and add it to your libp2p node as follows in the next example.
+You can install `@libp2p/mplex` and add it to your libp2p node as follows in the next example.
 
 ```sh
-npm install libp2p-mplex
+npm install @libp2p/mplex
 ```
 
 ```js
@@ -170,17 +170,17 @@ Peer discovery is an important part of creating a well connected libp2p node. A 
 For each discovered peer libp2p will emit a `peer:discovery` event which includes metadata about that peer. You can read the [Events](./API.md#events) in the API doc to learn more.
 
 Looking at the [available peer discovery](./CONFIGURATION.md#peer-discovery) protocols, there are several options to be considered:
-- If you already know the addresses of some other network peers, you should consider using `libp2p-bootstrap` as this is the easiest way of getting your peer into the network.
-- If it is likely that you will have other peers on your local network, `libp2p-mdns` is a must if you're node is not running in the browser. It allows peers to discover each other when on the same local network.
-- If your application is browser based you can use the `libp2p-webrtc-star` Transport, which includes a rendezvous based peer sharing service.
-- A random walk approach can be used via `libp2p-kad-dht`, to crawl the network and find new peers along the way.
+- If you already know the addresses of some other network peers, you should consider using `@libp2p/bootstrap` as this is the easiest way of getting your peer into the network.
+- If it is likely that you will have other peers on your local network, `@libp2p/mdns` is a must if you're node is not running in the browser. It allows peers to discover each other when on the same local network.
+- If your application is browser based you can use the `@libp2p/webrtc-star` Transport, which includes a rendezvous based peer sharing service.
+- A random walk approach can be used via `@libp2p/kad-dht`, to crawl the network and find new peers along the way.
 
-For this guide we will configure `libp2p-bootstrap` as this is useful for joining the public network.
+For this guide we will configure `@libp2p/bootstrap` as this is useful for joining the public network.
 
-Let's install `libp2p-bootstrap`.
+Let's install `@libp2p/bootstrap`.
 
 ```sh
-npm install libp2p-bootstrap
+npm install @libp2p/bootstrap
 ```
 
 We can provide specific configurations for each protocol within a `config.peerDiscovery` property in the options as shown below.

--- a/doc/GETTING_STARTED.md
+++ b/doc/GETTING_STARTED.md
@@ -148,11 +148,8 @@ const node = await createLibp2p({
 await node.start()
 console.log('libp2p has started')
 
-const listenAddrs = node.transportManager.getAddrs()
+const listenAddrs = node.getMultiaddrs()
 console.log('libp2p is listening on the following addresses: ', listenAddrs)
-
-const advertiseAddrs = node.multiaddrs
-console.log('libp2p is advertising the following addresses: ', advertiseAddrs)
 
 // stop libp2p
 await node.stop()

--- a/doc/GETTING_STARTED.md
+++ b/doc/GETTING_STARTED.md
@@ -218,12 +218,12 @@ const node = await createLibp2p({
   }
 })
 
-node.on('peer:discovery', (peer) => {
-  console.log('Discovered %s', peer.id.toB58String()) // Log discovered peer
+node.addEventListener('peer:discovery', (evt) => {
+  console.log('Discovered %s', evt.detail.id.toString()) // Log discovered peer
 })
 
-node.connectionManager.on('peer:connect', (connection) => {
-  console.log('Connected to %s', connection.remotePeer.toB58String()) // Log connected peer
+node.connectionManager.addEventListener('peer:connect', (evt) => {
+  console.log('Connected to %s', evt.detail.remotePeer.toString()) // Log connected peer
 })
 
 // start libp2p

--- a/examples/auto-relay/README.md
+++ b/examples/auto-relay/README.md
@@ -24,7 +24,7 @@ import { Mplex } from '@libp2p/mplex'
 const node = await createLibp2p({
   transports: [new WebSockets()],
   connectionEncryption: [new Noise()],
-  streamMuxers: [new Mplex()]
+  streamMuxers: [new Mplex()],
   addresses: {
     listen: ['/ip4/0.0.0.0/tcp/0/ws']
     // TODO check "What is next?" section
@@ -43,9 +43,9 @@ const node = await createLibp2p({
 
 await node.start()
 
-console.log(`Node started with id ${node.peerId.toB58String()}`)
+console.log(`Node started with id ${node.peerId.toString()}`)
 console.log('Listening on:')
-node.multiaddrs.forEach((ma) => console.log(`${ma.toString()}/p2p/${node.peerId.toB58String()}`))
+node.getMultiaddrs().forEach((ma) => console.log(ma.toString()))
 ```
 
 The Relay HOP advertise functionality is **NOT** required to be enabled. However, if you are interested in advertising on the network that this node is available to be used as a HOP Relay you can enable it. A content router module or Rendezvous needs to be configured to leverage this option.
@@ -94,17 +94,17 @@ const node = await createLibp2p({
 })
 
 await node.start()
-console.log(`Node started with id ${node.peerId.toB58String()}`)
+console.log(`Node started with id ${node.peerId.toString()}`)
 
 const conn = await node.dial(relayAddr)
 
 console.log(`Connected to the HOP relay ${conn.remotePeer.toString()}`)
 
 // Wait for connection and relay to be bind for the example purpose
-node.peerStore.on('change:multiaddrs', ({ peerId }) => {
+node.peerStore.addEventListener('change:multiaddrs', (evt) => {
   // Updated self multiaddrs?
-  if (peerId.equals(node.peerId)) {
-    console.log(`Advertising with a relay address of ${node.multiaddrs[0].toString()}/p2p/${node.peerId.toB58String()}`)
+  if (evt.detail.peerId.equals(node.peerId)) {
+    console.log(`Advertising with a relay address of ${node.getMultiaddrs()[0].toString()}`)
   }
 })
 ```
@@ -151,7 +151,7 @@ const node = await createLibp2p({
 })
 
 await node.start()
-console.log(`Node started with id ${node.peerId.toB58String()}`)
+console.log(`Node started with id ${node.peerId.toString()}`)
 
 const conn = await node.dial(autoRelayNodeAddr)
 console.log(`Connected to the auto relay node via ${conn.remoteAddr.toString()}`)

--- a/examples/peer-and-content-routing/README.md
+++ b/examples/peer-and-content-routing/README.md
@@ -15,34 +15,37 @@ First, let's update our config to support Peer Routing and Content Routing.
 ```JavaScript
 import { createLibp2p } from 'libp2p'
 import { KadDHT } from '@libp2p/kad-dht'
+import { TCP } from '@libp2p/tcp'
+import { Mplex } from '@libp2p/mplex'
+import { Noise } from '@chainsafe/libp2p-noise'
 
-const node = await createLibp2p({
-  addresses: {
-    listen: ['/ip4/0.0.0.0/tcp/0']
-  },
-  transports: [
-    new TCP()
-  ],
-  streamMuxers: [
-    new Mplex()
-  ],
-  connEncryption: [
-    new Noise()
-  ],
-  // we add the DHT module that will enable Peer and Content Routing
-  dht: KadDHT
-})
+const createNode = async () => {
+  const node = await createLibp2p({
+    addresses: {
+      listen: ['/ip4/0.0.0.0/tcp/0']
+    },
+    transports: [new TCP()],
+    streamMuxers: [new Mplex()],
+    connectionEncryption: [new Noise()],
+    dht: new KadDHT()
+  })
+
+  await node.start()
+  return node
+}
 ```
 
 Once that is done, we can use the createNode function we developed in the previous example to create 3 nodes. Connect node 1 to node 2 and node 2 to node 3. We will use node 2 as a way to find the whereabouts of node 3
 
 ```JavaScript
-const node1 = nodes[0]
-const node2 = nodes[1]
-const node3 = nodes[2]
+const [node1, node2, node3] = await Promise.all([
+  createNode(),
+  createNode(),
+  createNode()
+])
 
-await node1.peerStore.addressBook.set(node2.peerId, node2.multiaddrs)
-await node2.peerStore.addressBook.set(node3.peerId, node3.multiaddrs)
+await node1.peerStore.addressBook.set(node2.peerId, node2.getMultiaddrs())
+await node2.peerStore.addressBook.set(node3.peerId, node3.getMultiaddrs())
 
 await Promise.all([
   node1.dial(node2.peerId),
@@ -50,12 +53,12 @@ await Promise.all([
 ])
 
 // Set up of the cons might take time
-await delay(100)
+await new Promise(resolve => setTimeout(resolve, 100))
 
 const peer = await node1.peerRouting.findPeer(node3.peerId)
 
 console.log('Found it, multiaddrs are:')
-peer.multiaddrs.forEach((ma) => console.log(`${ma.toString()}/p2p/${peer.id.toB58String()}`))
+peer.multiaddrs.forEach((ma) => console.log(ma.toString()))
 ```
 
 You should see the output being something like:
@@ -78,12 +81,17 @@ You can find this example completed in [2.js](./2.js), however as you will see i
 Instead of calling `peerRouting.findPeer`, we will use `contentRouting.provide` and `contentRouting.findProviders`.
 
 ```JavaScript
+import { CID } from 'multiformats/cid'
+import all from 'it-all'
+
+const cid = CID.parse('QmTp9VkYvnHyrqKQuFPiuZkiX9gPcqj6x5LJ1rmWuSySnL')
 await node1.contentRouting.provide(cid)
-console.log('Node %s is providing %s', node1.peerId.toB58String(), cid.toString())
 
-const provs = await all(node3.contentRouting.findProviders(cid, { timeout: 5000 }))
+console.log('Node %s is providing %s', node1.peerId.toString(), cid.toString())
 
-console.log('Found provider:', providers[0].id.toB58String())
+const providers = await all(node3.contentRouting.findProviders(cid, { timeout: 5000 }))
+
+console.log('Found provider:', providers[0].id.toString())
 ```
 
 The output of your program should look like:

--- a/examples/pubsub/README.md
+++ b/examples/pubsub/README.md
@@ -1,6 +1,6 @@
 # Publish Subscribe
 
-Publish Subscribe is also included on the stack. Currently, we have two PubSub implementation available [libp2p-floodsub](https://github.com/libp2p/js-libp2p-floodsub) and [libp2p-gossipsub](https://github.com/ChainSafe/js-libp2p-gossipsub), with many more being researched at [research-pubsub](https://github.com/libp2p/research-pubsub).
+Publish Subscribe is also included on the stack. Currently, we have two PubSub implementation available [@libp2p/floodsub](https://github.com/libp2p/js-libp2p-floodsub) and [@chainsafe/libp2p-gossipsub](https://github.com/ChainSafe/js-libp2p-gossipsub), with many more being researched at [research-pubsub](https://github.com/libp2p/research-pubsub).
 
 We've seen many interesting use cases appear with this, here are some highlights:
 
@@ -22,54 +22,60 @@ First, let's update our libp2p configuration with a pubsub implementation.
 
 ```JavaScript
 import { createLibp2p } from 'libp2p'
-import { Gossipsub } from 'libp2p-gossipsub'
+import { GossipSub } from '@chainsafe/libp2p-gossipsub'
+import { TCP } from '@libp2p/tcp'
+import { Mplex } from '@libp2p/mplex'
+import { Noise } from '@chainsafe/libp2p-noise'
 
-const node = await createLibp2p({
-  addresses: {
-    listen: ['/ip4/0.0.0.0/tcp/0']
-  },
-  transports: [
-    new TCP()
-  ],
-  streamMuxers: [
-    new Mplex()
-  ],
-  connectionEncryption: [
-    new Noise()
-  ],
-  // we add the Pubsub module we want
-  pubsub: new Gossipsub()
-})
+const createNode = async () => {
+  const node = await createLibp2p({
+    addresses: {
+      listen: ['/ip4/0.0.0.0/tcp/0']
+    },
+    transports: [new TCP()],
+    streamMuxers: [new Mplex()],
+    connectionEncryption: [new Noise()],
+	  // we add the Pubsub module we want
+	  pubsub: new GossipSub({ allowPublishToZeroPeers: true })
+  })
+
+  await node.start()
+
+  return node
+}
 ```
 
 Once that is done, we only need to create a few libp2p nodes, connect them and everything is ready to start using pubsub.
 
 ```JavaScript
-const { fromString } from 'uint8arrays/from-string')
-const { toString } from 'uint8arrays/to-string')
+import { fromString as uint8ArrayFromString } from "uint8arrays/from-string";
+import { toString as uint8ArrayToString } from "uint8arrays/to-string";
+
 const topic = 'news'
 
-const node1 = nodes[0]
-const node2 = nodes[1]
+const [node1, node2] = await Promise.all([
+  createNode(),
+  createNode()
+])
 
 // Add node's 2 data to the PeerStore
-await node1.peerStore.addressBook.set(node2.peerId, node2.multiaddrs)
+await node1.peerStore.addressBook.set(node2.peerId, node2.getMultiaddrs())
 await node1.dial(node2.peerId)
 
-node1.pubsub.on(topic, (msg) => {
-  console.log(`node1 received: ${toString(msg.data)}`)
+node1.pubsub.addEventListener("message", (evt) => {
+  console.log(`node1 received: ${uint8ArrayToString(evt.detail.data)} on topic ${evt.detail.topic}`)
 })
 await node1.pubsub.subscribe(topic)
 
 // Will not receive own published messages by default
-node2.pubsub.on(topic, (msg) => {
-  console.log(`node2 received: ${toString(msg.data)}`)
+node2.pubsub.addEventListener("message", (evt) => {
+  console.log(`node2 received: ${uint8ArrayToString(evt.detail.data)} on topic ${evt.detail.topic}`)
 })
 await node2.pubsub.subscribe(topic)
 
 // node2 publishes "news" every second
 setInterval(() => {
-  node2.pubsub.publish(topic, fromString('Bird bird bird, bird is the word!')).catch(err => {
+  node2.pubsub.publish(topic, uint8ArrayFromString('Bird bird bird, bird is the word!')).catch(err => {
     console.error(err)
   })
 }, 1000)
@@ -87,14 +93,7 @@ node1 received: Bird bird bird, bird is the word!
 You can change the pubsub `emitSelf` option if you want the publishing node to receive its own messages.
 
 ```JavaScript
-const defaults = {
-  config: {
-    pubsub: {
-      enabled: true,
-      emitSelf: true
-    }
-  }
-}
+new GossipSub({ allowPublishToZeroPeers: true, emitSelf: true })
 ```
 
 The output of the program should look like:

--- a/examples/transports/README.md
+++ b/examples/transports/README.md
@@ -13,7 +13,7 @@ When using libp2p, you need properly configure it, that is, pick your set of mod
 You will need 4 dependencies total, so go ahead and install all of them with:
 
 ```bash
-> npm install libp2p libp2p-tcp @chainsafe/libp2p-noise
+> npm install libp2p @libp2p/tcp @chainsafe/libp2p-noise
 ```
 
 Then, in your favorite text editor create a file with the `.js` extension. I've called mine `1.js`.
@@ -58,7 +58,7 @@ console.log('node has started (true/false):', node.isStarted())
 // 0, which means "listen in any network interface and pick
 // a port for me
 console.log('listening on:')
-node.multiaddrs.forEach((ma) => console.log(`${ma.toString()}/p2p/${node.peerId.toB58String()}`))
+node.getMultiaddrs().forEach((ma) => console.log(ma.toString()))
 ```
 
 Running this should result in something like:
@@ -80,15 +80,15 @@ Now that we have our `createNode` function, let's create two nodes and make them
 For this step, we will need some more dependencies.
 
 ```bash
-> npm install it-pipe it-to-buffer @libp2p/mplex
+> npm install it-pipe it-all @libp2p/mplex
 ```
 
 And we also need to import the modules on our .js file:
 
 ```js
 import { pipe } from 'it-pipe'
-import toBuffer from 'it-to-buffer'
 import { Mplex } from '@libp2p/mplex'
+import all from 'it-all'
 ```
 
 We are going to reuse the `createNode` function from step 1, but this time add a stream multiplexer from `libp2p-mplex`.
@@ -114,38 +114,39 @@ We will also make things simpler by creating another function to print the multi
 ```JavaScript
 function printAddrs (node, number) {
   console.log('node %s is listening on:', number)
-  node.multiaddrs.forEach((ma) => console.log(`${ma.toString()}/p2p/${node.peerId.toB58String()}`))
+  node.getMultiaddrs().forEach((ma) => console.log(ma.toString()))
 }
 ```
 
 Then add,
 
 ```js
-(async () => {
-  const [node1, node2] = await Promise.all([
-    createNode(),
-    createNode()
-  ])
+import { fromString as uint8ArrayFromString } from "uint8arrays/from-string";
+import { toString as uint8ArrayToString } from "uint8arrays/to-string";
 
-  printAddrs(node1, '1')
-  printAddrs(node2, '2')
+const [node1, node2] = await Promise.all([
+  createNode(),
+  createNode()
+])
 
-  node2.handle('/print', async ({ stream }) => {
-    const result = await pipe(
-      stream,
-      toBuffer
-    )
-    console.log(result.toString())
-  })
+printAddrs(node1, '1')
+printAddrs(node2, '2')
 
-  await node1.peerStore.addressBook.set(node2.peerId, node2.multiaddrs)
-  const stream = await node1.dialProtocol(node2.peerId, '/print')
-
-  await pipe(
-    ['Hello', ' ', 'p2p', ' ', 'world', '!'],
-    stream
+node2.handle('/print', async ({ stream }) => {
+  const result = await pipe(
+    stream,
+    all
   )
-})();
+  console.log(result.map(buf => uint8ArrayToString(buf.subarray())).join(""))
+})
+
+await node1.peerStore.addressBook.set(node2.peerId, node2.getMultiaddrs())
+const stream = await node1.dialProtocol(node2.peerId, '/print')
+
+await pipe(
+  ['Hello', ' ', 'p2p', ' ', 'world', '!'].map(str => uint8ArrayFromString(str)),
+  stream
+)
 ```
 For more information refer to the [docs](https://github.com/libp2p/js-libp2p/blob/master/doc/API.md).
 
@@ -168,10 +169,10 @@ Next, we want nodes to have multiple transports available to increase their chan
 
 What we are going to do in this step is to create 3 nodes: one with TCP, another with TCP+WebSockets and another one with just WebSockets. The full solution can be found on [3.js](./3.js).
 
-In this example, we will need to also install `libp2p-websockets`:
+In this example, we will need to also install `@libp2p/websockets`:
 
 ```bash
-> npm install libp2p-websockets
+> npm install @libp2p/websockets
 ```
 
 We want to create 3 nodes: one with TCP, one with TCP+WebSockets and one with just WebSockets. We need to update our `createNode` function to accept WebSocket connections as well. Moreover, let's upgrade our function to enable us to pick the addresses over which a node will start a listener:
@@ -188,7 +189,7 @@ const createNode = async (transports, addresses = []) => {
     addresses: {
       listen: addresses
     },
-    transport: transports,
+    transports: transports,
     connectionEncryption: [new Noise()],
     streamMuxers: [new Mplex()]
   })
@@ -207,9 +208,9 @@ import { WebSockets } from '@libp2p/websockets'
 import { TCP } from '@libp2p/tcp'
 
 const [node1, node2, node3] = await Promise.all([
-  createNode([TCP], '/ip4/0.0.0.0/tcp/0'),
-  createNode([TCP, WebSockets], ['/ip4/0.0.0.0/tcp/0', '/ip4/127.0.0.1/tcp/10000/ws']),
-  createNode([WebSockets], '/ip4/127.0.0.1/tcp/20000/ws')
+  createNode([new TCP()], '/ip4/0.0.0.0/tcp/0'),
+  createNode([new TCP(), new WebSockets()], ['/ip4/0.0.0.0/tcp/0', '/ip4/127.0.0.1/tcp/10000/ws']),
+  createNode([new WebSockets()], '/ip4/127.0.0.1/tcp/20000/ws')
 ])
 
 printAddrs(node1, '1')
@@ -220,21 +221,21 @@ node1.handle('/print', print)
 node2.handle('/print', print)
 node3.handle('/print', print)
 
-await node1.peerStore.addressBook.set(node2.peerId, node2.multiaddrs)
-await node2.peerStore.addressBook.set(node3.peerId, node3.multiaddrs)
-await node3.peerStore.addressBook.set(node1.peerId, node1.multiaddrs)
+await node1.peerStore.addressBook.set(node2.peerId, node2.getMultiaddrs())
+await node2.peerStore.addressBook.set(node3.peerId, node3.getMultiaddrs())
+await node3.peerStore.addressBook.set(node1.peerId, node1.getMultiaddrs())
 
 // node 1 (TCP) dials to node 2 (TCP+WebSockets)
 const stream = await node1.dialProtocol(node2.peerId, '/print')
 await pipe(
-  ['node 1 dialed to node 2 successfully'],
+  ['node 1 dialed to node 2 successfully'].map(str => uint8ArrayFromString(str)),
   stream
 )
 
 // node 2 (TCP+WebSockets) dials to node 3 (WebSockets)
 const stream2 = await node2.dialProtocol(node3.peerId, '/print')
 await pipe(
-  ['node 2 dialed to node 3 successfully'],
+  ['node 2 dialed to node 3 successfully'].map(str => uint8ArrayFromString(str)),
   stream2
 )
 
@@ -254,7 +255,7 @@ function print ({ stream }) {
     stream,
     async function (source) {
       for await (const msg of source) {
-        console.log(msg.toString())
+        console.log(uint8ArrayToString(msg.subarray()))
       }
     }
   )

--- a/examples/webrtc-direct/README.md
+++ b/examples/webrtc-direct/README.md
@@ -1,6 +1,6 @@
 ### Webrtc-direct example
 
-An example that uses [js-libp2p-webrtc-direct](https://github.com/libp2p/js-libp2p-webrtc-direct) for connecting
+An example that uses [@libp2p/webrtc-direct](https://github.com/libp2p/js-libp2p-webrtc-direct) for connecting
 nodejs libp2p and browser libp2p clients. To run the example:
 
 ## 0. Run a nodejs libp2p listener


### PR DESCRIPTION
This PR fixes all the errors in the code snippets in the readme files contained in the examples directory and it fixes the doc/GETTING_STARTED.md file.

I have also updated the old package names, e.g. `libp2p-websockets` -> `@libp2p/websockets`.

Resolves #1367 and resolves #1361.