### PR TITLE
fix: removing stream methods from connection interface

### DIFF
--- a/packages/interface-connection/src/index.ts
+++ b/packages/interface-connection/src/index.ts
@@ -182,8 +182,6 @@ export interface Connection {
   streams: Stream[]
 
   newStream: (multicodecs: string | string[], options?: NewStreamOptions) => Promise<Stream>
-  addStream: (stream: Stream) => void
-  removeStream: (id: string) => void
   close: () => Promise<void>
 }
 


### PR DESCRIPTION
Moving the discussion from [this pull request](https://github.com/libp2p/js-libp2p-interfaces/pull/417), PR was originally opened in js-libp2p-interfaces before being moving to this monorepo

the muxers should be ultimately responsible for managing streams, that's why `addStream` and `removeStream` methods are being removed from the interface [see](https://github.com/libp2p/js-libp2p-interfaces/pull/417/files#r1230570032)

Fixes [issue libp2p/js-libp2p#1855](https://github.com/libp2p/js-libp2p/issues/1855)