### PR TITLE
Fixed the WebRTC import

### DIFF
--- a/examples/webrtc-direct/listener.js
+++ b/examples/webrtc-direct/listener.js
@@ -1,5 +1,5 @@
 import { createLibp2p } from 'libp2p'
-import { WebRTCDirect } from '@libp2p/webrtc-direct'
+import { webRTCDirect } from '@libp2p/webrtc-direct'
 import { mplex } from '@libp2p/mplex'
 import { noise } from '@chainsafe/libp2p-noise'
 import { createFromJSON } from '@libp2p/peer-id-factory'
@@ -18,7 +18,7 @@ import wrtc from 'wrtc'
     addresses: {
       listen: ['/ip4/127.0.0.1/tcp/9090/http/p2p-webrtc-direct']
     },
-    transports: [new WebRTCDirect({ wrtc })],
+    transports: [new webRTCDirect({ wrtc })],
     streamMuxers: [mplex()],
     connectionEncryption: [noise()]
   })

--- a/examples/webrtc-direct/listener.js
+++ b/examples/webrtc-direct/listener.js
@@ -18,7 +18,7 @@ import wrtc from 'wrtc'
     addresses: {
       listen: ['/ip4/127.0.0.1/tcp/9090/http/p2p-webrtc-direct']
     },
-    transports: [new webRTCDirect({ wrtc })],
+    transports: [webRTCDirect({ wrtc })],
     streamMuxers: [mplex()],
     connectionEncryption: [noise()]
   })


### PR DESCRIPTION
Previous import was importing WebRTCDirect instead of webRTCDirect.
```javascript
import { WebRTCDirect } from '@libp2p/webrtc-direct'
```
Is changed to 
```javascript
import { webRTCDirect } from '@libp2p/webrtc-direct'
```