### PR TITLE
fix: close stream after sending identify

### DIFF
--- a/src/identify/index.ts
+++ b/src/identify/index.ts
@@ -179,14 +179,14 @@ export class IdentifyService implements Startable {
         // make stream abortable
         const source = abortableDuplex(stream, timeoutController.signal)
 
-      await source.sink(pipe(
-        [Identify.encode({
-          listenAddrs,
-          signedPeerRecord,
-          protocols
-        })],
-        lp.encode(),
-      ))
+        await source.sink(pipe(
+          [Identify.encode({
+            listenAddrs,
+            signedPeerRecord,
+            protocols
+          })],
+          lp.encode()
+        ))
       } catch (err: any) {
         // Just log errors
         log.error('could not push identify update to peer', err)


### PR DESCRIPTION
Close the stream after we finish writing the identify message. This is behavior is specified https://github.com/libp2p/specs/blob/master/identify/README.md#identify

> The peer being identified responds by returning an Identify message and closes the stream.

This shows up when interacting with a go-libp2p node as go-libp2p waits for the stream to close before finishing reading the messages: https://github.com/libp2p/go-libp2p/blob/master/p2p/protocol/identify/id.go#L455.

