### PR TITLE
fix: build after updating version.ts

### DIFF
--- a/package.json
+++ b/package.json
@@ -100,7 +100,7 @@
     "clean": "aegir clean",
     "lint": "aegir lint",
     "dep-check": "aegir dep-check -i protons",
-    "prepublishOnly": "node scripts/update-version.js",
+    "prepublishOnly": "node scripts/update-version.js && npm run build",
     "build": "aegir build",
     "docs": "aegir docs",
     "generate": "run-s generate:proto:*",


### PR DESCRIPTION
The default agent version is pulled from `version.ts` which is updated before publish.  This is because dynamically reading from the `package.json` file would cause it to get included in the browser bundle and requires code contortions in ESM.

`version.ts` is updated in a `prepublishOnly` script to prevent PRs changing this file accidentally, the fix here is to rebuild the ts files after updating the version number, otherwise the published verison is still going to be `0.0.0`.