### PR TITLE
fix(@libp2p/webtransport): remove custom WebTransport types

### DIFF
--- a/packages/transport-webtransport/src/index.ts
+++ b/packages/transport-webtransport/src/index.ts
@@ -187,7 +187,7 @@ class WebTransportTransport implements Transport {
             yield val.value
           }
 
-          if (val.done === true) {
+          if (val.done) {
             break
           }
         }
@@ -220,7 +220,7 @@ class WebTransportTransport implements Transport {
     return true
   }
 
-  webtransportMuxer (wt: InstanceType<typeof WebTransport>, cleanUpWTSession: WebTransportSessionCleanup): StreamMuxerFactory {
+  webtransportMuxer (wt: WebTransport, cleanUpWTSession: WebTransportSessionCleanup): StreamMuxerFactory {
     let streamIDCounter = 0
     const config = this.config
     return {
@@ -242,7 +242,7 @@ class WebTransportTransport implements Transport {
           while (true) {
             const { done, value: wtStream } = await reader.read()
 
-            if (done === true) {
+            if (done) {
               break
             }
 

--- a/packages/transport-webtransport/src/index.ts
+++ b/packages/transport-webtransport/src/index.ts
@@ -12,16 +12,6 @@ import type { StreamMuxerFactory, StreamMuxerInit, StreamMuxer } from '@libp2p/i
 import type { Source } from 'it-stream-types'
 import type { MultihashDigest } from 'multiformats/hashes/interface'
 
-declare global {
-  var WebTransport: any
-}
-
-// https://www.w3.org/TR/webtransport/#web-transport-close-info
-interface WebTransportCloseInfo {
-  closeCode: number
-  reason: string
-}
-
 interface WebTransportSessionCleanup {
   (closeInfo?: WebTransportCloseInfo): void
 }

--- a/packages/transport-webtransport/test/browser.ts
+++ b/packages/transport-webtransport/test/browser.ts
@@ -7,12 +7,6 @@ import { expect } from 'aegir/chai'
 import { createLibp2p, type Libp2p } from 'libp2p'
 import { webTransport } from '../src/index.js'
 
-declare global {
-  interface Window {
-    WebTransport: any
-  }
-}
-
 describe('libp2p-webtransport', () => {
   let node: Libp2p
 


### PR DESCRIPTION
TypeScript has shipped a release with built in WebTransport types so use these instead.