### PR TITLE
fix(libp2p): filter out dnsaddrs for different peers

### DIFF
--- a/packages/libp2p/src/connection-manager/dial-queue.ts
+++ b/packages/libp2p/src/connection-manager/dial-queue.ts
@@ -309,8 +309,22 @@ export class DialQueue {
     ))
       .flat()
 
-    // filter out any multiaddrs that we do not have transports for
-    const filteredAddrs = resolvedAddresses.filter(addr => Boolean(this.transportManager.transportForMultiaddr(addr.multiaddr)))
+    const filteredAddrs = resolvedAddresses.filter(addr => {
+      // filter out any multiaddrs that we do not have transports for
+      if (this.transportManager.transportForMultiaddr(addr.multiaddr) == null) {
+        return false
+      }
+
+      // if the resolved multiaddr has a PeerID but it's the wrong one, ignore it
+      // - this can happen with addresses like bootstrap.libp2p.io that resolve
+      // to multiple different peers
+      const addrPeerId = addr.multiaddr.getPeerId()
+      if (peerId != null && addrPeerId != null) {
+        return peerId.equals(addrPeerId)
+      }
+
+      return true
+    })
 
     // deduplicate addresses
     const dedupedAddrs = new Map<string, Address>()

--- a/packages/libp2p/test/connection-manager/direct.spec.ts
+++ b/packages/libp2p/test/connection-manager/direct.spec.ts
@@ -165,7 +165,7 @@ describe('dialing (direct, WebSockets)', () => {
 
     const remotePeerId = peerIdFromString(remoteAddr.getPeerId() ?? '')
     await localComponents.peerStore.patch(remotePeerId, {
-      multiaddrs: Array.from({ length: 11 }, (_, i) => multiaddr(`/ip4/127.0.0.1/tcp/1500${i}/ws/p2p/12D3KooWHFKTMzwerBtsVmtz4ZZEQy2heafxzWw6wNn5PPYkBxJ5`))
+      multiaddrs: Array.from({ length: 11 }, (_, i) => multiaddr(`/ip4/127.0.0.1/tcp/1500${i}/ws/p2p/${remotePeerId.toString()}`))
     })
 
     await expect(connectionManager.openConnection(remotePeerId))


### PR DESCRIPTION
Some multiaddrs like `/dnsaddr/bootstrap.ipfs.io` resolve to multiple PeerIds.

E.g:

```console
% dig _dnsaddr.bootstrap.libp2p.io TXT

; <<>> DiG 9.10.6 <<>> _dnsaddr.bootstrap.libp2p.io TXT
;; global options: +cmd
;; Got answer:
;; ->>HEADER<<- opcode: QUERY, status: NOERROR, id: 53473
;; flags: qr rd ra; QUERY: 1, ANSWER: 4, AUTHORITY: 0, ADDITIONAL: 1

;; OPT PSEUDOSECTION:
; EDNS: version: 0, flags:; udp: 1232
;; QUESTION SECTION:
;_dnsaddr.bootstrap.libp2p.io.	IN	TXT

;; ANSWER SECTION:
_dnsaddr.bootstrap.libp2p.io. 261 IN	TXT	"dnsaddr=/dnsaddr/am6.bootstrap.libp2p.io/p2p/QmbLHAnMoJPWSCR5Zhtx6BHJX9KiKNN6tpvbUcqanj75Nb"
_dnsaddr.bootstrap.libp2p.io. 261 IN	TXT	"dnsaddr=/dnsaddr/ny5.bootstrap.libp2p.io/p2p/QmQCU2EcMqAqQPR2i9bChDtGNJchTbq5TbXJJ16u19uLTa"
_dnsaddr.bootstrap.libp2p.io. 261 IN	TXT	"dnsaddr=/dnsaddr/sg1.bootstrap.libp2p.io/p2p/QmcZf59bWwK5XFi76CZX8cbJ4BhTzzA3gU1ZjYZcYW3dwt"
_dnsaddr.bootstrap.libp2p.io. 261 IN	TXT	"dnsaddr=/dnsaddr/sv15.bootstrap.libp2p.io/p2p/QmNnooDu7bfjPFoTZYxMNLWUQJyrVwtbZg5gBMjTezGAJN"
```

This can cause problems when dialing those addresses with an explicit PeerId since resolving the dnsaddr returns addresses with embedded PeerIds that aren't for the node you are trying to dial so we need to filter those out.

The errors these cause are non-fatal but do consume resources dialing nodes we aren't going to be able to connect to.