### PR TITLE
fix: close short-lived connections first when pruning by tag value

### DIFF
--- a/doc/LIMITS.md
+++ b/doc/LIMITS.md
@@ -53,7 +53,7 @@ const node = await createLibp2pNode({
 
 ## Closing connections
 
-When choosing connections to close the connection manager sorts the list of connections by the value derived from the tags given to each peer. The values of all tags are summed and connections with lower valued peers are eligible for closing first.
+When choosing connections to close the connection manager sorts the list of connections by the value derived from the tags given to each peer. The values of all tags are summed and connections with lower valued peers are eligible for closing first. If there are tags with equal values, the shortest-lived connection will be closed first.
 
 ```js
 // tag a peer

--- a/src/connection-manager/index.ts
+++ b/src/connection-manager/index.ts
@@ -650,6 +650,18 @@ export class DefaultConnectionManager extends EventEmitter<ConnectionManagerEven
         return -1
       }
 
+      // if the peers have an equal tag value then we want to close short-lived connections first
+      const connectionALifespan = a.stat.timeline.open
+      const connectionBLifespan = b.stat.timeline.open
+
+      if (connectionALifespan < connectionBLifespan) {
+        return 1
+      }
+
+      if (connectionALifespan > connectionBLifespan) {
+        return -1
+      }
+
       return 0
     })
 


### PR DESCRIPTION
Closes https://github.com/libp2p/js-libp2p/issues/1509