### PR TITLE
fix: add start/stop events

### DIFF
--- a/package.json
+++ b/package.json
@@ -128,7 +128,7 @@
     "@libp2p/interface-connection-manager": "^3.0.0",
     "@libp2p/interface-content-routing": "^2.1.0",
     "@libp2p/interface-keychain": "^2.0.4",
-    "@libp2p/interface-libp2p": "^3.1.0",
+    "@libp2p/interface-libp2p": "^3.2.0",
     "@libp2p/interface-metrics": "^4.0.0",
     "@libp2p/interface-peer-discovery": "^2.0.0",
     "@libp2p/interface-peer-id": "^2.0.1",

--- a/src/libp2p.ts
+++ b/src/libp2p.ts
@@ -227,6 +227,8 @@ export class Libp2pNode<T extends ServiceMap = Record<string, unknown>> extends 
       await this.components.beforeStart?.()
       await this.components.start()
       await this.components.afterStart?.()
+
+      this.safeDispatchEvent('start', { detail: this })
       log('libp2p has started')
     } catch (err: any) {
       log.error('An error occurred starting libp2p', err)
@@ -251,6 +253,7 @@ export class Libp2pNode<T extends ServiceMap = Record<string, unknown>> extends 
     await this.components.stop()
     await this.components.afterStop?.()
 
+    this.safeDispatchEvent('stop', { detail: this })
     log('libp2p has stopped')
   }
 

--- a/test/core/events.spec.ts
+++ b/test/core/events.spec.ts
@@ -1,0 +1,51 @@
+/* eslint-env mocha */
+
+import { webSockets } from '@libp2p/websockets'
+import { expect } from 'aegir/chai'
+import { pEvent } from 'p-event'
+import { createLibp2p } from '../../src/index.js'
+import { plaintext } from '../../src/insecure/index.js'
+import type { Libp2p } from '@libp2p/interface-libp2p'
+
+describe('events', () => {
+  let node: Libp2p
+
+  afterEach(async () => {
+    if (node != null) {
+      await node.stop()
+    }
+  })
+
+  it('should emit a start event', async () => {
+    node = await createLibp2p({
+      start: false,
+      transports: [
+        webSockets()
+      ],
+      connectionEncryption: [
+        plaintext()
+      ]
+    })
+
+    const eventPromise = pEvent<'start', CustomEvent<Libp2p>>(node, 'start')
+
+    await node.start()
+    await expect(eventPromise).to.eventually.have.property('detail', node)
+  })
+
+  it('should emit a stop event', async () => {
+    node = await createLibp2p({
+      transports: [
+        webSockets()
+      ],
+      connectionEncryption: [
+        plaintext()
+      ]
+    })
+
+    const eventPromise = pEvent<'stop', CustomEvent<Libp2p>>(node, 'stop')
+
+    await node.stop()
+    await expect(eventPromise).to.eventually.have.property('detail', node)
+  })
+})


### PR DESCRIPTION
Add `start` and `stop` events when a node starts or stops.