### PR TITLE
feat: allow skipping encryption and custom muxer factory in upgrader

### DIFF
--- a/package.json
+++ b/package.json
@@ -78,7 +78,7 @@
   },
   "scripts": {
     "clean": "aegir clean",
-    "lint": "aegir lint",
+    "lint": "aegir lint --fix",
     "dep-check": "aegir dep-check",
     "prepublishOnly": "node scripts/update-version.js",
     "build": "aegir build",
@@ -116,7 +116,7 @@
     "@libp2p/interface-pubsub": "^2.0.1",
     "@libp2p/interface-registrar": "^2.0.3",
     "@libp2p/interface-stream-muxer": "^2.0.2",
-    "@libp2p/interface-transport": "^1.0.3",
+    "@libp2p/interface-transport": "file:../js-libp2p-interfaces/packages/interface-transport",
     "@libp2p/interfaces": "^3.0.3",
     "@libp2p/logger": "^2.0.1",
     "@libp2p/multistream-select": "^3.0.0",

--- a/package.json
+++ b/package.json
@@ -78,7 +78,7 @@
   },
   "scripts": {
     "clean": "aegir clean",
-    "lint": "aegir lint --fix",
+    "lint": "aegir lint",
     "dep-check": "aegir dep-check",
     "prepublishOnly": "node scripts/update-version.js",
     "build": "aegir build",
@@ -115,7 +115,7 @@
     "@libp2p/interface-peer-store": "^1.2.1",
     "@libp2p/interface-pubsub": "^2.0.1",
     "@libp2p/interface-registrar": "^2.0.3",
-    "@libp2p/interface-stream-muxer": "^2.0.2",
+    "@libp2p/interface-stream-muxer": "file:../js-libp2p-interfaces/packages/interface-stream-muxer",
     "@libp2p/interface-transport": "file:../js-libp2p-interfaces/packages/interface-transport",
     "@libp2p/interfaces": "^3.0.3",
     "@libp2p/logger": "^2.0.1",

--- a/src/upgrader.ts
+++ b/src/upgrader.ts
@@ -240,8 +240,6 @@ export class DefaultUpgrader extends EventEmitter<UpgraderEvents> implements Upg
       throw errCode(new Error('The multiaddr connection is blocked by connectionGater.denyOutboundConnection'), codes.ERR_CONNECTION_INTERCEPTED)
     }
 
-    const skipEncryption = opts?.skipEncryption === true
-
     let encryptedConn
     let remotePeer
     let upgradedConn
@@ -276,7 +274,7 @@ export class DefaultUpgrader extends EventEmitter<UpgraderEvents> implements Upg
     try {
       // Encrypt the connection
       encryptedConn = protectedConn
-      if (!skipEncryption) {
+      if (!opts?.skipEncryption) {
         ({
           conn: encryptedConn,
           remotePeer,
@@ -290,7 +288,6 @@ export class DefaultUpgrader extends EventEmitter<UpgraderEvents> implements Upg
           throw errCode(new Error('The multiaddr connection is blocked by gater.acceptEncryptedConnection'), codes.ERR_CONNECTION_INTERCEPTED)
         }
       } else {
-        // specify this somehow
         cryptoProtocol = 'native'
         remotePeer = remotePeerId
       }
@@ -333,7 +330,7 @@ export class DefaultUpgrader extends EventEmitter<UpgraderEvents> implements Upg
       maConn,
       upgradedConn,
       muxerFactory,
-      remotePeer: remotePeerId
+      remotePeer,
     })
   }
 


### PR DESCRIPTION
Updates the `DefaultUpgrader` to use the new `UpgraderOptions` which allows skipping encryption and/or adding a custom muxer factory for transports which inherently support encryption and muxing.