### PR TITLE
fix: add logging around filtered addresses

### DIFF
--- a/src/identify/index.ts
+++ b/src/identify/index.ts
@@ -348,7 +348,7 @@ export class IdentifyService implements Startable {
             await this.components.peerStore.metadataBook.setValue(id, 'ProtocolVersion', uint8ArrayFromString(protocolVersion))
           }
 
-          log('identify completed for peer %p and protocols %o', id, protocols)
+          log('identify completed for peer %p with and protocols %o', id, protocols)
 
           return
         }


### PR DESCRIPTION
To enable debugging errors like 'the dial request had no valid addresses', log the before/after state of addresses filtered by supported transport.