### PR TITLE
fix: do not append peer id to path addresses

### DIFF
--- a/src/address-manager/index.ts
+++ b/src/address-manager/index.ts
@@ -153,6 +153,11 @@ export class DefaultAddressManager extends EventEmitter<AddressManagerEvents> {
     return this.announceFilter(Array.from(addrSet)
       .map(str => multiaddr(str)))
       .map(ma => {
+        // do not append our peer id to a path multiaddr as it will become invalid
+        if (ma.protos().pop()?.path === true) {
+          return ma
+        }
+
         if (ma.getPeerId() === this.components.peerId.toString()) {
           return ma
         }

--- a/test/addresses/address-manager.spec.ts
+++ b/test/addresses/address-manager.spec.ts
@@ -179,6 +179,24 @@ describe('Address Manager', () => {
     expect(am.getObservedAddrs()).to.have.lengthOf(1)
     expect(am.getObservedAddrs().map(ma => ma.toString())).to.include(ma)
   })
+
+  it('should not add our peer id to path multiaddrs', () => {
+    const ma = '/unix/foo/bar/baz'
+    const transportManager = stubInterface<TransportManager>()
+    const am = new DefaultAddressManager({
+      peerId,
+      transportManager
+    }, {
+      listen: [ma],
+      announce: []
+    })
+
+    transportManager.getAddrs.returns([multiaddr(ma)])
+
+    const addrs = am.getAddresses()
+    expect(addrs).to.have.lengthOf(1)
+    expect(addrs[0].toString()).to.not.include(`/p2p/${peerId.toString()}`)
+  })
 })
 
 describe('libp2p.addressManager', () => {


### PR DESCRIPTION
Some multiaddrs have a path address as the final component - these components are terminal in that you cannot append further tuples to them, so do not do that when one is encountered.