### PR TITLE
fix!: remove connection manager autodial option

### DIFF
--- a/doc/CONFIGURATION.md
+++ b/doc/CONFIGURATION.md
@@ -284,12 +284,7 @@ const node = await createLibp2p({
       ],
       interval: 2000
     )
-  ],
-  connectionManager: {
-    autoDial: true             // Auto connect to discovered peers (limited by ConnectionManager minConnections)
-    // The `tag` property will be searched when creating the instance of your Peer Discovery service.
-    // The associated object, will be passed to the service when it is instantiated.
-  }
+  ]
 })
 ```
 

--- a/doc/GETTING_STARTED.md
+++ b/doc/GETTING_STARTED.md
@@ -206,12 +206,7 @@ const node = await createLibp2p({
     bootstrap({
       list: bootstrapMultiaddrs, // provide array of multiaddrs
     })
-  ],
-  connectionManager: {
-    autoDial: true, // Auto connect to discovered peers (limited by ConnectionManager minConnections)
-    // The `tag` property will be searched when creating the instance of your Peer Discovery service.
-    // The associated object, will be passed to the service when it is instantiated.
-  }
+  ]
 })
 
 node.addEventListener('peer:discovery', (evt) => {

--- a/doc/PEER_DISCOVERY.md
+++ b/doc/PEER_DISCOVERY.md
@@ -22,6 +22,7 @@
 * To ensure reasonable resource usage, discovered peers are not connected to automatically
 * Applications should lisen for the `peer:connect` event if they wish to take a specific action when new connections are established
 * Libp2p functions best with a good number of network connections to a diverse set of peers. When the number of connected peers a node has falls under the [ConnectionManager](./CONFIGURATION.md#configuring-connection-manager) `minConnections` setting, randomly selected peers from the peer store will be dialed until the node's number of connections rises above this number.
+  * Applications can disable this behaviour by setting the `connectionManager.minConnections` config property to `0`, and handle increasing the current number of connections themselves
 
 ## Scenarios
 

--- a/doc/PEER_DISCOVERY.md
+++ b/doc/PEER_DISCOVERY.md
@@ -22,7 +22,6 @@
 * To ensure reasonable resource usage, discovered peers are not connected to automatically
 * Applications should lisen for the `peer:connect` event if they wish to take a specific action when new connections are established
 * Libp2p functions best with a good number of network connections to a diverse set of peers. When the number of connected peers a node has falls under the [ConnectionManager](./CONFIGURATION.md#configuring-connection-manager) `minConnections` setting, randomly selected peers from the peer store will be dialed until the node's number of connections rises above this number.
-  * Applications can disable this behaviour via the `connectionManager.autoDial` config property, and handle increasing the current number of connections themselves
 
 ## Scenarios
 

--- a/doc/PEER_DISCOVERY.md
+++ b/doc/PEER_DISCOVERY.md
@@ -22,7 +22,7 @@
 * To ensure reasonable resource usage, discovered peers are not connected to automatically
 * Applications should lisen for the `peer:connect` event if they wish to take a specific action when new connections are established
 * Libp2p functions best with a good number of network connections to a diverse set of peers. When the number of connected peers a node has falls under the [ConnectionManager](./CONFIGURATION.md#configuring-connection-manager) `minConnections` setting, randomly selected peers from the peer store will be dialed until the node's number of connections rises above this number.
-  * Applications can disable this behaviour by setting the `connectionManager.minConnections` config property to `0`, and handle increasing the current number of connections themselves
+* Applications can disable this behaviour by setting the `connectionManager.minConnections` config property to `0`, but they will have to manage increasing the current number of connections themselves.
 
 ## Scenarios
 

--- a/doc/migrations/v0.42-v0.43.md
+++ b/doc/migrations/v0.42-v0.43.md
@@ -5,6 +5,7 @@ A migration guide for refactoring your application code from libp2p v0.42.x to v
 ## Table of Contents <!-- omit in toc -->
 
 - [Circuit Relay v2](#circuit-relay-v2)
+- [Connection manager autodial](#connection-manager-autodial)
 
 ## Circuit Relay v2
 
@@ -77,3 +78,40 @@ const node = await createLibp2p({
 ```
 
 Please see the [Setup with Relay](https://github.com/libp2p/js-libp2p/blob/master/doc/CONFIGURATION.md#setup-with-relay) section of the configuration for a full breakdown of all the options.
+
+## Connection manager autodial
+
+The `autoDial` configutation option has been removed from the connection manager.
+
+This setting used to control whether libp2p would automatically dial every discovered peer, then it was changed to control whether libp2p would try to dial peers from the peer store to keep the number of connections above `minConnections`.
+
+Instead, just set `minConnections` to `0` if you don't want to keep a minimum number of connections open.
+
+**Before**
+
+```js
+import { createLibp2p } from 'libp2p'
+
+const node = await createLibp2p({
+  // ... other options
+  connectionManager: {
+    autoDial: false,
+    minConnections: 10,
+    maxConnections: 100
+  }
+}
+```
+
+**After**
+
+```js
+import { createLibp2p } from 'libp2p'
+
+const node = await createLibp2p({
+  // ... other options
+  connectionManager: {
+    minConnections: 0,
+    maxConnections: 100
+  }
+}
+```

--- a/examples/discovery-mechanisms/1.js
+++ b/examples/discovery-mechanisms/1.js
@@ -30,7 +30,7 @@ import bootstrapers from './bootstrappers.js'
 
   node.addEventListener('peer:discovery', (evt) => {
     const peer = evt.detail
-    // No need to dial, autoDial is on
+
     console.log('Discovered:', peer.id.toString())
   })
 })();

