### PR TITLE
fix: examples should be self contained

### DIFF
--- a/examples/chat/README.md
+++ b/examples/chat/README.md
@@ -5,6 +5,7 @@ This example creates a simple chat app in your terminal.
 ## Setup
 1. Install the modules in the libp2p root directory, `npm install` and `npm run build`.
 2. Open 2 terminal windows in the `./examples/chat/src` directory.
+3. run `npm install @nodeutils/defaults-deep`
 
 ## Running
 1. Run the listener in window 1, `node listener.js`


### PR DESCRIPTION
examples should be self-contained:

right now you need to do what @achingbrain proposes,

or follow the readme (example chat) 

and also running `npm install @nodeutils/defaults-deep`

what should happen is:
git clone <js-libp2p>
cd js-libp2p
npm i
npm run build
cd examples/chat/src or cd examples
npm i
// cd chat/src
node listener.js // in one terminal
node dialer.js // in other terminal