### PR TITLE
fix: add register and unregister methods to root node object

### DIFF
--- a/doc/migrations/v0.41-v0.42.md
+++ b/doc/migrations/v0.41-v0.42.md
@@ -18,6 +18,7 @@ Not all fields from the returned object of the `createLibp2p` are defined on the
 
 ```js
 import { createLibp2p } from 'libp2p'
+import { createTopology } from '@libp2p/topology'
 
 const node = await createLibp2p({
   // ... other options
@@ -31,6 +32,10 @@ node.connectionManager.getConnections()
 
 await node.connectionManager.openConnection(peerId)
 // Connection
+
+// Topology operations
+const id = await node.registrar.register('/my/protocol/1.0.0', createTopology({}))
+node.registrar.unregister(id)
 ```
 
 **After**
@@ -50,6 +55,10 @@ node.getConnections()
 
 await node.dial(peerId)
 // Connection
+
+// Topology operations
+const id = await node.register('/my/protocol/1.0.0', createTopology({}))
+node.unregister(id)
 ```
 
 ## Connection manager events

--- a/src/libp2p.ts
+++ b/src/libp2p.ts
@@ -32,7 +32,7 @@ import type { Connection } from '@libp2p/interface-connection'
 import type { PeerRouting } from '@libp2p/interface-peer-routing'
 import type { ContentRouting } from '@libp2p/interface-content-routing'
 import type { PubSub } from '@libp2p/interface-pubsub'
-import type { Registrar, StreamHandler, StreamHandlerOptions } from '@libp2p/interface-registrar'
+import type { Registrar, StreamHandler, StreamHandlerOptions, Topology } from '@libp2p/interface-registrar'
 import type { ConnectionManager } from '@libp2p/interface-connection-manager'
 import type { PeerInfo } from '@libp2p/interface-peer-info'
 import type { Libp2p, Libp2pEvents, Libp2pInit, Libp2pOptions } from './index.js'
@@ -472,6 +472,14 @@ export class Libp2pNode extends EventEmitter<Libp2pEvents> implements Libp2p {
         await this.components.registrar.unhandle(protocol)
       })
     )
+  }
+
+  async register (protocol: string, topology: Topology): Promise<string> {
+    return await this.registrar.register(protocol, topology)
+  }
+
+  unregister (id: string) {
+    this.registrar.unregister(id)
   }
 
   /**


### PR DESCRIPTION
Expose the register and unregister methods as part of the root libp2p node object.