### PR TITLE
fix!: remove dialler language

### DIFF
--- a/doc/migrations/v0.46-v1.0.md
+++ b/doc/migrations/v0.46-v1.0.md
@@ -1,0 +1,53 @@
+<!--Specify versions for migration below-->
+# Migrating to libp2p@1.0 <!-- omit in toc -->
+
+A migration guide for refactoring your application code from libp2p v0.46 to v1.0.
+
+## Table of Contents <!-- omit in toc -->
+
+- [API](#api)
+- [Module Updates](#module-updates)
+- [Metrics](#metrics)
+
+## API
+
+<!--Describe breaking APIs with examples for Before and After
+Example:
+
+### Peer Discovery
+
+__Describe__
+
+**Before**
+
+```js
+
+```
+
+**After**
+
+```js
+
+```
+
+-->
+
+## Module Updates
+
+With this release you should update the following libp2p modules if you are relying on them:
+
+<!--Specify module versions in JSON for migration below.
+It's recommended to check package.json changes for this:
+`git diff <release> <prev> -- package.json`
+-->
+
+```json
+
+```
+
+## Metrics
+
+The following metrics were renamed:
+
+`libp2p_dialler_pending_dials` => `libp2p_dialler_pending_dials`
+`libp2p_dialler_in_progress_dials` => `libp2p_dial_queue_in_progress_dials`

--- a/doc/migrations/v0.46-v1.0.md
+++ b/doc/migrations/v0.46-v1.0.md
@@ -49,5 +49,5 @@ It's recommended to check package.json changes for this:
 
 The following metrics were renamed:
 
-`libp2p_dialler_pending_dials` => `libp2p_dialler_pending_dials`
+`libp2p_dialler_pending_dials` => `libp2p_dial_queue_pending_dials`
 `libp2p_dialler_in_progress_dials` => `libp2p_dial_queue_in_progress_dials`

--- a/packages/libp2p/src/connection-manager/dial-queue.ts
+++ b/packages/libp2p/src/connection-manager/dial-queue.ts
@@ -101,8 +101,8 @@ export class DialQueue {
       setMaxListeners?.(Infinity, this.shutDownController.signal)
     } catch {}
 
-    this.pendingDialCount = components.metrics?.registerMetric('libp2p_dialler_pending_dials')
-    this.inProgressDialCount = components.metrics?.registerMetric('libp2p_dialler_in_progress_dials')
+    this.pendingDialCount = components.metrics?.registerMetric('libp2p_dial_queue_pending_dials')
+    this.inProgressDialCount = components.metrics?.registerMetric('libp2p_dial_queue_in_progress_dials')
     this.pendingDials = []
 
     for (const [key, value] of Object.entries(init.resolvers ?? {})) {

--- a/packages/libp2p/test/connection-manager/auto-dial.spec.ts
+++ b/packages/libp2p/test/connection-manager/auto-dial.spec.ts
@@ -22,7 +22,7 @@ import type { PeerStore, Peer } from '@libp2p/interface/peer-store'
 import type { ConnectionManager } from '@libp2p/interface-internal/connection-manager'
 
 describe('auto-dial', () => {
-  let autoDial: AutoDial
+  let autoDialer: AutoDial
   let events: EventEmitter<Libp2pEvents>
   let peerStore: PeerStore
   let peerId: PeerId
@@ -38,8 +38,8 @@ describe('auto-dial', () => {
   })
 
   afterEach(() => {
-    if (autoDial != null) {
-      autoDial.stop()
+    if (autoDialer != null) {
+      autoDialer.stop()
     }
   })
 
@@ -73,7 +73,7 @@ describe('auto-dial', () => {
       getDialQueue: []
     })
 
-    autoDial = new AutoDial({
+    autoDialer = new AutoDial({
       peerStore,
       connectionManager,
       events
@@ -81,8 +81,8 @@ describe('auto-dial', () => {
       minConnections: 10,
       autoDialInterval: 10000
     })
-    autoDial.start()
-    void autoDial.autoDial()
+    autoDialer.start()
+    void autoDialer.autoDial()
 
     await pWaitFor(() => {
       return connectionManager.openConnection.callCount === 1
@@ -127,15 +127,15 @@ describe('auto-dial', () => {
       getDialQueue: []
     })
 
-    autoDial = new AutoDial({
+    autoDialer = new AutoDial({
       peerStore,
       connectionManager,
       events
     }, {
       minConnections: 10
     })
-    autoDial.start()
-    await autoDial.autoDial()
+    autoDialer.start()
+    await autoDialer.autoDial()
 
     await pWaitFor(() => connectionManager.openConnection.callCount === 1)
     await delay(1000)
@@ -181,15 +181,15 @@ describe('auto-dial', () => {
       }]
     })
 
-    autoDial = new AutoDial({
+    autoDialer = new AutoDial({
       peerStore,
       connectionManager,
       events
     }, {
       minConnections: 10
     })
-    autoDial.start()
-    await autoDial.autoDial()
+    autoDialer.start()
+    await autoDialer.autoDial()
 
     await pWaitFor(() => connectionManager.openConnection.callCount === 1)
     await delay(1000)
@@ -207,7 +207,7 @@ describe('auto-dial', () => {
       getDialQueue: []
     })
 
-    autoDial = new AutoDial({
+    autoDialer = new AutoDial({
       peerStore,
       connectionManager,
       events
@@ -215,12 +215,12 @@ describe('auto-dial', () => {
       minConnections: 10,
       autoDialInterval: 10000
     })
-    autoDial.start()
+    autoDialer.start()
 
     // call autodial twice
     await Promise.all([
-      autoDial.autoDial(),
-      autoDial.autoDial()
+      autoDialer.autoDial(),
+      autoDialer.autoDial()
     ])
 
     // should only have queried peer store once
@@ -258,7 +258,7 @@ describe('auto-dial', () => {
       getDialQueue: []
     })
 
-    autoDial = new AutoDial({
+    autoDialer = new AutoDial({
       peerStore,
       connectionManager,
       events
@@ -266,9 +266,9 @@ describe('auto-dial', () => {
       minConnections: 10,
       autoDialPeerRetryThreshold: 2000
     })
-    autoDial.start()
+    autoDialer.start()
 
-    void autoDial.autoDial()
+    void autoDialer.autoDial()
 
     await pWaitFor(() => {
       return connectionManager.openConnection.callCount === 1
@@ -282,7 +282,7 @@ describe('auto-dial', () => {
     await delay(2000)
 
     // autodial again
-    void autoDial.autoDial()
+    void autoDialer.autoDial()
 
     await pWaitFor(() => {
       return connectionManager.openConnection.callCount === 3

--- a/packages/libp2p/test/connection-manager/auto-dial.spec.ts
+++ b/packages/libp2p/test/connection-manager/auto-dial.spec.ts
@@ -22,7 +22,7 @@ import type { PeerStore, Peer } from '@libp2p/interface/peer-store'
 import type { ConnectionManager } from '@libp2p/interface-internal/connection-manager'
 
 describe('auto-dial', () => {
-  let autoDialler: AutoDial
+  let autoDial: AutoDial
   let events: EventEmitter<Libp2pEvents>
   let peerStore: PeerStore
   let peerId: PeerId
@@ -38,8 +38,8 @@ describe('auto-dial', () => {
   })
 
   afterEach(() => {
-    if (autoDialler != null) {
-      autoDialler.stop()
+    if (autoDial != null) {
+      autoDial.stop()
     }
   })
 
@@ -73,7 +73,7 @@ describe('auto-dial', () => {
       getDialQueue: []
     })
 
-    autoDialler = new AutoDial({
+    autoDial = new AutoDial({
       peerStore,
       connectionManager,
       events
@@ -81,8 +81,8 @@ describe('auto-dial', () => {
       minConnections: 10,
       autoDialInterval: 10000
     })
-    autoDialler.start()
-    void autoDialler.autoDial()
+    autoDial.start()
+    void autoDial.autoDial()
 
     await pWaitFor(() => {
       return connectionManager.openConnection.callCount === 1
@@ -127,15 +127,15 @@ describe('auto-dial', () => {
       getDialQueue: []
     })
 
-    autoDialler = new AutoDial({
+    autoDial = new AutoDial({
       peerStore,
       connectionManager,
       events
     }, {
       minConnections: 10
     })
-    autoDialler.start()
-    await autoDialler.autoDial()
+    autoDial.start()
+    await autoDial.autoDial()
 
     await pWaitFor(() => connectionManager.openConnection.callCount === 1)
     await delay(1000)
@@ -181,15 +181,15 @@ describe('auto-dial', () => {
       }]
     })
 
-    autoDialler = new AutoDial({
+    autoDial = new AutoDial({
       peerStore,
       connectionManager,
       events
     }, {
       minConnections: 10
     })
-    autoDialler.start()
-    await autoDialler.autoDial()
+    autoDial.start()
+    await autoDial.autoDial()
 
     await pWaitFor(() => connectionManager.openConnection.callCount === 1)
     await delay(1000)
@@ -207,7 +207,7 @@ describe('auto-dial', () => {
       getDialQueue: []
     })
 
-    autoDialler = new AutoDial({
+    autoDial = new AutoDial({
       peerStore,
       connectionManager,
       events
@@ -215,12 +215,12 @@ describe('auto-dial', () => {
       minConnections: 10,
       autoDialInterval: 10000
     })
-    autoDialler.start()
+    autoDial.start()
 
     // call autodial twice
     await Promise.all([
-      autoDialler.autoDial(),
-      autoDialler.autoDial()
+      autoDial.autoDial(),
+      autoDial.autoDial()
     ])
 
     // should only have queried peer store once
@@ -258,7 +258,7 @@ describe('auto-dial', () => {
       getDialQueue: []
     })
 
-    autoDialler = new AutoDial({
+    autoDial = new AutoDial({
       peerStore,
       connectionManager,
       events
@@ -266,9 +266,9 @@ describe('auto-dial', () => {
       minConnections: 10,
       autoDialPeerRetryThreshold: 2000
     })
-    autoDialler.start()
+    autoDial.start()
 
-    void autoDialler.autoDial()
+    void autoDial.autoDial()
 
     await pWaitFor(() => {
       return connectionManager.openConnection.callCount === 1
@@ -282,7 +282,7 @@ describe('auto-dial', () => {
     await delay(2000)
 
     // autodial again
-    void autoDialler.autoDial()
+    void autoDial.autoDial()
 
     await pWaitFor(() => {
       return connectionManager.openConnection.callCount === 3


### PR DESCRIPTION
## Description

- Remove the confusing "dialler" word in metrics, replacing with "dial_queue" 