### PR TITLE
fix: allow dialing multiaddrs without peer ids

### DIFF
--- a/src/get-peer.ts
+++ b/src/get-peer.ts
@@ -5,50 +5,28 @@ import errCode from 'err-code'
 import { codes } from './errors.js'
 import { isPeerId } from '@libp2p/interface-peer-id'
 import type { PeerId } from '@libp2p/interface-peer-id'
-import type { PeerInfo } from '@libp2p/interface-peer-info'
-
-function peerIdFromMultiaddr (ma: Multiaddr) {
-  const idStr = ma.getPeerId()
-
-  if (idStr == null) {
-    throw errCode(
-      new Error(`${ma.toString()} does not have a valid peer type`),
-      codes.ERR_INVALID_MULTIADDR
-    )
-  }
-
-  try {
-    return peerIdFromString(idStr)
-  } catch (err: any) {
-    throw errCode(
-      new Error(`${ma.toString()} is not a valid peer type`),
-      codes.ERR_INVALID_MULTIADDR
-    )
-  }
-}
 
 /**
- * Converts the given `peer` to a `PeerInfo` object.
+ * Extracts a PeerId and/or multiaddr from the passed PeerId or Multiaddr
  */
-export function getPeer (peer: PeerId | Multiaddr): PeerInfo {
+export function getPeerAddress (peer: PeerId | Multiaddr): { peerId?: PeerId, multiaddr?: Multiaddr } {
   if (isPeerId(peer)) {
     return {
-      id: peer,
-      multiaddrs: [],
-      protocols: []
+      peerId: peer
     }
   }
 
-  let addr
-
   if (isMultiaddr(peer)) {
-    addr = peer
-    peer = peerIdFromMultiaddr(peer)
+    const peerId = peer.getPeerId()
+
+    return {
+      multiaddr: peer,
+      peerId: peerId == null ? undefined : peerIdFromString(peerId)
+    }
   }
 
-  return {
-    id: peer,
-    multiaddrs: addr != null ? [addr] : [],
-    protocols: []
-  }
+  throw errCode(
+    new Error(`${peer} is not a PeerId or a Multiaddr`),
+    codes.ERR_INVALID_MULTIADDR
+  )
 }

--- a/test/dialing/direct.spec.ts
+++ b/test/dialing/direct.spec.ts
@@ -377,7 +377,7 @@ describe('Dialing (direct, WebSockets)', () => {
     const dialTarget = await createDialTargetSpy.getCall(0).returnValue
 
     expect(dialTarget).to.have.property('addrs').with.lengthOf(1)
-    expect(dialTarget.addrs[0]).to.equal(dialMultiaddr)
+    expect(dialTarget.addrs[0].toString()).to.equal(dialMultiaddr.toString())
   })
 })
 


### PR DESCRIPTION
Most multiaddrs have a peer id, e.g. `/ip4/123.123.123.123/tcp/234/p2p/Qmfoo` but some cannot, e.g. `/unix/tmp/app.sock` - we should still be able to dial these addresses with the caveat that the dialer shoul have some other way of obtaining the peer id to ensure they aren't being man-in-the-middled.

This also allows dialing `dnsaddrs` that are configured as round-robin addresses for load balancing.