### PR TITLE
fix: do not auto-dial connected peers

### DIFF
--- a/src/connection-manager/auto-dial.ts
+++ b/src/connection-manager/auto-dial.ts
@@ -101,7 +101,8 @@ export class AutoDial implements Startable {
       return
     }
 
-    const numConnections = this.connectionManager.getConnections().length
+    const connections = this.connectionManager.getConnectionsMap()
+    const numConnections = connections.size
 
     // Already has enough connections
     if (numConnections >= this.minConnections) {
@@ -118,6 +119,11 @@ export class AutoDial implements Startable {
     const filteredPeers = peers.filter((peer) => {
       // Remove peers without addresses
       if (peer.addresses.length === 0) {
+        return false
+      }
+
+      // remove peers we are already connected to
+      if (connections.has(peer.id)) {
         return false
       }
 
@@ -161,7 +167,7 @@ export class AutoDial implements Startable {
 
     for (const peer of sortedPeers) {
       this.queue.add(async () => {
-        const numConnections = this.connectionManager.getConnections().length
+        const numConnections = this.connectionManager.getConnectionsMap().size
 
         // Check to see if we still need to auto dial
         if (numConnections >= this.minConnections) {

--- a/test/connection-manager/auto-dial.spec.ts
+++ b/test/connection-manager/auto-dial.spec.ts
@@ -10,6 +10,7 @@ import type { ConnectionManager } from '@libp2p/interface-connection-manager'
 import type { PeerStore, Peer } from '@libp2p/interface-peer-store'
 import { multiaddr } from '@multiformats/multiaddr'
 import { EventEmitter } from '@libp2p/interfaces/events'
+import { PeerMap } from '@libp2p/peer-collections'
 
 describe('auto-dial', () => {
   let autoDialler: AutoDial
@@ -49,7 +50,7 @@ describe('auto-dial', () => {
     ]))
 
     const connectionManager = stubInterface<ConnectionManager>()
-    connectionManager.getConnections.returns([])
+    connectionManager.getConnectionsMap.returns(new PeerMap())
 
     autoDialler = new AutoDial({
       peerStore,


### PR DESCRIPTION
When selecting peers to auto-dial, exclude peers we are already connected to in order to not swamp the dial queue with pointless dials.  This reduces the amount of work browsers in particular have to do.