### PR TITLE
chore: add a PR template to guide contribution etiquette

### DIFF
--- a/.github/pull_request_template.md
+++ b/.github/pull_request_template.md
@@ -4,7 +4,7 @@ The title of the PR will be the commit message of the merge commit, so please ma
 We utilize the Conventional Commits specification for our commit messages. See <https://www.conventionalcommits.org/en/v1.0.0/#specification> for more information.
 The commit tag types can be of one of the following: feat, fix, deps, refactor, chore, docs. See <https://github.com/libp2p/js-libp2p/blob/master/.github/workflows/main.yml#L235-L242>
 
-The title must also be less than 72 characters long or it will fail the Semantic PR check. See <https://github.com/libp2p/js-libp2p/blob/master/.github/workflows/semantic-pull-request.yml>
+The title must also be fewer than 72 characters long or it will fail the Semantic PR check. See <https://github.com/libp2p/js-libp2p/blob/master/.github/workflows/semantic-pull-request.yml>
 
 --->
 

--- a/.github/pull_request_template.md
+++ b/.github/pull_request_template.md
@@ -1,0 +1,31 @@
+## Title
+<!---
+The title of the PR will be the commit message of the merge commit, so please make sure it is descriptive enough.
+We utilize the Conventional Commits specification for our commit messages. See <https://www.conventionalcommits.org/en/v1.0.0/#specification> for more information.
+The commit tag types can be of one of the following: feat, fix, deps, refactor, chore, docs. See <https://github.com/libp2p/js-libp2p/blob/master/.github/workflows/main.yml#L235-L242>
+
+The title must also be less than 72 characters long or it will fail the Semantic PR check. See <https://github.com/libp2p/js-libp2p/blob/master/.github/workflows/semantic-pull-request.yml>
+
+--->
+
+## Description
+
+<!--
+Please write a summary of your changes and why you made them.
+Please include any relevant issues in here, for example:
+
+Related https://github.com/libp2p/js-libp2p/issues/ABCD.
+Fixes https://github.com/libp2p/js-libp2p/issues/XYZ.
+-->
+
+## Notes & open questions
+
+<!--
+Any notes, remarks or open questions you have to make about the PR which don't need to go into the final commit message.
+-->
+
+## Change checklist
+
+- [ ] I have performed a self-review of my own code
+- [ ] I have made corresponding changes to the documentation if necessary (this includes comments as well)
+- [ ] I have added tests that prove my fix is effective or that my feature works


### PR DESCRIPTION
## Description

<!--
Please write a summary of your changes and why you made them.
Please include any relevant issues in here, for example:
Related [https://github.com/libp2p/js-libp2p/issues/ABCD.](https://github.com/libp2p/js-libp2p/issues/ABCD.?q=is%3Aissue+is%3Aopen+sort%3Aupdated-desc)
Fixes [https://github.com/libp2p/js-libp2p/issues/XYZ.](https://github.com/libp2p/js-libp2p/issues/XYZ.?q=is%3Aissue+is%3Aopen+sort%3Aupdated-desc)
-->

I have found the template used on PR to [rust-libp2p](https://github.com/libp2p/rust-libp2p/blob/master/.github/pull_request_template.md) helpful in guiding contributions to that repo. This PR serves to help the conversation around commit and code review etiquette to this repo
 
## Notes & open questions

<!--
Any notes, remarks or open questions you have to make about the PR which don't need to go into the final commit message.
-->

Open to any suggestions and feedback.

## Change checklist

- [x] I have performed a self-review of my own code
- [ ] I have made corresponding changes to the documentation if necessary (this includes comments as well)
- [ ] I have added tests that prove my fix is effective or that my feature works