### PR TITLE
fix: add gh credentials to publish docs

### DIFF
--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -257,6 +257,7 @@ jobs:
           git update-index --assume-unchanged packages/libp2p/src/version.ts
           npm run --if-present release
         env:
+          GITHUB_TOKEN: ${{ secrets.UCI_GITHUB_TOKEN || github.token }}
           NODE_AUTH_TOKEN: ${{ secrets.NPM_TOKEN }}
       - if: ${{ !steps.release.outputs.releases_created }}
         name: Run release rc
@@ -264,4 +265,5 @@ jobs:
             git update-index --assume-unchanged packages/libp2p/src/version.ts
             npm run --if-present release:rc
         env:
+          GITHUB_TOKEN: ${{ secrets.UCI_GITHUB_TOKEN || github.token }}
           NODE_AUTH_TOKEN: ${{ secrets.NPM_TOKEN }}


### PR DESCRIPTION
These are needed to publish to the gh-pages branch.