### PR TITLE
refactor: move setMaxListeners to @libp2p/interface

### DIFF
--- a/packages/interface/package.json
+++ b/packages/interface/package.json
@@ -39,6 +39,9 @@
     "!dist/test",
     "!**/*.tsbuildinfo"
   ],
+  "browser": {
+    "events": "./dist/src/events.browser.js"
+  },
   "exports": {
     ".": {
       "types": "./dist/src/index.d.ts",

--- a/packages/interface/src/events.browser.ts
+++ b/packages/interface/src/events.browser.ts
@@ -1,0 +1,2 @@
+/** Noop for browser compatibility */
+export function setMaxListeners (): void {}

--- a/packages/interface/src/events.ts
+++ b/packages/interface/src/events.ts
@@ -1,3 +1,5 @@
+import { setMaxListeners as nodeSetMaxListeners } from 'events'
+
 export interface EventCallback<EventType> { (evt: EventType): void }
 export interface EventObject<EventType> { handleEvent: EventCallback<EventType> }
 export type EventHandler<EventType> = EventCallback<EventType> | EventObject<EventType>
@@ -117,3 +119,12 @@ export const CustomEvent = globalThis.CustomEvent ?? CustomEventPolyfill
 
 // TODO: remove this in v1
 export { TypedEventEmitter as EventEmitter }
+
+// create a setMaxListeners that doesn't break browser usage
+export const setMaxListeners: typeof nodeSetMaxListeners = (n, ...eventTargets) => {
+  try {
+    nodeSetMaxListeners(n, ...eventTargets)
+  } catch {
+    // swallow error, gulp
+  }
+}

--- a/packages/kad-dht/package.json
+++ b/packages/kad-dht/package.json
@@ -49,7 +49,7 @@
     "test:chrome-webworker": "aegir test -t webworker",
     "test:firefox": "aegir test -t browser -- --browser firefox",
     "test:firefox-webworker": "aegir test -t webworker -- --browser firefox",
-    "dep-check": "aegir dep-check -i events"
+    "dep-check": "aegir dep-check"
   },
   "dependencies": {
     "@libp2p/crypto": "^2.0.6",
@@ -63,7 +63,6 @@
     "abortable-iterator": "^5.0.1",
     "any-signal": "^4.1.1",
     "datastore-core": "^9.0.1",
-    "events": "^3.3.0",
     "hashlru": "^2.3.0",
     "interface-datastore": "^8.2.0",
     "it-all": "^3.0.2",

--- a/packages/kad-dht/src/query-self.ts
+++ b/packages/kad-dht/src/query-self.ts
@@ -1,4 +1,4 @@
-import { setMaxListeners } from 'events'
+import { setMaxListeners } from '@libp2p/interface/events'
 import { logger, type Logger } from '@libp2p/logger'
 import { anySignal } from 'any-signal'
 import length from 'it-length'
@@ -110,11 +110,7 @@ export class QuerySelf implements Startable {
       const signal = anySignal([this.controller.signal, AbortSignal.timeout(this.queryTimeout)])
 
       // this controller will get used for lots of dial attempts so make sure we don't cause warnings to be logged
-      try {
-        if (setMaxListeners != null) {
-          setMaxListeners(Infinity, signal)
-        }
-      } catch {} // fails on node < 15.4
+      setMaxListeners(Infinity, signal)
 
       try {
         if (this.routingTable.size === 0) {

--- a/packages/kad-dht/src/query/manager.ts
+++ b/packages/kad-dht/src/query/manager.ts
@@ -1,6 +1,5 @@
-import { setMaxListeners } from 'events'
 import { AbortError } from '@libp2p/interface/errors'
-import { TypedEventEmitter, CustomEvent } from '@libp2p/interface/events'
+import { TypedEventEmitter, CustomEvent, setMaxListeners } from '@libp2p/interface/events'
 import { logger } from '@libp2p/logger'
 import { PeerSet } from '@libp2p/peer-collections'
 import { anySignal } from 'any-signal'
@@ -75,11 +74,7 @@ export class QueryManager implements Startable {
     // allow us to stop queries on shut down
     this.shutDownController = new AbortController()
     // make sure we don't make a lot of noise in the logs
-    try {
-      if (setMaxListeners != null) {
-        setMaxListeners(Infinity, this.shutDownController.signal)
-      }
-    } catch {} // fails on node < 15.4
+    setMaxListeners(Infinity, this.shutDownController.signal)
   }
 
   isStarted (): boolean {
@@ -122,22 +117,14 @@ export class QueryManager implements Startable {
 
       // this signal will get listened to for network requests, etc
       // so make sure we don't make a lot of noise in the logs
-      try {
-        if (setMaxListeners != null) {
-          setMaxListeners(Infinity, options.signal)
-        }
-      } catch {} // fails on node < 15.4
+      setMaxListeners(Infinity, options.signal)
     }
 
     const signal = anySignal([this.shutDownController.signal, options.signal])
 
     // this signal will get listened to for every invocation of queryFunc
     // so make sure we don't make a lot of noise in the logs
-    try {
-      if (setMaxListeners != null) {
-        setMaxListeners(Infinity, signal)
-      }
-    } catch {} // fails on node < 15.4
+    setMaxListeners(Infinity, signal)
 
     const log = logger(`libp2p:kad-dht:${this.lan ? 'lan' : 'wan'}:query:` + uint8ArrayToString(key, 'base58btc'))
 

--- a/packages/libp2p/package.json
+++ b/packages/libp2p/package.json
@@ -100,7 +100,7 @@
   "scripts": {
     "clean": "aegir clean",
     "lint": "aegir lint",
-    "dep-check": "aegir dep-check -i events",
+    "dep-check": "aegir dep-check",
     "prepublishOnly": "node scripts/update-version.js && npm run build",
     "build": "aegir build",
     "generate": "run-s generate:proto:*",
@@ -139,7 +139,6 @@
     "any-signal": "^4.1.1",
     "datastore-core": "^9.0.1",
     "delay": "^6.0.0",
-    "events": "^3.3.0",
     "interface-datastore": "^8.2.0",
     "it-all": "^3.0.2",
     "it-drain": "^3.0.2",

--- a/packages/libp2p/src/autonat/index.ts
+++ b/packages/libp2p/src/autonat/index.ts
@@ -19,8 +19,8 @@
  * ```
  */
 
-import { setMaxListeners } from 'events'
 import { CodeError } from '@libp2p/interface/errors'
+import { setMaxListeners } from '@libp2p/interface/events'
 import { logger } from '@libp2p/logger'
 import { peerIdFromBytes } from '@libp2p/peer-id'
 import { createEd25519PeerId } from '@libp2p/peer-id-factory'
@@ -164,10 +164,7 @@ class DefaultAutoNATService implements Startable {
 
     // this controller may be used while dialing lots of peers so prevent MaxListenersExceededWarning
     // appearing in the console
-    try {
-      // fails on node < 15.4
-      setMaxListeners?.(Infinity, signal)
-    } catch {}
+    setMaxListeners(Infinity, signal)
 
     const ourHosts = this.components.addressManager.getAddresses()
       .map(ma => ma.toOptions().host)
@@ -432,10 +429,7 @@ class DefaultAutoNATService implements Startable {
 
     // this controller may be used while dialing lots of peers so prevent MaxListenersExceededWarning
     // appearing in the console
-    try {
-      // fails on node < 15.4
-      setMaxListeners?.(Infinity, signal)
-    } catch {}
+    setMaxListeners(Infinity, signal)
 
     const self = this
 

--- a/packages/libp2p/src/circuit-relay/server/index.ts
+++ b/packages/libp2p/src/circuit-relay/server/index.ts
@@ -1,5 +1,4 @@
-import { setMaxListeners } from 'events'
-import { TypedEventEmitter } from '@libp2p/interface/events'
+import { TypedEventEmitter, setMaxListeners } from '@libp2p/interface/events'
 import { logger } from '@libp2p/logger'
 import { peerIdFromBytes } from '@libp2p/peer-id'
 import { RecordEnvelope } from '@libp2p/peer-record'
@@ -134,10 +133,7 @@ class CircuitRelayServer extends TypedEventEmitter<RelayServerEvents> implements
     this.maxOutboundHopStreams = init.maxOutboundHopStreams
     this.maxOutboundStopStreams = init.maxOutboundStopStreams ?? defaults.maxOutboundStopStreams
 
-    try {
-      // fails on node < 15.4
-      setMaxListeners?.(Infinity, this.shutdownController.signal)
-    } catch { }
+    setMaxListeners(Infinity, this.shutdownController.signal)
 
     if (init.advertise != null && init.advertise !== false) {
       this.advertService = new AdvertService(components, init.advertise === true ? undefined : init.advertise)

--- a/packages/libp2p/src/connection-manager/dial-queue.ts
+++ b/packages/libp2p/src/connection-manager/dial-queue.ts
@@ -1,5 +1,5 @@
-import { setMaxListeners } from 'events'
 import { AbortError, CodeError } from '@libp2p/interface/errors'
+import { setMaxListeners } from '@libp2p/interface/events'
 import { logger } from '@libp2p/logger'
 import { defaultAddressSort } from '@libp2p/utils/address-sort'
 import { type Multiaddr, type Resolver, resolvers } from '@multiformats/multiaddr'
@@ -96,10 +96,7 @@ export class DialQueue {
     this.transportManager = components.transportManager
     this.shutDownController = new AbortController()
 
-    try {
-      // This emitter gets listened to a lot
-      setMaxListeners?.(Infinity, this.shutDownController.signal)
-    } catch {}
+    setMaxListeners(Infinity, this.shutDownController.signal)
 
     this.pendingDialCount = components.metrics?.registerMetric('libp2p_dialler_pending_dials')
     this.inProgressDialCount = components.metrics?.registerMetric('libp2p_dialler_in_progress_dials')

--- a/packages/libp2p/src/connection-manager/utils.ts
+++ b/packages/libp2p/src/connection-manager/utils.ts
@@ -1,4 +1,4 @@
-import { setMaxListeners } from 'events'
+import { setMaxListeners } from '@libp2p/interface/events'
 import { logger } from '@libp2p/logger'
 import { type AbortOptions, multiaddr, type Multiaddr } from '@multiformats/multiaddr'
 import { type ClearableSignal, anySignal } from 'any-signal'
@@ -55,10 +55,7 @@ export function combineSignals (...signals: Array<AbortSignal | undefined>): Cle
 
   for (const sig of signals) {
     if (sig != null) {
-      try {
-        // fails on node < 15.4
-        setMaxListeners?.(Infinity, sig)
-      } catch { }
+      setMaxListeners(Infinity, sig)
       sigs.push(sig)
     }
   }
@@ -66,10 +63,7 @@ export function combineSignals (...signals: Array<AbortSignal | undefined>): Cle
   // let any signal abort the dial
   const signal = anySignal(sigs)
 
-  try {
-    // fails on node < 15.4
-    setMaxListeners?.(Infinity, signal)
-  } catch {}
+  setMaxListeners(Infinity, signal)
 
   return signal
 }

--- a/packages/libp2p/src/connection/index.ts
+++ b/packages/libp2p/src/connection/index.ts
@@ -1,6 +1,6 @@
-import { setMaxListeners } from 'events'
 import { symbol } from '@libp2p/interface/connection'
 import { CodeError } from '@libp2p/interface/errors'
+import { setMaxListeners } from '@libp2p/interface/events'
 import { logger } from '@libp2p/logger'
 import type { AbortOptions } from '@libp2p/interface'
 import type { Direction, Connection, Stream, ConnectionTimeline, ConnectionStatus, NewStreamOptions } from '@libp2p/interface/connection'
@@ -152,10 +152,7 @@ export class ConnectionImpl implements Connection {
 
     options.signal = options?.signal ?? AbortSignal.timeout(CLOSE_TIMEOUT)
 
-    try {
-      // fails on node < 15.4
-      setMaxListeners?.(Infinity, options.signal)
-    } catch { }
+    setMaxListeners(Infinity, options.signal)
 
     try {
       log.trace('closing all streams')

--- a/packages/libp2p/src/fetch/index.ts
+++ b/packages/libp2p/src/fetch/index.ts
@@ -1,5 +1,5 @@
-import { setMaxListeners } from 'events'
 import { CodeError } from '@libp2p/interface/errors'
+import { setMaxListeners } from '@libp2p/interface/events'
 import { logger } from '@libp2p/logger'
 import first from 'it-first'
 import * as lp from 'it-length-prefixed'
@@ -146,10 +146,7 @@ class DefaultFetchService implements Startable, FetchService {
       log('using default timeout of %d ms', this.init.timeout)
       signal = AbortSignal.timeout(this.init.timeout ?? DEFAULT_TIMEOUT)
 
-      try {
-        // fails on node < 15.4
-        setMaxListeners?.(Infinity, signal)
-      } catch {}
+      setMaxListeners(Infinity, signal)
     }
 
     try {

--- a/packages/libp2p/src/identify/identify.ts
+++ b/packages/libp2p/src/identify/identify.ts
@@ -1,5 +1,5 @@
-import { setMaxListeners } from 'events'
 import { CodeError } from '@libp2p/interface/errors'
+import { setMaxListeners } from '@libp2p/interface/events'
 import { logger } from '@libp2p/logger'
 import { peerIdFromKeys } from '@libp2p/peer-id'
 import { RecordEnvelope, PeerRecord } from '@libp2p/peer-record'
@@ -187,10 +187,7 @@ export class DefaultIdentifyService implements Startable, IdentifyService {
 
       const signal = AbortSignal.timeout(this.timeout)
 
-      try {
-        // fails on node < 15.4
-        setMaxListeners?.(Infinity, signal)
-      } catch {}
+      setMaxListeners(Infinity, signal)
 
       try {
         stream = await connection.newStream([this.identifyPushProtocolStr], {
@@ -345,10 +342,7 @@ export class DefaultIdentifyService implements Startable, IdentifyService {
 
     const signal = AbortSignal.timeout(this.timeout)
 
-    try {
-      // fails on node < 15.4
-      setMaxListeners?.(Infinity, signal)
-    } catch {}
+    setMaxListeners(Infinity, signal)
 
     try {
       const publicKey = this.peerId.publicKey ?? new Uint8Array(0)

--- a/packages/libp2p/src/libp2p.ts
+++ b/packages/libp2p/src/libp2p.ts
@@ -1,8 +1,7 @@
-import { setMaxListeners } from 'events'
 import { unmarshalPublicKey } from '@libp2p/crypto/keys'
 import { type ContentRouting, contentRouting } from '@libp2p/interface/content-routing'
 import { CodeError } from '@libp2p/interface/errors'
-import { TypedEventEmitter, CustomEvent } from '@libp2p/interface/events'
+import { TypedEventEmitter, CustomEvent, setMaxListeners } from '@libp2p/interface/events'
 import { peerDiscovery } from '@libp2p/interface/peer-discovery'
 import { type PeerRouting, peerRouting } from '@libp2p/interface/peer-routing'
 import { DefaultKeyChain } from '@libp2p/keychain'
@@ -70,10 +69,8 @@ export class Libp2pNode<T extends ServiceMap = Record<string, unknown>> extends 
       return internalResult || externalResult
     }
 
-    try {
-      // This emitter gets listened to a lot
-      setMaxListeners?.(Infinity, events)
-    } catch {}
+    // This emitter gets listened to a lot
+    setMaxListeners(Infinity, events)
 
     this.#started = false
     this.peerId = init.peerId

--- a/packages/libp2p/src/upgrader.ts
+++ b/packages/libp2p/src/upgrader.ts
@@ -1,5 +1,5 @@
-import { setMaxListeners } from 'events'
 import { CodeError } from '@libp2p/interface/errors'
+import { setMaxListeners } from '@libp2p/interface/events'
 import { logger } from '@libp2p/logger'
 import * as mss from '@libp2p/multistream-select'
 import { peerIdFromString } from '@libp2p/peer-id'
@@ -170,10 +170,7 @@ export class DefaultUpgrader implements Upgrader {
 
     signal.addEventListener('abort', onAbort, { once: true })
 
-    try {
-      // fails on node < 15.4
-      setMaxListeners?.(Infinity, signal)
-    } catch { }
+    setMaxListeners(Infinity, signal)
 
     try {
       if ((await this.components.connectionGater.denyInboundConnection?.(maConn)) === true) {
@@ -444,10 +441,7 @@ export class DefaultUpgrader implements Upgrader {
 
             options.signal = AbortSignal.timeout(30000)
 
-            try {
-              // fails on node < 15.4
-              setMaxListeners?.(Infinity, options.signal)
-            } catch { }
+            setMaxListeners(Infinity, options.signal)
           }
 
           const { stream, protocol } = await mss.select(muxedStream, protocols, options)


### PR DESCRIPTION
## Description

- Discussed in https://github.com/libp2p/js-libp2p/discussions/2138
- Move `setMaxListeners` handling into a single wrapped function exported from `@libp2p/interface/events`

## Notes

- Instead of setting `"browser": {"events": false}` as was discussed in #2138, an actual file is given. Without doing this, an annoying warning is produced in this package and every consumer package in the monorepo!


## Change checklist

- [x] I have performed a self-review of my own code
- [ ] I have made corresponding changes to the documentation if necessary (this includes comments as well)
- [ ] I have added tests that prove my fix is effective or that my feature works