### PR TITLE
fix: interpret circuit relay expiry as seconds

### DIFF
--- a/src/circuit/transport/reservation-store.ts
+++ b/src/circuit/transport/reservation-store.ts
@@ -8,7 +8,7 @@ import type { ConnectionManager } from '@libp2p/interface-connection-manager'
 import type { Connection } from '@libp2p/interface-connection'
 import type { Reservation } from '../pb/index.js'
 import { HopMessage, Status } from '../pb/index.js'
-import { getExpirationSeconds } from '../utils.js'
+import { getExpirationMilliseconds } from '../utils.js'
 import type { TransportManager } from '@libp2p/interface-transport'
 import type { Startable } from '@libp2p/interfaces/dist/src/startable.js'
 import { CustomEvent, EventEmitter } from '@libp2p/interfaces/events'
@@ -131,7 +131,7 @@ export class ReservationStore extends EventEmitter<ReservationStoreEvents> imple
         const existingReservation = this.reservations.get(peerId)
 
         if (existingReservation != null) {
-          if (getExpirationSeconds(existingReservation.reservation.expire) > REFRESH_WINDOW) {
+          if (getExpirationMilliseconds(existingReservation.reservation.expire) > REFRESH_WINDOW) {
             log('already have reservation on relay peer %p and it expires in more than 10 minutes', peerId)
             return
           }
@@ -162,7 +162,7 @@ export class ReservationStore extends EventEmitter<ReservationStoreEvents> imple
 
         log('created reservation on relay peer %p', peerId)
 
-        const expiration = getExpirationSeconds(reservation.expire)
+        const expiration = getExpirationMilliseconds(reservation.expire)
 
         const timeout = setTimeout(() => {
           this.addRelay(peerId, type).catch(err => {
@@ -171,7 +171,7 @@ export class ReservationStore extends EventEmitter<ReservationStoreEvents> imple
         },
         // TODO: If we get an expiration of 0, this will keep calling
         // addRelay
-        Math.max(expiration * 1000 - REFRESH_TIMEOUT, 0))
+        Math.max(expiration - REFRESH_TIMEOUT, 0))
 
         this.reservations.set(peerId, {
           timeout,

--- a/src/circuit/transport/reservation-store.ts
+++ b/src/circuit/transport/reservation-store.ts
@@ -23,7 +23,7 @@ const REFRESH_WINDOW = (60 * 1000) * 10
 // try to refresh relay reservations 5 minutes before expiry
 const REFRESH_TIMEOUT = (60 * 1000) * 5
 
-// maximum duration before which a reservation should be refereshed (2 hrs)
+// maximum duration before which a reservation should be refereshed
 const REFRESH_TIMEOUT_MAX = (60 * 1000) * 15
 // minimum duration before which a reservation must not be refreshed
 const REFRESH_TIMEOUT_MIN = 30 * 1000

--- a/src/circuit/transport/reservation-store.ts
+++ b/src/circuit/transport/reservation-store.ts
@@ -24,7 +24,9 @@ const REFRESH_WINDOW = (60 * 1000) * 10
 const REFRESH_TIMEOUT = (60 * 1000) * 5
 
 // maximum duration before which a reservation should be refereshed (2 hrs)
-const REFRESH_TIMEOUT_MAX = (60 * 1000) * 120
+const REFRESH_TIMEOUT_MAX = (60 * 1000) * 15
+// minimum duration before which a reservation must not be refreshed
+const REFRESH_TIMEOUT_MIN = 30 * 1000
 
 export interface RelayStoreComponents {
   peerId: PeerId
@@ -168,7 +170,7 @@ export class ReservationStore extends EventEmitter<ReservationStoreEvents> imple
         const expiration = getExpirationMilliseconds(reservation.expire)
 
         // sets a lower bound as 0 for the timeout
-        const timeoutDuration = Math.max(expiration - REFRESH_TIMEOUT, 0)
+        const timeoutDuration = Math.max(expiration - REFRESH_TIMEOUT, REFRESH_TIMEOUT_MIN)
         // sets an upper bound on the timeout
         const boundedTimeoutDuration = Math.min(timeoutDuration, REFRESH_TIMEOUT_MAX)
 

--- a/src/circuit/transport/reservation-store.ts
+++ b/src/circuit/transport/reservation-store.ts
@@ -23,8 +23,6 @@ const REFRESH_WINDOW = (60 * 1000) * 10
 // try to refresh relay reservations 5 minutes before expiry
 const REFRESH_TIMEOUT = (60 * 1000) * 5
 
-// maximum duration before which a reservation should be refreshed
-const REFRESH_TIMEOUT_MAX = (60 * 1000) * 15
 // minimum duration before which a reservation must not be refreshed
 const REFRESH_TIMEOUT_MIN = 30 * 1000
 
@@ -171,14 +169,12 @@ export class ReservationStore extends EventEmitter<ReservationStoreEvents> imple
 
         // sets a lower bound on the timeout
         const timeoutDuration = Math.max(expiration - REFRESH_TIMEOUT, REFRESH_TIMEOUT_MIN)
-        // sets an upper bound on the timeout
-        const boundedTimeoutDuration = Math.min(timeoutDuration, REFRESH_TIMEOUT_MAX)
 
         const timeout = setTimeout(() => {
           this.addRelay(peerId, type).catch(err => {
             log.error('could not refresh reservation to relay %p', peerId, err)
           })
-        }, boundedTimeoutDuration)
+        }, timeoutDuration)
 
         this.reservations.set(peerId, {
           timeout,

--- a/src/circuit/transport/reservation-store.ts
+++ b/src/circuit/transport/reservation-store.ts
@@ -23,7 +23,7 @@ const REFRESH_WINDOW = (60 * 1000) * 10
 // try to refresh relay reservations 5 minutes before expiry
 const REFRESH_TIMEOUT = (60 * 1000) * 5
 
-// maximum duration before which a reservation should be refereshed
+// maximum duration before which a reservation should be refreshed
 const REFRESH_TIMEOUT_MAX = (60 * 1000) * 15
 // minimum duration before which a reservation must not be refreshed
 const REFRESH_TIMEOUT_MIN = 30 * 1000
@@ -169,7 +169,7 @@ export class ReservationStore extends EventEmitter<ReservationStoreEvents> imple
 
         const expiration = getExpirationMilliseconds(reservation.expire)
 
-        // sets a lower bound as 0 for the timeout
+        // sets a lower bound on the timeout
         const timeoutDuration = Math.max(expiration - REFRESH_TIMEOUT, REFRESH_TIMEOUT_MIN)
         // sets an upper bound on the timeout
         const boundedTimeoutDuration = Math.min(timeoutDuration, REFRESH_TIMEOUT_MAX)

--- a/src/circuit/transport/reservation-store.ts
+++ b/src/circuit/transport/reservation-store.ts
@@ -8,7 +8,7 @@ import type { ConnectionManager } from '@libp2p/interface-connection-manager'
 import type { Connection } from '@libp2p/interface-connection'
 import type { Reservation } from '../pb/index.js'
 import { HopMessage, Status } from '../pb/index.js'
-import { getExpiration } from '../utils.js'
+import { getExpirationSeconds } from '../utils.js'
 import type { TransportManager } from '@libp2p/interface-transport'
 import type { Startable } from '@libp2p/interfaces/dist/src/startable.js'
 import { CustomEvent, EventEmitter } from '@libp2p/interfaces/events'
@@ -131,7 +131,7 @@ export class ReservationStore extends EventEmitter<ReservationStoreEvents> imple
         const existingReservation = this.reservations.get(peerId)
 
         if (existingReservation != null) {
-          if (getExpiration(existingReservation.reservation.expire) > REFRESH_WINDOW) {
+          if (getExpirationSeconds(existingReservation.reservation.expire) > REFRESH_WINDOW) {
             log('already have reservation on relay peer %p and it expires in more than 10 minutes', peerId)
             return
           }
@@ -162,13 +162,16 @@ export class ReservationStore extends EventEmitter<ReservationStoreEvents> imple
 
         log('created reservation on relay peer %p', peerId)
 
-        const expiration = getExpiration(reservation.expire)
+        const expiration = getExpirationSeconds(reservation.expire)
 
         const timeout = setTimeout(() => {
           this.addRelay(peerId, type).catch(err => {
             log.error('could not refresh reservation to relay %p', peerId, err)
           })
-        }, Math.max(expiration - REFRESH_TIMEOUT, 0))
+        },
+        // TODO: If we get an expiration of 0, this will keep calling
+        // addRelay
+        Math.max(expiration * 1000 - REFRESH_TIMEOUT, 0))
 
         this.reservations.set(peerId, {
           timeout,

--- a/src/circuit/utils.ts
+++ b/src/circuit/utils.ts
@@ -118,7 +118,7 @@ export async function namespaceToCid (namespace: string): Promise<CID> {
 export function getExpirationMilliseconds (expireTimeSeconds: bigint): number {
   const expireTimeMillis = expireTimeSeconds * BigInt(1000)
   const currentTime = new Date().getTime()
-  // The difference between expireTime and currentTime is much more
-  // likely to fit in a Number type.
+
+  // downcast to number to use with setTimeout
   return Number(expireTimeMillis - BigInt(currentTime))
 }

--- a/src/circuit/utils.ts
+++ b/src/circuit/utils.ts
@@ -115,6 +115,7 @@ export async function namespaceToCid (namespace: string): Promise<CID> {
 /**
  * returns number of ms between now and expiration time
  */
-export function getExpiration (expireTime: bigint): number {
-  return Number(expireTime) - new Date().getTime()
+export function getExpirationSeconds (expireTime: bigint): number {
+  const currentTimeSeconds = ((new Date().getTime()) / 1000) | 0
+  return Number(expireTime) - currentTimeSeconds
 }

--- a/src/circuit/utils.ts
+++ b/src/circuit/utils.ts
@@ -115,7 +115,10 @@ export async function namespaceToCid (namespace: string): Promise<CID> {
 /**
  * returns number of ms between now and expiration time
  */
-export function getExpirationSeconds (expireTime: bigint): number {
-  const currentTimeSeconds = ((new Date().getTime()) / 1000) | 0
-  return Number(expireTime) - currentTimeSeconds
+export function getExpirationMilliseconds (expireTimeSeconds: bigint): number {
+  const expireTimeMillis = expireTimeSeconds * BigInt(1000)
+  const currentTime = new Date().getTime()
+  // The difference between expireTime and currentTime is much more
+  // likely to fit in a Number type.
+  return Number(expireTimeMillis - BigInt(currentTime))
 }

--- a/test/circuit/utils.spec.ts
+++ b/test/circuit/utils.spec.ts
@@ -2,7 +2,7 @@
 
 import { mockStream } from '@libp2p/interface-mocks'
 import { expect } from 'aegir/chai'
-import { createLimitedRelay, getExpirationSeconds, namespaceToCid } from '../../src/circuit/utils.js'
+import { createLimitedRelay, getExpirationMilliseconds, namespaceToCid } from '../../src/circuit/utils.js'
 import { fromString as uint8arrayFromString } from 'uint8arrays/from-string'
 import delay from 'delay'
 import drain from 'it-drain'
@@ -209,7 +209,7 @@ describe('circuit-relay utils', () => {
   it('should get expiration time', () => {
     const delta = 10
     const time = BigInt(Date.now() + delta)
-    const expiration = getExpirationSeconds(time)
+    const expiration = getExpirationMilliseconds(time)
 
     expect(expiration).to.be.above(delta / 2)
   })

--- a/test/circuit/utils.spec.ts
+++ b/test/circuit/utils.spec.ts
@@ -2,7 +2,7 @@
 
 import { mockStream } from '@libp2p/interface-mocks'
 import { expect } from 'aegir/chai'
-import { createLimitedRelay, getExpiration, namespaceToCid } from '../../src/circuit/utils.js'
+import { createLimitedRelay, getExpirationSeconds, namespaceToCid } from '../../src/circuit/utils.js'
 import { fromString as uint8arrayFromString } from 'uint8arrays/from-string'
 import delay from 'delay'
 import drain from 'it-drain'
@@ -209,7 +209,7 @@ describe('circuit-relay utils', () => {
   it('should get expiration time', () => {
     const delta = 10
     const time = BigInt(Date.now() + delta)
-    const expiration = getExpiration(time)
+    const expiration = getExpirationSeconds(time)
 
     expect(expiration).to.be.above(delta / 2)
   })


### PR DESCRIPTION
This fixes #1635 which causes the circuit relay to repeatedly connect to a discovered relay. If the relay returns connection expiration in seconds, we get a negative ttl when calculating
`expiration - new Date().getTime()`.
This caused the `addRelay` function to set the timeout at 0ms. This timeout instantly triggers and calls `addRelay` recursively.