### PR TITLE
fix: expose identify service properties

### DIFF
--- a/src/identify/index.ts
+++ b/src/identify/index.ts
@@ -79,7 +79,7 @@ export class IdentifyService implements Startable {
   private readonly components: IdentifyServiceComponents
   private readonly identifyProtocolStr: string
   private readonly identifyPushProtocolStr: string
-  private readonly host: {
+  public readonly host: {
     protocolVersion: string
     agentVersion: string
   }

--- a/src/libp2p.ts
+++ b/src/libp2p.ts
@@ -56,7 +56,7 @@ export class Libp2pNode extends EventEmitter<Libp2pEvents> implements Libp2p {
   public peerId: PeerId
   public dht: DualDHT
   public pubsub: PubSub
-  public identifyService?: IdentifyService
+  public identifyService: IdentifyService
   public fetchService: FetchService
   public pingService: PingService
   public components: Components


### PR DESCRIPTION
To satisfy the types these need to be public