### PR TITLE
chore: add project field to eslint parser options

### DIFF
--- a/doc/package.json
+++ b/doc/package.json
@@ -15,6 +15,7 @@
   "eslintConfig": {
     "extends": "ipfs",
     "parserOptions": {
+      "project": true,
       "sourceType": "module"
     }
   },

--- a/examples/auto-relay/package.json
+++ b/examples/auto-relay/package.json
@@ -21,6 +21,7 @@
   "eslintConfig": {
     "extends": "ipfs",
     "parserOptions": {
+      "project": true,
       "sourceType": "module"
     }
   },

--- a/examples/chat/package.json
+++ b/examples/chat/package.json
@@ -21,6 +21,7 @@
   "eslintConfig": {
     "extends": "ipfs",
     "parserOptions": {
+      "project": true,
       "sourceType": "module"
     }
   },

--- a/examples/connection-encryption/package.json
+++ b/examples/connection-encryption/package.json
@@ -21,6 +21,7 @@
   "eslintConfig": {
     "extends": "ipfs",
     "parserOptions": {
+      "project": true,
       "sourceType": "module"
     }
   },

--- a/examples/discovery-mechanisms/package.json
+++ b/examples/discovery-mechanisms/package.json
@@ -21,6 +21,7 @@
   "eslintConfig": {
     "extends": "ipfs",
     "parserOptions": {
+      "project": true,
       "sourceType": "module"
     }
   },

--- a/examples/echo/package.json
+++ b/examples/echo/package.json
@@ -21,6 +21,7 @@
   "eslintConfig": {
     "extends": "ipfs",
     "parserOptions": {
+      "project": true,
       "sourceType": "module"
     }
   },

--- a/examples/libp2p-in-the-browser/websockets/package.json
+++ b/examples/libp2p-in-the-browser/websockets/package.json
@@ -21,6 +21,7 @@
   "eslintConfig": {
     "extends": "ipfs",
     "parserOptions": {
+      "project": true,
       "sourceType": "module"
     }
   },

--- a/examples/peer-and-content-routing/package.json
+++ b/examples/peer-and-content-routing/package.json
@@ -21,6 +21,7 @@
   "eslintConfig": {
     "extends": "ipfs",
     "parserOptions": {
+      "project": true,
       "sourceType": "module"
     }
   },

--- a/examples/pnet/package.json
+++ b/examples/pnet/package.json
@@ -21,6 +21,7 @@
   "eslintConfig": {
     "extends": "ipfs",
     "parserOptions": {
+      "project": true,
       "sourceType": "module"
     }
   },

--- a/examples/protocol-and-stream-muxing/package.json
+++ b/examples/protocol-and-stream-muxing/package.json
@@ -21,6 +21,7 @@
   "eslintConfig": {
     "extends": "ipfs",
     "parserOptions": {
+      "project": true,
       "sourceType": "module"
     }
   },

--- a/examples/pubsub/package.json
+++ b/examples/pubsub/package.json
@@ -21,6 +21,7 @@
   "eslintConfig": {
     "extends": "ipfs",
     "parserOptions": {
+      "project": true,
       "sourceType": "module"
     }
   },

--- a/examples/transports/package.json
+++ b/examples/transports/package.json
@@ -21,6 +21,7 @@
   "eslintConfig": {
     "extends": "ipfs",
     "parserOptions": {
+      "project": true,
       "sourceType": "module"
     }
   },

--- a/interop/package.json
+++ b/interop/package.json
@@ -39,6 +39,7 @@
   "eslintConfig": {
     "extends": "ipfs",
     "parserOptions": {
+      "project": true,
       "sourceType": "module"
     }
   },

