### PR TITLE
fix: do not autodial connected peers or those in the dial queue

### DIFF
--- a/src/connection-manager/auto-dial.ts
+++ b/src/connection-manager/auto-dial.ts
@@ -99,7 +99,7 @@ export class AutoDial implements Startable {
     log('not enough connections %d/%d - will dial peers to increase the number of connections', numConnections, this.minConnections)
 
     // Sort peers on whether we know protocols or public keys for them
-    let peers = await this.peerStore.all()
+    const peers = await this.peerStore.all()
 
     // Remove some peers
     const filteredPeers = peers.filter((peer) => {

--- a/src/connection-manager/auto-dial.ts
+++ b/src/connection-manager/auto-dial.ts
@@ -121,7 +121,8 @@ export class AutoDial implements Startable {
       return true
     })
 
-    // shuffle the peers
+    // shuffle the peers so peers with equal tag values will be dialled in a
+    // different order each time
     const shuffledPeers = filteredPeers.sort(() => Math.random() > 0.5 ? 1 : -1)
 
     // Sort shuffled peers by tag value
@@ -139,8 +140,8 @@ export class AutoDial implements Startable {
       }, 0))
     }
 
-    // sort by value, highest to lowest
-    const sortedPeers = peers.sort((a, b) => {
+    // sort by tag value, highest to lowest
+    const sortedPeers = shuffledPeers.sort((a, b) => {
       const peerAValue = peerValues.get(a.id) ?? 0
       const peerBValue = peerValues.get(b.id) ?? 0
 

--- a/src/connection-manager/auto-dial.ts
+++ b/src/connection-manager/auto-dial.ts
@@ -101,10 +101,8 @@ export class AutoDial implements Startable {
     // Sort peers on whether we know protocols or public keys for them
     let peers = await this.peerStore.all()
 
-    log('loaded %d peers from the peer store', peers.length)
-
     // Remove some peers
-    peers = peers.filter((peer) => {
+    const filteredPeers = peers.filter((peer) => {
       // Remove peers without addresses
       if (peer.addresses.length === 0) {
         return false
@@ -124,11 +122,11 @@ export class AutoDial implements Startable {
     })
 
     // shuffle the peers
-    peers = peers.sort(() => Math.random() > 0.5 ? 1 : -1)
+    const shuffledPeers = filteredPeers.sort(() => Math.random() > 0.5 ? 1 : -1)
 
     // Sort shuffled peers by tag value
     const peerValues = new PeerMap<number>()
-    for (const peer of peers) {
+    for (const peer of shuffledPeers) {
       if (peerValues.has(peer.id)) {
         continue
       }
@@ -157,7 +155,7 @@ export class AutoDial implements Startable {
       return 0
     })
 
-    log('selected %d peers to dial', sortedPeers.length)
+    log('selected %d/%d peers to dial', sortedPeers.length, peers.length)
 
     for (const peer of sortedPeers) {
       this.queue.add(async () => {

--- a/src/connection-manager/auto-dial.ts
+++ b/src/connection-manager/auto-dial.ts
@@ -161,7 +161,7 @@ export class AutoDial implements Startable {
 
     for (const peer of sortedPeers) {
       this.queue.add(async () => {
-        const numConnections = this.connectionManager.getConnections().length
+        const numConnections = this.connectionManager.getConnectionsMap().size
 
         // Check to see if we still need to auto dial
         if (numConnections >= this.minConnections) {

--- a/src/connection-manager/dial-queue.ts
+++ b/src/connection-manager/dial-queue.ts
@@ -235,7 +235,7 @@ export class DialQueue {
         timeoutController.clear()
       })
       .catch(err => {
-        log.error('dial failed to %s', addrsToDial.map(({ multiaddr }) => multiaddr.toString()).join(', '), err)
+        log.error('dial failed to %s', addrsToDial.map(({ multiaddr }) => multiaddr.toString()).join(', '), err.errors ?? err)
 
         // Error is a timeout
         if (timeoutController.signal.aborted) {
@@ -454,7 +454,7 @@ export class DialQueue {
               deferred.resolve(conn)
             } catch (err: any) {
               // something only went wrong if our signal was not aborted
-              log.error('error during dial of %s', addr, err)
+              log.error('error during dial of %s', addr, err.errors ?? err)
               deferred.reject(err)
             }
           }, {

--- a/test/connection-manager/auto-dial.spec.ts
+++ b/test/connection-manager/auto-dial.spec.ts
@@ -9,9 +9,11 @@ import { stubInterface } from 'sinon-ts'
 import type { ConnectionManager } from '@libp2p/interface-connection-manager'
 import type { PeerStore, Peer } from '@libp2p/interface-peer-store'
 import { multiaddr } from '@multiformats/multiaddr'
+import { PeerMap } from '@libp2p/peer-collections'
+import type { Connection } from '@libp2p/interface-connection'
 
 describe('auto-dial', () => {
-  it('should not dial peers without multiaddrs', async () => {
+  it('should not auto dial peers without multiaddrs', async () => {
     // peers with protocols are dialled before peers without protocols
     const peerWithAddress: Peer = {
       id: await createEd25519PeerId(),
@@ -38,7 +40,8 @@ describe('auto-dial', () => {
     ]))
 
     const connectionManager = stubInterface<ConnectionManager>()
-    connectionManager.getConnections.returns([])
+    connectionManager.getConnectionsMap.returns(new PeerMap())
+    connectionManager.getDialQueue.returns([])
 
     const autoDialler = new AutoDial({
       peerStore,
@@ -54,5 +57,109 @@ describe('auto-dial', () => {
     expect(connectionManager.openConnection.callCount).to.equal(1)
     expect(connectionManager.openConnection.calledWith(peerWithAddress.id)).to.be.true()
     expect(connectionManager.openConnection.calledWith(peerWithoutAddress.id)).to.be.false()
+  })
+
+  it('should not auto dial peers in the dial queue', async () => {
+    // peers with protocols are dialled before peers without protocols
+    const peers: Peer[] = [{
+      id: await createEd25519PeerId(),
+      protocols: [
+        '/foo/bar'
+      ],
+      addresses: [{
+        multiaddr: multiaddr('/ip4/127.0.0.1/tcp/4001'),
+        isCertified: true
+      }],
+      metadata: new Map()
+    }, {
+      id: await createEd25519PeerId(),
+      protocols: [
+        '/foo/bar'
+      ],
+      addresses: [{
+        multiaddr: multiaddr('/ip4/127.0.0.1/tcp/4001'),
+        isCertified: true
+      }],
+      metadata: new Map()
+    }]
+
+    const peerStore = stubInterface<PeerStore>()
+
+    peerStore.all.returns(Promise.resolve(peers))
+
+    const connectionManager = stubInterface<ConnectionManager>()
+    connectionManager.getConnectionsMap.returns(new PeerMap())
+    connectionManager.getDialQueue.returns([{
+      id: peers[0].id.toString(),
+      status: 'active',
+      peerId: peers[0].id,
+      multiaddrs: peers[0].addresses.map(a => a.multiaddr)
+    }])
+
+    const autoDialler = new AutoDial({
+      peerStore,
+      connectionManager
+    }, {
+      minConnections: 10
+    })
+    await autoDialler.autoDial()
+
+    await pWaitFor(() => connectionManager.openConnection.callCount === 1)
+    await delay(1000)
+
+    expect(connectionManager.openConnection.callCount).to.equal(1)
+    expect(connectionManager.openConnection.calledWith(peers[1].id)).to.be.true()
+    expect(connectionManager.openConnection.calledWith(peers[0].id)).to.be.false()
+  })
+
+  it('should not auto dial connected peers', async () => {
+    // peers with protocols are dialled before peers without protocols
+    const peers: Peer[] = [{
+      id: await createEd25519PeerId(),
+      protocols: [
+        '/foo/bar'
+      ],
+      addresses: [{
+        multiaddr: multiaddr('/ip4/127.0.0.1/tcp/4001'),
+        isCertified: true
+      }],
+      metadata: new Map()
+    }, {
+      id: await createEd25519PeerId(),
+      protocols: [
+        '/foo/bar'
+      ],
+      addresses: [{
+        multiaddr: multiaddr('/ip4/127.0.0.1/tcp/4001'),
+        isCertified: true
+      }],
+      metadata: new Map()
+    }]
+
+    const peerStore = stubInterface<PeerStore>()
+
+    peerStore.all.returns(Promise.resolve(peers))
+
+    const connections = new PeerMap<Connection[]>()
+    connections.set(peers[0].id, [stubInterface<Connection>()])
+
+    const connectionManager = stubInterface<ConnectionManager>()
+    connectionManager.getConnectionsMap.returns(connections)
+    connectionManager.getDialQueue.returns([])
+
+    const autoDialler = new AutoDial({
+      peerStore,
+      connectionManager
+    }, {
+      minConnections: 10
+    })
+    await autoDialler.autoDial()
+
+    await pWaitFor(() => connectionManager.openConnection.callCount === 1)
+    await delay(1000)
+
+    expect(connectionManager.openConnection.callCount).to.equal(1)
+    expect(connectionManager.openConnection.calledWith(peers[1].id)).to.be.true()
+    expect(connectionManager.openConnection.calledWith(peers[0].id)).to.be.false()
   })
 })


### PR DESCRIPTION
If we already have a connection to a peer, or the peer is already in the dial queue, do not select it to autodial.