### PR TITLE
chore: remove require-await comments in libp2p/crypto

### DIFF
--- a/packages/crypto/src/aes/index.ts
+++ b/packages/crypto/src/aes/index.ts
@@ -6,17 +6,17 @@ export interface AESCipher {
   decrypt: (data: Uint8Array) => Promise<Uint8Array>
 }
 
-export async function create (key: Uint8Array, iv: Uint8Array): Promise<AESCipher> { // eslint-disable-line require-await
+export async function create (key: Uint8Array, iv: Uint8Array): Promise<AESCipher> {
   const mode = cipherMode(key)
   const cipher = ciphers.createCipheriv(mode, key, iv)
   const decipher = ciphers.createDecipheriv(mode, key, iv)
 
   const res: AESCipher = {
-    async encrypt (data) { // eslint-disable-line require-await
+    async encrypt (data) {
       return cipher.update(data)
     },
 
-    async decrypt (data) { // eslint-disable-line require-await
+    async decrypt (data) {
       return decipher.update(data)
     }
   }

--- a/packages/crypto/src/ciphers/aes-gcm.browser.ts
+++ b/packages/crypto/src/ciphers/aes-gcm.browser.ts
@@ -32,7 +32,7 @@ export function create (opts?: CreateOptions): AESCipher {
    * Uses the provided password to derive a pbkdf2 key. The key
    * will then be used to encrypt the data.
    */
-  async function encrypt (data: Uint8Array, password: string | Uint8Array): Promise<Uint8Array> { // eslint-disable-line require-await
+  async function encrypt (data: Uint8Array, password: string | Uint8Array): Promise<Uint8Array> {
     const salt = crypto.getRandomValues(new Uint8Array(saltLength))
     const nonce = crypto.getRandomValues(new Uint8Array(nonceLength))
     const aesGcm = { name: algorithm, iv: nonce }

--- a/packages/crypto/src/ciphers/aes-gcm.ts
+++ b/packages/crypto/src/ciphers/aes-gcm.ts
@@ -14,7 +14,7 @@ export function create (opts?: CreateOptions): AESCipher {
   const iterations = opts?.iterations ?? 32767
   const algorithmTagLength = opts?.algorithmTagLength ?? 16
 
-  async function encryptWithKey (data: Uint8Array, key: Uint8Array): Promise<Uint8Array> { // eslint-disable-line require-await
+  async function encryptWithKey (data: Uint8Array, key: Uint8Array): Promise<Uint8Array> {
     const nonce = crypto.randomBytes(nonceLength)
 
     // Create the cipher instance.
@@ -31,7 +31,7 @@ export function create (opts?: CreateOptions): AESCipher {
    * Uses the provided password to derive a pbkdf2 key. The key
    * will then be used to encrypt the data.
    */
-  async function encrypt (data: Uint8Array, password: string | Uint8Array): Promise<Uint8Array> { // eslint-disable-line require-await
+  async function encrypt (data: Uint8Array, password: string | Uint8Array): Promise<Uint8Array> {
     // Generate a 128-bit salt using a CSPRNG.
     const salt = crypto.randomBytes(saltLength)
 
@@ -53,7 +53,7 @@ export function create (opts?: CreateOptions): AESCipher {
    * this decryption cipher must be the same as those used to create
    * the encryption cipher.
    */
-  async function decryptWithKey (ciphertextAndNonce: Uint8Array, key: Uint8Array): Promise<Uint8Array> { // eslint-disable-line require-await
+  async function decryptWithKey (ciphertextAndNonce: Uint8Array, key: Uint8Array): Promise<Uint8Array> {
     // Create Uint8Arrays of nonce, ciphertext and tag.
     const nonce = ciphertextAndNonce.subarray(0, nonceLength)
     const ciphertext = ciphertextAndNonce.subarray(nonceLength, ciphertextAndNonce.length - algorithmTagLength)
@@ -77,7 +77,7 @@ export function create (opts?: CreateOptions): AESCipher {
    * @param {Uint8Array} data - The data to decrypt
    * @param {string|Uint8Array} password - A plain password
    */
-  async function decrypt (data: Uint8Array, password: string | Uint8Array): Promise<Uint8Array> { // eslint-disable-line require-await
+  async function decrypt (data: Uint8Array, password: string | Uint8Array): Promise<Uint8Array> {
     // Create Uint8Arrays of salt and ciphertextAndNonce.
     const salt = data.subarray(0, saltLength)
     const ciphertextAndNonce = data.subarray(saltLength)

--- a/packages/crypto/src/hmac/index-browser.ts
+++ b/packages/crypto/src/hmac/index-browser.ts
@@ -27,7 +27,7 @@ export async function create (hashType: 'SHA1' | 'SHA256' | 'SHA512', secret: Ui
   )
 
   return {
-    async digest (data: Uint8Array) { // eslint-disable-line require-await
+    async digest (data: Uint8Array) {
       return sign(key, data)
     },
     length: lengths[hashType]

--- a/packages/crypto/src/hmac/index.ts
+++ b/packages/crypto/src/hmac/index.ts
@@ -8,7 +8,7 @@ export interface HMAC {
 
 export async function create (hash: 'SHA1' | 'SHA256' | 'SHA512', secret: Uint8Array): Promise<HMAC> {
   const res = {
-    async digest (data: Uint8Array) { // eslint-disable-line require-await
+    async digest (data: Uint8Array) {
       const hmac = crypto.createHmac(hash.toLowerCase(), secret)
       hmac.update(data)
       return hmac.digest()

--- a/packages/crypto/src/keys/ecdh.ts
+++ b/packages/crypto/src/keys/ecdh.ts
@@ -11,7 +11,7 @@ const curves = {
 const curveTypes = Object.keys(curves)
 const names = curveTypes.join(' / ')
 
-export async function generateEphmeralKeyPair (curve: string): Promise<ECDHKey> { // eslint-disable-line require-await
+export async function generateEphmeralKeyPair (curve: string): Promise<ECDHKey> {
   if (curve !== 'P-256' && curve !== 'P-384' && curve !== 'P-521') {
     throw new CodeError(`Unknown curve: ${curve}. Must be ${names}`, 'ERR_INVALID_CURVE')
   }
@@ -22,7 +22,7 @@ export async function generateEphmeralKeyPair (curve: string): Promise<ECDHKey> 
   return {
     key: ecdh.getPublicKey() as Uint8Array,
 
-    async genSharedKey (theirPub: Uint8Array, forcePrivate?: ECDHKeyPair): Promise<Uint8Array> { // eslint-disable-line require-await
+    async genSharedKey (theirPub: Uint8Array, forcePrivate?: ECDHKeyPair): Promise<Uint8Array> {
       if (forcePrivate != null) {
         ecdh.setPrivateKey(forcePrivate.private)
       }

--- a/packages/crypto/src/keys/ed25519-class.ts
+++ b/packages/crypto/src/keys/ed25519-class.ts
@@ -15,7 +15,7 @@ export class Ed25519PublicKey {
     this._key = ensureKey(key, crypto.publicKeyLength)
   }
 
-  async verify (data: Uint8Array, sig: Uint8Array): Promise<boolean> { // eslint-disable-line require-await
+  async verify (data: Uint8Array, sig: Uint8Array): Promise<boolean> {
     return crypto.hashAndVerify(this._key, sig, data)
   }
 
@@ -52,7 +52,7 @@ export class Ed25519PrivateKey {
     this._publicKey = ensureKey(publicKey, crypto.publicKeyLength)
   }
 
-  async sign (message: Uint8Array): Promise<Uint8Array> { // eslint-disable-line require-await
+  async sign (message: Uint8Array): Promise<Uint8Array> {
     return crypto.hashAndSign(this._key, message)
   }
 

--- a/packages/crypto/src/keys/index.ts
+++ b/packages/crypto/src/keys/index.ts
@@ -41,13 +41,13 @@ function typeToKey (type: string): typeof RSA | typeof Ed25519 | typeof Secp256k
 }
 
 // Generates a keypair of the given type and bitsize
-export async function generateKeyPair (type: KeyTypes, bits?: number): Promise<PrivateKey> { // eslint-disable-line require-await
+export async function generateKeyPair (type: KeyTypes, bits?: number): Promise<PrivateKey> {
   return typeToKey(type).generateKeyPair(bits ?? 2048)
 }
 
 // Generates a keypair of the given type and bitsize
 // seed is a 32 byte uint8array
-export async function generateKeyPairFromSeed (type: KeyTypes, seed: Uint8Array, bits?: number): Promise<PrivateKey> { // eslint-disable-line require-await
+export async function generateKeyPairFromSeed (type: KeyTypes, seed: Uint8Array, bits?: number): Promise<PrivateKey> {
   if (type.toLowerCase() !== 'ed25519') {
     throw new CodeError('Seed key derivation is unimplemented for RSA or secp256k1', 'ERR_UNSUPPORTED_KEY_DERIVATION_TYPE')
   }
@@ -82,7 +82,7 @@ export function marshalPublicKey (key: { bytes: Uint8Array }, type?: string): Ui
 
 // Converts a protobuf serialized private key into its
 // representative object
-export async function unmarshalPrivateKey (buf: Uint8Array): Promise<PrivateKey> { // eslint-disable-line require-await
+export async function unmarshalPrivateKey (buf: Uint8Array): Promise<PrivateKey> {
   const decoded = keysPBM.PrivateKey.decode(buf)
   const data = decoded.Data ?? new Uint8Array()
 
@@ -110,7 +110,7 @@ export function marshalPrivateKey (key: { bytes: Uint8Array }, type?: string): U
  * @param {string} encryptedKey
  * @param {string} password
  */
-export async function importKey (encryptedKey: string, password: string): Promise<PrivateKey> { // eslint-disable-line require-await
+export async function importKey (encryptedKey: string, password: string): Promise<PrivateKey> {
   try {
     const key = await importer(encryptedKey, password)
     return await unmarshalPrivateKey(key)

--- a/packages/crypto/src/keys/rsa-class.ts
+++ b/packages/crypto/src/keys/rsa-class.ts
@@ -19,7 +19,7 @@ export class RsaPublicKey {
     this._key = key
   }
 
-  async verify (data: Uint8Array, sig: Uint8Array): Promise<boolean> { // eslint-disable-line require-await
+  async verify (data: Uint8Array, sig: Uint8Array): Promise<boolean> {
     return crypto.hashAndVerify(this._key, sig, data)
   }
 
@@ -62,7 +62,7 @@ export class RsaPrivateKey {
     return crypto.getRandomValues(16)
   }
 
-  async sign (message: Uint8Array): Promise<Uint8Array> { // eslint-disable-line require-await
+  async sign (message: Uint8Array): Promise<Uint8Array> {
     return crypto.hashAndSign(this._key, message)
   }
 
@@ -114,7 +114,7 @@ export class RsaPrivateKey {
   /**
    * Exports the key into a password protected PEM format
    */
-  async export (password: string, format = 'pkcs-8'): Promise<Multibase<'m'>> { // eslint-disable-line require-await
+  async export (password: string, format = 'pkcs-8'): Promise<Multibase<'m'>> {
     if (format === 'pkcs-8') {
       const buffer = new forge.util.ByteBuffer(this.marshal())
       const asn1 = forge.asn1.fromDer(buffer)

--- a/packages/crypto/src/keys/rsa.ts
+++ b/packages/crypto/src/keys/rsa.ts
@@ -9,7 +9,7 @@ const keypair = promisify(crypto.generateKeyPair)
 
 export { utils }
 
-export async function generateKey (bits: number): Promise<JWKKeyPair> { // eslint-disable-line require-await
+export async function generateKey (bits: number): Promise<JWKKeyPair> {
   // @ts-expect-error node types are missing jwk as a format
   const key = await keypair('rsa', {
     modulusLength: bits,
@@ -26,7 +26,7 @@ export async function generateKey (bits: number): Promise<JWKKeyPair> { // eslin
 }
 
 // Takes a jwk key
-export async function unmarshalPrivateKey (key: JsonWebKey): Promise<JWKKeyPair> { // eslint-disable-line require-await
+export async function unmarshalPrivateKey (key: JsonWebKey): Promise<JWKKeyPair> {
   if (key == null) {
     throw new CodeError('Missing key parameter', 'ERR_MISSING_KEY')
   }
@@ -49,7 +49,7 @@ export async function hashAndSign (key: JsonWebKey, msg: Uint8Array): Promise<Ui
     .sign({ format: 'jwk', key })
 }
 
-export async function hashAndVerify (key: JsonWebKey, sig: Uint8Array, msg: Uint8Array): Promise<boolean> { // eslint-disable-line require-await
+export async function hashAndVerify (key: JsonWebKey, sig: Uint8Array, msg: Uint8Array): Promise<boolean> {
   return crypto.createVerify('RSA-SHA256')
     .update(msg)
     // @ts-expect-error node types are missing jwk as a format


### PR DESCRIPTION
These eslint-disable-line comments are no longer needed.
They were added ~3 years ago and do not affect current linting rules.

provenance: https://github.com/libp2p/js-libp2p/commit/7273739f045b33a46aae45f5003dd09f7ea6e37e

related: https://github.com/libp2p/js-libp2p/issues/1949
