### PR TITLE
fix: remove redundant nat-api override

### DIFF
--- a/packages/libp2p/package.json
+++ b/packages/libp2p/package.json
@@ -191,7 +191,6 @@
     "sinon-ts": "^1.0.0"
   },
   "browser": {
-    "./dist/src/config/connection-gater.js": "./dist/src/config/connection-gater.browser.js",
-    "nat-api": false
+    "./dist/src/config/connection-gater.js": "./dist/src/config/connection-gater.browser.js"
   }
 }


### PR DESCRIPTION
`nat-api` isn't used by this module any more.