### PR TITLE
fix(libp2p): reduce dialer activity in browsers

### DIFF
--- a/packages/libp2p/package.json
+++ b/packages/libp2p/package.json
@@ -191,6 +191,7 @@
     "sinon-ts": "^1.0.0"
   },
   "browser": {
+    "./dist/src/connection-manager/constants.js": "./dist/src/connection-manager/constants.browser.js",
     "./dist/src/config/connection-gater.js": "./dist/src/config/connection-gater.browser.js"
   }
 }

--- a/packages/libp2p/src/connection-manager/constants.browser.ts
+++ b/packages/libp2p/src/connection-manager/constants.browser.ts
@@ -3,19 +3,19 @@ export * from './constants.defaults.js'
 /**
  * @see https://libp2p.github.io/js-libp2p/interfaces/index._internal_.ConnectionManagerConfig.html#maxParallelDials
  */
-export const MAX_PARALLEL_DIALS = 100
+export const MAX_PARALLEL_DIALS = 10
 
 /**
  * @see https://libp2p.github.io/js-libp2p/interfaces/index._internal_.ConnectionManagerConfig.html#minConnections
  */
-export const MIN_CONNECTIONS = 50
+export const MIN_CONNECTIONS = 5
 
 /**
  * @see https://libp2p.github.io/js-libp2p/interfaces/index._internal_.ConnectionManagerConfig.html#maxConnections
  */
-export const MAX_CONNECTIONS = 300
+export const MAX_CONNECTIONS = 100
 
 /**
  * @see https://libp2p.github.io/js-libp2p/interfaces/index._internal_.ConnectionManagerConfig.html#autoDialConcurrency
  */
-export const AUTO_DIAL_CONCURRENCY = 25
+export const AUTO_DIAL_CONCURRENCY = 10

--- a/packages/libp2p/src/connection-manager/constants.defaults.ts
+++ b/packages/libp2p/src/connection-manager/constants.defaults.ts
@@ -1,0 +1,44 @@
+/**
+ * @see https://libp2p.github.io/js-libp2p/interfaces/index._internal_.ConnectionManagerConfig.html#dialTimeout
+ */
+export const DIAL_TIMEOUT = 30e3
+
+/**
+ * @see https://libp2p.github.io/js-libp2p/interfaces/index._internal_.ConnectionManagerConfig.html#inboundUpgradeTimeout
+ */
+export const INBOUND_UPGRADE_TIMEOUT = 30e3
+
+/**
+ * @see https://libp2p.github.io/js-libp2p/interfaces/index._internal_.ConnectionManagerConfig.html#maxPeerAddrsToDial
+ */
+export const MAX_PEER_ADDRS_TO_DIAL = 25
+
+/**
+ * @see https://libp2p.github.io/js-libp2p/interfaces/index._internal_.ConnectionManagerConfig.html#maxParallelDialsPerPeer
+ */
+export const MAX_PARALLEL_DIALS_PER_PEER = 10
+
+/**
+ * @see https://libp2p.github.io/js-libp2p/interfaces/index._internal_.ConnectionManagerConfig.html#autoDialInterval
+ */
+export const AUTO_DIAL_INTERVAL = 5000
+
+/**
+ * @see https://libp2p.github.io/js-libp2p/interfaces/index._internal_.ConnectionManagerConfig.html#autoDialPriority
+ */
+export const AUTO_DIAL_PRIORITY = 0
+
+/**
+ * @see https://libp2p.github.io/js-libp2p/interfaces/index._internal_.ConnectionManagerConfig.html#autoDialMaxQueueLength
+ */
+export const AUTO_DIAL_MAX_QUEUE_LENGTH = 100
+
+/**
+ * @see https://libp2p.github.io/js-libp2p/interfaces/index._internal_.ConnectionManagerConfig.html#inboundConnectionThreshold
+ */
+export const INBOUND_CONNECTION_THRESHOLD = 5
+
+/**
+ * @see https://libp2p.github.io/js-libp2p/interfaces/index._internal_.ConnectionManagerConfig.html#maxIncomingPendingConnections
+ */
+export const MAX_INCOMING_PENDING_CONNECTIONS = 10


### PR DESCRIPTION
Use a different set of defaults for browsers vs node - from testing we never really see more than 20x connections so there's no point having the auto-dialler trying to reach 50x, also reduce the number of concurrent dials and how many peers we try to autodial at once.