### PR TITLE
chore: update imports and remove unnecessary pending dial interfaces

### DIFF
--- a/package.json
+++ b/package.json
@@ -109,7 +109,7 @@
     "@libp2p/interface-content-routing": "^2.0.0",
     "@libp2p/interface-dht": "^2.0.0",
     "@libp2p/interface-keychain": "^2.0.4",
-    "@libp2p/interface-libp2p": "^1.0.0",
+    "@libp2p/interface-libp2p": "^1.3.0",
     "@libp2p/interface-metrics": "^4.0.0",
     "@libp2p/interface-peer-discovery": "^1.0.1",
     "@libp2p/interface-peer-id": "^2.0.1",

--- a/src/connection-manager/index.ts
+++ b/src/connection-manager/index.ts
@@ -7,7 +7,7 @@ import { codes } from '../errors.js'
 import type { PeerId } from '@libp2p/interface-peer-id'
 import { setMaxListeners } from 'events'
 import type { Connection, MultiaddrConnection } from '@libp2p/interface-connection'
-import type { ConnectionManager, ConnectionManagerEvents } from '@libp2p/interface-connection-manager'
+import type { ConnectionManager, ConnectionManagerEvents, PendingDial } from '@libp2p/interface-connection-manager'
 import type { AddressSorter, PeerStore } from '@libp2p/interface-peer-store'
 import { Multiaddr, Resolver, multiaddr } from '@multiformats/multiaddr'
 import { KEEP_ALIVE } from '@libp2p/interface-peer-store/tags'
@@ -23,7 +23,6 @@ import { PeerMap } from '@libp2p/peer-collections'
 import { publicAddressesFirst } from '@libp2p/utils/address-sort'
 import { AUTO_DIAL_CONCURRENCY, AUTO_DIAL_PRIORITY, DIAL_TIMEOUT, INBOUND_CONNECTION_THRESHOLD, MAX_CONNECTIONS, MAX_INCOMING_PENDING_CONNECTIONS, MAX_PARALLEL_DIALS, MAX_PEER_ADDRS_TO_DIAL, MIN_CONNECTIONS } from './constants.js'
 import { dnsaddrResolver } from '@multiformats/multiaddr/resolvers'
-import type { PendingDial } from '../libp2p.js'
 
 const log = logger('libp2p:connection-manager')
 

--- a/src/libp2p.ts
+++ b/src/libp2p.ts
@@ -50,17 +50,9 @@ import type { Datastore } from 'interface-datastore'
 import type { KeyChain } from '@libp2p/interface-keychain'
 import mergeOptions from 'merge-options'
 import type { CircuitRelayService } from './circuit-relay/index.js'
+import type { PendingDial } from '@libp2p/interface-libp2p'
 
 const log = logger('libp2p')
-
-export type PendingDialStatus = 'queued' | 'active' | 'error' | 'success'
-
-export interface PendingDial {
-  id: string
-  status: PendingDialStatus
-  peerId?: PeerId
-  multiaddrs: Multiaddr[]
-}
 
 export class Libp2pNode extends EventEmitter<Libp2pEvents> implements Libp2p {
   public peerId: PeerId


### PR DESCRIPTION
Given we have added these types to the interfaces we can update the imports 

Related: https://github.com/libp2p/js-libp2p-interfaces/pull/374 and https://github.com/libp2p/js-libp2p-interfaces/pull/371