### PR TITLE
fix: import path for interfaces module

### DIFF
--- a/src/address-manager/index.ts
+++ b/src/address-manager/index.ts
@@ -6,7 +6,7 @@ import type { Libp2pEvents } from '@libp2p/interface-libp2p'
 import type { PeerId } from '@libp2p/interface-peer-id'
 import type { PeerStore } from '@libp2p/interface-peer-store'
 import type { TransportManager } from '@libp2p/interface-transport'
-import type { EventEmitter } from '@libp2p/interfaces/dist/src/events'
+import type { EventEmitter } from '@libp2p/interfaces/events'
 import type { Multiaddr } from '@multiformats/multiaddr'
 
 const log = logger('libp2p:address-manager')


### PR DESCRIPTION
Fix import path for type from `@libp2p/interfaces` in `address-manager`. 

Without this fix, any clients building with typescript module resolution `node16` get the following error:

```
node_modules/libp2p/dist/src/address-manager/index.d.ts:5:35 - error TS2307: Cannot find module '@libp2p/interfaces/dist/src/events' or its corresponding type declarations.

5 import type { EventEmitter } from '@libp2p/interfaces/dist/src/events';
```

It can also be reproduced by changing the module resolution of this package to `node16` and rebuilding.