### PR TITLE
fix: allow reading PeerId from keychain

### DIFF
--- a/test/core/peer-id.spec.ts
+++ b/test/core/peer-id.spec.ts
@@ -15,7 +15,7 @@ describe('peer-id', () => {
     }
   })
 
-  it('it should create a PeerId if none is passed', async () => {
+  it('should create a PeerId if none is passed', async () => {
     libp2p = await createLibp2p({
       transports: [
         webSockets()
@@ -28,7 +28,7 @@ describe('peer-id', () => {
     expect(libp2p.peerId).to.be.ok()
   })
 
-  it('it should retrieve the PeerId from the datastore', async () => {
+  it('should retrieve the PeerId from the datastore', async () => {
     const datastore = new MemoryDatastore()
 
     libp2p = await createLibp2p({
@@ -62,7 +62,7 @@ describe('peer-id', () => {
     expect(libp2p.peerId.toString()).to.equal(peerId.toString())
   })
 
-  it('it should retrieve the PeerId from the datastore with a keychain password', async () => {
+  it('should retrieve the PeerId from the datastore with a keychain password', async () => {
     const datastore = new MemoryDatastore()
     const keychain = {
       pass: 'very-long-password-must-be-over-twenty-characters-long',
@@ -102,5 +102,44 @@ describe('peer-id', () => {
     // the new node should have read the PeerId from the datastore
     // instead of creating a new one
     expect(libp2p.peerId.toString()).to.equal(peerId.toString())
+  })
+
+  it('should fail to start if retrieving the PeerId from the datastore fails', async () => {
+    const datastore = new MemoryDatastore()
+    const keychain = {
+      pass: 'very-long-password-must-be-over-twenty-characters-long',
+      dek: {
+        salt: 'CpjNIxMqAZ+aJg+ezLfuzG4a'
+      }
+    }
+
+    libp2p = await createLibp2p({
+      datastore,
+      keychain,
+      transports: [
+        webSockets()
+      ],
+      connectionEncryption: [
+        plaintext()
+      ]
+    })
+    await libp2p.stop()
+
+    // creating a new node from the same datastore but with the wrong keychain config should fail
+    await expect(createLibp2p({
+      datastore,
+      keychain: {
+        pass: 'different-very-long-password-must-be-over-twenty-characters-long',
+        dek: {
+          salt: 'different-CpjNIxMqAZ+aJg+ezLfuzG4a'
+        }
+      },
+      transports: [
+        webSockets()
+      ],
+      connectionEncryption: [
+        plaintext()
+      ]
+    })).to.eventually.rejectedWith('Invalid PEM formatted message')
   })
 })

--- a/test/core/peer-id.spec.ts
+++ b/test/core/peer-id.spec.ts
@@ -1,0 +1,106 @@
+/* eslint-env mocha */
+
+import { expect } from 'aegir/chai'
+import { webSockets } from '@libp2p/websockets'
+import { plaintext } from '../../src/insecure/index.js'
+import { createLibp2p, Libp2p } from '../../src/index.js'
+import { MemoryDatastore } from 'datastore-core'
+
+describe('peer-id', () => {
+  let libp2p: Libp2p
+
+  afterEach(async () => {
+    if (libp2p != null) {
+      await libp2p.stop()
+    }
+  })
+
+  it('it should create a PeerId if none is passed', async () => {
+    libp2p = await createLibp2p({
+      transports: [
+        webSockets()
+      ],
+      connectionEncryption: [
+        plaintext()
+      ]
+    })
+
+    expect(libp2p.peerId).to.be.ok()
+  })
+
+  it('it should retrieve the PeerId from the datastore', async () => {
+    const datastore = new MemoryDatastore()
+
+    libp2p = await createLibp2p({
+      datastore,
+      transports: [
+        webSockets()
+      ],
+      connectionEncryption: [
+        plaintext()
+      ]
+    })
+
+    // this PeerId was created by default
+    const peerId = libp2p.peerId
+
+    await libp2p.stop()
+
+    // create a new node from the same datastore
+    libp2p = await createLibp2p({
+      datastore,
+      transports: [
+        webSockets()
+      ],
+      connectionEncryption: [
+        plaintext()
+      ]
+    })
+
+    // the new node should have read the PeerId from the datastore
+    // instead of creating a new one
+    expect(libp2p.peerId.toString()).to.equal(peerId.toString())
+  })
+
+  it('it should retrieve the PeerId from the datastore with a keychain password', async () => {
+    const datastore = new MemoryDatastore()
+    const keychain = {
+      pass: 'very-long-password-must-be-over-twenty-characters-long',
+      dek: {
+        salt: 'CpjNIxMqAZ+aJg+ezLfuzG4a'
+      }
+    }
+
+    libp2p = await createLibp2p({
+      datastore,
+      keychain,
+      transports: [
+        webSockets()
+      ],
+      connectionEncryption: [
+        plaintext()
+      ]
+    })
+
+    // this PeerId was created by default
+    const peerId = libp2p.peerId
+
+    await libp2p.stop()
+
+    // create a new node from the same datastore
+    libp2p = await createLibp2p({
+      datastore,
+      keychain,
+      transports: [
+        webSockets()
+      ],
+      connectionEncryption: [
+        plaintext()
+      ]
+    })
+
+    // the new node should have read the PeerId from the datastore
+    // instead of creating a new one
+    expect(libp2p.peerId.toString()).to.equal(peerId.toString())
+  })
+})


### PR DESCRIPTION
libp2p has a secure keychain where all items are stored in the datastore in an encrypted format, including the PeerId of the current node.

If no PeerId is passed into the factory function, a new PeerId is created for the current node.

Instead, if the factory function is passed a datastore, it should try to read the PeerId from the datastore and only create a new PeerId if the `self` key is not in the datastore.