### PR TITLE
feat: allow skipping upgrade steps for incoming connections

### DIFF
--- a/src/keychain/index.ts
+++ b/src/keychain/index.ts
@@ -118,7 +118,7 @@ export interface KeyChainComponents {
  */
 export class KeyChain implements Startable {
   private readonly components: KeyChainComponents
-  private init: KeyChainInit
+  private readonly init: KeyChainInit
   private started: boolean
 
   /**


### PR DESCRIPTION
We already allow skipping upgrade steps for outgoing connections, this PR adds the same capability of incoming connections.

This is to support listeners for new transports like webtransport and webrtc that manage their own encryption and multiplexing.