### PR TITLE
feat: add options to enable identify and identify push

### DIFF
--- a/src/config.ts
+++ b/src/config.ts
@@ -88,8 +88,8 @@ const DefaultConfig: Partial<Libp2pInit> = {
     maxOutboundStreams: 1,
     maxPushIncomingStreams: 1,
     maxPushOutgoingStreams: 1,
-    disableIdentify: false,
-    disableIdentifyPush: false
+    enable: true,
+    enablePush: true
   },
   ping: {
     protocolPrefix: 'ipfs',

--- a/src/config.ts
+++ b/src/config.ts
@@ -87,7 +87,9 @@ const DefaultConfig: Partial<Libp2pInit> = {
     maxInboundStreams: 1,
     maxOutboundStreams: 1,
     maxPushIncomingStreams: 1,
-    maxPushOutgoingStreams: 1
+    maxPushOutgoingStreams: 1,
+    disableIdentify: false,
+    disableIdentifyPush: false
   },
   ping: {
     protocolPrefix: 'ipfs',

--- a/src/identify/index.ts
+++ b/src/identify/index.ts
@@ -67,14 +67,14 @@ export interface IdentifyServiceInit {
   maxPushOutgoingStreams: number
 
   /**
-   * Disable the identify protocol completely
+   * Enable the identify protocol
    */
-  disableIdentify: boolean
+  enable: boolean
 
   /**
-   * Disable the identify-push protocol completely
+   * Enable the identify-push protocol
    */
-  disableIdentifyPush: boolean
+  enablePush: boolean
 }
 
 export interface IdentifyServiceComponents {
@@ -111,7 +111,7 @@ export class IdentifyService implements Startable {
       ...init.host
     }
 
-    if (!this.init.disableIdentify) {
+    if (this.init.enable) {
       // When a new connection happens, trigger identify
       this.components.connectionManager.addEventListener('peer:connect', (evt) => {
         const connection = evt.detail
@@ -119,7 +119,7 @@ export class IdentifyService implements Startable {
       })
     }
 
-    if (!this.init.disableIdentifyPush) {
+    if (this.init.enablePush) {
       // When self multiaddrs change, trigger identify-push
       this.components.peerStore.addEventListener('change:multiaddrs', (evt) => {
         const { peerId } = evt.detail
@@ -152,7 +152,7 @@ export class IdentifyService implements Startable {
     await this.components.peerStore.metadataBook.setValue(this.components.peerId, 'AgentVersion', uint8ArrayFromString(this.host.agentVersion))
     await this.components.peerStore.metadataBook.setValue(this.components.peerId, 'ProtocolVersion', uint8ArrayFromString(this.host.protocolVersion))
 
-    if (!this.init.disableIdentify) {
+    if (this.init.enable) {
       await this.components.registrar.handle(this.identifyProtocolStr, (data) => {
         void this._handleIdentify(data).catch(err => {
           log.error(err)
@@ -162,7 +162,7 @@ export class IdentifyService implements Startable {
         maxOutboundStreams: this.init.maxOutboundStreams
       })
     }
-    if (!this.init.disableIdentifyPush) {
+    if (this.init.enablePush) {
       await this.components.registrar.handle(this.identifyPushProtocolStr, (data) => {
         void this._handlePush(data).catch(err => {
           log.error(err)
@@ -177,10 +177,10 @@ export class IdentifyService implements Startable {
   }
 
   async stop () {
-    if (!this.init.disableIdentify) {
+    if (this.init.enable) {
       await this.components.registrar.unhandle(this.identifyProtocolStr)
     }
-    if (!this.init.disableIdentifyPush) {
+    if (this.init.enablePush) {
       await this.components.registrar.unhandle(this.identifyPushProtocolStr)
     }
 

--- a/test/identify/index.spec.ts
+++ b/test/identify/index.spec.ts
@@ -41,7 +41,9 @@ const defaultInit: IdentifyServiceInit = {
   maxOutboundStreams: 1,
   maxPushIncomingStreams: 1,
   maxPushOutgoingStreams: 1,
-  timeout: 1000
+  timeout: 1000,
+  disableIdentify: false,
+  disableIdentifyPush: false
 }
 
 const protocols = [MULTICODEC_IDENTIFY, MULTICODEC_IDENTIFY_PUSH]
@@ -382,5 +384,12 @@ describe('identify', () => {
 
     await expect(identifySpy.getCall(0).returnValue)
       .to.eventually.be.rejected.with.property('code', 'ABORT_ERR')
+  })
+
+  it('should disable identify and identify-push when initialized as disabled', async () => {
+    void new IdentifyService(localComponents, { ...defaultInit, disableIdentify: true, disableIdentifyPush: true })
+
+    expect(() => localComponents.registrar.getHandler(MULTICODEC_IDENTIFY)).to.throw().with.property('code', 'ERR_NO_HANDLER_FOR_PROTOCOL')
+    expect(() => localComponents.registrar.getHandler(MULTICODEC_IDENTIFY_PUSH)).to.throw().with.property('code', 'ERR_NO_HANDLER_FOR_PROTOCOL')
   })
 })

--- a/test/identify/index.spec.ts
+++ b/test/identify/index.spec.ts
@@ -42,8 +42,8 @@ const defaultInit: IdentifyServiceInit = {
   maxPushIncomingStreams: 1,
   maxPushOutgoingStreams: 1,
   timeout: 1000,
-  disableIdentify: false,
-  disableIdentifyPush: false
+  enable: true,
+  enablePush: false
 }
 
 const protocols = [MULTICODEC_IDENTIFY, MULTICODEC_IDENTIFY_PUSH]
@@ -387,7 +387,7 @@ describe('identify', () => {
   })
 
   it('should disable identify and identify-push when initialized as disabled', async () => {
-    void new IdentifyService(localComponents, { ...defaultInit, disableIdentify: true, disableIdentifyPush: true })
+    void new IdentifyService(localComponents, { ...defaultInit, enable: false, enablePush: false })
 
     expect(() => localComponents.registrar.getHandler(MULTICODEC_IDENTIFY)).to.throw().with.property('code', 'ERR_NO_HANDLER_FOR_PROTOCOL')
     expect(() => localComponents.registrar.getHandler(MULTICODEC_IDENTIFY_PUSH)).to.throw().with.property('code', 'ERR_NO_HANDLER_FOR_PROTOCOL')

--- a/test/identify/push.spec.ts
+++ b/test/identify/push.spec.ts
@@ -39,7 +39,9 @@ const defaultInit: IdentifyServiceInit = {
   maxOutboundStreams: 1,
   maxPushIncomingStreams: 1,
   maxPushOutgoingStreams: 1,
-  timeout: 1000
+  timeout: 1000,
+  disableIdentify: false,
+  disableIdentifyPush: false
 }
 
 const protocols = [MULTICODEC_IDENTIFY, MULTICODEC_IDENTIFY_PUSH]


### PR DESCRIPTION
Without rate limiting, identify push may be a DoS vector.

In the mean while it is useful to configure libp2p to completely disable identify and identify push if desired.

FYI was not able to test this test due to type errors installing the latest dependencies :(