### PR TITLE
docs: add limit configuration documentation

### DIFF
--- a/README.md
+++ b/README.md
@@ -45,6 +45,7 @@ If you are looking for the documentation of the latest release, you can view the
 - [Install](#install)
 - [Usage](#usage)
   - [Configuration](#configuration)
+  - [Limits](#limits)
   - [API](#api)
   - [Getting started](#getting-started)
   - [Tutorials and Examples](#tutorials-and-examples)
@@ -84,6 +85,10 @@ npm install libp2p
 ### Configuration
 
 For all the information on how you can configure libp2p see [CONFIGURATION.md](./doc/CONFIGURATION.md).
+
+### Limits
+
+For help configuring your node to resist malicious network peers, see [LIMITS.md](./doc/LIMITS.md)
 
 ### API
 

--- a/doc/CONFIGURATION.md
+++ b/doc/CONFIGURATION.md
@@ -1,4 +1,4 @@
-#
+# Configuration <!-- omit in toc -->
 
 - [Overview](#overview)
 - [Modules](#modules)
@@ -35,6 +35,7 @@
       - [UPnP and NAT-PMP](#upnp-and-nat-pmp)
     - [Configuring protocol name](#configuring-protocol-name)
 - [Configuration examples](#configuration-examples)
+- [Limits](#limits)
 
 ## Overview
 
@@ -67,13 +68,11 @@ Bear in mind that a **transport** and **connection encryption** module are **req
 
 Some available transports are:
 
-- [libp2p/js-libp2p-tcp](https://github.com/libp2p/js-libp2p-tcp)
-- [libp2p/js-libp2p-webrtc-star](https://github.com/libp2p/js-libp2p-webrtc-star)
-- [libp2p/js-libp2p-webrtc-direct](https://github.com/libp2p/js-libp2p-webrtc-direct)
-- [libp2p/js-libp2p-websockets](https://github.com/libp2p/js-libp2p-websockets)
-- [libp2p/js-libp2p-utp](https://github.com/libp2p/js-libp2p-utp) (Work in Progress)
-
-You should take into consideration that `js-libp2p-tcp` and `js-libp2p-utp` are not available in a **browser** environment.
+- [@libp2p/tcp](https://github.com/libp2p/js-libp2p-tcp) (not available in browsers)
+- [@libp2p/webrtc-star](https://github.com/libp2p/js-libp2p-webrtc-star)
+- [@libp2p/webrtc-direct](https://github.com/libp2p/js-libp2p-webrtc-direct)
+- [@libp2p/websockets](https://github.com/libp2p/js-libp2p-websockets)
+- [@libp2p/webtransport](https://github.com/libp2p/js-libp2p-webtransport) (Work in Progress)
 
 If none of the available transports fulfills your needs, you can create a libp2p compatible transport. A libp2p transport just needs to be compliant with the [Transport Interface](https://github.com/libp2p/js-interfaces/tree/master/src/transport).
 
@@ -88,7 +87,8 @@ If you want to know more about libp2p transports, you should read the following 
 
 Some available stream multiplexers are:
 
-- [libp2p/js-libp2p-mplex](https://github.com/libp2p/js-libp2p-mplex)
+- [@libp2p/mplex](https://github.com/libp2p/js-libp2p-mplex)
+- [@chainsafe/libp2p-yamux](https://github.com/chainsafe/js-libp2p-yamux)
 
 If none of the available stream multiplexers fulfills your needs, you can create a libp2p compatible stream multiplexer. A libp2p multiplexer just needs to be compliant with the [Stream Muxer Interface](https://github.com/libp2p/js-interfaces/tree/master/src/stream-muxer).
 
@@ -104,8 +104,8 @@ If you want to know more about libp2p stream multiplexing, you should read the f
 
 Some available connection encryption protocols:
 
-- [NodeFactoryIo/js-libp2p-noise](https://github.com/NodeFactoryIo/js-libp2p-noise)
-- [libp2p/js-libp2p-secio](https://github.com/libp2p/js-libp2p-secio) ⚠️ [DEPRECATED](https://blog.ipfs.io/2020-08-07-deprecating-secio)
+- [@chainsafe/libp2p-noise](https://github.com/chainsafe/js-libp2p-noise)
+- [Plaintext](https://github.com/libp2p/js-libp2p/blob/master/src/insecure/index.ts) (Not for production use)
 
 If none of the available connection encryption mechanisms fulfills your needs, you can create a libp2p compatible one. A libp2p connection encryption protocol just needs to be compliant with the [Crypto Interface](https://github.com/libp2p/js-interfaces/tree/master/src/crypto).
 
@@ -120,11 +120,11 @@ If you want to know more about libp2p connection encryption, you should read the
 
 Some available peer discovery modules are:
 
-- [js-libp2p-mdns](https://github.com/libp2p/js-libp2p-mdns)
-- [js-libp2p-bootstrap](https://github.com/libp2p/js-libp2p-bootstrap)
-- [js-libp2p-kad-dht](https://github.com/libp2p/js-libp2p-kad-dht)
-- [js-libp2p-webrtc-star](https://github.com/libp2p/js-libp2p-webrtc-star)
-- [discv5](https://github.com/chainsafe/discv5)
+- [@libp2p/mdns](https://github.com/libp2p/js-libp2p-mdns)
+- [@libp2p/bootstrap](https://github.com/libp2p/js-libp2p-bootstrap)
+- [@libp2p/kad-dht](https://github.com/libp2p/js-libp2p-kad-dht)
+- [@libp2p/webrtc-star](https://github.com/libp2p/js-libp2p-webrtc-star)
+- [@chainsafe/discv5](https://github.com/chainsafe/discv5)
 
 **Note**: `peer-discovery` services within transports (such as `js-libp2p-webrtc-star`) are automatically gathered from the `transport`, via it's `discovery` property. As such, they do not need to be added in the discovery modules. However, these transports can also be configured and disabled as the other ones.
 
@@ -140,8 +140,8 @@ If you want to know more about libp2p peer discovery, you should read the follow
 
 Some available content routing modules are:
 
-- [js-libp2p-kad-dht](https://github.com/libp2p/js-libp2p-kad-dht)
-- [js-libp2p-delegated-content-routing](https://github.com/libp2p/js-libp2p-delegated-content-routing)
+- [@libp2p/kad-dht](https://github.com/libp2p/js-libp2p-kad-dht)
+- [@libp2p/delegated-content-routing](https://github.com/libp2p/js-libp2p-delegated-content-routing)
 
 If none of the available content routing protocols fulfills your needs, you can create a libp2p compatible one. A libp2p content routing protocol just needs to be compliant with the [Content Routing Interface](https://github.com/libp2p/js-interfaces/tree/master/src/content-routing). **(WIP: This module is not yet implemented)**
 
@@ -155,8 +155,8 @@ If you want to know more about libp2p content routing, you should read the follo
 
 Some available peer routing modules are:
 
-- [js-libp2p-kad-dht](https://github.com/libp2p/js-libp2p-kad-dht)
-- [js-libp2p-delegated-peer-routing](https://github.com/libp2p/js-libp2p-delegated-peer-routing)
+- [@libp2p/kad-dht](https://github.com/libp2p/js-libp2p-kad-dht)
+- [@libp2p/delegated-peer-routing](https://github.com/libp2p/js-libp2p-delegated-peer-routing)
 
 If none of the available peer routing protocols fulfills your needs, you can create a libp2p compatible one. A libp2p peer routing protocol just needs to be compliant with the [Peer Routing Interface](https://github.com/libp2p/js-interfaces/tree/master/src/peer-routing). **(WIP: This module is not yet implemented)**
 
@@ -168,7 +168,7 @@ If you want to know more about libp2p peer routing, you should read the followin
 
 > A DHT can provide content and peer routing capabilities in a p2p system, as well as peer discovery capabilities.
 
-The DHT implementation currently available is [libp2p/js-libp2p-kad-dht](https://github.com/libp2p/js-libp2p-kad-dht). This implementation is largely based on the Kademlia whitepaper, augmented with notions from S/Kademlia, Coral and mainlineDHT.
+The DHT implementation currently available is [@libp2p/kad-dht](https://github.com/libp2p/js-libp2p-kad-dht). This implementation is largely based on the Kademlia whitepaper, augmented with notions from S/Kademlia, Coral and mainlineDHT.
 
 If this DHT implementation does not fulfill your needs and you want to create or use your own implementation, please get in touch with us through a github issue. We plan to work on improving the ability to bring your own DHT in a future release.
 
@@ -183,10 +183,10 @@ If you want to know more about libp2p DHT, you should read the following content
 
 Some available pubsub routers are:
 
-- [libp2p/js-libp2p-floodsub](https://github.com/libp2p/js-libp2p-floodsub)
-- [ChainSafe/js-libp2p-gossipsub](https://github.com/ChainSafe/js-libp2p-gossipsub)
+- [@chainsafe/libp2p-gossipsub](https://github.com/ChainSafe/js-libp2p-gossipsub)
+- [@libp2p/floodsub](https://github.com/libp2p/js-libp2p-floodsub) (Not for production use)
 
-If none of the available pubsub routers fulfills your needs, you can create a libp2p compatible one. A libp2p pubsub router just needs to be created on top of [libp2p/js-libp2p-pubsub](https://github.com/libp2p/js-libp2p-pubsub), which ensures `js-libp2p` API expectations.
+If none of the available pubsub routers fulfills your needs, you can create a libp2p compatible one. A libp2p pubsub router just needs to be created on top of [@libp2p/pubsub](https://github.com/libp2p/js-libp2p-pubsub), which ensures `js-libp2p` API expectations.
 
 If you want to know more about libp2p pubsub, you should read the following content:
 
@@ -379,7 +379,6 @@ import { Noise } from '@chainsafe/libp2p-noise'
 import { create as ipfsHttpClient } from 'ipfs-http-client'
 import { DelegatedPeerRouting } from '@libp2p/delegated-peer-routing'
 import { DelegatedContentRouting} from '@libp2p/delegated-content-routing'
-
 
 // create a peerId
 const peerId = await PeerId.create()
@@ -909,3 +908,7 @@ As libp2p is designed to be a modular networking library, its usage will vary ba
 If you have developed a project using `js-libp2p`, please consider submitting your configuration to this list so that it can be found easily by other users.
 
 The [examples](../examples) are also a good source of help for finding a configuration that suits your needs.
+
+## Limits
+
+Configuring the various limits of your node is important to protect it when it is part of hostile of adversarial networks. See [LIMITS.md](./LIMITS.md) for a full breakdown of the various built in protections and safeguards.

--- a/doc/LIMITS.md
+++ b/doc/LIMITS.md
@@ -1,0 +1,217 @@
+# Limits <!-- omit in toc -->
+
+In order to prevent excessive resource consumption by a libp2p node it's important to understand limits are applied and how to tune them to the needs of your application.
+
+## Table of contents
+
+- [Connection limits](#connection-limits)
+- [Inbound connection threshold](#inbound-connection-threshold)
+- [Data transfer and Event Loop limits](#data-transfer-and-event-loop-limits)
+- [Stream limits](#stream-limits)
+  - [Mplex](#mplex)
+  - [Yamux](#yamux)
+- [Closing connections](#closing-connections)
+- [Transport specific limits](#transport-specific-limits)
+  - [TCP](#tcp)
+
+## Connection limits
+
+It's possible to limit the amount of incoming and outgoing connections a node is able to make.  When this limit is reached and an attempt to open a new connection is made, existing connections may be closed to make room for the new connection.
+
+```js
+const node = await createLibp2pNode({
+  connectionManager: {
+    /**
+     * The total number of connections allowed to be open at one time
+     */
+    maxConnections: 200,
+
+    /**
+     * If the number of open connections goes below this number, the node
+     * will try to connect to nearby peers from the peer store
+     */
+    minConnections: 20
+  }
+})
+```
+
+## Inbound connection threshold
+
+To prevent individual peers from opening multiple connections to a node, an `inboundConnectionThreshold` is configurable. This is the number of connections per second an individual remote host can open to a node, once this threshold is crossed all further connections opened by that host will be rejected.
+
+
+```js
+const node = await createLibp2pNode({
+  connectionManager: {
+    /**
+     * A remote peer may attempt to open up to this many connections per second,
+     * any more than that will be automatically rejected
+     */
+    inboundConnectionThreshold: 5
+  }
+})
+```
+
+## Data transfer and Event Loop limits
+
+If metrics are enabled the node will track the amount of data being sent to and from the network. If the amount sent is over the threshold connections will be trimmed to free up resources.  The default amount is `Ininity` so this must be explicitly enabled.
+
+Connections may also be trimmed if [event loop](https://nodejs.org/en/docs/guides/event-loop-timers-and-nexttick) latency exceeds the configured limit.
+
+```js
+const node = await createLibp2pNode({
+  metrics: {
+    enabled: true
+  },
+  connectionManager: {
+    /**
+     * If the node transfers more than this amount of data in bytes/second
+     * low value connections may be closed
+     */
+    maxData: 1024 * 1024,
+
+    /**
+     * If the node sends more than this amount of data in bytes/second
+     * low value connections may be closed
+     */
+    maxSentData: 1024 * 1024
+
+    /**
+     * If the node receives more than this amount of data in bytes/second
+     * low value connections may be closed
+     */
+    maxReceivedData: 1024 * 1024,
+
+    /**
+     * If the event loop takes longer than this many ms to run,  low value
+     * connections may be closed
+     */
+    maxEventLoopDelay: 1000
+  }
+})
+```
+
+## Stream limits
+
+libp2p stream multiplexers impose limits on the amount of streams that can be opened per connection, and also the amount of data that will be buffered for a given stream. The data should be consumed as fast as possible - if a stream's input buffer exceeds the limits set the stream will be reset.
+
+These settings are done on a per-muxer basis, please see the README of the relevant muxer you are using.
+
+### Mplex
+
+[@libp2p/mplex](https://github.com/libp2p/js-libp2p-mplex) supports the following:
+
+```js
+const node = await createLibp2pNode({
+  muxers: [
+    new Mplex({
+      /**
+       * The total number of inbound protocol streams that can be opened on a given connection
+       */
+      maxInboundStreams: 1024,
+
+      /**
+       * The total number of outbound protocol streams that can be opened on a given connection
+       */
+      maxOutboundStreams: 1024,
+
+      /**
+       * How much incoming data to buffer before resetting the stream
+       */
+      maxStreamBufferSize: 4 * 1024 * 1024,
+
+      /**
+       * Mplex does not support backpressure so to protect ourselves, if `maxInboundStreams` is
+       * hit and the remote opens more than this many streams per second, close the connection
+       */
+      disconnectThreshold: 5
+    })
+  ]
+})
+```
+
+### Yamux
+
+[@chainsafe/libp2p-yamux](https://github.com/Chainsafe/js-libp2p-yamux) supports the following:
+
+```js
+const node = await createLibp2pNode({
+  muxers: [
+    new Yamux({
+      /**
+       * The total number of inbound protocol streams that can be opened on a given connection
+       */
+      maxInboundStreams: 1024,
+
+      /**
+       * The total number of outbound protocol streams that can be opened on a given connection
+       */
+      maxOutboundStreams: 1024
+    })
+  ]
+})
+```
+
+### Protocol limits
+
+When registering listeners for custom protocols, the maximum number of simultaneously open inbound and outbound streams per-connection can be specified. If not specified these will default to 32 inbound streams and 64 outbound streams.
+
+If more than this number of streams for the given protocol are opened on a single connection, subsequent new streams for that protocol will be immediately reset.
+
+Since incoming stream data is buffered until it is comsumed, you should attempt to specify the minimum amount of streams required to keep memory usage to a minimum.
+
+```js
+libp2p.handle('/my-protocol/1.0.0', (streamData) => {
+  // ..handle stream
+}, {
+  maxInboundStreams: 10, // defaults to 32
+  maxOutboundStreams: 10, // defaults to 64
+})
+```
+
+## Closing connections
+
+When choosing connections to close the connection manager sorts the list of connections by the value derived from the tags given to each peer. The values of all tags are summed and connections with lower valued peers are elibible for closing first.
+
+```js
+// tag a peer
+await libp2p.peerStore.tagPeer(peerId, 'my-tag', {
+  value: 50, // 0-100 is the typical value range
+  ttl: 1000 // optional field, this tag will be deleted after this many ms
+})
+```
+
+## Transport specific limits
+
+Some transports allow configuring additional limits, please see their READMEs for full config options.
+
+A non-exhaustive list follows:
+
+### TCP
+
+The [@libp2p/tcp](https://github.com/libp2p/js-libp2p-tcp) transport allows additional limits to be configured
+
+```js
+const node = await createLibp2pNode({
+  transports: [
+    new TCP({
+      /**
+       * Inbound connections with no activity in this timeframe (ms) will be closed
+       */
+      inboundSocketInactivityTimeout: 30000,
+
+      /**
+       * Outbound connections with no activity in this timeframe (ms) will be closed
+       */
+      outboundSocketInactivityTimeout: 60000,
+
+      /**
+       * Once this many connections are open on this listener any further connections
+       * will be rejected - this will have no effect if it is larger than the value
+       * configured for the ConnectionManager maxConnections parameter
+       */
+      maxConnections: 200
+    })
+  ]
+})
+```

--- a/doc/LIMITS.md
+++ b/doc/LIMITS.md
@@ -13,6 +13,7 @@ In order to prevent excessive resource consumption by a libp2p node it's importa
 - [Closing connections](#closing-connections)
 - [Transport specific limits](#transport-specific-limits)
   - [TCP](#tcp)
+- [Allow/deny lists](#allowdeny-lists)
 
 ## Connection limits
 
@@ -213,5 +214,38 @@ const node = await createLibp2pNode({
       maxConnections: 200
     })
   ]
+})
+```
+
+## Allow/deny lists
+
+It is possible to configure some hosts to always accept connections from and some to always reject connections from.
+
+```js
+const node = await createLibp2pNode({
+  connectionManager: {
+    /**
+     * A list of multiaddrs, any connection with a `remoteAddress` property
+     * that has any of these addresses as a prefix will be accepted ignoring
+     * all connection limits
+     */
+    allow: [
+      '/ip4/43.123.5.23/tcp/3984',
+      '/ip4/234.243.64.2',
+      '/ip4/52.55',
+      // etc
+    ],
+
+    /**
+     * Any connection with a `remoteAddress` property that has any of these
+     * addresses as a prefix will be immediately rejected
+     */
+     deny: [
+      '/ip4/132.14.52.64/tcp/3984',
+      '/ip4/234.243.64.2',
+      '/ip4/34.42',
+      // etc
+    ]
+  }
 })
 ```


### PR DESCRIPTION
To help people better configure their libp2p nodes to defend against malicious peers, document all the limit settings and protections in one place.