### PR TITLE
fix(@libp2p/webrtc): update stream logger name to webrtc

### DIFF
--- a/packages/transport-webrtc/src/stream.ts
+++ b/packages/transport-webrtc/src/stream.ts
@@ -281,6 +281,6 @@ export function createStream (options: WebRTCStreamOptions): WebRTCStream {
     dataChannelOptions,
     onEnd,
     channel,
-    log: logger(`libp2p:mplex:stream:${direction}:${channel.id}`)
+    log: logger(`libp2p:webrtc:stream:${direction}:${channel.id}`)
   })
 }


### PR DESCRIPTION
Fixes typo in stream logger name for webrtc transport