### PR TITLE
fix: close circuit-relay streams on connection failure

### DIFF
--- a/src/circuit-relay/transport/index.ts
+++ b/src/circuit-relay/transport/index.ts
@@ -183,8 +183,11 @@ class CircuitRelayTransport implements Transport {
       disconnectOnFailure = true
     }
 
-    const stream = await relayConnection.newStream([RELAY_V2_HOP_CODEC])
+    let stream: Stream | undefined
+
     try {
+      stream = await relayConnection.newStream([RELAY_V2_HOP_CODEC])
+
       return await this.connectV2({
         stream,
         connection: relayConnection,
@@ -196,7 +199,11 @@ class CircuitRelayTransport implements Transport {
       })
     } catch (err: any) {
       log.error(`Circuit relay dial to destination ${destinationPeer.toString()} via relay ${relayPeer.toString()} failed`, err)
-      stream.close()
+
+      if (stream != null) {
+        stream.abort(err)
+      }
+
       disconnectOnFailure && await relayConnection.close()
       throw err
     }

--- a/src/circuit-relay/transport/index.ts
+++ b/src/circuit-relay/transport/index.ts
@@ -183,9 +183,8 @@ class CircuitRelayTransport implements Transport {
       disconnectOnFailure = true
     }
 
+    const stream = await relayConnection.newStream([RELAY_V2_HOP_CODEC])
     try {
-      const stream = await relayConnection.newStream([RELAY_V2_HOP_CODEC])
-
       return await this.connectV2({
         stream,
         connection: relayConnection,
@@ -197,6 +196,7 @@ class CircuitRelayTransport implements Transport {
       })
     } catch (err: any) {
       log.error(`Circuit relay dial to destination ${destinationPeer.toString()} via relay ${relayPeer.toString()} failed`, err)
+      stream.close()
       disconnectOnFailure && await relayConnection.close()
       throw err
     }

--- a/test/circuit-relay/relay.node.ts
+++ b/test/circuit-relay/relay.node.ts
@@ -552,6 +552,30 @@ describe('circuit-relay', () => {
       expect(conns).to.have.nested.property('[0].stat.status', 'OPEN')
     })
 
+    it('dialer should close hop stream on hop failure', async () => {
+      await local.dial(relay1.getMultiaddrs()[0])
+
+      // dial the remote through the relay
+      const relayedMultiaddr = relay1.getMultiaddrs()[0].encapsulate(`/p2p-circuit/p2p/${remote.peerId.toString()}`)
+
+      await expect(local.dial(relayedMultiaddr))
+        .to.eventually.be.rejected()
+        .and.to.have.property('message').that.matches(/NO_RESERVATION/)
+
+      // we should still be connected to the relay
+      const conns = local.getConnections(relay1.peerId)
+      expect(conns).to.have.lengthOf(1)
+      expect(conns).to.have.nested.property('[0].stat.status', 'OPEN')
+
+      // we should not have any streams with the hop codec
+      const streams = local.getConnections(relay1.peerId)
+        .map(conn => conn.streams)
+        .flat()
+        .filter(stream => stream.stat.protocol === RELAY_V2_HOP_CODEC)
+
+      expect(streams).to.be.empty()
+    })
+
     it('destination peer should stay connected to an already connected relay on hop failure', async () => {
       await local.dial(relay1.getMultiaddrs()[0])
       await usingAsRelay(local, relay1)


### PR DESCRIPTION
If a dial to a relayed address fails, e.g. with status `NO_RESERVATION`, the newly created `/libp2p/circuit/relay/0.2.0/hop` stream is **never closed**. This can be particularly bad if the connection manager keeps auto-dialing the address, since the streams just accumulate until they hit the max per-protocol stream limit (64). I believe this is the ultimate issue behind [#1695](https://github.com/libp2p/js-libp2p/issues/1695).

I don't know whether closing or aborting the stream is more correct, or if it's important to catch potential exceptions in `await relayConnection.newStream` call, so this may need a little revision from someone with more context.

Also, I know that you typically want PRs to include tests covering the fix - I gave it a couple tries but couldn't figure out how to set one up for this scenario. Sorry!