### PR TITLE
fix: remove stream add/remove methods from connection interface

### DIFF
--- a/packages/interface-compliance-tests/package.json
+++ b/packages/interface-compliance-tests/package.json
@@ -130,7 +130,6 @@
     "p-wait-for": "^5.0.2",
     "protons-runtime": "^5.0.0",
     "sinon": "^15.1.2",
-    "ts-sinon": "^2.0.2",
     "uint8arraylist": "^2.4.3",
     "uint8arrays": "^4.0.4"
   },

--- a/packages/interface-compliance-tests/src/connection/index.ts
+++ b/packages/interface-compliance-tests/src/connection/index.ts
@@ -1,8 +1,7 @@
 import { expect } from 'aegir/chai'
 import sinon from 'sinon'
-import { stubInterface } from 'ts-sinon'
 import type { TestSetup } from '../index.js'
-import type { Connection, Stream } from '@libp2p/interface/connection'
+import type { Connection } from '@libp2p/interface/connection'
 
 export default (test: TestSetup<Connection>): void => {
   describe('connection', () => {
@@ -122,13 +121,6 @@ export default (test: TestSetup<Connection>): void => {
         const protocol = '/echo/0.0.1'
         const stream = await connection.newStream(protocol)
         expect(stream).to.have.property('direction', 'outbound')
-      })
-
-      it.skip('should track inbound streams', async () => {
-        // Add an remotely opened stream
-        const stream = stubInterface<Stream>()
-        connection.addStream(stream)
-        expect(stream).to.have.property('direction', 'inbound')
       })
 
       it('should support a proxy on the timeline', async () => {

--- a/packages/interface-compliance-tests/src/mocks/connection.ts
+++ b/packages/interface-compliance-tests/src/mocks/connection.ts
@@ -94,14 +94,6 @@ class MockConnection implements Connection {
     return stream
   }
 
-  addStream (stream: Stream): void {
-    this.streams.push(stream)
-  }
-
-  removeStream (id: string): void {
-    this.streams = this.streams.filter(stream => stream.id !== id)
-  }
-
   async close (options?: AbortOptions): Promise<void> {
     this.status = 'closing'
     await Promise.all(
@@ -147,7 +139,7 @@ export function mockConnection (maConn: MultiaddrConnection, opts: MockConnectio
             muxedStream.sink = stream.sink
             muxedStream.source = stream.source
 
-            connection.addStream(muxedStream)
+            connection.streams.push(muxedStream)
             const { handler } = registrar.getHandler(protocol)
 
             handler({ connection, stream: muxedStream })
@@ -159,7 +151,7 @@ export function mockConnection (maConn: MultiaddrConnection, opts: MockConnectio
       }
     },
     onStreamEnd: (muxedStream) => {
-      connection.removeStream(muxedStream.id)
+      connection.streams = connection.streams.filter(stream => stream.id !== muxedStream.id)
     }
   })
 

--- a/packages/interface/src/connection/index.ts
+++ b/packages/interface/src/connection/index.ts
@@ -259,16 +259,6 @@ export interface Connection {
   newStream: (protocols: string | string[], options?: NewStreamOptions) => Promise<Stream>
 
   /**
-   * Add a stream to this connection
-   */
-  addStream: (stream: Stream) => void
-
-  /**
-   * Remove a stream from this connection
-   */
-  removeStream: (id: string) => void
-
-  /**
    * Gracefully close the connection. All queued data will be written to the
    * underlying transport.
    */

--- a/packages/libp2p/src/connection/index.ts
+++ b/packages/libp2p/src/connection/index.ts
@@ -139,20 +139,6 @@ export class ConnectionImpl implements Connection {
   }
 
   /**
-   * Add a stream when it is opened to the registry
-   */
-  addStream (stream: Stream): void {
-    stream.direction = 'inbound'
-  }
-
-  /**
-   * Remove stream registry after it is closed
-   */
-  removeStream (id: string): void {
-
-  }
-
-  /**
    * Close the connection
    */
   async close (options: AbortOptions = {}): Promise<void> {

--- a/packages/libp2p/src/upgrader.ts
+++ b/packages/libp2p/src/upgrader.ts
@@ -415,7 +415,6 @@ export class DefaultUpgrader implements Upgrader {
                 protocols: [protocol]
               })
 
-              connection.addStream(muxedStream)
               this.components.metrics?.trackProtocolStream(muxedStream, connection)
 
               this._onStream({ connection, stream: muxedStream, protocol })
@@ -427,10 +426,6 @@ export class DefaultUpgrader implements Upgrader {
                 await muxedStream.close()
               }
             })
-        },
-        // Run anytime a stream closes
-        onStreamEnd: muxedStream => {
-          connection?.removeStream(muxedStream.id)
         }
       })
 

--- a/packages/libp2p/test/connection/compliance.spec.ts
+++ b/packages/libp2p/test/connection/compliance.spec.ts
@@ -35,7 +35,6 @@ describe('connection compliance', () => {
             ...pair(),
             close: async () => {
               void stream.sink(async function * () {}())
-              connection.removeStream(stream.id)
               openStreams = openStreams.filter(s => s.id !== id)
             },
             closeRead: async () => {},


### PR DESCRIPTION
remove (add|remove)Stream from connection interface

remove (add|remove)Stream use from interface-compliance-tests

remove (add|remove)Stream from libp2p connection methods

remove (add|remove)Stream from libp2p upgrader methods

Closes #1855
