### PR TITLE
chore: publish multidim interop test module

### DIFF
--- a/interop/README.md
+++ b/interop/README.md
@@ -1,11 +1,11 @@
-# multidim-interop <!-- omit in toc -->
+# @libp2p/multidim-interop <!-- omit in toc -->
 
 [![libp2p.io](https://img.shields.io/badge/project-libp2p-yellow.svg?style=flat-square)](http://libp2p.io/)
 [![Discuss](https://img.shields.io/discourse/https/discuss.libp2p.io/posts.svg?style=flat-square)](https://discuss.libp2p.io)
 [![codecov](https://img.shields.io/codecov/c/github/libp2p/js-libp2p.svg?style=flat-square)](https://codecov.io/gh/libp2p/js-libp2p)
 [![CI](https://img.shields.io/github/actions/workflow/status/libp2p/js-libp2p/main.yml?branch=master\&style=flat-square)](https://github.com/libp2p/js-libp2p/actions/workflows/main.yml?query=branch%3Amaster)
 
-> Multidimension Interop Test
+> Multidimensional interop tests
 
 ## Table of contents <!-- omit in toc -->
 

--- a/interop/package.json
+++ b/interop/package.json
@@ -1,7 +1,7 @@
 {
-  "name": "multidim-interop",
+  "name": "@libp2p/multidim-interop",
   "version": "1.0.0",
-  "description": "Multidimension Interop Test",
+  "description": "Multidimensional interop tests",
   "author": "Glen De Cauwsemaecker <glen@littlebearlabs.io> / @marcopolo",
   "license": "Apache-2.0 OR MIT",
   "homepage": "https://github.com/libp2p/js-libp2p/tree/master/interop#readme",
@@ -16,8 +16,18 @@
   "types": "./dist/src/index.d.ts",
   "files": [
     "src",
+    "test",
     "dist",
-    "!dist/test",
+    ".aegir.js",
+    "BrowserDockerfile",
+    "chromium-version.json",
+    "Dockerfile",
+    "firefox-version.json",
+    "Makefile",
+    "node-version.json",
+    "relay.js",
+    "tsconfig.json",
+    "webkit-version.json",
     "!**/*.tsbuildinfo"
   ],
   "exports": {
@@ -56,6 +66,5 @@
   },
   "browser": {
     "@libp2p/tcp": false
-  },
-  "private": true
+  }
 }


### PR DESCRIPTION
This module is now published as `@libp2p/multidim-interop`.

Closes #2005