### PR TITLE
fix: copy monorepo packages to multidim docker image

### DIFF
--- a/interop/Dockerfile
+++ b/interop/Dockerfile
@@ -3,7 +3,7 @@ FROM node:18
 WORKDIR /app
 COPY package.json .
 COPY ./node_modules ./node_modules
-COPY ./packages/libp2p ./packages/libp2p
+COPY ./packages ./packages
 
 WORKDIR /app/interop
 COPY ./interop/node_modules ./node_modules


### PR DESCRIPTION
Otherwise the tests can't find the modules. Addresses some parts of https://github.com/libp2p/js-libp2p/issues/824