### PR TITLE
fix(libp2p): update peer store with supported protocols after unhandle

### DIFF
--- a/packages/libp2p/src/registrar.ts
+++ b/packages/libp2p/src/registrar.ts
@@ -109,7 +109,7 @@ export class DefaultRegistrar implements Registrar {
 
     // Update self protocols in the peer store
     await this.components.peerStore.patch(this.components.peerId, {
-      protocols: protocolList
+      protocols: this.getProtocols()
     })
   }
 

--- a/packages/libp2p/test/registrar/registrar.spec.ts
+++ b/packages/libp2p/test/registrar/registrar.spec.ts
@@ -297,6 +297,10 @@ describe('registrar', () => {
       await libp2p.unhandle(['/echo/1.0.0'])
       expect(registrar.getProtocols()).to.not.have.any.keys(['/echo/1.0.0'])
       expect(registrar.getHandler('/echo/1.0.1')).to.have.property('handler', echoHandler)
+
+      await expect(libp2p.peerStore.get(libp2p.peerId)).to.eventually.have.deep.property('protocols', [
+        '/echo/1.0.1'
+      ])
     })
   })
 })


### PR DESCRIPTION
When unhandling a protocol, update the peer store entry for the current peer with the correct set of protocols.