### PR TITLE
fix: do not override known address after identify is done

### DIFF
--- a/src/identify/index.ts
+++ b/src/identify/index.ts
@@ -362,7 +362,7 @@ export class IdentifyService implements Startable {
 
     // LEGACY: Update peers data in PeerStore
     try {
-      await this.components.peerStore.addressBook.set(id, listenAddrs.map((addr) => multiaddr(addr)))
+      await this.components.peerStore.addressBook.add(id, listenAddrs.map((addr) => multiaddr(addr)))
     } catch (err: any) {
       log.error('received invalid addrs', err)
     }


### PR DESCRIPTION
Identify protocol being executed it means that both peers are somehow connected. Hence, it should not override working multiaddresses but only add to it.

Fixes #1484