### PR TITLE
fix!: remove strings from fetch and hangUp

### DIFF
--- a/examples/auto-relay/dialer.js
+++ b/examples/auto-relay/dialer.js
@@ -2,6 +2,7 @@ import { createLibp2p } from 'libp2p'
 import { webSockets } from '@libp2p/websockets'
 import { noise } from '@chainsafe/libp2p-noise'
 import { mplex } from '@libp2p/mplex'
+import { multiaddr } from '@multiformats/multiaddr'
 
 async function main () {
   const autoRelayNodeAddr = process.argv[2]
@@ -24,7 +25,7 @@ async function main () {
   await node.start()
   console.log(`Node started with id ${node.peerId.toString()}`)
 
-  const conn = await node.dial(autoRelayNodeAddr)
+  const conn = await node.dial(multiaddr(autoRelayNodeAddr))
   console.log(`Connected to the auto relay node via ${conn.remoteAddr.toString()}`)
 }
 

--- a/examples/auto-relay/listener.js
+++ b/examples/auto-relay/listener.js
@@ -2,6 +2,7 @@ import { createLibp2p } from 'libp2p'
 import { webSockets } from '@libp2p/websockets'
 import { noise } from '@chainsafe/libp2p-noise'
 import { mplex } from '@libp2p/mplex'
+import { multiaddr } from '@multiformats/multiaddr'
 
 async function main () {
   const relayAddr = process.argv[2]
@@ -31,7 +32,7 @@ async function main () {
   await node.start()
   console.log(`Node started with id ${node.peerId.toString()}`)
 
-  const conn = await node.dial(relayAddr)
+  const conn = await node.dial(multiaddr(relayAddr))
 
   console.log(`Connected to the HOP relay ${conn.remotePeer.toString()}`)
 

--- a/examples/echo/src/dialer.js
+++ b/examples/echo/src/dialer.js
@@ -11,6 +11,7 @@ import idl from './id-l.js'
 import { createFromJSON } from '@libp2p/peer-id-factory'
 import { toString as uint8ArrayToString } from 'uint8arrays/to-string'
 import { fromString as uint8ArrayFromString } from 'uint8arrays/from-string'
+import { multiaddr } from '@multiformats/multiaddr'
 
 async function run() {
   const [dialerId, listenerId] = await Promise.all([
@@ -27,7 +28,7 @@ async function run() {
   })
 
   // Add peer to Dial (the listener) into the PeerStore
-  const listenerMultiaddr = '/ip4/127.0.0.1/tcp/10333/p2p/' + listenerId.toString()
+  const listenerMultiaddr = multiaddr('/ip4/127.0.0.1/tcp/10333/p2p/' + listenerId.toString())
 
   // Start the dialer libp2p node
   await dialerNode.start()

--- a/src/get-peer.ts
+++ b/src/get-peer.ts
@@ -1,6 +1,6 @@
 import { peerIdFromString } from '@libp2p/peer-id'
 import type { Multiaddr } from '@multiformats/multiaddr'
-import { multiaddr, isMultiaddr } from '@multiformats/multiaddr'
+import { isMultiaddr } from '@multiformats/multiaddr'
 import errCode from 'err-code'
 import { codes } from './errors.js'
 import { isPeerId } from '@libp2p/interface-peer-id'
@@ -28,19 +28,15 @@ function peerIdFromMultiaddr (ma: Multiaddr) {
 }
 
 /**
- * Converts the given `peer` to a `Peer` object.
+ * Converts the given `peer` to a `PeerInfo` object.
  */
-export function getPeer (peer: PeerId | Multiaddr | string): PeerInfo {
+export function getPeer (peer: PeerId | Multiaddr): PeerInfo {
   if (isPeerId(peer)) {
     return {
       id: peer,
       multiaddrs: [],
       protocols: []
     }
-  }
-
-  if (typeof peer === 'string') {
-    peer = multiaddr(peer)
   }
 
   let addr

--- a/src/index.ts
+++ b/src/index.ts
@@ -178,7 +178,7 @@ export interface Libp2p extends Startable, EventEmitter<Libp2pEvents> {
   /**
    * Disconnects all connections to the given `peer`
    */
-  hangUp: (peer: PeerId | Multiaddr | string) => Promise<void>
+  hangUp: (peer: PeerId | Multiaddr) => Promise<void>
 
   /**
    * Registers the `handler` for each protocol
@@ -194,12 +194,12 @@ export interface Libp2p extends Startable, EventEmitter<Libp2pEvents> {
   /**
    * Pings the given peer in order to obtain the operation latency
    */
-  ping: (peer: Multiaddr | PeerId, options?: AbortOptions) => Promise<number>
+  ping: (peer: PeerId | Multiaddr, options?: AbortOptions) => Promise<number>
 
   /**
    * Sends a request to fetch the value associated with the given key from the given peer.
    */
-  fetch: (peer: PeerId | Multiaddr | string, key: string, options?: AbortOptions) => Promise<Uint8Array | null>
+  fetch: (peer: PeerId | Multiaddr, key: string, options?: AbortOptions) => Promise<Uint8Array | null>
 
   /**
    * Returns the public key for the passed PeerId. If the PeerId is of the 'RSA' type

--- a/src/libp2p.ts
+++ b/src/libp2p.ts
@@ -373,7 +373,7 @@ export class Libp2pNode extends EventEmitter<Libp2pEvents> implements Libp2p {
     return this.components.addressManager.getAddresses()
   }
 
-  async hangUp (peer: PeerId | Multiaddr | string): Promise<void> {
+  async hangUp (peer: PeerId | Multiaddr): Promise<void> {
     const { id } = getPeer(peer)
 
     await this.components.connectionManager.closeConnections(id)
@@ -418,7 +418,7 @@ export class Libp2pNode extends EventEmitter<Libp2pEvents> implements Libp2p {
     throw errCode(new Error(`Node not responding with its public key: ${peer.toString()}`), codes.ERR_INVALID_RECORD)
   }
 
-  async fetch (peer: PeerId | Multiaddr | string, key: string, options: AbortOptions = {}): Promise<Uint8Array | null> {
+  async fetch (peer: PeerId | Multiaddr, key: string, options: AbortOptions = {}): Promise<Uint8Array | null> {
     const { id, multiaddrs } = getPeer(peer)
 
     if (multiaddrs != null) {
@@ -428,7 +428,7 @@ export class Libp2pNode extends EventEmitter<Libp2pEvents> implements Libp2p {
     return await this.fetchService.fetch(id, key, options)
   }
 
-  async ping (peer: PeerId | Multiaddr | string, options: AbortOptions = {}): Promise<number> {
+  async ping (peer: PeerId | Multiaddr, options: AbortOptions = {}): Promise<number> {
     const { id, multiaddrs } = getPeer(peer)
 
     if (multiaddrs.length > 0) {


### PR DESCRIPTION
Only accept PeerId or Multiaddr objects as arguments to fetch and hangUp the same as ping, dial, etc.

This was missed during the typescript refactor.

BREAKING CHANGE: libp2p.hangUp and libp2p.fetch require PeerId or Multiaddr objects the same as other methods