### PR TITLE
feat: add mock stream pair

### DIFF
--- a/packages/interface-compliance-tests/src/mocks/connection.ts
+++ b/packages/interface-compliance-tests/src/mocks/connection.ts
@@ -170,7 +170,13 @@ export function mockConnection (maConn: MultiaddrConnection, opts: MockConnectio
   return connection
 }
 
-export function mockStream (stream: Duplex<AsyncGenerator<Uint8ArrayList>, Source<Uint8ArrayList | Uint8Array>, Promise<void>>): Stream {
+export interface StreamInit {
+  direction?: Direction
+  protocol?: string
+  id?: string
+}
+
+export function mockStream (stream: Duplex<AsyncGenerator<Uint8ArrayList>, Source<Uint8ArrayList | Uint8Array>, Promise<void>>, init: StreamInit = {}): Stream {
   return {
     ...stream,
     close: async () => {},
@@ -186,8 +192,29 @@ export function mockStream (stream: Duplex<AsyncGenerator<Uint8ArrayList>, Sourc
     id: `stream-${Date.now()}`,
     status: 'open',
     readStatus: 'ready',
-    writeStatus: 'ready'
+    writeStatus: 'ready',
+    ...init
   }
+}
+
+export interface StreamPairInit {
+  duplex: Duplex<AsyncGenerator<Uint8ArrayList>, Source<Uint8ArrayList | Uint8Array>, Promise<void>>
+  init?: StreamInit
+}
+
+export function streamPair (a: StreamPairInit, b: StreamPairInit, init: StreamInit = {}): [Stream, Stream] {
+  return [
+    mockStream(a.duplex, {
+      direction: 'outbound',
+      ...init,
+      ...(a.init ?? {})
+    }),
+    mockStream(b.duplex, {
+      direction: 'inbound',
+      ...init,
+      ...(b.init ?? {})
+    })
+  ]
 }
 
 export interface Peer {

--- a/packages/interface-compliance-tests/src/mocks/index.ts
+++ b/packages/interface-compliance-tests/src/mocks/index.ts
@@ -1,7 +1,7 @@
 export { mockConnectionEncrypter } from './connection-encrypter.js'
 export { mockConnectionGater } from './connection-gater.js'
 export { mockConnectionManager, mockNetwork } from './connection-manager.js'
-export { mockConnection, mockStream, connectionPair } from './connection.js'
+export { mockConnection, mockStream, streamPair, connectionPair } from './connection.js'
 export { mockMultiaddrConnection, mockMultiaddrConnPair } from './multiaddr-connection.js'
 export { mockMuxer } from './muxer.js'
 export { mockRegistrar } from './registrar.js'


### PR DESCRIPTION
Adds a `streamPair` convenience function to the interface mocks that returns two `Stream` objects where the duplex streams read/write to/from the other.