### PR TITLE
fix!: forward connection manager events on and update types

### DIFF
--- a/src/libp2p.ts
+++ b/src/libp2p.ts
@@ -132,6 +132,14 @@ export class Libp2pNode extends EventEmitter<Libp2pEvents> implements Libp2p {
     // Create the Connection Manager
     this.connectionManager = this.components.connectionManager = new DefaultConnectionManager(this.components, init.connectionManager)
 
+    // forward connection manager events
+    this.components.connectionManager.addEventListener('peer:disconnect', (event) => {
+      this.dispatchEvent(new CustomEvent<Connection>('peer:disconnect', { detail: event.detail }))
+    })
+    this.components.connectionManager.addEventListener('peer:connect', (event) => {
+      this.dispatchEvent(new CustomEvent<Connection>('peer:connect', { detail: event.detail }))
+    })
+
     // Create the Registrar
     this.registrar = this.components.registrar = new DefaultRegistrar(this.components)
 


### PR DESCRIPTION
BREAKING CHANGE: the connection manager and registrar are internal types and as such not part of the libp2p interface, instead use the methods exposed on the root libp2p type for obtaining connections and protocols