--- a/packages/crypto/package.json
+++ b/packages/crypto/package.json
@@ -63,6 +63,7 @@
   "eslintConfig": {
     "extends": "ipfs",
     "parserOptions": {
+      "project": true,
       "sourceType": "module"
     },
     "ignorePatterns": [

--- a/packages/interface-compliance-tests/package.json
+++ b/packages/interface-compliance-tests/package.json
@@ -84,6 +84,7 @@
   "eslintConfig": {
     "extends": "ipfs",
     "parserOptions": {
+      "project": true,
       "sourceType": "module"
     }
   },

--- a/packages/interface-internal/package.json
+++ b/packages/interface-internal/package.json
@@ -68,6 +68,7 @@
   "eslintConfig": {
     "extends": "ipfs",
     "parserOptions": {
+      "project": true,
       "sourceType": "module"
     }
   },

--- a/packages/interface/package.json
+++ b/packages/interface/package.json
@@ -140,6 +140,7 @@
   "eslintConfig": {
     "extends": "ipfs",
     "parserOptions": {
+      "project": true,
       "sourceType": "module"
     }
   },

--- a/packages/kad-dht/package.json
+++ b/packages/kad-dht/package.json
@@ -31,6 +31,7 @@
   "eslintConfig": {
     "extends": "ipfs",
     "parserOptions": {
+      "project": true,
       "sourceType": "module"
     },
     "ignorePatterns": [

--- a/packages/keychain/package.json
+++ b/packages/keychain/package.json
@@ -36,6 +36,7 @@
   "eslintConfig": {
     "extends": "ipfs",
     "parserOptions": {
+      "project": true,
       "sourceType": "module"
     }
   },

--- a/packages/libp2p/package.json
+++ b/packages/libp2p/package.json
@@ -88,6 +88,7 @@
   "eslintConfig": {
     "extends": "ipfs",
     "parserOptions": {
+      "project": true,
       "sourceType": "module"
     },
     "ignorePatterns": [

--- a/packages/logger/package.json
+++ b/packages/logger/package.json
@@ -31,6 +31,7 @@
   "eslintConfig": {
     "extends": "ipfs",
     "parserOptions": {
+      "project": true,
       "sourceType": "module"
     }
   },

--- a/packages/metrics-prometheus/package.json
+++ b/packages/metrics-prometheus/package.json
@@ -29,6 +29,7 @@
   "eslintConfig": {
     "extends": "ipfs",
     "parserOptions": {
+      "project": true,
       "sourceType": "module"
     }
   },

--- a/packages/multistream-select/package.json
+++ b/packages/multistream-select/package.json
@@ -35,6 +35,7 @@
   "eslintConfig": {
     "extends": "ipfs",
     "parserOptions": {
+      "project": true,
       "sourceType": "module"
     }
   },

--- a/packages/peer-collections/package.json
+++ b/packages/peer-collections/package.json
@@ -31,6 +31,7 @@
   "eslintConfig": {
     "extends": "ipfs",
     "parserOptions": {
+      "project": true,
       "sourceType": "module"
     }
   },

--- a/packages/peer-discovery-bootstrap/package.json
+++ b/packages/peer-discovery-bootstrap/package.json
@@ -31,6 +31,7 @@
   "eslintConfig": {
     "extends": "ipfs",
     "parserOptions": {
+      "project": true,
       "sourceType": "module"
     }
   },

--- a/packages/peer-discovery-mdns/package.json
+++ b/packages/peer-discovery-mdns/package.json
@@ -31,6 +31,7 @@
   "eslintConfig": {
     "extends": "ipfs",
     "parserOptions": {
+      "project": true,
       "sourceType": "module"
     }
   },

--- a/packages/peer-id-factory/package.json
+++ b/packages/peer-id-factory/package.json
@@ -31,6 +31,7 @@
   "eslintConfig": {
     "extends": "ipfs",
     "parserOptions": {
+      "project": true,
       "sourceType": "module"
     },
     "ignorePatterns": [

--- a/packages/peer-id/package.json
+++ b/packages/peer-id/package.json
@@ -31,6 +31,7 @@
   "eslintConfig": {
     "extends": "ipfs",
     "parserOptions": {
+      "project": true,
       "sourceType": "module"
     }
   },

--- a/packages/peer-record/package.json
+++ b/packages/peer-record/package.json
@@ -31,6 +31,7 @@
   "eslintConfig": {
     "extends": "ipfs",
     "parserOptions": {
+      "project": true,
       "sourceType": "module"
     },
     "ignorePatterns": [

--- a/packages/peer-store/package.json
+++ b/packages/peer-store/package.json
@@ -31,6 +31,7 @@
   "eslintConfig": {
     "extends": "ipfs",
     "parserOptions": {
+      "project": true,
       "sourceType": "module"
     },
     "ignorePatterns": [

--- a/packages/protocol-perf/package.json
+++ b/packages/protocol-perf/package.json
@@ -29,6 +29,7 @@
   "eslintConfig": {
     "extends": "ipfs",
     "parserOptions": {
+      "project": true,
       "sourceType": "module"
     }
   },

--- a/packages/pubsub-floodsub/package.json
+++ b/packages/pubsub-floodsub/package.json
@@ -36,6 +36,7 @@
   "eslintConfig": {
     "extends": "ipfs",
     "parserOptions": {
+      "project": true,
       "sourceType": "module"
     }
   },

--- a/packages/pubsub/package.json
+++ b/packages/pubsub/package.json
@@ -60,6 +60,7 @@
   "eslintConfig": {
     "extends": "ipfs",
     "parserOptions": {
+      "project": true,
       "sourceType": "module"
     }
   },

--- a/packages/stream-multiplexer-mplex/package.json
+++ b/packages/stream-multiplexer-mplex/package.json
@@ -38,6 +38,7 @@
   "eslintConfig": {
     "extends": "ipfs",
     "parserOptions": {
+      "project": true,
       "sourceType": "module"
     }
   },

--- a/packages/transport-tcp/package.json
+++ b/packages/transport-tcp/package.json
@@ -37,6 +37,7 @@
   "eslintConfig": {
     "extends": "ipfs",
     "parserOptions": {
+      "project": true,
       "sourceType": "module"
     }
   },

--- a/packages/transport-webrtc/package.json
+++ b/packages/transport-webrtc/package.json
@@ -28,6 +28,7 @@
   "eslintConfig": {
     "extends": "ipfs",
     "parserOptions": {
+      "project": true,
       "sourceType": "module"
     }
   },

--- a/packages/transport-websockets/package.json
+++ b/packages/transport-websockets/package.json
@@ -51,6 +51,7 @@
   "eslintConfig": {
     "extends": "ipfs",
     "parserOptions": {
+      "project": true,
       "sourceType": "module"
     }
   },

--- a/packages/transport-webtransport/package.json
+++ b/packages/transport-webtransport/package.json
@@ -47,6 +47,7 @@
   "eslintConfig": {
     "extends": "ipfs",
     "parserOptions": {
+      "project": true,
       "sourceType": "module"
     }
   },

--- a/packages/utils/package.json
+++ b/packages/utils/package.json
@@ -68,6 +68,7 @@
   "eslintConfig": {
     "extends": "ipfs",
     "parserOptions": {
+      "project": true,
       "sourceType": "module"
     }
   },

--- a/tsconfig.json
+++ b/tsconfig.json
@@ -1,6 +1,0 @@
-// This root tsconfig allows the linter to work properly in vscode
-// It is not used to build subpackages
-{
-  "extends": "aegir/src/config/tsconfig.aegir.json",
-  "include": ["packages/**/*.ts"]
-}


### PR DESCRIPTION
The project field causes eslint to look up the closest tsconfig.json when linting ts files instead of always going to the root of the project to find it.

Reverts #2109
Fixes #2095
