### PR TITLE
chore: update @chainsafe/libp2p-noise dep in examples

### DIFF
--- a/examples/delegated-routing/package.json
+++ b/examples/delegated-routing/package.json
@@ -3,7 +3,7 @@
   "version": "0.1.0",
   "private": true,
   "dependencies": {
-    "@chainsafe/libp2p-noise": "^10.0.1",
+    "@chainsafe/libp2p-noise": "^11.0.0",
     "ipfs-core": "^0.15.4",
     "ipfs-http-client": "^58.0.1",
     "libp2p": "../../",

--- a/examples/libp2p-in-the-browser/package.json
+++ b/examples/libp2p-in-the-browser/package.json
@@ -9,7 +9,7 @@
   },
   "license": "ISC",
   "dependencies": {
-    "@chainsafe/libp2p-noise": "^10.0.1",
+    "@chainsafe/libp2p-noise": "^11.0.0",
     "@libp2p/bootstrap": "^6.0.0",
     "@libp2p/mplex": "^7.0.0",
     "@libp2p/webrtc-star": "^6.0.0",

--- a/examples/webrtc-direct/package.json
+++ b/examples/webrtc-direct/package.json
@@ -10,7 +10,7 @@
   "license": "ISC",
   "dependencies": {
     "@libp2p/webrtc-direct": "^5.0.0",
-    "@chainsafe/libp2p-noise": "^10.0.1",
+    "@chainsafe/libp2p-noise": "^11.0.0",
     "@libp2p/bootstrap": "^5.0.0",
     "@libp2p/mplex": "^7.0.0",
     "libp2p": "../../",


### PR DESCRIPTION
Update to v11