### PR TITLE
test: address length test should accept a single address

### DIFF
--- a/test/core/listening.node.ts
+++ b/test/core/listening.node.ts
@@ -42,7 +42,7 @@ describe('Listening', () => {
     // Should get something like:
     //   /ip4/127.0.0.1/tcp/50866
     //   /ip4/192.168.1.2/tcp/50866
-    expect(addrs.length).to.be.at.least(2)
+    expect(addrs.length).to.be.at.least(1)
     for (const addr of addrs) {
       const opts = addr.toOptions()
       expect(opts.family).to.equal(4)


### PR DESCRIPTION
If you're running the tests on a computer not attached to a network, for example on an aeroplane with flight-safe mode enabled, this test fails so allow detecting a single (loopback) address.