### PR TITLE
fix!: remove min/max from topologies

### DIFF
--- a/packages/interface/src/topology/index.ts
+++ b/packages/interface/src/topology/index.ts
@@ -2,9 +2,6 @@ import type { Connection } from '../connection/index.js'
 import type { PeerId } from '../peer-id/index.js'
 
 export interface Topology {
-  min?: number
-  max?: number
-
   onConnect?(peerId: PeerId, conn: Connection): void
   onDisconnect?(peerId: PeerId): void
 }


### PR DESCRIPTION
Once upon a time these options were intended to cause libp2p to close connections or search for more peers that support a given protocol but it was never implemented.

Remove the options since they don't do anything, they may be restored in future if the functionality is ever required.

## Change checklist

- [x] I have performed a self-review of my own code
- [ ] I have made corresponding changes to the documentation if necessary (this includes comments as well)
- [ ] I have added tests that prove my fix is effective or that my feature works