### PR TITLE
docs: pubsub example topic validator fix

### DIFF
--- a/examples/pubsub/message-filtering/README.md
+++ b/examples/pubsub/message-filtering/README.md
@@ -8,7 +8,7 @@ First, let's update our libp2p configuration with a pubsub implementation.
 
 ```JavaScript
 import { createLibp2p } from 'libp2p'
-import { GossipSub } from '@chainsafe/libp2p-gossipsub'
+import { gossipsub } from '@chainsafe/libp2p-gossipsub'
 import { tcp } from '@libp2p/tcp'
 import { mplex } from '@libp2p/mplex'
 import { yamux } from '@chainsafe/libp2p-yamux'
@@ -23,7 +23,9 @@ const createNode = async () => {
     streamMuxers: [yamux(), mplex()],
     connectionEncryption: [noise()],
 	  // we add the Pubsub module we want
-	  pubsub: gossipsub({ allowPublishToZeroPeers: true })
+    services: {
+      pubsub: gossipsub({ allowPublishToZeroPeers: true })
+    }
   })
 
   return node
@@ -88,13 +90,17 @@ await node3.services.pubsub.subscribe(topic)
 Finally, let's define the additional filter in the fruit topic.
 
 ```JavaScript
+import { TopicValidatorResult } from '@libp2p/interface/pubsub'
+
 const validateFruit = (msgTopic, msg) => {
   const fruit = uint8ArrayToString(msg.data)
   const validFruit = ['banana', 'apple', 'orange']
 
+  // car is not a fruit !
   if (!validFruit.includes(fruit)) {
     throw new Error('no valid fruit received')
   }
+  return TopicValidatorResult.Accept
 }
 
 node1.services.pubsub.topicValidators.set(topic, validateFruit)


### PR DESCRIPTION
## Title

docs: pubsub example topic validator fix

## Description

Fixes https://github.com/libp2p/js-libp2p/issues/1394.

topic validators for gossipsub require a specific return type to accept the message.

## Notes & open questions

<!--
Any notes, remarks or open questions you have to make about the PR which don't need to go into the final commit message.
-->

## Change checklist

- [x] I have performed a self-review of my own code
- [x] I have made corresponding changes to the documentation if necessary (this includes comments as well)
- [ ] I have added tests that prove my fix is effective or that my feature works