### PR TITLE
fix: only call closeWrite if we are still writing to the stream

### DIFF
--- a/packages/interface/src/stream-muxer/stream.ts
+++ b/packages/interface/src/stream-muxer/stream.ts
@@ -174,10 +174,14 @@ export abstract class AbstractStream implements Stream {
       }
 
       this.log.trace('sink finished reading from source')
-      this.writeStatus = 'done'
 
-      this.log.trace('sink calling closeWrite')
-      await this.closeWrite(options)
+      if (this.writeStatus === 'writing') {
+        this.writeStatus = 'done'
+
+        this.log.trace('sink calling closeWrite')
+        await this.closeWrite(options)
+      }
+
       this.onSinkEnd()
     } catch (err: any) {
       this.log.trace('sink ended with error, calling abort with error', err)


### PR DESCRIPTION
After a stream's source ends, only call `this.closeWrite` if `this.writeStatus` is still `"writing"`.

The stream could be closed by other mechanisms which call `.closeWrite` so guard on the stream writeable end state to ensure we don't duplicate closing actions.