### PR TITLE
fix: log websocket error on graceful close failure

### DIFF
--- a/packages/transport-websockets/src/socket-to-conn.ts
+++ b/packages/transport-websockets/src/socket-to-conn.ts
@@ -56,6 +56,7 @@ export function socketToMaConn (stream: DuplexWebSocket, remoteAddr: Multiaddr, 
       try {
         await stream.close()
       } catch (err: any) {
+        log.error('error closing WebSocket gracefully', err)
         this.abort(err)
       } finally {
         options.signal.removeEventListener('abort', listener)


### PR DESCRIPTION
When gracefully closing a websocket connection fails, log the error to make debugging easier.