### PR TITLE
fix(@libp2p/interface-compliance-tests): add aegir to deps

### DIFF
--- a/packages/interface-compliance-tests/package.json
+++ b/packages/interface-compliance-tests/package.json
@@ -111,6 +111,7 @@
     "@libp2p/peer-id-factory": "^3.0.3",
     "@multiformats/multiaddr": "^12.1.5",
     "abortable-iterator": "^5.0.1",
+    "aegir": "^40.0.11",
     "delay": "^6.0.0",
     "it-all": "^3.0.2",
     "it-drain": "^3.0.2",
@@ -134,7 +135,6 @@
     "uint8arrays": "^4.0.6"
   },
   "devDependencies": {
-    "aegir": "^40.0.8",
     "protons": "^7.0.2"
   }
 }


### PR DESCRIPTION
Given that this package is primarily responsible for testing, I think that `aegir` is required as a dependency to utilize it properly.

Closes #1974