### PR TITLE
test: temporarily remove webRTC tests 

### DIFF
--- a/interop/chromium-version.json
+++ b/interop/chromium-version.json
@@ -1,26 +1,16 @@
 {
-    "id": "chromium-js-libp2p-head",
-    "containerImageID": "chromium-js-libp2p-head",
-    "transports": [
-        {
-            "name": "webtransport",
-            "onlyDial": true
-        },
-        {
-            "name": "webrtc-direct",
-            "onlyDial": true
-        },
-        "webrtc",
-        {
-            "name": "wss",
-            "onlyDial": true
-        }
-    ],
-    "secureChannels": [
-        "noise"
-    ],
-    "muxers": [
-        "mplex",
-        "yamux"
-    ]
+  "id": "chromium-js-libp2p-head",
+  "containerImageID": "chromium-js-libp2p-head",
+  "transports": [
+    {
+      "name": "webtransport",
+      "onlyDial": true
+    },
+    {
+      "name": "wss",
+      "onlyDial": true
+    }
+  ],
+  "secureChannels": ["noise"],
+  "muxers": ["mplex", "yamux"]
 }

--- a/interop/firefox-version.json
+++ b/interop/firefox-version.json
@@ -1,22 +1,12 @@
 {
-    "id": "firefox-js-libp2p-head",
-    "containerImageID": "firefox-js-libp2p-head",
-    "transports": [
-        {
-            "name": "webrtc-direct",
-            "onlyDial": true
-        },
-        "webrtc",
-        {
-            "name": "wss",
-            "onlyDial": true
-        }
-    ],
-    "secureChannels": [
-        "noise"
-    ],
-    "muxers": [
-        "mplex",
-        "yamux"
-    ]
+  "id": "firefox-js-libp2p-head",
+  "containerImageID": "firefox-js-libp2p-head",
+  "transports": [
+    {
+      "name": "wss",
+      "onlyDial": true
+    }
+  ],
+  "secureChannels": ["noise"],
+  "muxers": ["mplex", "yamux"]
 }


### PR DESCRIPTION
Following the discussion [here](https://github.com/libp2p/js-libp2p/issues/1809#issuecomment-1599357723) we need to investigate why webRTC tests are inconsistent. 

Closes #1809