### PR TITLE
fix(@libp2p/webrtc): work around messages not being sent on node.js

### DIFF
--- a/packages/transport-webrtc/src/webrtc/rtc-data-channel.ts
+++ b/packages/transport-webrtc/src/webrtc/rtc-data-channel.ts
@@ -120,9 +120,12 @@ export class DataChannel extends EventTarget implements RTCDataChannel {
 
   close (): void {
     this.#readyState = 'closing'
-    this.dispatchEvent(new Event('closing'))
 
-    this.#dataChannel.close()
+    // temporary workaround for https://github.com/murat-dogan/node-datachannel/issues/188
+    setTimeout(() => {
+      this.dispatchEvent(new Event('closing'))
+      this.#dataChannel.close()
+    }, 1000)
   }
 
   send (data: string): void


### PR DESCRIPTION
Adds a small delay before closing streams to allow any queued messages to be sent.  Affects node.js only.

This should be revisited in future.

Refs: https://github.com/murat-dogan/node-datachannel/issues/188