### PR TITLE
docs: remove loadkeychain from instance methods

### DIFF
--- a/doc/API.md
+++ b/doc/API.md
@@ -3,7 +3,6 @@
 * [Static Functions](#static-functions)
   * [`create`](#create)
 * [Instance Methods](#libp2p-instance-methods)
-  * [`loadkeychain`](#loadkeychain)
   * [`start`](#start)
   * [`stop`](#stop)
   * [`dial`](#dial)


### PR DESCRIPTION
Doesn't seem like this exists in the API anymore?