### PR TITLE
Fix a property name of `websockets` option in README.md: `filters` => `filter`

### DIFF
--- a/packages/transport-websockets/README.md
+++ b/packages/transport-websockets/README.md
@@ -90,7 +90,7 @@ const node = await Libp2p.create({
   transport: [
     websockets({
       // connect to all sockets, even insecure ones
-      filters: filters.all
+      filter: filters.all
     })
   ],
   streamMuxers: [


### PR DESCRIPTION
The libp2p transport `websockets` option's valid property name would be `filter`; not `filters`.  

I struggled how to`libp2p.dial()` from in browser to helia on nodejs, added filter**s** option for libp2p in browser  as in example of README.
Today I tried to use `filter` instead of `filters`, it can dial from browser to nodejs...

