### PR TITLE
fix: allow listening on duplicate addresses

### DIFF
--- a/src/address-manager/index.ts
+++ b/src/address-manager/index.ts
@@ -38,7 +38,8 @@ const defaultAddressFilter = (addrs: Multiaddr[]): Multiaddr[] => addrs
 
 export class DefaultAddressManager extends EventEmitter<AddressManagerEvents> {
   private readonly components: DefaultAddressManagerComponents
-  private readonly listen: Set<string>
+  // this is an array to allow for duplicates, e.g. multiples of `/ip4/0.0.0.0/tcp/0`
+  private readonly listen: string[]
   private readonly announce: Set<string>
   private readonly observed: Set<string>
   private readonly announceFilter: AddressFilter
@@ -55,7 +56,7 @@ export class DefaultAddressManager extends EventEmitter<AddressManagerEvents> {
     const { listen = [], announce = [] } = init
 
     this.components = components
-    this.listen = new Set(listen.map(ma => ma.toString()))
+    this.listen = listen.map(ma => ma.toString())
     this.announce = new Set(announce.map(ma => ma.toString()))
     this.observed = new Set()
     this.announceFilter = init.announceFilter ?? defaultAddressFilter

--- a/test/addresses/address-manager.spec.ts
+++ b/test/addresses/address-manager.spec.ts
@@ -84,6 +84,25 @@ describe('Address Manager', () => {
     expect(am.getObservedAddrs()).to.have.lengthOf(1)
   })
 
+  it('should allow duplicate listen addresses', () => {
+    const ma = multiaddr('/ip4/0.0.0.0/tcp/0')
+    const am = new DefaultAddressManager({
+      peerId,
+      transportManager: stubInterface<TransportManager>()
+    }, {
+      announceFilter: stubInterface<AddressFilter>(),
+      listen: [
+        ma.toString(),
+        ma.toString()
+      ]
+    })
+
+    expect(am.getListenAddrs()).to.deep.equal([
+      ma,
+      ma
+    ])
+  })
+
   it('should dedupe added observed addresses', () => {
     const ma = '/ip4/123.123.123.123/tcp/39201'
     const am = new DefaultAddressManager({


### PR DESCRIPTION
Some listen addresses are turned into valid unique addresses when listening on them, for example `/ip4/0.0.0.0/tcp/0`, so we should be able to listen on multiple versions of addresses like these.

Currently we dedupe listen addresses before listening starts so this isn't possible.

This PR removes the deduping and adds a test.