### PR TITLE
fix: add events bus to pubsub compliance tests

### DIFF
--- a/packages/interface-pubsub-compliance-tests/src/utils.ts
+++ b/packages/interface-pubsub-compliance-tests/src/utils.ts
@@ -1,4 +1,5 @@
 import { mockConnectionManager, mockRegistrar, mockNetwork } from '@libp2p/interface-mocks'
+import { EventEmitter } from '@libp2p/interfaces/events'
 import { createEd25519PeerId } from '@libp2p/peer-id-factory'
 import { pEvent } from 'p-event'
 import pWaitFor from 'p-wait-for'
@@ -17,7 +18,8 @@ export async function waitForSubscriptionUpdate (a: PubSub, b: PeerId): Promise<
 export async function createComponents (): Promise<MockNetworkComponents> {
   const components: any = {
     peerId: await createEd25519PeerId(),
-    registrar: mockRegistrar()
+    registrar: mockRegistrar(),
+    events: new EventEmitter()
   }
   components.connectionManager = mockConnectionManager(components)
 


### PR DESCRIPTION
This is necessary to emit events from components