--- a/examples/transports/4.js
+++ b/examples/transports/4.js
@@ -35,12 +35,7 @@ const createNode = async (addresses = []) => {
       })
     ],
     connectionEncryption: [noise()],
-    streamMuxers: [mplex()],
-    connectionManager: {
-      // Disable autoDial as it would fail because we are using a self-signed cert.
-      // `dialProtocol` does not fail because we pass `rejectUnauthorized: false`.
-      autoDial: false
-    }
+    streamMuxers: [mplex()]
   })
 
   return node

--- a/src/config.ts
+++ b/src/config.ts
@@ -21,7 +21,6 @@ const DefaultConfig: Partial<Libp2pInit> = {
   connectionManager: {
     maxConnections: 300,
     minConnections: 50,
-    autoDial: true,
     autoDialInterval: 10000,
     maxParallelDials: Constants.MAX_PARALLEL_DIALS,
     maxDialsPerPeer: Constants.MAX_PER_PEER_DIALS,

--- a/src/connection-manager/auto-dialler.ts
+++ b/src/connection-manager/auto-dialler.ts
@@ -11,11 +11,6 @@ const log = logger('libp2p:connection-manager:auto-dialler')
 
 export interface AutoDiallerInit {
   /**
-   * Should preemptively guarantee connections are above the low watermark
-   */
-  enabled?: boolean
-
-  /**
    * The minimum number of connections to avoid pruning
    */
   minConnections?: number
@@ -33,7 +28,6 @@ export interface AutoDiallerComponents {
 }
 
 const defaultOptions: Partial<AutoDiallerInit> = {
-  enabled: true,
   minConnections: 0,
   autoDialInterval: 10000
 }
@@ -66,11 +60,6 @@ export class AutoDialler implements Startable {
    * Starts the auto dialer
    */
   async start (): Promise<void> {
-    if (!this.options.enabled) {
-      log('not enabled')
-      return
-    }
-
     this.running = true
 
     void this._autoDial().catch(err => {
@@ -84,11 +73,6 @@ export class AutoDialler implements Startable {
    * Stops the auto dialler
    */
   async stop (): Promise<void> {
-    if (!this.options.enabled) {
-      log('not enabled')
-      return
-    }
-
     this.running = false
 
     if (this.autoDialTimeout != null) {

--- a/src/connection-manager/index.ts
+++ b/src/connection-manager/index.ts
@@ -45,11 +45,6 @@ export interface ConnectionManagerConfig {
   pollInterval?: number
 
   /**
-   * If true, try to connect to all discovered peers up to the connection manager limit
-   */
-  autoDial?: boolean
-
-  /**
    * How long to wait between attempting to keep our number of concurrent connections
    * above minConnections
    */

--- a/src/libp2p.ts
+++ b/src/libp2p.ts
@@ -157,12 +157,6 @@ export class Libp2pNode extends EventEmitter<Libp2pEvents> implements Libp2p {
     // update our peer record when addresses change
     this.configureComponent(new PeerRecordUpdater(this.components))
 
-    this.configureComponent(new AutoDialler(this.components, {
-      enabled: init.connectionManager.autoDial,
-      minConnections: init.connectionManager.minConnections,
-      autoDialInterval: init.connectionManager.autoDialInterval
-    }))
-
     // Create keychain
     const keychainOpts = DefaultKeyChain.generateOptions()
     this.keychain = this.configureComponent(new DefaultKeyChain(this.components, {
@@ -237,7 +231,6 @@ export class Libp2pNode extends EventEmitter<Libp2pEvents> implements Libp2p {
     }))
 
     this.configureComponent(new AutoDialler(this.components, {
-      enabled: init.connectionManager.autoDial,
       minConnections: init.connectionManager.minConnections,
       autoDialInterval: init.connectionManager.autoDialInterval
     }))

--- a/test/circuit/utils.ts
+++ b/test/circuit/utils.ts
@@ -20,9 +20,6 @@ export function createNodeOptions (...overrides: Libp2pOptions[]): Libp2pOptions
   return createBaseOptions({
     addresses: {
       listen: [listenAddr]
-    },
-    connectionManager: {
-      autoDial: false
     }
   }, ...overrides)
 }

--- a/test/dialing/resolver.spec.ts
+++ b/test/dialing/resolver.spec.ts
@@ -49,7 +49,6 @@ describe('Dialing (resolvable addresses)', () => {
             listen: [`${relayAddr.toString()}/p2p-circuit`]
           },
           connectionManager: {
-            autoDial: false,
             resolvers: {
               dnsaddr: resolver
             }
@@ -62,7 +61,6 @@ describe('Dialing (resolvable addresses)', () => {
             listen: [`${relayAddr.toString()}/p2p-circuit`]
           },
           connectionManager: {
-            autoDial: false,
             resolvers: {
               dnsaddr: resolver
             }

--- a/test/peer-discovery/index.node.ts
+++ b/test/peer-discovery/index.node.ts
@@ -74,9 +74,6 @@ describe('peer discovery scenarios', () => {
           listenAddr.toString()
         ]
       },
-      connectionManager: {
-        autoDial: false
-      },
       peerDiscovery: [
         bootstrap({
           list: bootstrappers
@@ -122,10 +119,7 @@ describe('peer discovery scenarios', () => {
           interval: 200, // discover quickly
           serviceTag
         })
-      ],
-      connectionManager: {
-        autoDial: false
-      }
+      ]
     })
 
     libp2p = await createLibp2pNode(getConfig(peerId))
@@ -169,9 +163,6 @@ describe('peer discovery scenarios', () => {
         listen: [
           listenAddr.toString()
         ]
-      },
-      connectionManager: {
-        autoDial: false
       },
       dht: kadDHT()
     })


### PR DESCRIPTION
The connection manager's `autoDial` option originally meant "dial every peer we discover".  Then it changed to "if we have fewer than `minConnections`, dial peers from the peer store until we have more than `minConnections`".

This is confusing and also redundant, since if we don't want to dial peers to ensure we have more than `minConnections` we can just set `minConnections` to `0`.

Adds a section to the upgrade guide covering the removal.

Also fixes a bug where we actually configured two autodialer components.