### PR TITLE
refactor(libp2p): remove unnecessary any-signal

### DIFF
--- a/packages/libp2p/src/autonat/index.ts
+++ b/packages/libp2p/src/autonat/index.ts
@@ -25,7 +25,6 @@ import { peerIdFromBytes } from '@libp2p/peer-id'
 import { createEd25519PeerId } from '@libp2p/peer-id-factory'
 import { multiaddr, protocols } from '@multiformats/multiaddr'
 import { abortableDuplex } from 'abortable-iterator'
-import { anySignal } from 'any-signal'
 import first from 'it-first'
 import * as lp from 'it-length-prefixed'
 import map from 'it-map'
@@ -154,7 +153,7 @@ class DefaultAutoNATService implements Startable {
    * Handle an incoming AutoNAT request
    */
   async handleIncomingAutonatStream (data: IncomingStreamData): Promise<void> {
-    const signal = anySignal([AbortSignal.timeout(this.timeout)])
+    const signal = AbortSignal.timeout(this.timeout)
 
     // this controller may be used while dialing lots of peers so prevent MaxListenersExceededWarning
     // appearing in the console
@@ -386,8 +385,6 @@ class DefaultAutoNATService implements Startable {
       )
     } catch (err) {
       log.error('error handling incoming autonat stream', err)
-    } finally {
-      signal.clear()
     }
   }
 

--- a/packages/libp2p/src/upgrader.ts
+++ b/packages/libp2p/src/upgrader.ts
@@ -4,7 +4,6 @@ import { logger } from '@libp2p/logger'
 import * as mss from '@libp2p/multistream-select'
 import { peerIdFromString } from '@libp2p/peer-id'
 import { abortableDuplex } from 'abortable-iterator'
-import { anySignal } from 'any-signal'
 import { createConnection } from './connection/index.js'
 import { INBOUND_UPGRADE_TIMEOUT } from './connection-manager/constants.js'
 import { codes } from './errors.js'
@@ -164,7 +163,7 @@ export class DefaultUpgrader implements Upgrader {
     let muxerFactory: StreamMuxerFactory | undefined
     let cryptoProtocol
 
-    const signal = anySignal([AbortSignal.timeout(this.inboundUpgradeTimeout)])
+    const signal = AbortSignal.timeout(this.inboundUpgradeTimeout)
 
     try {
       // fails on node < 15.4
@@ -257,7 +256,6 @@ export class DefaultUpgrader implements Upgrader {
       })
     } finally {
       this.components.connectionManager.afterUpgradeInbound()
-      signal.clear()
     }
   }
 


### PR DESCRIPTION
Removes use of `any-signal` where we only have one signal.