### PR TITLE
fix: exclude peers without multiaddrs from auto dial

### DIFF
--- a/src/connection-manager/auto-dialler.ts
+++ b/src/connection-manager/auto-dialler.ts
@@ -121,11 +121,6 @@ export class AutoDialler implements Startable {
         return false
       }
 
-      // do not dial peers without public keys
-      if (peer.id.publicKey == null) {
-        return false
-      }
-
       // do not dial peers without multiaddrs
       if (peer.addresses.length === 0) {
         return false
@@ -137,9 +132,14 @@ export class AutoDialler implements Startable {
     // shuffle the peers
     peers = peers.sort(() => Math.random() > 0.5 ? 1 : -1)
 
-    // dial peers with the most protocols first
     peers = peers.sort((a, b) => {
+      // dial peers with the most protocols first
       if (b.protocols.length > a.protocols.length) {
+        return 1
+      }
+
+      // dial peers with public keys first
+      if (b.id.publicKey != null && a.id.publicKey == null) {
         return 1
       }
 

--- a/test/connection-manager/auto-dialler.spec.ts
+++ b/test/connection-manager/auto-dialler.spec.ts
@@ -8,6 +8,7 @@ import { createEd25519PeerId } from '@libp2p/peer-id-factory'
 import { stubInterface } from 'sinon-ts'
 import type { ConnectionManager } from '@libp2p/interface-connection-manager'
 import type { PeerStore, Peer } from '@libp2p/interface-peer-store'
+import { multiaddr } from '@multiformats/multiaddr'
 
 describe('Auto-dialler', () => {
   it('should not dial self', async () => {
@@ -23,7 +24,10 @@ describe('Auto-dialler', () => {
     const other: Peer = {
       id: await createEd25519PeerId(),
       protocols: [],
-      addresses: [],
+      addresses: [{
+        multiaddr: multiaddr('/ip4/127.0.0.1/tcp/4001'),
+        isCertified: true
+      }],
       metadata: new Map()
     }
 
@@ -53,5 +57,54 @@ describe('Auto-dialler', () => {
 
     expect(connectionManager.openConnection.callCount).to.equal(1)
     expect(connectionManager.openConnection.calledWith(self.id)).to.be.false()
+  })
+
+  it('should not dial peers without multiaddrs', async () => {
+    // peers with protocols are dialled before peers without protocols
+    const peerWithAddress: Peer = {
+      id: await createEd25519PeerId(),
+      protocols: [
+        '/foo/bar'
+      ],
+      addresses: [{
+        multiaddr: multiaddr('/ip4/127.0.0.1/tcp/4001'),
+        isCertified: true
+      }],
+      metadata: new Map()
+    }
+    const peerWithoutAddress: Peer = {
+      id: await createEd25519PeerId(),
+      protocols: [],
+      addresses: [],
+      metadata: new Map()
+    }
+
+    const peerStore = stubInterface<PeerStore>()
+
+    peerStore.all.returns(Promise.resolve([
+      peerWithAddress, peerWithoutAddress
+    ]))
+
+    const connectionManager = stubInterface<ConnectionManager>()
+    connectionManager.getConnections.returns([])
+
+    const autoDialler = new AutoDialler({
+      peerId: await createEd25519PeerId(),
+      peerStore,
+      connectionManager
+    }, {
+      minConnections: 10
+    })
+
+    await autoDialler.start()
+
+    await pWaitFor(() => connectionManager.openConnection.callCount === 1)
+    await delay(1000)
+
+    await autoDialler.stop()
+
+    expect(connectionManager.openConnection.callCount).to.equal(1)
+    expect(connectionManager.openConnection.calledWith(peerWithAddress.id)).to.be.true()
+    expect(connectionManager.openConnection.calledWith(peerWithoutAddress.id)).to.be.false()
   })
 })


### PR DESCRIPTION
When the number of connections the node has drops below the low watermark and auto-dial begins, exclude peers without multiaddrs from the list of peers that the node tries to connect to as dialing a peer without multiaddrs will fail.

Also removes use of `it-pipe` to make it a little faster as there's no need for the peer filtering/sorting to be asynchronous.