### PR TITLE
fix: remove duplicated peer id logic

### DIFF
--- a/src/connection-manager/dialer/index.ts
+++ b/src/connection-manager/dialer/index.ts
@@ -303,7 +303,7 @@ export class DefaultDialer implements Startable, Dialer {
    * Loads a list of addresses from the peer store for the passed peer id
    */
   async _loadAddresses (peer: PeerId): Promise<Multiaddr[]> {
-    let addresses = await this.components.peerStore.addressBook.get(peer)
+    const addresses = await this.components.peerStore.addressBook.get(peer)
 
     return (await Promise.all(
       addresses.map(async address => {


### PR DESCRIPTION
Partial revert of #1649 but prevents the node from appending the peer id to path multiaddrs.