### PR TITLE
feat: track failed/successful dials per-address

### DIFF
--- a/packages/interface/src/peer-store/index.ts
+++ b/packages/interface/src/peer-store/index.ts
@@ -14,6 +14,16 @@ export interface Address {
    * Obtained from a signed peer record
    */
   isCertified: boolean
+
+  /**
+   * A timestamp of the last successful dial of this multiaddr
+   */
+  lastSuccess?: number
+
+  /**
+   * A timestamp of the last unsuccessful dial of this multiaddr
+   */
+  lastFailure?: number
 }
 
 /**

--- a/packages/peer-store/src/pb/peer.proto
+++ b/packages/peer-store/src/pb/peer.proto
@@ -26,6 +26,12 @@ message Address {
 
   // Flag to indicate if the address comes from a certified source
   optional bool isCertified = 2;
+
+  // ms timestamp when we last succesfully dialed this address
+  optional uint64 lastSuccess = 3;
+
+  // ms timestamp when we last failed to dial this address
+  optional uint64 lastFailure = 4;
 }
 
 message Tag {

--- a/packages/peer-store/src/pb/peer.ts
+++ b/packages/peer-store/src/pb/peer.ts
@@ -264,6 +264,8 @@ export namespace Peer {
 export interface Address {
   multiaddr: Uint8Array
   isCertified?: boolean
+  lastSuccess?: bigint
+  lastFailure?: bigint
 }
 
 export namespace Address {
@@ -286,6 +288,16 @@ export namespace Address {
           w.bool(obj.isCertified)
         }
 
+        if (obj.lastSuccess != null) {
+          w.uint32(24)
+          w.uint64(obj.lastSuccess)
+        }
+
+        if (obj.lastFailure != null) {
+          w.uint32(32)
+          w.uint64(obj.lastFailure)
+        }
+
         if (opts.lengthDelimited !== false) {
           w.ldelim()
         }
@@ -305,6 +317,12 @@ export namespace Address {
               break
             case 2:
               obj.isCertified = reader.bool()
+              break
+            case 3:
+              obj.lastSuccess = reader.uint64()
+              break
+            case 4:
+              obj.lastFailure = reader.uint64()
               break
             default:
               reader.skipType(tag & 7)

--- a/packages/peer-store/src/utils/bytes-to-peer.ts
+++ b/packages/peer-store/src/utils/bytes-to-peer.ts
@@ -30,10 +30,12 @@ export function bytesToPeer (peerId: PeerId, buf: Uint8Array): Peer {
   return {
     ...peer,
     id: peerId,
-    addresses: peer.addresses.map(({ multiaddr: ma, isCertified }) => {
+    addresses: peer.addresses.map(({ multiaddr: ma, isCertified, lastFailure, lastSuccess }) => {
       return {
         multiaddr: multiaddr(ma),
-        isCertified: isCertified ?? false
+        isCertified: isCertified ?? false,
+        lastFailure: lastFailure != null ? Number(lastFailure) : undefined,
+        lastSuccess: lastSuccess != null ? Number(lastSuccess) : undefined
       }
     }),
     metadata: peer.metadata,

--- a/packages/peer-store/src/utils/dedupe-addresses.ts
+++ b/packages/peer-store/src/utils/dedupe-addresses.ts
@@ -32,10 +32,14 @@ export async function dedupeFilterAndSortAddresses (peerId: PeerId, filter: Addr
 
     if (existingAddr != null) {
       addr.isCertified = existingAddr.isCertified || isCertified
+      addr.lastFailure = existingAddr.lastFailure != null ? BigInt(existingAddr.lastFailure) : undefined
+      addr.lastSuccess = existingAddr.lastSuccess != null ? BigInt(existingAddr.lastSuccess) : undefined
     } else {
       addressMap.set(maStr, {
         multiaddr: addr.multiaddr,
-        isCertified
+        isCertified,
+        lastFailure: addr.lastFailure != null ? Number(addr.lastFailure) : undefined,
+        lastSuccess: addr.lastSuccess != null ? Number(addr.lastSuccess) : undefined
       })
     }
   }
@@ -44,8 +48,10 @@ export async function dedupeFilterAndSortAddresses (peerId: PeerId, filter: Addr
     .sort((a, b) => {
       return a.multiaddr.toString().localeCompare(b.multiaddr.toString())
     })
-    .map(({ isCertified, multiaddr }) => ({
+    .map(({ isCertified, multiaddr, lastFailure, lastSuccess }) => ({
       isCertified,
-      multiaddr: multiaddr.bytes
+      multiaddr: multiaddr.bytes,
+      lastFailure: lastFailure != null ? BigInt(lastFailure) : undefined,
+      lastSuccess: lastSuccess != null ? BigInt(lastSuccess) : undefined
     }))
 }

--- a/packages/peer-store/src/utils/peer-data-to-datastore-peer.ts
+++ b/packages/peer-store/src/utils/peer-data-to-datastore-peer.ts
@@ -36,9 +36,11 @@ export function toDatastorePeer (peerId: PeerId, data: PeerData): PeerPB {
       .sort((a, b) => {
         return a.multiaddr.toString().localeCompare(b.multiaddr.toString())
       })
-      .map(({ multiaddr, isCertified }) => ({
+      .map(({ multiaddr, isCertified, lastFailure, lastSuccess }) => ({
         multiaddr: multiaddr.bytes,
-        isCertified
+        isCertified,
+        lastFailure: lastFailure != null ? BigInt(lastFailure) : undefined,
+        lastSuccess: lastSuccess != null ? BigInt(lastSuccess) : undefined
       })),
     protocols: (data.protocols ?? []).sort(),
     metadata: new Map(),


### PR DESCRIPTION
Instead of tracking which peer we failed to dial, track dial success or failure on a per-address basis.

This will let us detect when IPv6 is unsupported or certain transports (e.g. UDP ones) are blocked.

Refs: 2010