### PR TITLE
fix(@libp2p/mdns): do not send TXT records that are too long

### DIFF
--- a/packages/peer-discovery-mdns/package.json
+++ b/packages/peer-discovery-mdns/package.json
@@ -47,6 +47,7 @@
     "@libp2p/interface": "^0.1.2",
     "@libp2p/logger": "^3.0.2",
     "@libp2p/peer-id": "^3.0.2",
+    "@libp2p/utils": "^4.0.2",
     "@multiformats/multiaddr": "^12.1.5",
     "@types/multicast-dns": "^7.2.1",
     "dns-packet": "^5.4.0",

--- a/packages/peer-discovery-mdns/src/query.ts
+++ b/packages/peer-discovery-mdns/src/query.ts
@@ -1,6 +1,5 @@
 import { logger } from '@libp2p/logger'
 import { peerIdFromString } from '@libp2p/peer-id'
-import { isLoopback } from '@libp2p/utils/multiaddr/is-loopback'
 import { isPrivate } from '@libp2p/utils/multiaddr/is-private'
 import { multiaddr, type Multiaddr, protocols } from '@multiformats/multiaddr'
 import type { PeerInfo } from '@libp2p/interface/peer-info'
@@ -139,13 +138,7 @@ export function gotQuery (qry: QueryPacket, mdns: MulticastDNS, peerName: string
 }
 
 function isLinkLocal (ma: Multiaddr): boolean {
-  // loopback addresses should not be sent
-  // https://github.com/libp2p/specs/blob/master/discovery/mdns.md#issues
-  if (isLoopback(ma)) {
-    return false
-  }
-
-  // match private ip4/ip6 addresses
+  // match private ip4/ip6 & loopback addresses
   if (isPrivate(ma)) {
     return true
   }

--- a/packages/peer-discovery-mdns/src/query.ts
+++ b/packages/peer-discovery-mdns/src/query.ts
@@ -1,6 +1,8 @@
 import { logger } from '@libp2p/logger'
 import { peerIdFromString } from '@libp2p/peer-id'
-import { multiaddr, type Multiaddr } from '@multiformats/multiaddr'
+import { isLoopback } from '@libp2p/utils/multiaddr/is-loopback'
+import { isPrivate } from '@libp2p/utils/multiaddr/is-private'
+import { multiaddr, type Multiaddr, protocols } from '@multiformats/multiaddr'
 import type { PeerInfo } from '@libp2p/interface/peer-info'
 import type { Answer, StringAnswer, TxtAnswer } from 'dns-packet'
 import type { MulticastDNS, QueryPacket, ResponsePacket } from 'multicast-dns'
@@ -9,7 +11,7 @@ const log = logger('libp2p:mdns:query')
 
 export function queryLAN (mdns: MulticastDNS, serviceTag: string, interval: number): ReturnType<typeof setInterval> {
   const query = (): void => {
-    log('query', serviceTag)
+    log.trace('query', serviceTag)
 
     mdns.query({
       questions: [{
@@ -40,6 +42,16 @@ export function gotResponse (rsp: ResponsePacket, localPeerName: string, service
     }
   })
 
+  // according to the spec, peer details should be in the additional records,
+  // not the answers though it seems go-libp2p at least ignores this?
+  // https://github.com/libp2p/specs/blob/master/discovery/mdns.md#response
+  rsp.additionals.forEach((answer) => {
+    switch (answer.type) {
+      case 'TXT': txtAnswers.push(answer); break
+      default: break
+    }
+  })
+
   if (answerPTR == null ||
     answerPTR?.name !== serviceTag ||
     txtAnswers.length === 0 ||
@@ -63,7 +75,7 @@ export function gotResponse (rsp: ResponsePacket, localPeerName: string, service
 
     return {
       id: peerIdFromString(peerId),
-      multiaddrs,
+      multiaddrs: multiaddrs.map(addr => addr.decapsulateCode(protocols('p2p').code)),
       protocols: []
     }
   } catch (e) {
@@ -92,20 +104,51 @@ export function gotQuery (qry: QueryPacket, mdns: MulticastDNS, peerName: string
       data: peerName + '.' + serviceTag
     })
 
-    multiaddrs.forEach((addr) => {
-      // spec mandates multiaddr contains peer id
-      if (addr.getPeerId() != null) {
+    multiaddrs
+      // mDNS requires link-local addresses only
+      // https://github.com/libp2p/specs/blob/master/discovery/mdns.md#issues
+      .filter(isLinkLocal)
+      .forEach((addr) => {
+        const data = 'dnsaddr=' + addr.toString()
+
+        // TXT record fields have a max data length of 255 bytes
+        // see 6.1 - https://www.ietf.org/rfc/rfc6763.txt
+        if (data.length > 255) {
+          log('multiaddr %a is too long to use in mDNS query response', addr)
+          return
+        }
+
+        // spec mandates multiaddr contains peer id
+        if (addr.getPeerId() == null) {
+          log('multiaddr %a did not have a peer ID so cannot be used in mDNS query response', addr)
+          return
+        }
+
         answers.push({
           name: peerName + '.' + serviceTag,
           type: 'TXT',
           class: 'IN',
           ttl: 120,
-          data: 'dnsaddr=' + addr.toString()
+          data
         })
-      }
-    })
+      })
 
-    log('responding to query')
+    log.trace('responding to query')
     mdns.respond(answers)
   }
+}
+
+function isLinkLocal (ma: Multiaddr): boolean {
+  // loopback addresses should not be sent
+  // https://github.com/libp2p/specs/blob/master/discovery/mdns.md#issues
+  if (isLoopback(ma)) {
+    return false
+  }
+
+  // match private ip4/ip6 addresses
+  if (isPrivate(ma)) {
+    return true
+  }
+
+  return false
 }

--- a/packages/peer-discovery-mdns/test/compliance.spec.ts
+++ b/packages/peer-discovery-mdns/test/compliance.spec.ts
@@ -1,6 +1,7 @@
 /* eslint-env mocha */
 
 import { CustomEvent } from '@libp2p/interface/events'
+import { isStartable } from '@libp2p/interface/startable'
 import tests from '@libp2p/interface-compliance-tests/peer-discovery'
 import { createEd25519PeerId } from '@libp2p/peer-id-factory'
 import { multiaddr } from '@multiformats/multiaddr'
@@ -32,16 +33,21 @@ describe('compliance tests', () => {
       })
 
       // Trigger discovery
-      const maStr = '/ip4/127.0.0.1/tcp/15555/ws/p2p-webrtc-star/p2p/QmcgpsyWgH8Y8ajJz1Cu72KnS5uo2Aa2LpzU7kinSooo2d'
+      const maStr = '/ip4/127.0.0.1/tcp/15555/ws/p2p-webrtc-star'
 
-      // @ts-expect-error not a PeerDiscovery field
-      intervalId = setInterval(() => discovery._onPeer(new CustomEvent('peer', {
-        detail: {
-          id: peerId2,
-          multiaddrs: [multiaddr(maStr)],
-          protocols: []
+      intervalId = setInterval(() => {
+        if (isStartable(discovery) && !discovery.isStarted()) {
+          return
         }
-      })), 1000)
+
+        discovery.dispatchEvent(new CustomEvent('peer', {
+          detail: {
+            id: peerId2,
+            multiaddrs: [multiaddr(maStr)],
+            protocols: []
+          }
+        }))
+      }, 1000)
 
       return discovery
     },

--- a/packages/peer-discovery-mdns/test/multicast-dns.spec.ts
+++ b/packages/peer-discovery-mdns/test/multicast-dns.spec.ts
@@ -219,8 +219,6 @@ describe('MulticastDNS', () => {
     const publicAddress = '/ip4/48.52.76.32/tcp/1234'
     const relayDnsAddress = `/dnsaddr/example.org/tcp/1234/p2p/${pD.toString()}/p2p-circuit`
     const dnsAddress = '/dns4/example.org/tcp/1234'
-    const loopbackAddress = '/ip4/127.0.0.1/tcp/1234'
-    const loopbackAddress6 = '/ip6/::1/tcp/1234'
 
     // this address is too long to fit in a TXT record
     const longAddress = `/ip4/192.168.1.142/udp/4001/quic-v1/webtransport/certhash/uEiDils3hWFJmsWOJIoMPxAcpzlyFNxTDZpklIoB8643ddw/certhash/uEiAM4BGr4OMK3O9cFGwfbNc4J7XYnsKE5wNPKKaTLa4fkw/p2p/${pD.toString()}/p2p-circuit`
@@ -229,6 +227,11 @@ describe('MulticastDNS', () => {
     const relayAddress = `/ip4/192.168.1.142/tcp/1234/p2p/${pD.toString()}/p2p-circuit`
     const localAddress = '/ip4/192.168.1.123/tcp/1234'
     const localWsAddress = '/ip4/192.168.1.123/tcp/1234/ws'
+
+    // these are not link-local but go-libp2p advertises loopback addresses even
+    // though you shouldn't for mDNS
+    const loopbackAddress = '/ip4/127.0.0.1/tcp/1234'
+    const loopbackAddress6 = '/ip6/::1/tcp/1234'
 
     const mdnsA = mdns({
       broadcast: false, // do not talk to ourself
@@ -265,9 +268,7 @@ describe('MulticastDNS', () => {
       publicAddress,
       relayDnsAddress,
       dnsAddress,
-      longAddress,
-      loopbackAddress,
-      loopbackAddress6
+      longAddress
     ].forEach(addr => {
       expect(multiaddrs.map(ma => ma.toString()))
         .to.not.include(addr)
@@ -276,7 +277,9 @@ describe('MulticastDNS', () => {
     ;[
       relayAddress,
       localAddress,
-      localWsAddress
+      localWsAddress,
+      loopbackAddress,
+      loopbackAddress6
     ].forEach(addr => {
       expect(multiaddrs.map(ma => ma.toString()))
         .to.include(addr)


### PR DESCRIPTION
The data field of mDNS TXT records has a [hard limit of 255 characters](https://agnat.github.io/node_mdns/user_guide.html#txt_records) - some multiaddrs can be longer than this so filter them out before sending, otherwise remote peers can fail to parse our mDNS response.

We should also only be sending [link-local addresses](https://github.com/libp2p/specs/blob/master/discovery/mdns.md#issues) in mDNS responses so filter any non-link-local addresses out too, though go-libp2p includes loopback addresses even though it probably shouldn't (according to the mDNS spec which conflicts with our mDNS Peer Discovery spec) so we continue to do so as well.

Fixes #2012