### PR TITLE
docs: add migration guide for 0.42.x

### DIFF
--- a/doc/migrations/v0.40-v0.41.md
+++ b/doc/migrations/v0.40-v0.41.md
@@ -4,8 +4,7 @@ A migration guide for refactoring your application code from libp2p v0.40.x to v
 
 ## Table of Contents <!-- omit in toc -->
 
-- [Modules](#modules)
-- [Autodial](#autodial)
+- [Metrics](#metrics)
 
 ## Metrics
 

--- a/doc/migrations/v0.41-v0.42.md
+++ b/doc/migrations/v0.41-v0.42.md
@@ -1,0 +1,105 @@
+# Migrating to libp2p@42 <!-- omit in toc -->
+
+A migration guide for refactoring your application code from libp2p v0.41.x to v0.42.0.
+
+## Table of Contents <!-- omit in toc -->
+
+- [libp2p interface](#libp2p-interface)
+- [Connection manager events](#connection-manager-events)
+- [Transport manager](#transport-manager)
+
+## libp2p interface
+
+A definition of the libp2p interface is now available from the module `@libp2p/interface-libp2p`.  This allows modules to signal what fields and methods they expect from a libp2p node without having to depend on the `libp2p` module directly making it lighter-weight and easier to consume.
+
+Not all fields from the returned object of the `createLibp2p` are defined on the interface, notably the `registrar` and `connectionManager` fields have been removed.  The functionality of these fields is available by calling methods on the root `libp2p` object instead.
+
+**Before**
+
+```js
+import { createLibp2p } from 'libp2p'
+
+const node = await createLibp2p({
+  // ... other options
+})
+
+node.registrar.getProtocols()
+// ['/ipfs/ping/1.0.0', '/ipfs/id/1.0.0']
+
+node.connectionManager.getConnections()
+// [Connection, Connection]
+
+await node.connectionManager.openConnection(peerId)
+// Connection
+```
+
+**After**
+
+```js
+import { createLibp2p } from 'libp2p'
+
+const node = await createLibp2p({
+  // ... other options
+})
+
+node.getProtocols()
+// ['/ipfs/ping/1.0.0', '/ipfs/id/1.0.0']
+
+node.getConnections()
+// [Connection, Connection]
+
+await node.dial(peerId)
+// Connection
+```
+
+## Connection manager events
+
+The connection manager events `peer:connect` and `peer:disconnect` are now emitted by the libp2p node.
+
+**Before**
+
+```js
+import { createLibp2p } from 'libp2p'
+
+const node = await createLibp2p({
+  // ... other options
+})
+
+node.connectionManager.on('peer:connect', (event) => {
+  // ...
+})
+node.connectionManager.on('peer:disconnect', (event) => {
+  // ...
+})
+```
+
+**After**
+
+```js
+import { createLibp2p } from 'libp2p'
+
+const node = await createLibp2p({
+  // ... other options
+})
+
+node.on('peer:connect', (event) => {
+  // ...
+})
+node.on('peer:disconnect', (event) => {
+  // ...
+})
+```
+
+## Transport manager
+
+The transport manager has been removed from the exports map. To access the `FaultTolerance` enum, import it from the `@libp2p/interface-transport` module instead:
+
+```js
+import { FaultTolerance } from 'libp2p/transport-manager'
+```
+
+**After**
+
+```js
+import { FaultTolerance } from '@libp2p/interface-transport'
+```


### PR DESCRIPTION
Adds migration guide for the breaking changes in 0.42.x