### PR TITLE
fix(libp2p): emit peer:discovered event on internal event bus

### DIFF
--- a/packages/libp2p/src/connection-manager/auto-dial.ts
+++ b/packages/libp2p/src/connection-manager/auto-dial.ts
@@ -77,6 +77,15 @@ export class AutoDial implements Startable {
           log.error(err)
         })
     })
+
+    // when new peers are discovered, dial them if we don't have
+    // enough connections
+    components.events.addEventListener('peer:discovery', () => {
+      this.autoDial()
+        .catch(err => {
+          log.error(err)
+        })
+    })
   }
 
   isStarted (): boolean {

--- a/packages/libp2p/src/connection-manager/constants.defaults.ts
+++ b/packages/libp2p/src/connection-manager/constants.defaults.ts
@@ -39,6 +39,11 @@ export const AUTO_DIAL_MAX_QUEUE_LENGTH = 100
 export const AUTO_DIAL_PEER_RETRY_THRESHOLD = 1000 * 60
 
 /**
+ * @see https://libp2p.github.io/js-libp2p/interfaces/libp2p.index.unknown.ConnectionManagerInit.html#autoDialDiscoveredPeersDebounce
+ */
+export const AUTO_DIAL_DISCOVERED_PEERS_DEBOUNCE = 10
+
+/**
  * @see https://libp2p.github.io/js-libp2p/interfaces/index._internal_.ConnectionManagerConfig.html#inboundConnectionThreshold
  */
 export const INBOUND_CONNECTION_THRESHOLD = 5

--- a/packages/libp2p/src/connection-manager/index.ts
+++ b/packages/libp2p/src/connection-manager/index.ts
@@ -73,6 +73,14 @@ export interface ConnectionManagerInit {
   autoDialPeerRetryThreshold?: number
 
   /**
+   * Newly discovered peers may be auto-dialed to increase the number of open
+   * connections, but they can be discovered in quick succession so add a small
+   * delay before attempting to dial them in case more peers have been
+   * discovered. (default: 10ms)
+   */
+  autoDialDiscoveredPeersDebounce?: number
+
+  /**
    * Sort the known addresses of a peer before trying to dial, By default public
    * addresses will be dialled before private (e.g. loopback or LAN) addresses.
    */

--- a/packages/libp2p/src/libp2p.ts
+++ b/packages/libp2p/src/libp2p.ts
@@ -105,7 +105,7 @@ export class Libp2pNode<T extends ServiceMap = Record<string, unknown>> extends 
           protocols: evt.detail.peer.protocols
         }
 
-        this.safeDispatchEvent('peer:discovery', { detail: peerInfo })
+        components.events.safeDispatchEvent('peer:discovery', { detail: peerInfo })
       }
     })
 


### PR DESCRIPTION
To notifiy components that a new peer has been discovered, emit the `peer:discovered` event on the event bus component.

Allows the auto-dialer to choose to dial newly discovered peers immediately instead of waiting for the next autodial interval.