### PR TITLE
fix: allow services to indicate their dependencies

### DIFF
--- a/src/circuit-relay/server/index.ts
+++ b/src/circuit-relay/server/index.ts
@@ -17,6 +17,7 @@ import { createLimitedRelay } from '../utils.js'
 import { AdvertService, type AdvertServiceComponents, type AdvertServiceInit } from './advert-service.js'
 import { ReservationStore, type ReservationStoreInit } from './reservation-store.js'
 import { ReservationVoucherRecord } from './reservation-voucher.js'
+import type { IdentifyService } from '../../identify/index.js'
 import type { CircuitRelayService, RelayReservation } from '../index.js'
 import type { AddressManager } from '@libp2p/interface-address-manager'
 import type { Connection, Stream } from '@libp2p/interface-connection'
@@ -422,7 +423,7 @@ class CircuitRelayServer extends EventEmitter<RelayServerEvents> implements Star
   }
 }
 
-export function circuitRelayServer (init: CircuitRelayServerInit = {}): (components: CircuitRelayServerComponents) => CircuitRelayService {
+export function circuitRelayServer (init: CircuitRelayServerInit = {}): (components: CircuitRelayServerComponents & { identify: IdentifyService }) => CircuitRelayService {
   return (components) => {
     return new CircuitRelayServer(components, init)
   }

--- a/src/circuit-relay/transport/index.ts
+++ b/src/circuit-relay/transport/index.ts
@@ -12,6 +12,7 @@ import { StopMessage, HopMessage, Status } from '../pb/index.js'
 import { RelayDiscovery, type RelayDiscoveryComponents } from './discovery.js'
 import { createListener } from './listener.js'
 import { type RelayStoreInit, ReservationStore } from './reservation-store.js'
+import type { IdentifyService } from '../../identify/index.js'
 import type { AddressManager } from '@libp2p/interface-address-manager'
 import type { Connection, Stream } from '@libp2p/interface-connection'
 import type { ConnectionGater } from '@libp2p/interface-connection-gater'
@@ -68,10 +69,10 @@ interface ConnectOptions {
  */
 export interface CircuitRelayTransportInit extends RelayStoreInit {
   /**
-   * The number of peers running diable relays to search for and
-   * connect to. (default: 0)
+   * The number of peers running relays to search for and connect to.
+   * (default: 0)
    */
-  discoverRelays?: number
+  discoverRelays: number
 }
 
 class CircuitRelayTransport implements Transport {
@@ -318,7 +319,9 @@ class CircuitRelayTransport implements Transport {
   }
 }
 
-export function circuitRelayTransport (init: CircuitRelayTransportInit = {}): (components: CircuitRelayTransportComponents) => Transport {
+export function circuitRelayTransport (init: CircuitRelayTransportInit): (components: CircuitRelayTransportComponents & { identify: IdentifyService }) => Transport
+export function circuitRelayTransport (init?: RelayStoreInit): (components: CircuitRelayTransportComponents) => Transport
+export function circuitRelayTransport (init: any = {}): (components: any) => Transport {
   return (components) => {
     return new CircuitRelayTransport(components, init)
   }

--- a/src/components.ts
+++ b/src/components.ts
@@ -5,7 +5,7 @@ import type { ConnectionProtector } from '@libp2p/interface-connection'
 import type { ConnectionGater } from '@libp2p/interface-connection-gater'
 import type { ConnectionManager } from '@libp2p/interface-connection-manager'
 import type { ContentRouting } from '@libp2p/interface-content-routing'
-import type { Libp2pEvents } from '@libp2p/interface-libp2p'
+import type { Libp2pEvents, ServiceMap } from '@libp2p/interface-libp2p'
 import type { Metrics } from '@libp2p/interface-metrics'
 import type { PeerId } from '@libp2p/interface-peer-id'
 import type { PeerRouting } from '@libp2p/interface-peer-routing'
@@ -15,7 +15,7 @@ import type { TransportManager, Upgrader } from '@libp2p/interface-transport'
 import type { EventEmitter } from '@libp2p/interfaces/events'
 import type { Datastore } from 'interface-datastore'
 
-export interface Components extends Record<string, any>, Startable {
+export interface BuiltInComponents extends Startable {
   peerId: PeerId
   events: EventEmitter<Libp2pEvents>
   addressManager: AddressManager
@@ -31,6 +31,8 @@ export interface Components extends Record<string, any>, Startable {
   connectionProtector?: ConnectionProtector
   metrics?: Metrics
 }
+
+export type Components<T extends ServiceMap = ServiceMap> = T & BuiltInComponents
 
 export interface ComponentsInit {
   peerId?: PeerId
@@ -120,7 +122,7 @@ const NON_SERVICE_PROPERTIES = [
   '_invokeStartableMethod'
 ]
 
-export function defaultComponents (init: ComponentsInit = {}): Components {
+export function defaultComponents <T extends Record<string, unknown>> (init: ComponentsInit = {}): Components<T> {
   const components = new DefaultComponents(init)
 
   const proxy = new Proxy(components, {

--- a/src/config.ts
+++ b/src/config.ts
@@ -9,7 +9,7 @@ import type { ServiceMap } from '@libp2p/interface-libp2p'
 import type { RecursivePartial } from '@libp2p/interfaces'
 import type { Multiaddr } from '@multiformats/multiaddr'
 
-const DefaultConfig: Partial<Libp2pInit> = {
+const DefaultConfig: Partial<Libp2pInit<any>> = {
   addresses: {
     listen: [],
     announce: [],

--- a/src/identify/index.ts
+++ b/src/identify/index.ts
@@ -60,6 +60,8 @@ export const multicodecs = {
 
 export const Message = { Identify }
 
-export function identifyService (init: IdentifyServiceInit = {}): (components: IdentifyServiceComponents) => DefaultIdentifyService {
+export type IdentifyService = unknown
+
+export function identifyService (init: IdentifyServiceInit = {}): (components: IdentifyServiceComponents) => IdentifyService {
   return (components) => new DefaultIdentifyService(components, init)
 }

--- a/src/index.ts
+++ b/src/index.ts
@@ -35,14 +35,14 @@ import type { KeyChainInit } from '@libp2p/keychain'
 import type { PersistentPeerStoreInit } from '@libp2p/peer-store'
 import type { Datastore } from 'interface-datastore'
 
-export type ServiceFactoryMap<T extends Record<string, unknown> = Record<string, unknown>> = {
-  [Property in keyof T]: (components: Components) => T[Property]
+export type ServiceFactoryMap<T extends ServiceMap = ServiceMap> = {
+  [Property in keyof T]: (components: Components<T>) => T[Property]
 }
 
 /**
  * For Libp2p configurations and modules details read the [Configuration Document](./CONFIGURATION.md).
  */
-export interface Libp2pInit<T extends ServiceMap = { x: Record<string, unknown> }> {
+export interface Libp2pInit<T extends ServiceMap = ServiceMap> {
   /**
    * peerId instance (it will be created if not provided)
    */
@@ -88,22 +88,22 @@ export interface Libp2pInit<T extends ServiceMap = { x: Record<string, unknown> 
   /**
    * An array that must include at least 1 compliant transport
    */
-  transports: Array<(components: Components) => Transport>
-  streamMuxers?: Array<(components: Components) => StreamMuxerFactory>
-  connectionEncryption?: Array<(components: Components) => ConnectionEncrypter>
-  peerDiscovery?: Array<(components: Components) => PeerDiscovery>
-  peerRouters?: Array<(components: Components) => PeerRouting>
-  contentRouters?: Array<(components: Components) => ContentRouting>
+  transports: Array<(components: Components<T>) => Transport>
+  streamMuxers?: Array<(components: Components<T>) => StreamMuxerFactory>
+  connectionEncryption?: Array<(components: Components<T>) => ConnectionEncrypter>
+  peerDiscovery?: Array<(components: Components<T>) => PeerDiscovery>
+  peerRouters?: Array<(components: Components<T>) => PeerRouting>
+  contentRouters?: Array<(components: Components<T>) => ContentRouting>
 
   /**
    * A Metrics implementation can be supplied to collect metrics on this node
    */
-  metrics?: (components: Components) => Metrics
+  metrics?: (components: Components<T>) => Metrics
 
   /**
    * A ConnectionProtector can be used to create a secure overlay on top of the network using pre-shared keys
    */
-  connectionProtector?: (components: Components) => ConnectionProtector
+  connectionProtector?: (components: Components<T>) => ConnectionProtector
 
   /**
    * Arbitrary libp2p modules
@@ -113,7 +113,7 @@ export interface Libp2pInit<T extends ServiceMap = { x: Record<string, unknown> 
 
 export type { Libp2p }
 
-export type Libp2pOptions<T extends ServiceMap = Record<string, unknown>> = RecursivePartial<Libp2pInit<T>> & { start?: boolean }
+export type Libp2pOptions<T extends ServiceMap = ServiceMap> = RecursivePartial<Libp2pInit<T>> & { start?: boolean }
 
 /**
  * Returns a new instance of the Libp2p interface, generating a new PeerId
@@ -141,7 +141,7 @@ export type Libp2pOptions<T extends ServiceMap = Record<string, unknown>> = Recu
  * const libp2p = await createLibp2p(options)
  * ```
  */
-export async function createLibp2p <T extends ServiceMap = { x: Record<string, unknown> }> (options: Libp2pOptions<T>): Promise<Libp2p<T>> {
+export async function createLibp2p <T extends ServiceMap = ServiceMap> (options: Libp2pOptions<T>): Promise<Libp2p<T>> {
   const node = await createLibp2pNode(options)
 
   if (options.start !== false) {

--- a/src/index.ts
+++ b/src/index.ts
@@ -35,14 +35,14 @@ import type { KeyChainInit } from '@libp2p/keychain'
 import type { PersistentPeerStoreInit } from '@libp2p/peer-store'
 import type { Datastore } from 'interface-datastore'
 
-export type ServiceFactoryMap<T extends ServiceMap = ServiceMap> = {
+export type ServiceFactoryMap<T extends ServiceMap> = {
   [Property in keyof T]: (components: Components<T>) => T[Property]
 }
 
 /**
  * For Libp2p configurations and modules details read the [Configuration Document](./CONFIGURATION.md).
  */
-export interface Libp2pInit<T extends ServiceMap = ServiceMap> {
+export interface Libp2pInit<T extends ServiceMap> {
   /**
    * peerId instance (it will be created if not provided)
    */
@@ -113,7 +113,7 @@ export interface Libp2pInit<T extends ServiceMap = ServiceMap> {
 
 export type { Libp2p }
 
-export type Libp2pOptions<T extends ServiceMap = ServiceMap> = RecursivePartial<Libp2pInit<T>> & { start?: boolean }
+export type Libp2pOptions<T extends ServiceMap> = RecursivePartial<Libp2pInit<T>> & { start?: boolean }
 
 /**
  * Returns a new instance of the Libp2p interface, generating a new PeerId
@@ -141,7 +141,7 @@ export type Libp2pOptions<T extends ServiceMap = ServiceMap> = RecursivePartial<
  * const libp2p = await createLibp2p(options)
  * ```
  */
-export async function createLibp2p <T extends ServiceMap = ServiceMap> (options: Libp2pOptions<T>): Promise<Libp2p<T>> {
+export async function createLibp2p <T extends ServiceMap> (options: Libp2pOptions<T>): Promise<Libp2p<T>> {
   const node = await createLibp2pNode(options)
 
   if (options.start !== false) {

--- a/test/circuit-relay/discovery.node.ts
+++ b/test/circuit-relay/discovery.node.ts
@@ -5,6 +5,7 @@ import { tcp } from '@libp2p/tcp'
 import { expect } from 'aegir/chai'
 import { pEvent } from 'p-event'
 import { circuitRelayServer, type CircuitRelayService, circuitRelayTransport } from '../../src/circuit-relay/index.js'
+import { identifyService } from '../../src/identify/index.js'
 import { createLibp2p } from '../../src/index.js'
 import { plaintext } from '../../src/insecure/index.js'
 import { getRelayAddress, hasRelay, MockContentRouting, mockContentRouting } from './utils.js'
@@ -17,6 +18,7 @@ describe('circuit-relay discovery', () => {
 
   beforeEach(async () => {
     // create relay first so it has time to advertise itself via content routing
+    // @ts-expect-error TODO: typescript cannot infer the service map type
     relay = await createLibp2p({
       addresses: {
         listen: ['/ip4/127.0.0.1/tcp/0']
@@ -34,10 +36,10 @@ describe('circuit-relay discovery', () => {
         mockContentRouting()
       ],
       services: {
+        identify: identifyService(),
+        // @ts-expect-error TODO: typescript cannot infer the service map type
         relay: circuitRelayServer({
-          advertise: {
-            bootDelay: 10
-          }
+          advertise: true
         })
       }
     })

--- a/test/circuit-relay/hop.spec.ts
+++ b/test/circuit-relay/hop.spec.ts
@@ -95,7 +95,8 @@ describe('circuit-relay hop protocol', function () {
       peerId,
       peerStore,
       registrar,
-      connectionGater
+      connectionGater,
+      identify: {}
     })
 
     if (isStartable(service)) {

--- a/test/connection-manager/resolver.spec.ts
+++ b/test/connection-manager/resolver.spec.ts
@@ -14,6 +14,7 @@ import sinon from 'sinon'
 import { RELAY_V2_HOP_CODEC } from '../../src/circuit-relay/constants.js'
 import { circuitRelayServer, type CircuitRelayService, circuitRelayTransport } from '../../src/circuit-relay/index.js'
 import { codes as ErrorCodes } from '../../src/errors.js'
+import { identifyService } from '../../src/identify/index.js'
 import { plaintext } from '../../src/insecure/index.js'
 import { createLibp2pNode, type Libp2pNode } from '../../src/libp2p.js'
 import { MULTIADDRS_WEBSOCKETS } from '../fixtures/browser.js'
@@ -94,6 +95,7 @@ describe('dialing (resolvable addresses)', () => {
           plaintext()
         ],
         services: {
+          identify: identifyService(),
           relay: circuitRelayServer()
         },
         connectionGater: mockConnectionGater()

--- a/test/content-routing/content-routing.node.ts
+++ b/test/content-routing/content-routing.node.ts
@@ -1,5 +1,6 @@
 /* eslint-env mocha */
 
+import { EventTypes, type KadDHT } from '@libp2p/kad-dht'
 import { peerIdFromString } from '@libp2p/peer-id'
 import { multiaddr } from '@multiformats/multiaddr'
 import { expect } from 'aegir/chai'
@@ -15,7 +16,6 @@ import { createNode, createPeerId, populateAddressBooks } from '../utils/creator
 import { createRoutingOptions } from './utils.js'
 import type { ContentRouting } from '@libp2p/interface-content-routing'
 import type { PeerInfo } from '@libp2p/interface-peer-info'
-import type { KadDHT } from '@libp2p/kad-dht'
 
 describe('content-routing', () => {
   describe('no routers', () => {
@@ -100,7 +100,7 @@ describe('content-routing', () => {
       sinon.stub(nodes[0].services.dht, 'findProviders').callsFake(async function * () {
         yield {
           from: nodes[0].peerId,
-          type: 0,
+          type: EventTypes.PROVIDER,
           name: 'PROVIDER',
           providers: [{
             id: nodes[0].peerId,
@@ -322,7 +322,7 @@ describe('content-routing', () => {
       sinon.stub(node.services.dht, 'findProviders').callsFake(async function * () {
         yield {
           from: providerPeerId,
-          type: 0,
+          type: EventTypes.PROVIDER,
           name: 'PROVIDER',
           providers: [
             result
@@ -362,7 +362,7 @@ describe('content-routing', () => {
       sinon.stub(node.services.dht, 'findProviders').callsFake(async function * () {
         yield {
           from: providerPeerId,
-          type: 0,
+          type: EventTypes.PROVIDER,
           name: 'PROVIDER',
           providers: [
             result1
@@ -423,7 +423,7 @@ describe('content-routing', () => {
       sinon.stub(node.services.dht, 'findProviders').callsFake(async function * () {
         yield {
           from: providerPeerId,
-          type: 0,
+          type: EventTypes.PROVIDER,
           name: 'PROVIDER',
           providers: [
             results[0]

--- a/test/content-routing/dht/operation.node.ts
+++ b/test/content-routing/dht/operation.node.ts
@@ -8,6 +8,7 @@ import { multiaddr } from '@multiformats/multiaddr'
 import { expect } from 'aegir/chai'
 import pWaitFor from 'p-wait-for'
 import { fromString as uint8ArrayFromString } from 'uint8arrays/from-string'
+import { identifyService } from '../../../src/identify/index.js'
 import { createLibp2p } from '../../../src/index.js'
 import { plaintext } from '../../../src/insecure/index.js'
 import { createPeerId } from '../../utils/creators/peer.js'
@@ -66,7 +67,8 @@ describe('DHT subsystem operates correctly', () => {
         services: {
           dht: kadDHT({
             allowQueryWithZeroPeers: true
-          })
+          }),
+          identify: identifyService()
         }
       })
 
@@ -88,7 +90,8 @@ describe('DHT subsystem operates correctly', () => {
         services: {
           dht: kadDHT({
             allowQueryWithZeroPeers: true
-          })
+          }),
+          identify: identifyService()
         }
       })
 

--- a/test/content-routing/utils.ts
+++ b/test/content-routing/utils.ts
@@ -3,7 +3,7 @@ import { createBaseOptions } from '../utils/base-options.js'
 import type { Libp2pOptions } from '../../src/index.js'
 import type { KadDHT } from '@libp2p/kad-dht'
 
-export function createRoutingOptions (...overrides: Libp2pOptions[]): Libp2pOptions<{ dht: KadDHT }> {
+export function createRoutingOptions (...overrides: Array<Libp2pOptions<any>>): Libp2pOptions<{ dht: KadDHT }> {
   return createBaseOptions({
     services: {
       dht: kadDHT()

--- a/test/core/encryption.spec.ts
+++ b/test/core/encryption.spec.ts
@@ -4,6 +4,7 @@ import { webSockets } from '@libp2p/websockets'
 import { createLibp2p, type Libp2pOptions } from '../../src/index.js'
 import { plaintext } from '../../src/insecure/index.js'
 import { createPeerId } from '../utils/creators/peer.js'
+import type { ServiceMap } from '@libp2p/interface-libp2p'
 import type { PeerId } from '@libp2p/interface-peer-id'
 
 describe('Connection encryption configuration', () => {
@@ -14,7 +15,7 @@ describe('Connection encryption configuration', () => {
   })
 
   it('can be created', async () => {
-    const config: Libp2pOptions = {
+    const config: Libp2pOptions<ServiceMap> = {
       peerId,
       start: false,
       transports: [

--- a/test/core/get-public-key.spec.ts
+++ b/test/core/get-public-key.spec.ts
@@ -4,6 +4,7 @@ import { kadDHT } from '@libp2p/kad-dht'
 import { webSockets } from '@libp2p/websockets'
 import { expect } from 'aegir/chai'
 import sinon from 'sinon'
+import { identifyService } from '../../src/identify/index.js'
 import { plaintext } from '../../src/insecure/index.js'
 import { createLibp2pNode } from '../../src/libp2p.js'
 import { createPeerId } from '../utils/creators/peer.js'
@@ -24,7 +25,8 @@ describe('getPublicKey', () => {
         plaintext()
       ],
       services: {
-        dht: kadDHT()
+        dht: kadDHT(),
+        identify: identifyService()
       }
     })
 

--- a/test/interop.ts
+++ b/test/interop.ts
@@ -21,7 +21,7 @@ import { path as p2pd } from 'go-libp2p'
 import pDefer from 'p-defer'
 import { circuitRelayServer, circuitRelayTransport } from '../src/circuit-relay/index.js'
 import { identifyService } from '../src/identify/index.js'
-import { createLibp2p, type Libp2pOptions, type ServiceFactoryMap } from '../src/index.js'
+import { createLibp2p, type Libp2pOptions } from '../src/index.js'
 import type { ServiceMap } from '@libp2p/interface-libp2p'
 import type { PeerId } from '@libp2p/interface-peer-id'
 import type { SpawnOptions, Daemon, DaemonFactory } from '@libp2p/interop'
@@ -132,7 +132,7 @@ async function createJsPeer (options: SpawnOptions): Promise<Daemon> {
     connectionEncryption: [noise()]
   }
 
-  const services: ServiceFactoryMap = {
+  const services: Record<string, any> = {
     identify: identifyService()
   }
 
@@ -146,7 +146,6 @@ async function createJsPeer (options: SpawnOptions): Promise<Daemon> {
     if (options.pubsubRouter === 'floodsub') {
       services.pubsub = floodsub()
     } else {
-      // @ts-expect-error remove after gossipsub is upgraded to @libp2p/interface-peer-store@2.x.x
       services.pubsub = gossipsub()
     }
   }

--- a/test/peer-discovery/index.node.ts
+++ b/test/peer-discovery/index.node.ts
@@ -16,7 +16,7 @@ import { createLibp2p } from '../../src/index.js'
 import { createBaseOptions } from '../utils/base-options.js'
 import { createPeerId } from '../utils/creators/peer.js'
 import type { Libp2pOptions } from '../../src/index.js'
-import type { Libp2p } from '@libp2p/interface-libp2p'
+import type { Libp2p, ServiceMap } from '@libp2p/interface-libp2p'
 import type { PeerDiscovery, PeerDiscoveryEvents } from '@libp2p/interface-peer-discovery'
 import type { PeerId } from '@libp2p/interface-peer-id'
 
@@ -122,7 +122,7 @@ describe('peer discovery scenarios', () => {
     // use a random tag to prevent CI collision
     const serviceTag = `libp2p-test-${uint8ArrayToString(randomBytes(4), 'base16')}.local`
 
-    const getConfig = (peerId: PeerId): Libp2pOptions => createBaseOptions({
+    const getConfig = (peerId: PeerId): Libp2pOptions<ServiceMap> => createBaseOptions({
       peerId,
       addresses: {
         listen: [

--- a/test/peer-discovery/index.node.ts
+++ b/test/peer-discovery/index.node.ts
@@ -4,13 +4,14 @@ import { bootstrap } from '@libp2p/bootstrap'
 import { randomBytes } from '@libp2p/crypto'
 import { peerDiscovery } from '@libp2p/interface-peer-discovery'
 import { EventEmitter } from '@libp2p/interfaces/events'
-import { kadDHT } from '@libp2p/kad-dht'
+import { type DualKadDHT, kadDHT } from '@libp2p/kad-dht'
 import { mdns } from '@libp2p/mdns'
 import { multiaddr } from '@multiformats/multiaddr'
 import { expect } from 'aegir/chai'
 import defer from 'p-defer'
 import sinon from 'sinon'
 import { toString as uint8ArrayToString } from 'uint8arrays/to-string'
+import { type IdentifyService, identifyService } from '../../src/identify/index.js'
 import { createLibp2p } from '../../src/index.js'
 import { createBaseOptions } from '../utils/base-options.js'
 import { createPeerId } from '../utils/creators/peer.js'
@@ -18,7 +19,6 @@ import type { Libp2pOptions } from '../../src/index.js'
 import type { Libp2p } from '@libp2p/interface-libp2p'
 import type { PeerDiscovery, PeerDiscoveryEvents } from '@libp2p/interface-peer-discovery'
 import type { PeerId } from '@libp2p/interface-peer-id'
-import type { KadDHT } from '@libp2p/kad-dht'
 
 const listenAddr = multiaddr('/ip4/127.0.0.1/tcp/0')
 
@@ -172,7 +172,7 @@ describe('peer discovery scenarios', () => {
   it('kad-dht should discover other peers', async () => {
     const deferred = defer()
 
-    const getConfig = (peerId: PeerId): Libp2pOptions<{ dht: KadDHT }> => createBaseOptions({
+    const getConfig = (peerId: PeerId): Libp2pOptions<{ dht: DualKadDHT, identify: IdentifyService }> => createBaseOptions({
       peerId,
       addresses: {
         listen: [
@@ -180,7 +180,8 @@ describe('peer discovery scenarios', () => {
         ]
       },
       services: {
-        dht: kadDHT()
+        dht: kadDHT(),
+        identify: identifyService()
       }
     })
 

--- a/test/peer-routing/utils.ts
+++ b/test/peer-routing/utils.ts
@@ -3,7 +3,7 @@ import { createBaseOptions } from '../utils/base-options.js'
 import type { Libp2pOptions } from '../../src/index.js'
 import type { KadDHT } from '@libp2p/kad-dht'
 
-export function createRoutingOptions (...overrides: Libp2pOptions[]): Libp2pOptions<{ dht: KadDHT }> {
+export function createRoutingOptions (...overrides: Array<Libp2pOptions<any>>): Libp2pOptions<{ dht: KadDHT }> {
   return createBaseOptions({
     services: {
       dht: kadDHT()

--- a/test/utils/base-options.browser.ts
+++ b/test/utils/base-options.browser.ts
@@ -10,8 +10,8 @@ import { plaintext } from '../../src/insecure/index.js'
 import type { Libp2pOptions } from '../../src/index.js'
 import type { ServiceMap } from '@libp2p/interface-libp2p'
 
-export function createBaseOptions <T extends ServiceMap = Record<string, unknown>> (overrides?: Libp2pOptions<T>): Libp2pOptions<T> {
-  const options: Libp2pOptions = {
+export function createBaseOptions <T extends ServiceMap> (overrides?: Libp2pOptions<T>): Libp2pOptions<T> {
+  const options: Libp2pOptions<T> = {
     transports: [
       webSockets({
         filter: filters.all

--- a/test/utils/base-options.ts
+++ b/test/utils/base-options.ts
@@ -10,8 +10,8 @@ import { MULTIADDRS_WEBSOCKETS } from '../fixtures/browser.js'
 import type { Libp2pOptions } from '../../src'
 import type { ServiceMap } from '@libp2p/interface-libp2p'
 
-export function createBaseOptions <T extends ServiceMap = Record<string, unknown>> (...overrides: Array<Libp2pOptions<T>>): Libp2pOptions<T> {
-  const options: Libp2pOptions = {
+export function createBaseOptions <T extends ServiceMap> (...overrides: Array<Libp2pOptions<T>>): Libp2pOptions<T> {
+  const options: Libp2pOptions<T> = {
     addresses: {
       listen: [`${MULTIADDRS_WEBSOCKETS}/p2p-circuit`]
     },


### PR DESCRIPTION
Some services depend on others, for example circuit relay v2 and kad-dht don't really work without identify so we need a way to prompt the user to configure these dependencies.

The change is to allow extending the components a service requires with a service map of the dependencies.

The components type in the `Libp2pInit` type is extended by the `ServiceMap` generic type so when the user configures a node without the required dependencies, TypeScript will fail to compile as the components being passed to the factory function don't have type overlap with the required components.