### PR TITLE
deps(@multidim-interop): add aegir to deps

### DIFF
--- a/interop/package.json
+++ b/interop/package.json
@@ -58,11 +58,9 @@
     "@libp2p/webtransport": "^3.0.0",
     "@multiformats/mafmt": "^12.1.2",
     "@multiformats/multiaddr": "^12.1.5",
+    "aegir": "^40.0.12",
     "libp2p": "^0.46.0",
     "redis": "^4.5.1"
-  },
-  "devDependencies": {
-    "aegir": "^40.0.8"
   },
   "browser": {
     "@libp2p/tcp": false


### PR DESCRIPTION
This whole package should have `aegir` as a dep since it's core functionality is built around testing js-libp2p with `aegir` via the [test command](https://github.com/libp2p/js-libp2p/blob/master/interop/package.json#L49) but especially In order to utilize `aegir` for browser multidim interop testing we should add `aegir` as a dependency here.

Related: https://github.com/libp2p/test-plans/pull/288