### PR TITLE
chore: bump @libp2p/interface-connection-encrypter

### DIFF
--- a/package.json
+++ b/package.json
@@ -103,7 +103,7 @@
     "@libp2p/crypto": "^1.0.4",
     "@libp2p/interface-address-manager": "^1.0.3",
     "@libp2p/interface-connection": "^3.0.2",
-    "@libp2p/interface-connection-encrypter": "^2.0.1",
+    "@libp2p/interface-connection-encrypter": "^3.0.0",
     "@libp2p/interface-connection-manager": "^1.1.1",
     "@libp2p/interface-content-routing": "^1.0.2",
     "@libp2p/interface-dht": "^1.0.1",


### PR DESCRIPTION
We changed the interface here: https://github.com/libp2p/js-libp2p-interfaces/pull/293 and now need to update the dep here so that we can properly pass in Noise as a connection encrypter (types are currently mismatched).