### PR TITLE
fix: close webrtc streams

### DIFF
--- a/packages/interface/src/connection/index.ts
+++ b/packages/interface/src/connection/index.ts
@@ -82,7 +82,7 @@ export type ReadStatus = 'ready' | 'closing' | 'closed'
  * closing - the writable end is closing
  * closed - the writable end has closed
  */
-export type WriteStatus = 'ready' | 'writing' | 'done' | 'closing' | 'closed'
+export type WriteStatus = 'ready' | 'writing' | 'closing' | 'closed'
 
 /**
  * A Stream is a data channel between two peers that

--- a/packages/interface/src/connection/index.ts
+++ b/packages/interface/src/connection/index.ts
@@ -82,7 +82,7 @@ export type ReadStatus = 'ready' | 'closing' | 'closed'
  * closing - the writable end is closing
  * closed - the writable end has closed
  */
-export type WriteStatus = 'ready' | 'writing' | 'closing' | 'closed'
+export type WriteStatus = 'ready' | 'writing' | 'done' | 'closing' | 'closed'
 
 /**
  * A Stream is a data channel between two peers that

--- a/packages/interface/src/stream-muxer/stream.ts
+++ b/packages/interface/src/stream-muxer/stream.ts
@@ -225,7 +225,10 @@ export abstract class AbstractStream implements Stream {
     if (this.timeline.closeWrite != null) {
       this.log.trace('source and sink ended')
       this.timeline.close = Date.now()
-      this.status = 'closed'
+
+      if (this.status != 'aborted' && this.status != 'reset') {
+        this.status = 'closed'
+      }
 
       if (this.onEnd != null) {
         this.onEnd(this.endErr)
@@ -252,7 +255,10 @@ export abstract class AbstractStream implements Stream {
     if (this.timeline.closeRead != null) {
       this.log.trace('sink and source ended')
       this.timeline.close = Date.now()
-      this.status = 'closed'
+
+      if (this.status != 'aborted' && this.status != 'reset') {
+        this.status = 'closed'
+      }
 
       if (this.onEnd != null) {
         this.onEnd(this.endErr)

--- a/packages/interface/src/stream-muxer/stream.ts
+++ b/packages/interface/src/stream-muxer/stream.ts
@@ -226,7 +226,7 @@ export abstract class AbstractStream implements Stream {
       this.log.trace('source and sink ended')
       this.timeline.close = Date.now()
 
-      if (this.status != 'aborted' && this.status != 'reset') {
+      if (this.status !== 'aborted' && this.status !== 'reset') {
         this.status = 'closed'
       }
 
@@ -256,7 +256,7 @@ export abstract class AbstractStream implements Stream {
       this.log.trace('sink and source ended')
       this.timeline.close = Date.now()
 
-      if (this.status != 'aborted' && this.status != 'reset') {
+      if (this.status !== 'aborted' && this.status !== 'reset') {
         this.status = 'closed'
       }
 

--- a/packages/transport-webrtc/package.json
+++ b/packages/transport-webrtc/package.json
@@ -66,6 +66,7 @@
     "p-event": "^6.0.0",
     "p-timeout": "^6.1.2",
     "protons-runtime": "^5.0.0",
+    "race-signal": "^1.0.0",
     "uint8arraylist": "^2.4.3",
     "uint8arrays": "^4.0.6"
   },
@@ -77,10 +78,12 @@
     "@types/sinon": "^10.0.15",
     "aegir": "^40.0.8",
     "delay": "^6.0.0",
+    "it-drain": "^3.0.3",
     "it-length": "^3.0.2",
     "it-map": "^3.0.3",
     "it-pair": "^2.0.6",
     "libp2p": "^0.46.11",
+    "p-retry": "^6.1.0",
     "protons": "^7.0.2",
     "sinon": "^16.0.0",
     "sinon-ts": "^1.0.0"

--- a/packages/transport-webrtc/package.json
+++ b/packages/transport-webrtc/package.json
@@ -67,8 +67,7 @@
     "p-timeout": "^6.1.2",
     "protons-runtime": "^5.0.0",
     "uint8arraylist": "^2.4.3",
-    "uint8arrays": "^4.0.6",
-    "wherearewe": "^2.0.1"
+    "uint8arrays": "^4.0.6"
   },
   "devDependencies": {
     "@chainsafe/libp2p-yamux": "^5.0.0",

--- a/packages/transport-webrtc/src/muxer.ts
+++ b/packages/transport-webrtc/src/muxer.ts
@@ -172,7 +172,6 @@ export class DataChannelMuxer implements StreamMuxer {
       onEnd: () => {
         log.trace('stream %s %s %s onEnd', stream.direction, stream.id, stream.protocol)
         drainAndClose(channel, `outbound ${stream.id} ${stream.protocol}`, this.dataChannelOptions.drainTimeout)
-        channel.close() // Stream initiator is responsible for closing the channel
         this.streams = this.streams.filter(s => s.id !== stream.id)
         this.metrics?.increment({ stream_end: true })
         this.init?.onStreamEnd?.(stream)

--- a/packages/transport-webrtc/src/pb/message.proto
+++ b/packages/transport-webrtc/src/pb/message.proto
@@ -12,6 +12,12 @@ message Message {
     // The sender abruptly terminates the sending part of the stream. The
     // receiver can discard any data that it already received on that stream.
     RESET = 2;
+
+    // The sender previously received a FIN, when the reciever receives this
+    // it knows the sender has received it's FIN. It should send a FIN_ACK_ACK
+    // back to the sender.
+    // Workaround for https://bugs.chromium.org/p/chromium/issues/detail?id=1484907
+    FIN_ACK = 3;
   }
 
   optional Flag flag = 1;

--- a/packages/transport-webrtc/src/pb/message.proto
+++ b/packages/transport-webrtc/src/pb/message.proto
@@ -2,7 +2,8 @@ syntax = "proto3";
 
 message Message {
   enum Flag {
-    // The sender will no longer send messages on the stream.
+    // The sender will no longer send messages on the stream. The recipient
+    // should send a FIN_ACK back to the sender.
     FIN = 0;
 
     // The sender will no longer read messages on the stream. Incoming data is
@@ -13,9 +14,7 @@ message Message {
     // receiver can discard any data that it already received on that stream.
     RESET = 2;
 
-    // The sender previously received a FIN, when the reciever receives this
-    // it knows the sender has received it's FIN. It should send a FIN_ACK_ACK
-    // back to the sender.
+    // The sender previously received a FIN.
     // Workaround for https://bugs.chromium.org/p/chromium/issues/detail?id=1484907
     FIN_ACK = 3;
   }

--- a/packages/transport-webrtc/src/pb/message.ts
+++ b/packages/transport-webrtc/src/pb/message.ts
@@ -17,13 +17,15 @@ export namespace Message {
   export enum Flag {
     FIN = 'FIN',
     STOP_SENDING = 'STOP_SENDING',
-    RESET = 'RESET'
+    RESET = 'RESET',
+    FIN_ACK = 'FIN_ACK'
   }
 
   enum __FlagValues {
     FIN = 0,
     STOP_SENDING = 1,
-    RESET = 2
+    RESET = 2,
+    FIN_ACK = 3
   }
 
   export namespace Flag {

--- a/packages/transport-webrtc/src/private-to-private/initiate-connection.ts
+++ b/packages/transport-webrtc/src/private-to-private/initiate-connection.ts
@@ -4,7 +4,6 @@ import { peerIdFromString } from '@libp2p/peer-id'
 import { multiaddr, type Multiaddr } from '@multiformats/multiaddr'
 import { pbStream } from 'it-protobuf-stream'
 import pDefer, { type DeferredPromise } from 'p-defer'
-import { isNode, isElectronMain } from 'wherearewe'
 import { type RTCPeerConnection, RTCSessionDescription } from '../webrtc/index.js'
 import { Message } from './pb/message.js'
 import { SIGNALING_PROTO_ID, splitAddr, type WebRTCTransportMetrics } from './transport.js'
@@ -152,13 +151,8 @@ export async function initiateConnection ({ peerConnection, signal, metrics, mul
         signal
       })
 
-      // TODO: workaround for https://github.com/murat-dogan/node-datachannel/issues/196
-      if (!isNode && !isElectronMain) {
-        log.trace('initiator connected, closing init channel')
-
-        // close init channel as we are connected now
-        channel.close()
-      }
+      log.trace('initiator connected, closing init channel')
+      channel.close()
 
       const remoteAddress = parseRemoteAddress(peerConnection.currentRemoteDescription?.sdp ?? '')
 

--- a/packages/transport-webrtc/src/private-to-private/initiate-connection.ts
+++ b/packages/transport-webrtc/src/private-to-private/initiate-connection.ts
@@ -154,16 +154,14 @@ export async function initiateConnection ({ peerConnection, signal, metrics, mul
       log.trace('initiator connected, closing init channel')
       channel.close()
 
-      const remoteAddress = parseRemoteAddress(peerConnection.currentRemoteDescription?.sdp ?? '')
-
-      log.trace('initiator connected to remote address %s', remoteAddress)
-
-      // close the signalling stream
+      log.trace('initiator closing signalling stream')
       await messageStream.unwrap().unwrap().close({
         signal
       })
 
-      log.trace('initiator closed signalling stream')
+      const remoteAddress = parseRemoteAddress(peerConnection.currentRemoteDescription?.sdp ?? '')
+
+      log.trace('initiator connected to remote address %s', remoteAddress)
 
       return {
         remoteAddress: multiaddr(remoteAddress).encapsulate(`/p2p/${peerId.toString()}`)

--- a/packages/transport-webrtc/src/private-to-private/signaling-stream-handler.ts
+++ b/packages/transport-webrtc/src/private-to-private/signaling-stream-handler.ts
@@ -106,7 +106,6 @@ export async function handleIncomingStream ({ peerConnection, stream, signal, co
     })
 
     log.trace('recipient connected, closing signaling stream')
-
     await messageStream.unwrap().unwrap().close({
       signal
     })

--- a/packages/transport-webrtc/src/stream.ts
+++ b/packages/transport-webrtc/src/stream.ts
@@ -82,7 +82,6 @@ export class WebRTCStream extends AbstractStream {
    * When this promise is resolved, the remote has sent us a FIN flag
    */
   private readonly receiveFinAck: DeferredPromise<void>
