### PR TITLE
feat!: start libp2p nodes by default

### DIFF
--- a/.aegir.js
+++ b/.aegir.js
@@ -53,7 +53,6 @@ export default {
         pipe(stream, stream)
           .catch() // sometimes connections are closed before multistream-select finishes which causes an error
       })
-      await libp2p.start()
 
       return {
         libp2p

--- a/doc/API.md
+++ b/doc/API.md
@@ -186,7 +186,7 @@ Required keys in the `options` object:
 
 ### start
 
-Starts the libp2p node.
+By default nodes are started when returned from `createLibp2p` - to override this, pass `start: false` as an option. You can then use `libp2p.start()` to start the node.
 
 `libp2p.start()`
 
@@ -203,7 +203,10 @@ import { createLibp2p } from 'libp2p'
 
 // ...
 
-const libp2p = await createLibp2p(options)
+const libp2p = await createLibp2p({
+  start: false,
+  ...options
+})
 
 // start libp2p
 await libp2p.start()

--- a/doc/GETTING_STARTED.md
+++ b/doc/GETTING_STARTED.md
@@ -136,6 +136,8 @@ import { noise } from '@chainsafe/libp2p-noise'
 import { mplex } from '@libp2p/mplex'
 
 const node = await createLibp2p({
+  // libp2p nodes are started by default, pass false to override this
+  start: false,
   addresses: {
     listen: ['/ip4/127.0.0.1/tcp/8000/ws']
   },
@@ -219,9 +221,6 @@ node.addEventListener('peer:discovery', (evt) => {
 node.connectionManager.addEventListener('peer:connect', (evt) => {
   console.log('Connected to %s', evt.detail.remotePeer.toString()) // Log connected peer
 })
-
-// start libp2p
-await node.start()
 ```
 
 <details><summary>Read More</summary>

--- a/examples/auto-relay/README.md
+++ b/examples/auto-relay/README.md
@@ -41,8 +41,6 @@ const node = await createLibp2p({
   }
 })
 
-await node.start()
-
 console.log(`Node started with id ${node.peerId.toString()}`)
 console.log('Listening on:')
 node.getMultiaddrs().forEach((ma) => console.log(ma.toString()))
@@ -93,7 +91,6 @@ const node = await createLibp2p({
   }
 })
 
-await node.start()
 console.log(`Node started with id ${node.peerId.toString()}`)
 
 const conn = await node.dial(relayAddr)
@@ -150,7 +147,6 @@ const node = await createLibp2p({
   streamMuxers: [mplex()]
 })
 
-await node.start()
 console.log(`Node started with id ${node.peerId.toString()}`)
 
 const conn = await node.dial(autoRelayNodeAddr)

--- a/examples/auto-relay/dialer.js
+++ b/examples/auto-relay/dialer.js
@@ -22,7 +22,6 @@ async function main () {
     ]
   })
 
-  await node.start()
   console.log(`Node started with id ${node.peerId.toString()}`)
 
   const conn = await node.dial(multiaddr(autoRelayNodeAddr))

--- a/examples/auto-relay/listener.js
+++ b/examples/auto-relay/listener.js
@@ -29,7 +29,6 @@ async function main () {
     }
   })
 
-  await node.start()
   console.log(`Node started with id ${node.peerId.toString()}`)
 
   const conn = await node.dial(multiaddr(relayAddr))

--- a/examples/auto-relay/relay.js
+++ b/examples/auto-relay/relay.js
@@ -30,8 +30,6 @@ async function main () {
     }
   })
 
-  await node.start()
-
   console.log(`Node started with id ${node.peerId.toString()}`)
   console.log('Listening on:')
   node.getMultiaddrs().forEach((ma) => console.log(ma.toString()))

--- a/examples/chat/src/dialer.js
+++ b/examples/chat/src/dialer.js
@@ -21,9 +21,6 @@ async function run () {
     }
   })
 
-  // Start the libp2p host
-  await nodeDialer.start()
-
   // Output this node's address
   console.log('Dialer ready, listening on:')
   nodeDialer.getMultiaddrs().forEach((ma) => {

--- a/examples/chat/src/listener.js
+++ b/examples/chat/src/listener.js
@@ -29,9 +29,6 @@ async function run () {
     streamToConsole(stream)
   })
 
-  // Start listening
-  await nodeListener.start()
-
   // Output listen addresses to the console
   console.log('Listener ready, listening on:')
   nodeListener.getMultiaddrs().forEach((ma) => {

--- a/examples/connection-encryption/1.js
+++ b/examples/connection-encryption/1.js
@@ -16,8 +16,6 @@ const createNode = async () => {
     connectionEncryption: [noise()]
   })
 
-  await node.start()
-
   return node
 }
 

--- a/examples/discovery-mechanisms/1.js
+++ b/examples/discovery-mechanisms/1.js
@@ -33,6 +33,4 @@ import bootstrapers from './bootstrappers.js'
     // No need to dial, autoDial is on
     console.log('Discovered:', peer.id.toString())
   })
-
-  await node.start()
 })();

--- a/examples/discovery-mechanisms/2.js
+++ b/examples/discovery-mechanisms/2.js
@@ -38,9 +38,4 @@ const createNode = async () => {
 
   node1.addEventListener('peer:discovery', (evt) => console.log('Discovered:', evt.detail.id.toString()))
   node2.addEventListener('peer:discovery', (evt) => console.log('Discovered:', evt.detail.id.toString()))
-
-  await Promise.all([
-    node1.start(),
-    node2.start()
-  ])
 })();

--- a/examples/discovery-mechanisms/3.js
+++ b/examples/discovery-mechanisms/3.js
@@ -53,8 +53,7 @@ const createNode = async (bootstrappers) => {
       }
     }
   })
-  console.log(`libp2p relay starting with id: ${relay.peerId.toString()}`)
-  await relay.start()
+  console.log(`libp2p relay started with id: ${relay.peerId.toString()}`)
 
   const relayMultiaddrs = relay.getMultiaddrs().map((m) => m.toString())
 
@@ -71,10 +70,4 @@ const createNode = async (bootstrappers) => {
     const peer = evt.detail
     console.log(`Peer ${node2.peerId.toString()} discovered: ${peer.id.toString()}`)
   })
-
-  ;[node1, node2].forEach((node, index) => console.log(`Node ${index} starting with id: ${node.peerId.toString()}`))
-  await Promise.all([
-    node1.start(),
-    node2.start()
-  ])
 })()

--- a/examples/discovery-mechanisms/README.md
+++ b/examples/discovery-mechanisms/README.md
@@ -55,6 +55,7 @@ Now, once we create and start the node, we can listen for events such as `peer:d
 
 ```JavaScript
 const node = await createLibp2p({
+  start: false,
   addresses: {
     listen: ['/ip4/0.0.0.0/tcp/0']
   },
@@ -151,11 +152,6 @@ const [node1, node2] = await Promise.all([
 
 node1.addEventListener('peer:discovery', (evt) => console.log('Discovered:', evt.detail.id.toString()))
 node2.addEventListener('peer:discovery', (evt) => console.log('Discovered:', evt.detail.id.toString()))
-
-await Promise.all([
-  node1.start(),
-  node2.start()
-])
 ```
 
 If you run this example, you will see the other peers being discovered.

--- a/examples/echo/src/dialer.js
+++ b/examples/echo/src/dialer.js
@@ -30,9 +30,6 @@ async function run() {
   // Add peer to Dial (the listener) into the PeerStore
   const listenerMultiaddr = multiaddr('/ip4/127.0.0.1/tcp/10333/p2p/' + listenerId.toString())
 
-  // Start the dialer libp2p node
-  await dialerNode.start()
-
   console.log('Dialer ready, listening on:')
   dialerNode.getMultiaddrs().forEach((ma) => console.log(ma.toString()))
 

--- a/examples/echo/src/listener.js
+++ b/examples/echo/src/listener.js
@@ -30,9 +30,6 @@ async function run() {
   // back to itself (an echo)
   await listenerNode.handle('/echo/1.0.0', ({ stream }) => pipe(stream.source, stream.sink))
 
-  // Start listening
-  await listenerNode.start()
-
   console.log('Listener ready, listening on:')
   listenerNode.getMultiaddrs().forEach((ma) => {
     console.log(ma.toString())

--- a/examples/libp2p-in-the-browser/index.js
+++ b/examples/libp2p-in-the-browser/index.js
@@ -73,7 +73,6 @@ document.addEventListener('DOMContentLoaded', async () => {
     log(`Disconnected from ${connection.remotePeer.toString()}`)
   })
 
-  await libp2p.start()
   status.innerText = 'libp2p started!'
   log(`libp2p id is ${libp2p.peerId.toString()}`)
 

--- a/examples/peer-and-content-routing/1.js
+++ b/examples/peer-and-content-routing/1.js
@@ -18,7 +18,6 @@ const createNode = async () => {
     dht: kadDHT()
   })
 
-  await node.start()
   return node
 }
 

--- a/examples/peer-and-content-routing/2.js
+++ b/examples/peer-and-content-routing/2.js
@@ -20,7 +20,6 @@ const createNode = async () => {
     dht: kadDHT()
   })
 
-  await node.start()
   return node
 }
 

--- a/examples/peer-and-content-routing/README.md
+++ b/examples/peer-and-content-routing/README.md
@@ -30,7 +30,6 @@ const createNode = async () => {
     dht: kadDHT()
   })
 
-  await node.start()
   return node
 }
 ```

--- a/examples/pnet/index.js
+++ b/examples/pnet/index.js
@@ -21,11 +21,6 @@ generateKey(otherSwarmKey)
   const node2 = await privateLibp2pNode(swarmKey)
   // const node2 = await privateLibp2pNode(otherSwarmKey)
 
-  await Promise.all([
-    node1.start(),
-    node2.start()
-  ])
-
   console.log('nodes started...')
 
   // Add node 2 data to node1's PeerStore

--- a/examples/protocol-and-stream-muxing/1.js
+++ b/examples/protocol-and-stream-muxing/1.js
@@ -16,8 +16,6 @@ const createNode = async () => {
     connectionEncryption: [noise()]
   })
 
-  await node.start()
-
   return node
 }
 

--- a/examples/protocol-and-stream-muxing/2.js
+++ b/examples/protocol-and-stream-muxing/2.js
@@ -16,8 +16,6 @@ const createNode = async () => {
     connectionEncryption: [noise()]
   })
 
-  await node.start()
-
   return node
 }
 

--- a/examples/protocol-and-stream-muxing/3.js
+++ b/examples/protocol-and-stream-muxing/3.js
@@ -18,8 +18,6 @@ const createNode = async () => {
     connectionEncryption: [noise()]
   })
 
-  await node.start()
-
   return node
 }
 

--- a/examples/protocol-and-stream-muxing/README.md
+++ b/examples/protocol-and-stream-muxing/README.md
@@ -185,8 +185,6 @@ const createNode = async () => {
     connectionEncryption: [noise()],
   })
 
-  await node.start()
-
   return node
 }
 ```

--- a/examples/pubsub/1.js
+++ b/examples/pubsub/1.js
@@ -19,7 +19,6 @@ const createNode = async () => {
     pubsub: floodsub()
   })
 
-  await node.start()
   return node
 }
 

--- a/examples/pubsub/README.md
+++ b/examples/pubsub/README.md
@@ -39,8 +39,6 @@ const createNode = async () => {
 	  pubsub: gossipsub({ allowPublishToZeroPeers: true })
   })
 
