### PR TITLE
docs: removes redundant setup step

### DIFF
--- a/examples/chat/README.md
+++ b/examples/chat/README.md
@@ -16,7 +16,7 @@
 
 ## Setup
 
-1. Install the modules in the libp2p root directory, `npm install` and `npm run build`.
+1. Install the modules in the libp2p root directory, `npm install`.
 2. Open 2 terminal windows in the `./examples/chat/src` directory.
 
 ## Running


### PR DESCRIPTION
removes redundant 'npm run build' command

I have tested the guides and npm run build is not only redundant for this POC but also might make someone think that they are doing things wrong.