### PR TITLE
fix: yield only final peers from dht getClosestPeers

### DIFF
--- a/src/dht/dht-peer-routing.ts
+++ b/src/dht/dht-peer-routing.ts
@@ -27,8 +27,8 @@ export class DHTPeerRouting implements PeerRouting {
 
   async * getClosestPeers (key: Uint8Array, options: AbortOptions = {}) {
     for await (const event of this.dht.getClosestPeers(key, options)) {
-      if (event.name === 'PEER_RESPONSE') {
-        yield * event.closer
+      if (event.name === 'FINAL_PEER') {
+        yield event.peer
       }
     }
   }

--- a/test/peer-routing/peer-routing.node.ts
+++ b/test/peer-routing/peer-routing.node.ts
@@ -115,16 +115,15 @@ describe('peer-routing', () => {
       const dhtGetClosestPeersStub = sinon.stub(nodes[0].dht, 'getClosestPeers').callsFake(async function * () {
         yield {
           from: nodes[2].peerId,
-          type: EventTypes.PEER_RESPONSE,
-          name: 'PEER_RESPONSE',
+          type: EventTypes.FINAL_PEER,
+          name: 'FINAL_PEER',
           messageName: 'FIND_NODE',
           messageType: MessageType.FIND_NODE,
-          closer: [{
+          peer: {
             id: nodes[1].peerId,
             multiaddrs: [],
             protocols: []
-          }],
-          providers: []
+          }
         }
       })
 
@@ -673,26 +672,20 @@ describe('peer-routing', () => {
       const peerStoreAddressBookAddStub = sinon.spy(node.peerStore.addressBook, 'add')
       const dhtGetClosestPeersStub = sinon.stub(node.dht, 'getClosestPeers').callsFake(async function * () {
         yield {
-          name: 'PEER_RESPONSE',
-          type: EventTypes.PEER_RESPONSE,
+          name: 'FINAL_PEER',
+          type: EventTypes.FINAL_PEER,
           messageName: 'FIND_NODE',
           messageType: MessageType.FIND_NODE,
           from: peerIds[0],
-          closer: [
-            results[0]
-          ],
-          providers: []
+          peer: results[0]
         }
         yield {
-          name: 'PEER_RESPONSE',
-          type: EventTypes.PEER_RESPONSE,
+          name: 'FINAL_PEER',
+          type: EventTypes.FINAL_PEER,
           messageName: 'FIND_NODE',
           messageType: MessageType.FIND_NODE,
           from: peerIds[0],
-          closer: [
-            results[1]
-          ],
-          providers: []
+          peer: results[1]
         }
       })
 


### PR DESCRIPTION
`PEER_RESPONSE` is an intermediate event, we should only yield from `FINAL_PEER` events as we'll only get `K` of those.

n.b. this will make the `libp2p.peerRouting.getClosestPeers` call take longer to start yielding results if they are only findable by the DHT but they'll be more accurate.

If you want status events, call the lower level [`libp2p.dht.getClosestPeers` method](https://github.com/libp2p/js-libp2p-interfaces/blob/master/packages/interface-dht/src/index.ts#L154) instead.