### PR TITLE
fix: allow specifiying maxOutboundStreams in connection.newStream

### DIFF
--- a/packages/libp2p/package.json
+++ b/packages/libp2p/package.json
@@ -121,7 +121,7 @@
     "@achingbrain/nat-port-mapper": "^1.0.9",
     "@libp2p/crypto": "^1.0.17",
     "@libp2p/interface-address-manager": "^3.0.0",
-    "@libp2p/interface-connection": "^5.0.0",
+    "@libp2p/interface-connection": "^5.1.1",
     "@libp2p/interface-connection-encrypter": "^4.0.0",
     "@libp2p/interface-connection-gater": "^3.0.0",
     "@libp2p/interface-connection-manager": "^3.0.0",

--- a/packages/libp2p/src/circuit-relay/transport/index.ts
+++ b/packages/libp2p/src/circuit-relay/transport/index.ts
@@ -82,14 +82,15 @@ export interface CircuitRelayTransportInit extends RelayStoreInit {
 
   /**
    * The maximum number of simultaneous STOP outbound streams that can be open at
-   * once. STOP streams are opened by the relay server so this setting is
-   * effectively ignored. (default: 32)
+   * once. If this transport is used along with the relay server these settings
+   * should be set to the same value (default: 300)
    */
   maxOutboundStopStreams?: number
 }
 
 const defaults = {
-  maxInboundStopStreams: MAX_CONNECTIONS
+  maxInboundStopStreams: MAX_CONNECTIONS,
+  maxOutboundStopStreams: MAX_CONNECTIONS
 }
 
 class CircuitRelayTransport implements Transport {
@@ -115,7 +116,7 @@ class CircuitRelayTransport implements Transport {
     this.addressManager = components.addressManager
     this.connectionGater = components.connectionGater
     this.maxInboundStopStreams = init.maxInboundStopStreams ?? defaults.maxInboundStopStreams
-    this.maxOutboundStopStreams = init.maxOutboundStopStreams
+    this.maxOutboundStopStreams = init.maxOutboundStopStreams ?? defaults.maxOutboundStopStreams
 
     if (init.discoverRelays != null && init.discoverRelays > 0) {
       this.discovery = new RelayDiscovery(components)


### PR DESCRIPTION
To allow overriding the default maximum outbound streams for a protocol when it's not been specified in a handler, allow passing it as an option when opening a new outbound stream.