### PR TITLE
chore: add interop to release-please config

### DIFF
--- a/.release-please.json
+++ b/.release-please.json
@@ -4,6 +4,7 @@
   "bump-patch-for-minor-pre-major": true,
   "group-pull-request-title-pattern": "chore: release ${component}",
   "packages": {
+    "interop": {},
     "packages/crypto": {},
     "packages/interface": {},
     "packages/interface-compliance-tests": {},


### PR DESCRIPTION
Otherwise releases are not created for changes.

I think this is why #2023 did not create a "release master" issue.

Missed from #2008.