### PR TITLE
fix: crypto: limit RSA key size to <= 8192 bits

### DIFF
--- a/packages/crypto/src/keys/rsa-browser.ts
+++ b/packages/crypto/src/keys/rsa-browser.ts
@@ -156,7 +156,7 @@ export function decrypt (key: JsonWebKey, msg: Uint8Array): Uint8Array {
   return convertKey(key, false, msg, (msg, key) => key.decrypt(msg))
 }
 
-export function keySize (jwk: JsonWebKey) {
+export function keySize (jwk: JsonWebKey): number {
   if (jwk.kty !== 'RSA') {
     throw new CodeError('invalid key type', 'ERR_INVALID_KEY_TYPE')
   } else if (jwk.n == null) {
@@ -164,8 +164,8 @@ export function keySize (jwk: JsonWebKey) {
   }
   let n = jwk.n
   // Replace base64url characters with base64 characters
-  n = n.replace(/-/g, '+').replace(/_/g, '/');
-  const binString = atob(n);
-  const bytes = Uint8Array.from(binString, (m) => m.codePointAt(0) as number);
-  return bytes.length * 8;
+  n = n.replace(/-/g, '+').replace(/_/g, '/')
+  const binString = atob(n)
+  const bytes = Uint8Array.from(binString, (m) => m.codePointAt(0) as number)
+  return bytes.length * 8
 }

--- a/packages/crypto/src/keys/rsa-browser.ts
+++ b/packages/crypto/src/keys/rsa-browser.ts
@@ -155,3 +155,17 @@ export function encrypt (key: JsonWebKey, msg: Uint8Array): Uint8Array {
 export function decrypt (key: JsonWebKey, msg: Uint8Array): Uint8Array {
   return convertKey(key, false, msg, (msg, key) => key.decrypt(msg))
 }
+
+export function keySize (jwk: JsonWebKey) {
+  if (jwk.kty !== 'RSA') {
+    throw new CodeError('invalid key type', 'ERR_INVALID_KEY_TYPE')
+  } else if (jwk.n == null) {
+    throw new CodeError('invalid key modulus', 'ERR_INVALID_KEY_MODULUS')
+  }
+  let n = jwk.n
+  // Replace base64url characters with base64 characters
+  n = n.replace(/-/g, '+').replace(/_/g, '/');
+  const binString = atob(n);
+  const bytes = Uint8Array.from(binString, (m) => m.codePointAt(0) as number);
+  return bytes.length * 8;
+}

--- a/packages/crypto/src/keys/rsa-class.ts
+++ b/packages/crypto/src/keys/rsa-class.ts
@@ -10,7 +10,7 @@ import * as pbm from './keys.js'
 import * as crypto from './rsa.js'
 import type { Multibase } from 'multiformats'
 
-var maxKeySize = 8192
+let maxKeySize = 8192
 
 export class RsaPublicKey {
   private readonly _key: JsonWebKey

--- a/packages/crypto/src/keys/rsa.ts
+++ b/packages/crypto/src/keys/rsa.ts
@@ -67,3 +67,13 @@ export function decrypt (key: JsonWebKey, bytes: Uint8Array): Uint8Array {
   // @ts-expect-error node types are missing jwk as a format
   return crypto.privateDecrypt({ format: 'jwk', key, padding }, bytes)
 }
+
+export function keySize (jwk: JsonWebKey) {
+  if (jwk.kty !== 'RSA') {
+    throw new CodeError('invalid key type', 'ERR_INVALID_KEY_TYPE')
+  } else if (jwk.n == null) {
+    throw new CodeError('invalid key modulus', 'ERR_INVALID_KEY_MODULUS')
+  }
+  const modulus = Buffer.from(jwk.n, 'base64');
+  return modulus.length * 8;
+}

--- a/packages/crypto/src/keys/rsa.ts
+++ b/packages/crypto/src/keys/rsa.ts
@@ -68,12 +68,12 @@ export function decrypt (key: JsonWebKey, bytes: Uint8Array): Uint8Array {
   return crypto.privateDecrypt({ format: 'jwk', key, padding }, bytes)
 }
 
-export function keySize (jwk: JsonWebKey) {
+export function keySize (jwk: JsonWebKey): number {
   if (jwk.kty !== 'RSA') {
     throw new CodeError('invalid key type', 'ERR_INVALID_KEY_TYPE')
   } else if (jwk.n == null) {
     throw new CodeError('invalid key modulus', 'ERR_INVALID_KEY_MODULUS')
   }
-  const modulus = Buffer.from(jwk.n, 'base64');
-  return modulus.length * 8;
+  const modulus = Buffer.from(jwk.n, 'base64')
+  return modulus.length * 8
 }

--- a/packages/crypto/test/keys/rsa.spec.ts
+++ b/packages/crypto/test/keys/rsa.spec.ts
@@ -31,11 +31,11 @@ describe('RSA', function () {
   })
 
   it('Does not unmarshal a big key', async () => {
-    const reset = overrideMaxKeySize(4096-8)
+    const reset = overrideMaxKeySize(4096 - 8)
     try {
       const k = await rsaCrypto.generateKey(4096)
-      const sk =  new RsaPrivateKey(k.privateKey, k.publicKey)
-      const pubk =  new RsaPublicKey(k.publicKey)
+      const sk = new RsaPrivateKey(k.privateKey, k.publicKey)
+      const pubk = new RsaPublicKey(k.publicKey)
       const m = sk.marshal()
       const pubm = pubk.marshal()
       await expect(rsa.unmarshalRsaPrivateKey(m)).to.be.rejectedWith(/too large/)


### PR DESCRIPTION
Restrict the RSA key sizes we expect from peers. Protects us from spending a lot of compute on verifying signatures from big keys. Similar to https://github.com/libp2p/go-libp2p/pull/2454