-  await node.start()
-
   return node
 }
 ```

--- a/examples/pubsub/message-filtering/1.js
+++ b/examples/pubsub/message-filtering/1.js
@@ -19,7 +19,6 @@ const createNode = async () => {
     pubsub: floodsub()
   })
 
-  await node.start()
   return node
 }
 

--- a/examples/pubsub/message-filtering/README.md
+++ b/examples/pubsub/message-filtering/README.md
@@ -25,8 +25,6 @@ const createNode = async () => {
 	  pubsub: gossipsub({ allowPublishToZeroPeers: true })
   })
 
-  await node.start()
-
   return node
 }
 ```

--- a/examples/transports/1.js
+++ b/examples/transports/1.js
@@ -21,7 +21,6 @@ const createNode = async () => {
     ]
   })
 
-  await node.start()
   return node
 }
 

--- a/examples/transports/2.js
+++ b/examples/transports/2.js
@@ -21,7 +21,6 @@ const createNode = async () => {
     streamMuxers: [mplex()]
   })
 
-  await node.start()
   return node
 }
 

--- a/examples/transports/3.js
+++ b/examples/transports/3.js
@@ -23,7 +23,6 @@ const createNode = async (transports, addresses = []) => {
     streamMuxers: [mplex()]
   })
 
-  await node.start()
   return node
 }
 

