### PR TITLE
fix(@libp2p/webtransport): remove filters export

### DIFF
--- a/packages/transport-webtransport/package.json
+++ b/packages/transport-webtransport/package.json
@@ -42,10 +42,6 @@
     ".": {
       "types": "./src/index.d.ts",
       "import": "./dist/src/index.js"
-    },
-    "./filters": {
-      "types": "./dist/src/filters.d.ts",
-      "import": "./dist/src/filters.js"
     }
   },
   "eslintConfig": {

--- a/packages/transport-webtransport/typedoc.json
+++ b/packages/transport-webtransport/typedoc.json
@@ -1,6 +1,5 @@
 {
   "entryPoints": [
-    "./src/index.ts",
-    "./src/filters.ts"
+    "./src/index.ts"
   ]
 }


### PR DESCRIPTION
This file does not exist in this project so remove it from the exports map.