### PR TITLE
fix: add getProtocols method

### DIFF
--- a/src/libp2p.ts
+++ b/src/libp2p.ts
@@ -373,6 +373,10 @@ export class Libp2pNode extends EventEmitter<Libp2pEvents> implements Libp2p {
     return this.components.addressManager.getAddresses()
   }
 
+  getProtocols (): string[] {
+    return this.components.registrar.getProtocols()
+  }
+
   async hangUp (peer: PeerId | Multiaddr): Promise<void> {
     const { id } = getPeer(peer)
 


### PR DESCRIPTION
So we don't have to expose the registrar component, add a method to get the currently supported protocols