### PR TITLE
fix: make address manager responsible for addresses

### DIFF
--- a/src/address-manager/utils.ts
+++ b/src/address-manager/utils.ts
@@ -1,0 +1,14 @@
+
+export function debounce (func: () => void, wait: number): () => void {
+  let timeout: ReturnType<typeof setTimeout> | undefined
+
+  return function () {
+    const later = function (): void {
+      timeout = undefined
+      func()
+    }
+
+    clearTimeout(timeout)
+    timeout = setTimeout(later, wait)
+  }
+}

--- a/src/transport-manager.ts
+++ b/src/transport-manager.ts
@@ -12,8 +12,6 @@ import { trackedMap } from '@libp2p/tracked-map'
 import type { Metrics } from '@libp2p/interface-metrics'
 import type { AddressManager } from '@libp2p/interface-address-manager'
 import type { Libp2pEvents } from '@libp2p/interface-libp2p'
-import type { PeerStore } from '@libp2p/interface-peer-store'
-import type { PeerId } from '@libp2p/interface-peer-id'
 
 const log = logger('libp2p:transports')
 
@@ -26,8 +24,6 @@ export interface DefaultTransportManagerComponents {
   addressManager: AddressManager
   upgrader: Upgrader
   events: EventEmitter<Libp2pEvents>
-  peerId: PeerId
-  peerStore: PeerStore
 }
 
 export class DefaultTransportManager implements TransportManager, Startable {
@@ -210,17 +206,9 @@ export class DefaultTransportManager implements TransportManager, Startable {
 
         // Track listen/close events
         listener.addEventListener('listening', () => {
-          this.components.peerStore.patch(this.components.peerId, {
-            multiaddrs: this.getAddrs()
+          this.components.events.safeDispatchEvent('transport:listening', {
+            detail: listener
           })
-            .then(() => {
-              this.components.events.safeDispatchEvent('transport:listening', {
-                detail: listener
-              })
-            })
-            .catch(err => {
-              log.error('error while updating peer record after listener began listening', err)
-            })
         })
         listener.addEventListener('close', () => {
           const index = listeners.findIndex(l => l === listener)
@@ -228,17 +216,9 @@ export class DefaultTransportManager implements TransportManager, Startable {
           // remove the listener
           listeners.splice(index, 1)
 
-          this.components.peerStore.patch(this.components.peerId, {
-            multiaddrs: this.getAddrs()
+          this.components.events.safeDispatchEvent('transport:close', {
+            detail: listener
           })
-            .then(() => {
-              this.components.events.safeDispatchEvent('transport:close', {
-                detail: listener
-              })
-            })
-            .catch(err => {
-              log.error('error while updating peer record after listener stopped listening', err)
-            })
         })
 
         // We need to attempt to listen on everything

--- a/test/addresses/addresses.node.ts
+++ b/test/addresses/addresses.node.ts
@@ -7,11 +7,15 @@ import { isLoopback } from '@libp2p/utils/multiaddr/is-loopback'
 import { AddressesOptions } from './utils.js'
 import { createNode } from '../utils/creators/peer.js'
 import type { Libp2pNode } from '../../src/libp2p.js'
+import { webSockets } from '@libp2p/websockets'
+import { plaintext } from '../../src/insecure/index.js'
+import { pEvent } from 'p-event'
+import type { PeerUpdate } from '@libp2p/interface-libp2p'
 
 const listenAddresses = ['/ip4/127.0.0.1/tcp/0', '/ip4/127.0.0.1/tcp/8000/ws']
 const announceAddreses = ['/dns4/peer.io/tcp/433/p2p/12D3KooWNvSZnPi3RrhrTwEY4LuuBeB6K6facKUCJcyWG1aoDd2p']
 
-describe('libp2p.multiaddrs', () => {
+describe('libp2p.addressManager', () => {
   let libp2p: Libp2pNode
 
   afterEach(async () => {
@@ -169,5 +173,89 @@ describe('libp2p.multiaddrs', () => {
 
     expect(libp2p.components.addressManager.getAddresses()).to.have.lengthOf(listenAddresses.length + 1)
     expect(libp2p.components.addressManager.getAddresses().map(ma => ma.decapsulateCode(protocols('p2p').code).toString())).to.include(ma)
+  })
+
+  it('should populate the AddressManager from the config', async () => {
+    libp2p = await createNode({
+      started: false,
+      config: {
+        addresses: {
+          listen: listenAddresses,
+          announce: announceAddreses
+        },
+        transports: [
+          webSockets()
+        ],
+        connectionEncryption: [
+          plaintext()
+        ]
+      }
+    })
+
+    expect(libp2p.getMultiaddrs().map(ma => ma.decapsulateCode(protocols('p2p').code).toString())).to.have.members(announceAddreses)
+    expect(libp2p.getMultiaddrs().map(ma => ma.decapsulateCode(protocols('p2p').code).toString())).to.not.have.members(listenAddresses)
+  })
+
+  it('should update our peer record with announce addresses on startup', async () => {
+    libp2p = await createNode({
+      started: false,
+      config: {
+        addresses: {
+          listen: listenAddresses,
+          announce: announceAddreses
+        },
+        transports: [
+          webSockets()
+        ],
+        connectionEncryption: [
+          plaintext()
+        ]
+      }
+    })
+
+    const eventPromise = pEvent<'self:peer:update', CustomEvent<PeerUpdate>>(libp2p, 'self:peer:update')
+
+    await libp2p.start()
+
+    const event = await eventPromise
+
+    expect(event.detail.peer.addresses.map(({ multiaddr }) => multiaddr.toString()))
+      .to.include.members(announceAddreses, 'peer info did not include announce addresses')
+  })
+
+  it('should only include confirmed observed addresses in peer record', async () => {
+    libp2p = await createNode({
+      started: false,
+      config: {
+        addresses: {
+          listen: listenAddresses,
+          announce: announceAddreses
+        },
+        transports: [
+          webSockets()
+        ],
+        connectionEncryption: [
+          plaintext()
+        ]
+      }
+    })
+
+    await libp2p.start()
+
+    const eventPromise = pEvent<'self:peer:update', CustomEvent<PeerUpdate>>(libp2p, 'self:peer:update')
+
+    const unconfirmedAddress = multiaddr('/ip4/127.0.0.1/tcp/4010/ws')
+    libp2p.components.addressManager.addObservedAddr(unconfirmedAddress)
+
+    const confirmedAddress = multiaddr('/ip4/127.0.0.1/tcp/4011/ws')
+    libp2p.components.addressManager.confirmObservedAddr(confirmedAddress)
+
+    const event = await eventPromise
+
+    expect(event.detail.peer.addresses.map(({ multiaddr }) => multiaddr.toString()))
+      .to.not.include(unconfirmedAddress.toString(), 'peer info included unconfirmed observed address')
+
+    expect(event.detail.peer.addresses.map(({ multiaddr }) => multiaddr.toString()))
+      .to.include(confirmedAddress.toString(), 'peer info did not include confirmed observed address')
   })
 })

--- a/test/connection-manager/direct.node.ts
+++ b/test/connection-manager/direct.node.ts
@@ -65,7 +65,10 @@ describe('dialing (direct, TCP)', () => {
       events: remoteEvents,
       datastore: new MemoryDatastore(),
       upgrader: mockUpgrader({ events: remoteEvents }),
-      connectionGater: mockConnectionGater()
+      connectionGater: mockConnectionGater(),
+      transportManager: stubInterface<TransportManager>({
+        getAddrs: []
+      })
     })
     remoteComponents.peerStore = new PersistentPeerStore(remoteComponents)
     remoteComponents.addressManager = new DefaultAddressManager(remoteComponents, {

--- a/test/connection-manager/index.node.ts
+++ b/test/connection-manager/index.node.ts
@@ -458,9 +458,9 @@ describe('libp2p.connections', () => {
         multiaddrs: [fullMultiaddr]
       })
 
-      expect(filterMultiaddrForPeer.callCount).to.equal(2)
+      expect(filterMultiaddrForPeer.callCount).to.equal(1)
 
-      const args = filterMultiaddrForPeer.getCall(1).args
+      const args = filterMultiaddrForPeer.getCall(0).args
       expect(args[0].toString()).to.equal(remoteLibp2p.peerId.toString())
       expect(args[1].toString()).to.equal(fullMultiaddr.toString())
     })


### PR DESCRIPTION
Refactors the transport manager to just start and stop transports.

Now the address manager is responsible for writing addresses into the peer store.

Debounces writes to the peer store so we don't get lots of `self:peer:update` events on startup as each transport starts to listen on configured addresses.