-  private receivedFinAck: boolean
   private readonly finAckTimeout: number
 
   constructor (init: WebRTCStreamInit) {
@@ -95,8 +94,6 @@ export class WebRTCStream extends AbstractStream {
           this.log.error('error sending FIN_ACK', err)
         })
         .then(async () => {
-          this.receivedFinAck.toString()
-
           await pTimeout(this.receiveFinAck.promise, {
             milliseconds: this.finAckTimeout
           })
@@ -119,7 +116,6 @@ export class WebRTCStream extends AbstractStream {
     this.maxBufferedAmount = init.maxBufferedAmount ?? MAX_BUFFERED_AMOUNT
     this.maxMessageSize = (init.maxMessageSize ?? MAX_MESSAGE_SIZE) - PROTOBUF_OVERHEAD - VARINT_LENGTH
     this.receiveFinAck = pDefer()
-    this.receivedFinAck = false
     this.finAckTimeout = init.closeTimeout ?? FIN_ACK_TIMEOUT
 
     // set up initial state
@@ -298,7 +294,6 @@ export class WebRTCStream extends AbstractStream {
 
       if (message.flag === Message.Flag.FIN_ACK) {
         this.log.trace('received FIN_ACK')
-        this.receivedFinAck = true
         this.receiveFinAck.resolve()
       }
     }

--- a/packages/transport-webrtc/src/util.ts
+++ b/packages/transport-webrtc/src/util.ts
@@ -1,6 +1,6 @@
 import { logger } from '@libp2p/logger'
 import { detect } from 'detect-browser'
-import pDefer, { type DeferredPromise } from 'p-defer'
+import pDefer from 'p-defer'
 import pTimeout from 'p-timeout'
 
 const log = logger('libp2p:webrtc:utils')
@@ -65,27 +65,4 @@ export function drainAndClose (channel: RTCDataChannel, direction: string, drain
 export interface AbortPromiseOptions {
   signal?: AbortSignal
   message?: string
-}
-
-export function abortPromise (opts: AbortPromiseOptions = {}): { promise: Promise<void>, cleanup: () => void } {
-  const deferred: DeferredPromise<void> = pDefer()
-
-  const listener = (): void => {
-    deferred.reject(new Error(opts.message ?? 'aborted'))
-  }
-
-  if (opts.signal?.aborted === true) {
-    listener()
-  }
-
-  opts.signal?.addEventListener('abort', listener, {
-    once: true
-  })
-
-  return {
-    promise: deferred.promise,
-    cleanup: () => {
-      opts.signal?.removeEventListener('abort', listener)
-    }
-  }
 }

--- a/packages/transport-webrtc/test/basics.spec.ts
+++ b/packages/transport-webrtc/test/basics.spec.ts
@@ -7,15 +7,18 @@ import * as filter from '@libp2p/websockets/filters'
 import { WebRTC } from '@multiformats/mafmt'
 import { multiaddr } from '@multiformats/multiaddr'
 import { expect } from 'aegir/chai'
+import drain from 'it-drain'
 import map from 'it-map'
 import { pipe } from 'it-pipe'
+import { pushable } from 'it-pushable'
 import toBuffer from 'it-to-buffer'
 import { createLibp2p } from 'libp2p'
 import { circuitRelayTransport } from 'libp2p/circuit-relay'
 import pDefer from 'p-defer'
+import pRetry from 'p-retry'
 import { webRTC } from '../src/index.js'
 import type { Libp2p } from '@libp2p/interface'
-import type { Connection } from '@libp2p/interface/connection'
+import type { Connection, Stream } from '@libp2p/interface/connection'
 import type { StreamHandler } from '@libp2p/interface/stream-handler'
 
 async function createNode (): Promise<Libp2p> {
@@ -204,4 +207,139 @@ describe('basics', () => {
     // asset that we got the right data
     expect(output).to.equalBytes(toBuffer(input))
   })
+
+  it('can close local stream for writing and reading while a remote stream is writing', async () => {
+    /**
+     * NodeA             NodeB
+     * |   <--- STOP_SENDING |
+     * | FIN --->            |
+     * |            <--- FIN |
+     * | FIN_ACK --->        |
+     * |        <--- FIN_ACK |
+     */
+
+    const getRemoteStream = pDefer<Stream>()
+
+    streamHandler = ({ stream }) => {
+      void Promise.resolve().then(async () => {
+        getRemoteStream.resolve(stream)
+      })
+    }
+
+    const connection = await connectNodes()
+
+    // open a stream on the echo protocol
+    const stream = await connection.newStream(echo, {
+      runOnTransientConnection: true
+    })
+
+    const remoteStream = await getRemoteStream.promise
+    // close the readable end of the remote stream
+    await remoteStream.closeRead()
+
+    // keep the remote write end open, this should delay the FIN_ACK reply to the local stream
+    const remoteInputStream = pushable()
+    void remoteStream.sink(remoteInputStream)
+
+    const p = stream.closeWrite()
+
+    // wait for remote to receive local close-write
+    await pRetry(() => {
+      if (remoteStream.readStatus !== 'closed') {
+        throw new Error('Remote stream read status ' + remoteStream.readStatus)
+      }
+    }, {
+      minTimeout: 100
+    })
+
+    // remote closes write
+    remoteInputStream.end()
+
+    // wait to receive FIN_ACK
+    await p
+
+    // wait for remote to notice closure
+    await pRetry(() => {
+      if (remoteStream.status !== 'closed') {
+        throw new Error('Remote stream not closed')
+      }
+    })
+
+    assertStreamClosed(stream)
+    assertStreamClosed(remoteStream)
+  })
+
+  it('can close local stream for writing and reading while a remote stream is writing using source/sink', async () => {
+    /**
+     * NodeA             NodeB
+     * | FIN --->            |
+     * |            <--- FIN |
+     * | FIN_ACK --->        |
+     * |        <--- FIN_ACK |
+     */
+
+    const getRemoteStream = pDefer<Stream>()
+
+    streamHandler = ({ stream }) => {
+      void Promise.resolve().then(async () => {
+        getRemoteStream.resolve(stream)
+      })
+    }
+
+    const connection = await connectNodes()
+
+    // open a stream on the echo protocol
+    const stream = await connection.newStream(echo, {
+      runOnTransientConnection: true
+    })
+
+    const remoteStream = await getRemoteStream.promise
+    // close the readable end of the remote stream
+    await remoteStream.closeRead()
+    // readable end should finish
+    await drain(remoteStream.source)
+
+    // keep the remote write end open, this should delay the FIN_ACK reply to the local stream
+    const p = stream.sink([])
+
+    // wait for remote to receive local close-write
+    await pRetry(() => {
+      if (remoteStream.readStatus !== 'closed') {
+        throw new Error('Remote stream read status ' + remoteStream.readStatus)
+      }
+    }, {
+      minTimeout: 100
+    })
+
+    // remote closes write
+    await remoteStream.sink([])
+
+    // wait to receive FIN_ACK
+    await p
+
+    // close read end of stream
+    await stream.closeRead()
+    // readable end should finish
+    await drain(stream.source)
+
+    // wait for remote to notice closure
+    await pRetry(() => {
+      if (remoteStream.status !== 'closed') {
+        throw new Error('Remote stream not closed')
+      }
+    })
+
+    assertStreamClosed(stream)
+    assertStreamClosed(remoteStream)
+  })
 })
+
+function assertStreamClosed (stream: Stream): void {
+  expect(stream.status).to.equal('closed')
+  expect(stream.readStatus).to.equal('closed')
+  expect(stream.writeStatus).to.equal('closed')
+
+  expect(stream.timeline.close).to.be.a('number')
+  expect(stream.timeline.closeRead).to.be.a('number')
+  expect(stream.timeline.closeWrite).to.be.a('number')
+}

--- a/packages/transport-webrtc/test/stream.browser.spec.ts
+++ b/packages/transport-webrtc/test/stream.browser.spec.ts
@@ -5,6 +5,7 @@ import { bytes } from 'multiformats'
 import { Message } from '../src/pb/message.js'
 import { createStream, type WebRTCStream } from '../src/stream.js'
 import { RTCPeerConnection } from '../src/webrtc/index.js'
+import { receiveFinAck } from './util.js'
 import type { Stream } from '@libp2p/interface/connection'
 const TEST_MESSAGE = 'test_message'
 
@@ -47,12 +48,8 @@ describe('Stream Stats', () => {
   it('close marks it closed', async () => {
     expect(stream.timeline.close).to.not.exist()
 
-    const msgbuf = Message.encode({ flag: Message.Flag.FIN_ACK })
-    const prefixedBuf = lengthPrefixed.encode.single(msgbuf)
-
-    const p = stream.close()
-    dataChannel.dispatchEvent(new MessageEvent('message', { data: prefixedBuf }))
-    await p
+    receiveFinAck(dataChannel)
+    await stream.close()
 
     expect(stream.timeline.close).to.be.a('number')
   })
@@ -66,15 +63,23 @@ describe('Stream Stats', () => {
 
   it('closeWrite marks it write-closed only', async () => {
     expect(stream.timeline.close).to.not.exist()
+
+    receiveFinAck(dataChannel)
     await stream.closeWrite()
+
     expect(stream.timeline.close).to.not.exist()
     expect(stream.timeline.closeWrite).to.be.greaterThanOrEqual(stream.timeline.open)
   })
 
   it('closeWrite AND closeRead = close', async () => {
     expect(stream.timeline.close).to.not.exist()
-    await stream.closeWrite()
-    await stream.closeRead()
+
+    receiveFinAck(dataChannel)
+    await Promise.all([
+      stream.closeRead(),
+      stream.closeWrite()
+    ])
+
     expect(stream.timeline.close).to.be.a('number')
     expect(stream.timeline.closeWrite).to.be.greaterThanOrEqual(stream.timeline.open)
     expect(stream.timeline.closeRead).to.be.greaterThanOrEqual(stream.timeline.open)

--- a/packages/transport-webrtc/test/stream.spec.ts
+++ b/packages/transport-webrtc/test/stream.spec.ts
@@ -8,38 +8,31 @@ import pDefer from 'p-defer'
 import { Uint8ArrayList } from 'uint8arraylist'
 import { Message } from '../src/pb/message.js'
 import { MAX_BUFFERED_AMOUNT, MAX_MESSAGE_SIZE, PROTOBUF_OVERHEAD, createStream } from '../src/stream.js'
-
-const mockDataChannel = (opts: { send: (bytes: Uint8Array) => void, bufferedAmount?: number }): RTCDataChannel => {
-  return {
-    readyState: 'open',
-    close: () => { },
-    addEventListener: (_type: string, _listener: () => void) => { },
-    removeEventListener: (_type: string, _listener: () => void) => { },
-    ...opts
-  } as RTCDataChannel
-}
+import { mockDataChannel, receiveFinAck } from './util.js'
 
 describe('Max message size', () => {
   it(`sends messages smaller or equal to ${MAX_MESSAGE_SIZE} bytes in one`, async () => {
     const sent: Uint8ArrayList = new Uint8ArrayList()
     const data = new Uint8Array(MAX_MESSAGE_SIZE - PROTOBUF_OVERHEAD)
     const p = pushable()
+    const channel = mockDataChannel({
+      send: (bytes) => {
+        sent.append(bytes)
+      }
+    })
 
     // Make sure that the data that ought to be sent will result in a message with exactly MAX_MESSAGE_SIZE
     const messageLengthEncoded = lengthPrefixed.encode.single(Message.encode({ message: data }))
     expect(messageLengthEncoded.length).eq(MAX_MESSAGE_SIZE)
     const webrtcStream = createStream({
-      channel: mockDataChannel({
-        send: (bytes) => {
-          sent.append(bytes)
-        }
-      }),
+      channel,
       direction: 'outbound',
       closeTimeout: 1
     })
 
     p.push(data)
     p.end()
+    receiveFinAck(channel)
     await webrtcStream.sink(p)
 
     expect(length(sent)).to.equal(6)
@@ -53,22 +46,24 @@ describe('Max message size', () => {
     const sent: Uint8ArrayList = new Uint8ArrayList()
     const data = new Uint8Array(MAX_MESSAGE_SIZE)
     const p = pushable()
+    const channel = mockDataChannel({
+      send: (bytes) => {
+        sent.append(bytes)
+      }
+    })
 
     // Make sure that the data that ought to be sent will result in a message with exactly MAX_MESSAGE_SIZE + 1
     // const messageLengthEncoded = lengthPrefixed.encode.single(Message.encode({ message: data })).subarray()
     // expect(messageLengthEncoded.length).eq(MAX_MESSAGE_SIZE + 1)
 
     const webrtcStream = createStream({
-      channel: mockDataChannel({
-        send: (bytes) => {
-          sent.append(bytes)
-        }
-      }),
+      channel,
       direction: 'outbound'
     })
 
     p.push(data)
     p.end()
+    receiveFinAck(channel)
     await webrtcStream.sink(p)
 
     expect(length(sent)).to.equal(6)
@@ -81,15 +76,16 @@ describe('Max message size', () => {
   it('closes the stream if bufferamountlow timeout', async () => {
     const timeout = 100
     const closed = pDefer()
+    const channel = mockDataChannel({
+      send: () => {
+        throw new Error('Expected to not send')
+      },
+      bufferedAmount: MAX_BUFFERED_AMOUNT + 1
+    })
     const webrtcStream = createStream({
       bufferedAmountLowEventTimeout: timeout,
       closeTimeout: 1,
-      channel: mockDataChannel({
-        send: () => {
-          throw new Error('Expected to not send')
-        },
-        bufferedAmount: MAX_BUFFERED_AMOUNT + 1
-      }),
+      channel,
       direction: 'outbound',
       onEnd: () => {
         closed.resolve()

--- a/packages/transport-webrtc/test/util.ts
+++ b/packages/transport-webrtc/test/util.ts
@@ -1,4 +1,6 @@
 import { expect } from 'aegir/chai'
+import * as lengthPrefixed from 'it-length-prefixed'
+import { Message } from '../src/pb/message.js'
 
 export const expectError = (error: unknown, message: string): void => {
   if (error instanceof Error) {
@@ -6,4 +8,29 @@ export const expectError = (error: unknown, message: string): void => {
   } else {
     expect('Did not throw error:').to.equal(message)
   }
+}
+
+/**
+ * simulates receiving a FIN_ACK on the passed datachannel
+ */
+export function receiveFinAck (channel: RTCDataChannel): void {
+  const msgbuf = Message.encode({ flag: Message.Flag.FIN_ACK })
+  const data = lengthPrefixed.encode.single(msgbuf).subarray()
+  channel.onmessage?.(new MessageEvent<ArrayBuffer>('message', { data }))
+}
+
+let mockDataChannelId = 0
+
+export const mockDataChannel = (opts: { send: (bytes: Uint8Array) => void, bufferedAmount?: number }): RTCDataChannel => {
+  // @ts-expect-error incomplete implementation
+  const channel: RTCDataChannel = {
+    readyState: 'open',
+    close: () => { },
+    addEventListener: (_type: string, _listener: (_: any) => void) => { },
+    removeEventListener: (_type: string, _listener: (_: any) => void) => { },
+    id: mockDataChannelId++,
+    ...opts
+  }
+
+  return channel
 }


### PR DESCRIPTION
Chrome does not always send all messages after closing a datachannel even if `bufferedAmount` is `0` before closing.

This PR adds a `FIN_ACK` message that is sent in reply to a `FIN` message - because all messages are send in-order, when this is received we know the remote has recieved all of our data messages and it's safe to close the channel.

- Depends on
- [ ] #2073
- [ ] https://github.com/libp2p/specs/pull/582