### PR TITLE
fix: compare unsanitized number using gte

### DIFF
--- a/src/connection-manager/index.ts
+++ b/src/connection-manager/index.ts
@@ -651,7 +651,7 @@ export class DefaultConnectionManager extends EventEmitter<ConnectionManagerEven
       log('too many connections open - closing a connection to %p', connection.remotePeer)
       toClose.push(connection)
 
-      if (toClose.length === toPrune) {
+      if (toClose.length >= toPrune) {
         break
       }
     }


### PR DESCRIPTION
If maxConnections is passed in as a float, this will result in disconnecting all peers due to this strict equality check.

This may happen unintentionally if maxConnections is set dynamically.

This is a patch to avoid this unfortunate failure mode.

Likely more thought should go into a systematic approach to handling these situations.