--- a/examples/transports/4.js
+++ b/examples/transports/4.js
@@ -43,7 +43,6 @@ const createNode = async (addresses = []) => {
     }
   })
 
-  await node.start()
   return node
 }
 

--- a/examples/transports/README.md
+++ b/examples/transports/README.md
@@ -40,7 +40,6 @@ const createNode = async () => {
     ]
   })
 
-  await node.start()
   return node
 }
 ```
@@ -105,7 +104,6 @@ const createNode = async () => {
     streamMuxers: [mplex()] // <--- Add this line
   })
 
-  await node.start()
   return node
 }
 ```
@@ -194,7 +192,6 @@ const createNode = async (transports, addresses = []) => {
     streamMuxers: [mplex()]
   })
 
-  await node.start()
   return node
 }
 ```

--- a/examples/webrtc-direct/dialer.js
+++ b/examples/webrtc-direct/dialer.js
@@ -48,7 +48,6 @@ document.addEventListener('DOMContentLoaded', async () => {
     log(`Disconnected from ${evt.detail.remotePeer.toString()}`)
   })
 
-  await libp2p.start()
   status.innerText = 'libp2p started!'
   log(`libp2p id is ${libp2p.peerId.toString()}`)
 })

--- a/examples/webrtc-direct/listener.js
+++ b/examples/webrtc-direct/listener.js
@@ -27,8 +27,6 @@ import wrtc from 'wrtc'
     console.info(`Connected to ${evt.detail.remotePeer.toString()}!`)
   })
 
-  await node.start()
-
   console.log('Listening on:')
   node.getMultiaddrs().forEach((ma) => console.log(ma.toString()))
 })()

--- a/src/index.ts
+++ b/src/index.ts
@@ -208,12 +208,20 @@ export interface Libp2p extends Startable, EventEmitter<Libp2pEvents> {
   getPublicKey: (peer: PeerId, options?: AbortOptions) => Promise<Uint8Array>
 }
 
-export type Libp2pOptions = RecursivePartial<Libp2pInit>
+export type Libp2pOptions = RecursivePartial<Libp2pInit> & { start?: boolean }
 
 /**
  * Returns a new instance of the Libp2p interface, generating a new PeerId
  * if one is not passed as part of the options.
+ *
+ * The node will be started unless `start: false` is passed as an option.
  */
 export async function createLibp2p (options: Libp2pOptions): Promise<Libp2p> {
-  return await createLibp2pNode(options)
+  const node = await createLibp2pNode(options)
+
+  if (options.start !== false) {
+    await node.start()
+  }
+
+  return node
 }

--- a/test/configuration/pubsub.spec.ts
+++ b/test/configuration/pubsub.spec.ts
@@ -36,6 +36,7 @@ describe('Pubsub subsystem is configurable', () => {
     const peerId = await createPeerId()
 
     const customOptions = mergeOptions(pubsubSubsystemOptions, {
+      start: false,
       peerId
     })
 

--- a/test/core/encryption.spec.ts
+++ b/test/core/encryption.spec.ts
@@ -42,6 +42,7 @@ describe('Connection encryption configuration', () => {
   it('can be created', async () => {
     const config: Libp2pOptions = {
       peerId,
+      start: false,
       transports: [
         webSockets()
       ],

--- a/test/core/start.spec.ts
+++ b/test/core/start.spec.ts
@@ -1,0 +1,47 @@
+/* eslint-env mocha */
+
+import { expect } from 'aegir/chai'
+import { webSockets } from '@libp2p/websockets'
+import { plaintext } from '../../src/insecure/index.js'
+import { createLibp2p, Libp2p } from '../../src/index.js'
+
+describe('start', () => {
+  let libp2p: Libp2p
+
+  afterEach(async () => {
+    if (libp2p != null) {
+      await libp2p.stop()
+    }
+  })
+
+  it('it should start by default', async () => {
+    libp2p = await createLibp2p({
+      transports: [
+        webSockets()
+      ],
+      connectionEncryption: [
+        plaintext()
+      ]
+    })
+
+    expect(libp2p.isStarted()).to.be.true()
+  })
+
+  it('it should allow overriding', async () => {
+    libp2p = await createLibp2p({
+      start: false,
+      transports: [
+        webSockets()
+      ],
+      connectionEncryption: [
+        plaintext()
+      ]
+    })
+
+    expect(libp2p.isStarted()).to.be.false()
+
+    await libp2p.start()
+
+    expect(libp2p.isStarted()).to.be.true()
+  })
+})

--- a/test/peer-routing/peer-routing.node.ts
+++ b/test/peer-routing/peer-routing.node.ts
@@ -575,6 +575,7 @@ describe('peer-routing', () => {
 
       node = await createNode({
         config: createRoutingOptions({
+          start: false,
           peerRouting: {
             refreshManager: {
               enabled: true,
@@ -630,6 +631,7 @@ describe('peer-routing', () => {
     it('should support being disabled', async () => {
       node = await createNode({
         config: createRoutingOptions({
+          start: false,
           peerRouting: {
             refreshManager: {
               bootDelay: 100,
@@ -664,6 +666,7 @@ describe('peer-routing', () => {
     it('should start and run on interval', async () => {
       node = await createNode({
         config: createRoutingOptions({
+          start: false,
           peerRouting: {
             refreshManager: {
               interval: 500,


### PR DESCRIPTION
Nodes returned from `createLibp2p` are now started by default. To override this pass `start: false` as an option.

Fixes #1499

BREAKING CHANGE: nodes returned from `createLibp2p` are now started by default