### PR TITLE
refactor: rename event emitter class

### DIFF
--- a/packages/interface-compliance-tests/src/mocks/connection-manager.ts
+++ b/packages/interface-compliance-tests/src/mocks/connection-manager.ts
@@ -1,4 +1,5 @@
 import { CodeError } from '@libp2p/interface/errors'
+import { CustomEvent } from '@libp2p/interface/events'
 import { isPeerId, type PeerId } from '@libp2p/interface/peer-id'
 import { PeerMap } from '@libp2p/peer-collections'
 import { peerIdFromString } from '@libp2p/peer-id'
@@ -6,7 +7,7 @@ import { isMultiaddr, type Multiaddr } from '@multiformats/multiaddr'
 import { connectionPair } from './connection.js'
 import type { Libp2pEvents, PendingDial } from '@libp2p/interface'
 import type { Connection } from '@libp2p/interface/connection'
-import type { EventEmitter } from '@libp2p/interface/events'
+import type { TypedEventTarget } from '@libp2p/interface/events'
 import type { PubSub } from '@libp2p/interface/pubsub'
 import type { Startable } from '@libp2p/interface/startable'
 import type { ConnectionManager } from '@libp2p/interface-internal/connection-manager'
@@ -16,7 +17,7 @@ export interface MockNetworkComponents {
   peerId: PeerId
   registrar: Registrar
   connectionManager: ConnectionManager
-  events: EventEmitter<Libp2pEvents>
+  events: TypedEventTarget<Libp2pEvents>
   pubsub?: PubSub
 }
 
@@ -51,7 +52,7 @@ export const mockNetwork = new MockNetwork()
 export interface MockConnectionManagerComponents {
   peerId: PeerId
   registrar: Registrar
-  events: EventEmitter<Libp2pEvents>
+  events: TypedEventTarget<Libp2pEvents>
 }
 
 class MockConnectionManager implements ConnectionManager, Startable {
@@ -130,9 +131,9 @@ class MockConnectionManager implements ConnectionManager, Startable {
     this.connections.push(aToB)
     ;(componentsB.connectionManager as MockConnectionManager).connections.push(bToA)
 
-    this.components.events.safeDispatchEvent('connection:open', {
+    this.components.events.dispatchEvent(new CustomEvent('connection:open', {
       detail: aToB
-    })
+    }))
 
     for (const protocol of this.components.registrar.getProtocols()) {
       for (const topology of this.components.registrar.getTopologies(protocol)) {
@@ -140,11 +141,11 @@ class MockConnectionManager implements ConnectionManager, Startable {
       }
     }
 
-    this.components.events.safeDispatchEvent('peer:connect', { detail: componentsB.peerId })
+    this.components.events.dispatchEvent(new CustomEvent('peer:connect', { detail: componentsB.peerId }))
 
-    componentsB.events.safeDispatchEvent('connection:open', {
+    componentsB.events.dispatchEvent(new CustomEvent('connection:open', {
       detail: bToA
-    })
+    }))
 
     for (const protocol of componentsB.registrar.getProtocols()) {
       for (const topology of componentsB.registrar.getTopologies(protocol)) {

--- a/packages/interface-compliance-tests/src/mocks/connection-manager.ts
+++ b/packages/interface-compliance-tests/src/mocks/connection-manager.ts
@@ -1,5 +1,4 @@
 import { CodeError } from '@libp2p/interface/errors'
-import { CustomEvent } from '@libp2p/interface/events'
 import { isPeerId, type PeerId } from '@libp2p/interface/peer-id'
 import { PeerMap } from '@libp2p/peer-collections'
 import { peerIdFromString } from '@libp2p/peer-id'
@@ -131,9 +130,9 @@ class MockConnectionManager implements ConnectionManager, Startable {
     this.connections.push(aToB)
     ;(componentsB.connectionManager as MockConnectionManager).connections.push(bToA)
 
-    this.components.events.dispatchEvent(new CustomEvent('connection:open', {
+    this.components.events.safeDispatchEvent('connection:open', {
       detail: aToB
-    }))
+    })
 
     for (const protocol of this.components.registrar.getProtocols()) {
       for (const topology of this.components.registrar.getTopologies(protocol)) {
@@ -141,11 +140,11 @@ class MockConnectionManager implements ConnectionManager, Startable {
       }
     }
 
-    this.components.events.dispatchEvent(new CustomEvent('peer:connect', { detail: componentsB.peerId }))
+    this.components.events.safeDispatchEvent('peer:connect', { detail: componentsB.peerId })
 
-    componentsB.events.dispatchEvent(new CustomEvent('connection:open', {
+    componentsB.events.safeDispatchEvent('connection:open', {
       detail: bToA
-    }))
+    })
 
     for (const protocol of componentsB.registrar.getProtocols()) {
       for (const topology of componentsB.registrar.getTopologies(protocol)) {

--- a/packages/interface-compliance-tests/src/mocks/peer-discovery.ts
+++ b/packages/interface-compliance-tests/src/mocks/peer-discovery.ts
@@ -1,4 +1,4 @@
-import { EventEmitter } from '@libp2p/interface/events'
+import { TypedEventEmitter } from '@libp2p/interface/events'
 import { peerDiscovery } from '@libp2p/interface/peer-discovery'
 import * as PeerIdFactory from '@libp2p/peer-id-factory'
 import { multiaddr } from '@multiformats/multiaddr'
@@ -12,7 +12,7 @@ interface MockDiscoveryInit {
 /**
  * Emits 'peer' events on discovery.
  */
-export class MockDiscovery extends EventEmitter<PeerDiscoveryEvents> implements PeerDiscovery {
+export class MockDiscovery extends TypedEventEmitter<PeerDiscoveryEvents> implements PeerDiscovery {
   public readonly options: MockDiscoveryInit
   private _isRunning: boolean
   private _timer: any

--- a/packages/interface-compliance-tests/src/mocks/upgrader.ts
+++ b/packages/interface-compliance-tests/src/mocks/upgrader.ts
@@ -1,18 +1,18 @@
 import { mockConnection } from './connection.js'
 import type { Libp2pEvents } from '@libp2p/interface'
 import type { Connection, MultiaddrConnection } from '@libp2p/interface/connection'
-import type { EventEmitter } from '@libp2p/interface/events'
+import type { TypedEventTarget } from '@libp2p/interface/events'
 import type { Upgrader, UpgraderOptions } from '@libp2p/interface/transport'
 import type { Registrar } from '@libp2p/interface-internal/registrar'
 
 export interface MockUpgraderInit {
   registrar?: Registrar
-  events?: EventEmitter<Libp2pEvents>
+  events?: TypedEventTarget<Libp2pEvents>
 }
 
 class MockUpgrader implements Upgrader {
   private readonly registrar?: Registrar
-  private readonly events?: EventEmitter<Libp2pEvents>
+  private readonly events?: TypedEventTarget<Libp2pEvents>
 
   constructor (init: MockUpgraderInit) {
     this.registrar = init.registrar

--- a/packages/interface-compliance-tests/src/pubsub/utils.ts
+++ b/packages/interface-compliance-tests/src/pubsub/utils.ts
@@ -1,4 +1,4 @@
-import { EventEmitter } from '@libp2p/interface/events'
+import { TypedEventEmitter } from '@libp2p/interface/events'
 import { createEd25519PeerId } from '@libp2p/peer-id-factory'
 import { pEvent } from 'p-event'
 import pWaitFor from 'p-wait-for'
@@ -19,7 +19,7 @@ export async function createComponents (): Promise<MockNetworkComponents> {
   const components: any = {
     peerId: await createEd25519PeerId(),
     registrar: mockRegistrar(),
-    events: new EventEmitter()
+    events: new TypedEventEmitter()
   }
   components.connectionManager = mockConnectionManager(components)
 

--- a/packages/interface-compliance-tests/src/transport/dial-test.ts
+++ b/packages/interface-compliance-tests/src/transport/dial-test.ts
@@ -1,5 +1,5 @@
 import { AbortError } from '@libp2p/interface/errors'
-import { EventEmitter } from '@libp2p/interface/events'
+import { TypedEventEmitter } from '@libp2p/interface/events'
 import { expect } from 'aegir/chai'
 import all from 'it-all'
 import drain from 'it-drain'
@@ -27,7 +27,7 @@ export default (common: TestSetup<TransportTestFixtures>): void => {
       registrar = mockRegistrar()
       upgrader = mockUpgrader({
         registrar,
-        events: new EventEmitter()
+        events: new TypedEventEmitter()
       });
 
       ({ addrs, transport, connector } = await common.setup())

--- a/packages/interface-compliance-tests/src/transport/listen-test.ts
+++ b/packages/interface-compliance-tests/src/transport/listen-test.ts
@@ -1,5 +1,5 @@
 /* eslint max-nested-callbacks: ["error", 8] */
-import { CustomEvent, EventEmitter } from '@libp2p/interface/events'
+import { CustomEvent, TypedEventEmitter } from '@libp2p/interface/events'
 import { expect } from 'aegir/chai'
 import drain from 'it-drain'
 import { pipe } from 'it-pipe'
@@ -27,7 +27,7 @@ export default (common: TestSetup<TransportTestFixtures>): void => {
       registrar = mockRegistrar()
       upgrader = mockUpgrader({
         registrar,
-        events: new EventEmitter()
+        events: new TypedEventEmitter()
       });
 
       ({ transport, addrs } = await common.setup())

--- a/packages/interface/src/events.ts
+++ b/packages/interface/src/events.ts
@@ -15,7 +15,23 @@ interface Listener {
  * https://github.com/microsoft/TypeScript/issues/299
  * etc
  */
-export class EventEmitter<EventMap extends Record<string, any>> extends EventTarget {
+export interface TypedEventTarget <EventMap extends Record<string, any>> extends EventTarget {
+  addEventListener<K extends keyof EventMap>(type: K, listener: EventHandler<EventMap[K]> | null, options?: boolean | AddEventListenerOptions): void
+
+  listenerCount (type: string): number
+
+  removeEventListener<K extends keyof EventMap>(type: K, listener?: EventHandler<EventMap[K]> | null, options?: boolean | EventListenerOptions): void
+
+  removeEventListener (type: string, listener?: EventHandler<Event>, options?: boolean | EventListenerOptions): void
+
+  safeDispatchEvent<Detail>(type: keyof EventMap, detail: CustomEventInit<Detail>): boolean
+}
+
+/**
+ * An implementation of a typed event target
+ * etc
+ */
+export class TypedEventEmitter<EventMap extends Record<string, any>> extends EventTarget implements TypedEventTarget<EventMap> {
   #listeners = new Map<any, Listener[]>()
 
   listenerCount (type: string): number {
@@ -98,3 +114,6 @@ class CustomEventPolyfill<T = any> extends Event {
 }
 
 export const CustomEvent = globalThis.CustomEvent ?? CustomEventPolyfill
+
+// TODO: remove this in v1
+export { TypedEventEmitter as EventEmitter }

--- a/packages/interface/src/index.ts
+++ b/packages/interface/src/index.ts
@@ -16,7 +16,7 @@
 
 import type { Connection, NewStreamOptions, Stream } from './connection/index.js'
 import type { ContentRouting } from './content-routing/index.js'
-import type { EventEmitter } from './events.js'
+import type { TypedEventTarget } from './events.js'
 import type { KeyChain } from './keychain/index.js'
 import type { Metrics } from './metrics/index.js'
 import type { PeerId } from './peer-id/index.js'
@@ -303,7 +303,7 @@ export interface PendingDial {
 /**
  * Libp2p nodes implement this interface.
  */
-export interface Libp2p<T extends ServiceMap = ServiceMap> extends Startable, EventEmitter<Libp2pEvents<T>> {
+export interface Libp2p<T extends ServiceMap = ServiceMap> extends Startable, TypedEventTarget<Libp2pEvents<T>> {
   /**
    * The PeerId is a unique identifier for a node on the network.
    *

--- a/packages/interface/src/peer-discovery/index.ts
+++ b/packages/interface/src/peer-discovery/index.ts
@@ -1,4 +1,4 @@
-import type { EventEmitter } from '../events.js'
+import type { TypedEventTarget } from '../events.js'
 import type { PeerInfo } from '../peer-info/index.js'
 
 /**
@@ -26,4 +26,4 @@ export interface PeerDiscoveryEvents {
   'peer': CustomEvent<PeerInfo>
 }
 
-export interface PeerDiscovery extends EventEmitter<PeerDiscoveryEvents> {}
+export interface PeerDiscovery extends TypedEventTarget<PeerDiscoveryEvents> {}

--- a/packages/interface/src/pubsub/index.ts
+++ b/packages/interface/src/pubsub/index.ts
@@ -1,5 +1,5 @@
 import type { Stream } from '../connection/index.js'
-import type { EventEmitter } from '../events.js'
+import type { TypedEventTarget } from '../events.js'
 import type { PeerId } from '../peer-id/index.js'
 import type { Pushable } from 'it-pushable'
 import type { Uint8ArrayList } from 'uint8arraylist'
@@ -65,7 +65,7 @@ export interface PubSubRPC {
   messages: PubSubRPCMessage[]
 }
 
-export interface PeerStreams extends EventEmitter<PeerStreamEvents> {
+export interface PeerStreams extends TypedEventTarget<PeerStreamEvents> {
   id: PeerId
   protocol: string
   outboundStream?: Pushable<Uint8ArrayList>
@@ -152,7 +152,7 @@ export interface TopicValidatorFn {
   (peer: PeerId, message: Message): TopicValidatorResult | Promise<TopicValidatorResult>
 }
 
-export interface PubSub<Events extends Record<string, any> = PubSubEvents> extends EventEmitter<Events> {
+export interface PubSub<Events extends Record<string, any> = PubSubEvents> extends TypedEventTarget<Events> {
   /**
    * The global signature policy controls whether or not we sill send and receive
    * signed or unsigned messages.

--- a/packages/interface/src/transport/index.ts
+++ b/packages/interface/src/transport/index.ts
@@ -1,5 +1,5 @@
 import type { Connection, MultiaddrConnection } from '../connection/index.js'
-import type { EventEmitter } from '../events.js'
+import type { TypedEventTarget } from '../events.js'
 import type { AbortOptions } from '../index.js'
 import type { StreamMuxerFactory } from '../stream-muxer/index.js'
 import type { Multiaddr } from '@multiformats/multiaddr'
@@ -11,7 +11,7 @@ export interface ListenerEvents {
   'close': CustomEvent
 }
 
-export interface Listener extends EventEmitter<ListenerEvents> {
+export interface Listener extends TypedEventTarget<ListenerEvents> {
   /**
    * Start a listener
    */

--- a/packages/kad-dht/src/dual-kad-dht.ts
+++ b/packages/kad-dht/src/dual-kad-dht.ts
@@ -1,6 +1,6 @@
 import { type ContentRouting, contentRouting } from '@libp2p/interface/content-routing'
 import { CodeError } from '@libp2p/interface/errors'
-import { EventEmitter, CustomEvent } from '@libp2p/interface/events'
+import { TypedEventEmitter, CustomEvent } from '@libp2p/interface/events'
 import { type PeerDiscovery, peerDiscovery, type PeerDiscoveryEvents } from '@libp2p/interface/peer-discovery'
 import { type PeerRouting, peerRouting } from '@libp2p/interface/peer-routing'
 import { logger } from '@libp2p/logger'
@@ -121,7 +121,7 @@ function multiaddrIsPublic (multiaddr: Multiaddr): boolean {
  * A DHT implementation modelled after Kademlia with S/Kademlia modifications.
  * Original implementation in go: https://github.com/libp2p/go-libp2p-kad-dht.
  */
-export class DefaultDualKadDHT extends EventEmitter<PeerDiscoveryEvents> implements DualKadDHT, PeerDiscovery {
+export class DefaultDualKadDHT extends TypedEventEmitter<PeerDiscoveryEvents> implements DualKadDHT, PeerDiscovery {
   public readonly wan: DefaultKadDHT
   public readonly lan: DefaultKadDHT
   public readonly components: KadDHTComponents

--- a/packages/kad-dht/src/index.ts
+++ b/packages/kad-dht/src/index.ts
@@ -1,7 +1,7 @@
 import { DefaultDualKadDHT } from './dual-kad-dht.js'
 import type { ProvidersInit } from './providers.js'
 import type { Libp2pEvents, AbortOptions } from '@libp2p/interface'
-import type { EventEmitter } from '@libp2p/interface/events'
+import type { TypedEventTarget } from '@libp2p/interface/events'
 import type { Metrics } from '@libp2p/interface/metrics'
 import type { PeerId } from '@libp2p/interface/peer-id'
 import type { PeerInfo } from '@libp2p/interface/peer-info'
@@ -314,7 +314,7 @@ export interface KadDHTComponents {
   metrics?: Metrics
   connectionManager: ConnectionManager
   datastore: Datastore
-  events: EventEmitter<Libp2pEvents>
+  events: TypedEventTarget<Libp2pEvents>
 }
 
 export function kadDHT (init?: KadDHTInit): (components: KadDHTComponents) => DualKadDHT {

--- a/packages/kad-dht/src/kad-dht.ts
+++ b/packages/kad-dht/src/kad-dht.ts
@@ -1,4 +1,4 @@
-import { CustomEvent, EventEmitter } from '@libp2p/interface/events'
+import { CustomEvent, TypedEventEmitter } from '@libp2p/interface/events'
 import { type Logger, logger } from '@libp2p/logger'
 import pDefer from 'p-defer'
 import { PROTOCOL_DHT, PROTOCOL_PREFIX, LAN_PREFIX } from './constants.js'
@@ -39,7 +39,7 @@ export interface SingleKadDHTInit extends KadDHTInit {
  * A DHT implementation modelled after Kademlia with S/Kademlia modifications.
  * Original implementation in go: https://github.com/libp2p/go-libp2p-kad-dht.
  */
-export class DefaultKadDHT extends EventEmitter<PeerDiscoveryEvents> implements KadDHT {
+export class DefaultKadDHT extends TypedEventEmitter<PeerDiscoveryEvents> implements KadDHT {
   public protocol: string
   public routingTable: RoutingTable
   public providers: Providers

--- a/packages/kad-dht/src/network.ts
+++ b/packages/kad-dht/src/network.ts
@@ -1,5 +1,5 @@
 import { CodeError } from '@libp2p/interface/errors'
-import { EventEmitter, CustomEvent } from '@libp2p/interface/events'
+import { TypedEventEmitter, CustomEvent } from '@libp2p/interface/events'
 import { logger } from '@libp2p/logger'
 import { abortableDuplex } from 'abortable-iterator'
 import drain from 'it-drain'
@@ -35,7 +35,7 @@ interface NetworkEvents {
 /**
  * Handle network operations for the dht
  */
-export class Network extends EventEmitter<NetworkEvents> implements Startable {
+export class Network extends TypedEventEmitter<NetworkEvents> implements Startable {
   private readonly log: Logger
   private readonly protocol: string
   private running: boolean

--- a/packages/kad-dht/src/query/manager.ts
+++ b/packages/kad-dht/src/query/manager.ts
@@ -1,6 +1,6 @@
 import { setMaxListeners } from 'events'
 import { AbortError } from '@libp2p/interface/errors'
-import { EventEmitter, CustomEvent } from '@libp2p/interface/events'
+import { TypedEventEmitter, CustomEvent } from '@libp2p/interface/events'
 import { logger } from '@libp2p/logger'
 import { PeerSet } from '@libp2p/peer-collections'
 import { anySignal } from 'any-signal'
@@ -143,7 +143,7 @@ export class QueryManager implements Startable {
 
     // query a subset of peers up to `kBucketSize / 2` in length
     const startTime = Date.now()
-    const cleanUp = new EventEmitter<CleanUpEvents>()
+    const cleanUp = new TypedEventEmitter<CleanUpEvents>()
 
     try {
       if (options.isSelfQuery !== true && this.initialQuerySelfHasRun != null) {

--- a/packages/kad-dht/src/query/query-path.ts
+++ b/packages/kad-dht/src/query/query-path.ts
@@ -9,7 +9,7 @@ import { queryErrorEvent } from './events.js'
 import type { CleanUpEvents } from './manager.js'
 import type { QueryEvent, QueryOptions } from '../index.js'
 import type { QueryFunc } from '../query/types.js'
-import type { EventEmitter } from '@libp2p/interface/events'
+import type { TypedEventTarget } from '@libp2p/interface/events'
 import type { PeerId } from '@libp2p/interface/peer-id'
 import type { Logger } from '@libp2p/logger'
 import type { PeerSet } from '@libp2p/peer-collections'
@@ -60,7 +60,7 @@ export interface QueryPathOptions extends QueryOptions {
   /**
    * will emit a 'cleanup' event if the caller exits the for..await of early
    */
-  cleanUp: EventEmitter<CleanUpEvents>
+  cleanUp: TypedEventTarget<CleanUpEvents>
 
   /**
    * A timeout for queryFunc in ms
@@ -185,7 +185,7 @@ export async function * queryPath (options: QueryPathOptions): AsyncGenerator<Qu
   yield * toGenerator(queue, signal, cleanUp, log)
 }
 
-async function * toGenerator (queue: Queue, signal: AbortSignal, cleanUp: EventEmitter<CleanUpEvents>, log: Logger): AsyncGenerator<QueryEvent, void, undefined> {
+async function * toGenerator (queue: Queue, signal: AbortSignal, cleanUp: TypedEventTarget<CleanUpEvents>, log: Logger): AsyncGenerator<QueryEvent, void, undefined> {
   let deferred = defer()
   let running = true
   const results: QueryEvent[] = []

--- a/packages/kad-dht/src/routing-table/index.ts
+++ b/packages/kad-dht/src/routing-table/index.ts
@@ -1,4 +1,4 @@
-import { EventEmitter } from '@libp2p/interface/events'
+import { TypedEventEmitter } from '@libp2p/interface/events'
 import { logger } from '@libp2p/logger'
 import { PeerSet } from '@libp2p/peer-collections'
 import Queue from 'p-queue'
@@ -43,7 +43,7 @@ export interface RoutingTableEvents {
  * A wrapper around `k-bucket`, to provide easy store and
  * retrieval for peers.
  */
-export class RoutingTable extends EventEmitter<RoutingTableEvents> implements Startable {
+export class RoutingTable extends TypedEventEmitter<RoutingTableEvents> implements Startable {
   public kBucketSize: number
   public kb?: KBucket
   public pingQueue: Queue

--- a/packages/kad-dht/src/routing-table/k-bucket.ts
+++ b/packages/kad-dht/src/routing-table/k-bucket.ts
@@ -27,7 +27,7 @@ FROM, OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR
 OTHER DEALINGS IN THE SOFTWARE.
 */
 
-import { EventEmitter } from '@libp2p/interface/events'
+import { TypedEventEmitter } from '@libp2p/interface/events'
 import type { PeerId } from '@libp2p/interface/peer-id'
 
 function arrayEquals (array1: Uint8Array, array2: Uint8Array): boolean {
@@ -122,10 +122,8 @@ export interface Bucket {
 /**
  * Implementation of a Kademlia DHT k-bucket used for storing
  * contact (peer node) information.
- *
- * @extends EventEmitter
  */
-export class KBucket extends EventEmitter<KBucketEvents> {
+export class KBucket extends TypedEventEmitter<KBucketEvents> {
   public localNodeId: Uint8Array
   public root: Bucket
   private readonly numberOfNodesPerKBucket: number

--- a/packages/kad-dht/src/topology-listener.ts
+++ b/packages/kad-dht/src/topology-listener.ts
@@ -1,4 +1,4 @@
-import { CustomEvent, EventEmitter } from '@libp2p/interface/events'
+import { CustomEvent, TypedEventEmitter } from '@libp2p/interface/events'
 import { logger } from '@libp2p/logger'
 import type { KadDHTComponents } from '.'
 import type { PeerId } from '@libp2p/interface/peer-id'
@@ -17,7 +17,7 @@ export interface TopologyListenerEvents {
 /**
  * Receives notifications of new peers joining the network that support the DHT protocol
  */
-export class TopologyListener extends EventEmitter<TopologyListenerEvents> implements Startable {
+export class TopologyListener extends TypedEventEmitter<TopologyListenerEvents> implements Startable {
   private readonly log: Logger
   private readonly components: KadDHTComponents
   private readonly protocol: string

--- a/packages/kad-dht/test/routing-table.spec.ts
+++ b/packages/kad-dht/test/routing-table.spec.ts
@@ -1,6 +1,6 @@
 /* eslint-env mocha */
 
-import { EventEmitter, CustomEvent } from '@libp2p/interface/events'
+import { TypedEventEmitter, CustomEvent } from '@libp2p/interface/events'
 import { mockConnectionManager } from '@libp2p/interface-compliance-tests/mocks'
 import { PeerSet } from '@libp2p/peer-collections'
 import { peerIdFromString } from '@libp2p/peer-id'
@@ -33,7 +33,7 @@ describe('Routing Table', () => {
   beforeEach(async function () {
     this.timeout(20 * 1000)
 
-    const events = new EventEmitter<Libp2pEvents>()
+    const events = new TypedEventEmitter<Libp2pEvents>()
 
     components = {
       peerId: await createPeerId(),

--- a/packages/kad-dht/test/rpc/handlers/get-providers.spec.ts
+++ b/packages/kad-dht/test/rpc/handlers/get-providers.spec.ts
@@ -1,6 +1,6 @@
 /* eslint-env mocha */
 
-import { EventEmitter } from '@libp2p/interface/events'
+import { TypedEventEmitter } from '@libp2p/interface/events'
 import { PersistentPeerStore } from '@libp2p/peer-store'
 import { multiaddr } from '@multiformats/multiaddr'
 import { expect } from 'aegir/chai'
@@ -43,7 +43,7 @@ describe('rpc - handlers - GetProviders', () => {
     peerStore = new PersistentPeerStore({
       peerId,
       datastore: new MemoryDatastore(),
-      events: new EventEmitter<Libp2pEvents>()
+      events: new TypedEventEmitter<Libp2pEvents>()
     })
 
     const components: GetProvidersHandlerComponents = {

--- a/packages/kad-dht/test/rpc/handlers/get-value.spec.ts
+++ b/packages/kad-dht/test/rpc/handlers/get-value.spec.ts
@@ -1,6 +1,6 @@
 /* eslint-env mocha */
 
-import { EventEmitter } from '@libp2p/interface/events'
+import { TypedEventEmitter } from '@libp2p/interface/events'
 import { PersistentPeerStore } from '@libp2p/peer-store'
 import { expect } from 'aegir/chai'
 import { MemoryDatastore } from 'datastore-core'
@@ -40,7 +40,7 @@ describe('rpc - handlers - GetValue', () => {
     peerStore = new PersistentPeerStore({
       peerId,
       datastore,
-      events: new EventEmitter<Libp2pEvents>()
+      events: new TypedEventEmitter<Libp2pEvents>()
     })
 
     const components: GetValueHandlerComponents = {

--- a/packages/kad-dht/test/rpc/index.node.ts
+++ b/packages/kad-dht/test/rpc/index.node.ts
@@ -1,6 +1,6 @@
 /* eslint-env mocha */
 
-import { EventEmitter } from '@libp2p/interface/events'
+import { TypedEventEmitter } from '@libp2p/interface/events'
 import { start } from '@libp2p/interface/startable'
 import { mockStream } from '@libp2p/interface-compliance-tests/mocks'
 import { PersistentPeerStore } from '@libp2p/peer-store'
@@ -51,7 +51,7 @@ describe('rpc', () => {
     }
     components.peerStore = new PersistentPeerStore({
       ...components,
-      events: new EventEmitter<Libp2pEvents>()
+      events: new TypedEventEmitter<Libp2pEvents>()
     })
 
     await start(...Object.values(components))

--- a/packages/kad-dht/test/utils/test-dht.ts
+++ b/packages/kad-dht/test/utils/test-dht.ts
@@ -1,4 +1,4 @@
-import { EventEmitter } from '@libp2p/interface/events'
+import { TypedEventEmitter } from '@libp2p/interface/events'
 import { start, stop } from '@libp2p/interface/startable'
 import { mockRegistrar, mockConnectionManager, mockNetwork } from '@libp2p/interface-compliance-tests/mocks'
 import { logger } from '@libp2p/logger'
@@ -29,7 +29,7 @@ export class TestDHT {
   }
 
   async spawn (options: Partial<KadDHTInit> = {}, autoStart = true): Promise<DefaultDualKadDHT> {
-    const events = new EventEmitter<Libp2pEvents>()
+    const events = new TypedEventEmitter<Libp2pEvents>()
     const components: KadDHTComponents = {
       peerId: await createPeerId(),
       datastore: new MemoryDatastore(),

--- a/packages/libp2p/src/address-manager/index.ts
+++ b/packages/libp2p/src/address-manager/index.ts
@@ -3,7 +3,7 @@ import { peerIdFromString } from '@libp2p/peer-id'
 import { multiaddr } from '@multiformats/multiaddr'
 import { debounce } from './utils.js'
 import type { Libp2pEvents } from '@libp2p/interface'
-import type { EventEmitter } from '@libp2p/interface/events'
+import type { TypedEventTarget } from '@libp2p/interface/events'
 import type { PeerId } from '@libp2p/interface/peer-id'
 import type { PeerStore } from '@libp2p/interface/peer-store'
 import type { TransportManager } from '@libp2p/interface-internal/transport-manager'
@@ -38,7 +38,7 @@ export interface DefaultAddressManagerComponents {
   peerId: PeerId
   transportManager: TransportManager
   peerStore: PeerStore
-  events: EventEmitter<Libp2pEvents>
+  events: TypedEventTarget<Libp2pEvents>
 }
 
 /**

--- a/packages/libp2p/src/circuit-relay/index.ts
+++ b/packages/libp2p/src/circuit-relay/index.ts
@@ -35,7 +35,7 @@
  */
 
 import type { Limit } from './pb/index.js'
-import type { EventEmitter } from '@libp2p/interface/events'
+import type { TypedEventEmitter } from '@libp2p/interface/events'
 import type { PeerMap } from '@libp2p/peer-collections'
 import type { Multiaddr } from '@multiformats/multiaddr'
 
@@ -51,7 +51,7 @@ export interface CircuitRelayServiceEvents {
   'relay:advert:error': CustomEvent<Error>
 }
 
-export interface CircuitRelayService extends EventEmitter<CircuitRelayServiceEvents> {
+export interface CircuitRelayService extends TypedEventEmitter<CircuitRelayServiceEvents> {
   reservations: PeerMap<RelayReservation>
 }
 

--- a/packages/libp2p/src/circuit-relay/server/advert-service.ts
+++ b/packages/libp2p/src/circuit-relay/server/advert-service.ts
@@ -1,4 +1,4 @@
-import { EventEmitter } from '@libp2p/interface/events'
+import { TypedEventEmitter } from '@libp2p/interface/events'
 import { logger } from '@libp2p/logger'
 import pRetry from 'p-retry'
 import { codes } from '../../errors.js'
@@ -31,7 +31,7 @@ export interface AdvertServiceEvents {
   'advert:error': CustomEvent<Error>
 }
 
-export class AdvertService extends EventEmitter<AdvertServiceEvents> implements Startable {
+export class AdvertService extends TypedEventEmitter<AdvertServiceEvents> implements Startable {
   private readonly contentRouting: ContentRouting
   private timeout?: any
   private started: boolean

--- a/packages/libp2p/src/circuit-relay/server/index.ts
+++ b/packages/libp2p/src/circuit-relay/server/index.ts
@@ -1,5 +1,5 @@
 import { setMaxListeners } from 'events'
-import { EventEmitter } from '@libp2p/interface/events'
+import { TypedEventEmitter } from '@libp2p/interface/events'
 import { logger } from '@libp2p/logger'
 import { peerIdFromBytes } from '@libp2p/peer-id'
 import { RecordEnvelope } from '@libp2p/peer-record'
@@ -99,7 +99,7 @@ const defaults = {
   maxOutboundStopStreams: MAX_CONNECTIONS
 }
 
-class CircuitRelayServer extends EventEmitter<RelayServerEvents> implements Startable, CircuitRelayService {
+class CircuitRelayServer extends TypedEventEmitter<RelayServerEvents> implements Startable, CircuitRelayService {
   private readonly registrar: Registrar
   private readonly peerStore: PeerStore
   private readonly addressManager: AddressManager

--- a/packages/libp2p/src/circuit-relay/transport/discovery.ts
+++ b/packages/libp2p/src/circuit-relay/transport/discovery.ts
@@ -1,4 +1,4 @@
-import { EventEmitter } from '@libp2p/interface/events'
+import { TypedEventEmitter } from '@libp2p/interface/events'
 import { logger } from '@libp2p/logger'
 import {
   RELAY_RENDEZVOUS_NS,
@@ -32,7 +32,7 @@ export interface RelayDiscoveryComponents {
  * ReservationManager automatically makes a circuit v2 reservation on any connected
  * peers that support the circuit v2 HOP protocol.
  */
-export class RelayDiscovery extends EventEmitter<RelayDiscoveryEvents> implements Startable {
+export class RelayDiscovery extends TypedEventEmitter<RelayDiscoveryEvents> implements Startable {
   private readonly peerId: PeerId
   private readonly peerStore: PeerStore
   private readonly contentRouting: ContentRouting

--- a/packages/libp2p/src/circuit-relay/transport/index.ts
+++ b/packages/libp2p/src/circuit-relay/transport/index.ts
@@ -17,7 +17,7 @@ import type { Libp2pEvents, AbortOptions } from '@libp2p/interface'
 import type { Connection, Stream } from '@libp2p/interface/connection'
 import type { ConnectionGater } from '@libp2p/interface/connection-gater'
 import type { ContentRouting } from '@libp2p/interface/content-routing'
-import type { EventEmitter } from '@libp2p/interface/events'
+import type { TypedEventTarget } from '@libp2p/interface/events'
 import type { PeerId } from '@libp2p/interface/peer-id'
 import type { PeerStore } from '@libp2p/interface/peer-store'
 import type { AddressManager } from '@libp2p/interface-internal/address-manager'
@@ -50,7 +50,7 @@ export interface CircuitRelayTransportComponents extends RelayDiscoveryComponent
   addressManager: AddressManager
   contentRouting: ContentRouting
   connectionGater: ConnectionGater
-  events: EventEmitter<Libp2pEvents>
+  events: TypedEventTarget<Libp2pEvents>
 }
 
 interface ConnectOptions {

--- a/packages/libp2p/src/circuit-relay/transport/listener.ts
+++ b/packages/libp2p/src/circuit-relay/transport/listener.ts
@@ -1,5 +1,5 @@
 import { CodeError } from '@libp2p/interface/errors'
-import { EventEmitter } from '@libp2p/interface/events'
+import { TypedEventEmitter } from '@libp2p/interface/events'
 import { logger } from '@libp2p/logger'
 import { PeerMap } from '@libp2p/peer-collections'
 import { peerIdFromString } from '@libp2p/peer-id'
@@ -18,7 +18,7 @@ export interface CircuitRelayTransportListenerComponents {
   relayStore: ReservationStore
 }
 
-class CircuitRelayTransportListener extends EventEmitter<ListenerEvents> implements Listener {
+class CircuitRelayTransportListener extends TypedEventEmitter<ListenerEvents> implements Listener {
   private readonly connectionManager: ConnectionManager
   private readonly relayStore: ReservationStore
   private readonly listeningAddrs: PeerMap<Multiaddr[]>

--- a/packages/libp2p/src/circuit-relay/transport/reservation-store.ts
+++ b/packages/libp2p/src/circuit-relay/transport/reservation-store.ts
@@ -1,4 +1,4 @@
-import { EventEmitter } from '@libp2p/interface/events'
+import { TypedEventEmitter, type TypedEventTarget } from '@libp2p/interface/events'
 import { logger } from '@libp2p/logger'
 import { PeerMap } from '@libp2p/peer-collections'
 import { multiaddr } from '@multiformats/multiaddr'
@@ -32,7 +32,7 @@ export interface RelayStoreComponents {
   connectionManager: ConnectionManager
   transportManager: TransportManager
   peerStore: PeerStore
-  events: EventEmitter<Libp2pEvents>
+  events: TypedEventTarget<Libp2pEvents>
 }
 
 export interface RelayStoreInit {
@@ -76,12 +76,12 @@ export interface ReservationStoreEvents {
   'relay:removed': CustomEvent<PeerId>
 }
 
-export class ReservationStore extends EventEmitter<ReservationStoreEvents> implements Startable {
+export class ReservationStore extends TypedEventEmitter<ReservationStoreEvents> implements Startable {
   private readonly peerId: PeerId
   private readonly connectionManager: ConnectionManager
   private readonly transportManager: TransportManager
   private readonly peerStore: PeerStore
-  private readonly events: EventEmitter<Libp2pEvents>
+  private readonly events: TypedEventTarget<Libp2pEvents>
   private readonly reserveQueue: PeerJobQueue
   private readonly reservations: PeerMap<RelayEntry>
   private readonly maxDiscoveredRelays: number

--- a/packages/libp2p/src/components.ts
+++ b/packages/libp2p/src/components.ts
@@ -4,7 +4,7 @@ import type { Libp2pEvents } from '@libp2p/interface'
 import type { ConnectionProtector } from '@libp2p/interface/connection'
 import type { ConnectionGater } from '@libp2p/interface/connection-gater'
 import type { ContentRouting } from '@libp2p/interface/content-routing'
-import type { EventEmitter } from '@libp2p/interface/events'
+import type { TypedEventTarget } from '@libp2p/interface/events'
 import type { Metrics } from '@libp2p/interface/metrics'
 import type { PeerId } from '@libp2p/interface/peer-id'
 import type { PeerRouting } from '@libp2p/interface/peer-routing'
@@ -18,7 +18,7 @@ import type { Datastore } from 'interface-datastore'
 
 export interface Components extends Record<string, any>, Startable {
   peerId: PeerId
-  events: EventEmitter<Libp2pEvents>
+  events: TypedEventTarget<Libp2pEvents>
   addressManager: AddressManager
   peerStore: PeerStore
   upgrader: Upgrader
@@ -35,7 +35,7 @@ export interface Components extends Record<string, any>, Startable {
 
 export interface ComponentsInit {
   peerId?: PeerId
-  events?: EventEmitter<Libp2pEvents>
+  events?: TypedEventTarget<Libp2pEvents>
   addressManager?: AddressManager
   peerStore?: PeerStore
   upgrader?: Upgrader

--- a/packages/libp2p/src/connection-manager/auto-dial.ts
+++ b/packages/libp2p/src/connection-manager/auto-dial.ts
@@ -4,7 +4,7 @@ import { toString as uint8ArrayToString } from 'uint8arrays/to-string'
 import { PeerJobQueue } from '../utils/peer-job-queue.js'
 import { AUTO_DIAL_CONCURRENCY, AUTO_DIAL_DISCOVERED_PEERS_DEBOUNCE, AUTO_DIAL_INTERVAL, AUTO_DIAL_MAX_QUEUE_LENGTH, AUTO_DIAL_PEER_RETRY_THRESHOLD, AUTO_DIAL_PRIORITY, LAST_DIAL_FAILURE_KEY, MIN_CONNECTIONS } from './constants.js'
 import type { Libp2pEvents } from '@libp2p/interface'
-import type { EventEmitter } from '@libp2p/interface/events'
+import type { TypedEventTarget } from '@libp2p/interface/events'
 import type { PeerStore } from '@libp2p/interface/peer-store'
 import type { Startable } from '@libp2p/interface/startable'
 import type { ConnectionManager } from '@libp2p/interface-internal/connection-manager'
@@ -24,7 +24,7 @@ interface AutoDialInit {
 interface AutoDialComponents {
   connectionManager: ConnectionManager
   peerStore: PeerStore
-  events: EventEmitter<Libp2pEvents>
+  events: TypedEventTarget<Libp2pEvents>
 }
 
 const defaultOptions = {

--- a/packages/libp2p/src/connection-manager/connection-pruner.ts
+++ b/packages/libp2p/src/connection-manager/connection-pruner.ts
@@ -2,7 +2,7 @@ import { logger } from '@libp2p/logger'
 import { PeerMap } from '@libp2p/peer-collections'
 import { MAX_CONNECTIONS } from './constants.js'
 import type { Libp2pEvents } from '@libp2p/interface'
-import type { EventEmitter } from '@libp2p/interface/events'
+import type { TypedEventTarget } from '@libp2p/interface/events'
 import type { PeerStore } from '@libp2p/interface/peer-store'
 import type { ConnectionManager } from '@libp2p/interface-internal/connection-manager'
 import type { Multiaddr } from '@multiformats/multiaddr'
@@ -17,7 +17,7 @@ interface ConnectionPrunerInit {
 interface ConnectionPrunerComponents {
   connectionManager: ConnectionManager
   peerStore: PeerStore
-  events: EventEmitter<Libp2pEvents>
+  events: TypedEventTarget<Libp2pEvents>
 }
 
 const defaultOptions = {
@@ -33,7 +33,7 @@ export class ConnectionPruner {
   private readonly connectionManager: ConnectionManager
   private readonly peerStore: PeerStore
   private readonly allow: Multiaddr[]
-  private readonly events: EventEmitter<Libp2pEvents>
+  private readonly events: TypedEventTarget<Libp2pEvents>
 
   constructor (components: ConnectionPrunerComponents, init: ConnectionPrunerInit = {}) {
     this.maxConnections = init.maxConnections ?? defaultOptions.maxConnections

--- a/packages/libp2p/src/connection-manager/index.ts
+++ b/packages/libp2p/src/connection-manager/index.ts
@@ -15,7 +15,7 @@ import { DialQueue } from './dial-queue.js'
 import type { PendingDial, AddressSorter, Libp2pEvents, AbortOptions } from '@libp2p/interface'
 import type { Connection, MultiaddrConnection } from '@libp2p/interface/connection'
 import type { ConnectionGater } from '@libp2p/interface/connection-gater'
-import type { EventEmitter } from '@libp2p/interface/events'
+import type { TypedEventTarget } from '@libp2p/interface/events'
 import type { Metrics } from '@libp2p/interface/metrics'
 import type { PeerId } from '@libp2p/interface/peer-id'
 import type { Peer, PeerStore } from '@libp2p/interface/peer-store'
@@ -165,7 +165,7 @@ export interface DefaultConnectionManagerComponents {
   peerStore: PeerStore
   transportManager: TransportManager
   connectionGater: ConnectionGater
-  events: EventEmitter<Libp2pEvents>
+  events: TypedEventTarget<Libp2pEvents>
 }
 
 /**
@@ -187,7 +187,7 @@ export class DefaultConnectionManager implements ConnectionManager, Startable {
 
   private readonly peerStore: PeerStore
   private readonly metrics?: Metrics
-  private readonly events: EventEmitter<Libp2pEvents>
+  private readonly events: TypedEventTarget<Libp2pEvents>
 
   constructor (components: DefaultConnectionManagerComponents, init: ConnectionManagerInit = {}) {
     this.maxConnections = init.maxConnections ?? defaultOptions.maxConnections

--- a/packages/libp2p/src/identify/identify.ts
+++ b/packages/libp2p/src/identify/identify.ts
@@ -21,7 +21,7 @@ import { Identify } from './pb/message.js'
 import type { IdentifyService, IdentifyServiceComponents, IdentifyServiceInit } from './index.js'
 import type { Libp2pEvents, IdentifyResult, SignedPeerRecord, AbortOptions } from '@libp2p/interface'
 import type { Connection, Stream } from '@libp2p/interface/connection'
-import type { EventEmitter } from '@libp2p/interface/events'
+import type { TypedEventTarget } from '@libp2p/interface/events'
 import type { PeerId } from '@libp2p/interface/peer-id'
 import type { Peer, PeerStore } from '@libp2p/interface/peer-store'
 import type { Startable } from '@libp2p/interface/startable'
@@ -70,7 +70,7 @@ export class DefaultIdentifyService implements Startable, IdentifyService {
   private readonly maxPushOutgoingStreams: number
   private readonly maxIdentifyMessageSize: number
   private readonly maxObservedAddresses: number
-  private readonly events: EventEmitter<Libp2pEvents>
+  private readonly events: TypedEventTarget<Libp2pEvents>
   private readonly runOnTransientConnection: boolean
 
   constructor (components: IdentifyServiceComponents, init: IdentifyServiceInit) {

--- a/packages/libp2p/src/identify/index.ts
+++ b/packages/libp2p/src/identify/index.ts
@@ -5,7 +5,7 @@ import {
 import { DefaultIdentifyService } from './identify.js'
 import { Identify } from './pb/message.js'
 import type { AbortOptions, IdentifyResult, Libp2pEvents } from '@libp2p/interface'
-import type { EventEmitter } from '@libp2p/interface/events'
+import type { TypedEventTarget } from '@libp2p/interface/events'
 import type { PeerId } from '@libp2p/interface/peer-id'
 import type { PeerStore } from '@libp2p/interface/peer-store'
 import type { Connection } from '@libp2p/interface/src/connection/index.js'
@@ -58,7 +58,7 @@ export interface IdentifyServiceComponents {
   connectionManager: ConnectionManager
   registrar: Registrar
   addressManager: AddressManager
-  events: EventEmitter<Libp2pEvents>
+  events: TypedEventTarget<Libp2pEvents>
 }
 
 /**

--- a/packages/libp2p/src/libp2p.ts
+++ b/packages/libp2p/src/libp2p.ts
@@ -2,7 +2,7 @@ import { setMaxListeners } from 'events'
 import { unmarshalPublicKey } from '@libp2p/crypto/keys'
 import { type ContentRouting, contentRouting } from '@libp2p/interface/content-routing'
 import { CodeError } from '@libp2p/interface/errors'
-import { EventEmitter, CustomEvent } from '@libp2p/interface/events'
+import { TypedEventEmitter, CustomEvent } from '@libp2p/interface/events'
 import { peerDiscovery } from '@libp2p/interface/peer-discovery'
 import { type PeerRouting, peerRouting } from '@libp2p/interface/peer-routing'
 import { DefaultKeyChain } from '@libp2p/keychain'
@@ -42,7 +42,7 @@ import type { Datastore } from 'interface-datastore'
 
 const log = logger('libp2p')
 
-export class Libp2pNode<T extends ServiceMap = Record<string, unknown>> extends EventEmitter<Libp2pEvents> implements Libp2p<T> {
+export class Libp2pNode<T extends ServiceMap = Record<string, unknown>> extends TypedEventEmitter<Libp2pEvents> implements Libp2p<T> {
   public peerId: PeerId
   public peerStore: PeerStore
   public contentRouting: ContentRouting
@@ -59,7 +59,7 @@ export class Libp2pNode<T extends ServiceMap = Record<string, unknown>> extends 
 
     // event bus - components can listen to this emitter to be notified of system events
     // and also cause them to be emitted
-    const events = new EventEmitter<Libp2pEvents>()
+    const events = new TypedEventEmitter<Libp2pEvents>()
     const originalDispatch = events.dispatchEvent.bind(events)
     events.dispatchEvent = (evt: any) => {
       const internalResult = originalDispatch(evt)

--- a/packages/libp2p/src/registrar.ts
+++ b/packages/libp2p/src/registrar.ts
@@ -3,7 +3,7 @@ import { logger } from '@libp2p/logger'
 import merge from 'merge-options'
 import { codes } from './errors.js'
 import type { Libp2pEvents, PeerUpdate } from '@libp2p/interface'
-import type { EventEmitter } from '@libp2p/interface/events'
+import type { TypedEventTarget } from '@libp2p/interface/events'
 import type { PeerId } from '@libp2p/interface/peer-id'
 import type { PeerStore } from '@libp2p/interface/peer-store'
 import type { Topology } from '@libp2p/interface/topology'
@@ -19,7 +19,7 @@ export interface RegistrarComponents {
   peerId: PeerId
   connectionManager: ConnectionManager
   peerStore: PeerStore
-  events: EventEmitter<Libp2pEvents>
+  events: TypedEventTarget<Libp2pEvents>
 }
 
 /**

--- a/packages/libp2p/src/transport-manager.ts
+++ b/packages/libp2p/src/transport-manager.ts
@@ -5,7 +5,7 @@ import { logger } from '@libp2p/logger'
 import { codes } from './errors.js'
 import type { Libp2pEvents, AbortOptions } from '@libp2p/interface'
 import type { Connection } from '@libp2p/interface/connection'
-import type { EventEmitter } from '@libp2p/interface/events'
+import type { TypedEventTarget } from '@libp2p/interface/events'
 import type { Metrics } from '@libp2p/interface/metrics'
 import type { Startable } from '@libp2p/interface/startable'
 import type { Listener, Transport, Upgrader } from '@libp2p/interface/transport'
@@ -23,7 +23,7 @@ export interface DefaultTransportManagerComponents {
   metrics?: Metrics
   addressManager: AddressManager
   upgrader: Upgrader
-  events: EventEmitter<Libp2pEvents>
+  events: TypedEventTarget<Libp2pEvents>
 }
 
 export class DefaultTransportManager implements TransportManager, Startable {

--- a/packages/libp2p/src/upgrader.ts
+++ b/packages/libp2p/src/upgrader.ts
@@ -11,7 +11,7 @@ import type { Libp2pEvents, AbortOptions } from '@libp2p/interface'
 import type { MultiaddrConnection, Connection, Stream, ConnectionProtector, NewStreamOptions } from '@libp2p/interface/connection'
 import type { ConnectionEncrypter, SecuredConnection } from '@libp2p/interface/connection-encrypter'
 import type { ConnectionGater } from '@libp2p/interface/connection-gater'
-import type { EventEmitter } from '@libp2p/interface/events'
+import type { TypedEventTarget } from '@libp2p/interface/events'
 import type { Metrics } from '@libp2p/interface/metrics'
 import type { PeerId } from '@libp2p/interface/peer-id'
 import type { PeerStore } from '@libp2p/interface/peer-store'
@@ -104,7 +104,7 @@ export interface DefaultUpgraderComponents {
   connectionProtector?: ConnectionProtector
   registrar: Registrar
   peerStore: PeerStore
-  events: EventEmitter<Libp2pEvents>
+  events: TypedEventTarget<Libp2pEvents>
 }
 
 type EncryptedConn = Duplex<AsyncGenerator<Uint8Array, any, unknown>, Source<Uint8Array>, Promise<void>>
@@ -116,7 +116,7 @@ export class DefaultUpgrader implements Upgrader {
   private readonly connectionEncryption: Map<string, ConnectionEncrypter>
   private readonly muxers: Map<string, StreamMuxerFactory>
   private readonly inboundUpgradeTimeout: number
-  private readonly events: EventEmitter<Libp2pEvents>
+  private readonly events: TypedEventTarget<Libp2pEvents>
 
   constructor (components: DefaultUpgraderComponents, init: UpgraderInit) {
     this.components = components

--- a/packages/libp2p/test/addresses/address-manager.spec.ts
+++ b/packages/libp2p/test/addresses/address-manager.spec.ts
@@ -1,6 +1,6 @@
 /* eslint-env mocha */
 
-import { EventEmitter } from '@libp2p/interface/events'
+import { TypedEventEmitter, type TypedEventTarget } from '@libp2p/interface/events'
 import { createEd25519PeerId } from '@libp2p/peer-id-factory'
 import { multiaddr } from '@multiformats/multiaddr'
 import { expect } from 'aegir/chai'
@@ -18,7 +18,7 @@ const announceAddreses = ['/dns4/peer.io']
 describe('Address Manager', () => {
   let peerId: PeerId
   let peerStore: StubbedInstance<PeerStore>
-  let events: EventEmitter<Libp2pEvents>
+  let events: TypedEventTarget<Libp2pEvents>
 
   beforeEach(async () => {
     peerId = await createEd25519PeerId()
@@ -26,7 +26,7 @@ describe('Address Manager', () => {
       // @ts-expect-error incorrect return type
       patch: Promise.resolve({})
     })
-    events = new EventEmitter()
+    events = new TypedEventEmitter()
   })
 
   it('should not need any addresses', () => {

--- a/packages/libp2p/test/circuit-relay/hop.spec.ts
+++ b/packages/libp2p/test/circuit-relay/hop.spec.ts
@@ -1,7 +1,7 @@
 /* eslint-env mocha */
 /* eslint max-nested-callbacks: ['error', 5] */
 
-import { EventEmitter } from '@libp2p/interface/events'
+import { TypedEventEmitter, type TypedEventTarget } from '@libp2p/interface/events'
 import { isStartable } from '@libp2p/interface/startable'
 import { mockRegistrar, mockUpgrader, mockNetwork, mockConnectionManager, mockConnectionGater } from '@libp2p/interface-compliance-tests/mocks'
 import { PeerMap } from '@libp2p/peer-collections'
@@ -38,7 +38,7 @@ interface Node {
   connectionManager: ConnectionManager
   circuitRelayTransport: Transport
   connectionGater: ConnectionGater
-  events: EventEmitter<Libp2pEvents>
+  events: TypedEventTarget<Libp2pEvents>
 }
 
 let peerIndex = 0
@@ -66,7 +66,7 @@ describe('circuit-relay hop protocol', function () {
     ])
     const peerStore = stubInterface<PeerStore>()
 
-    const events = new EventEmitter()
+    const events = new TypedEventEmitter()
     events.addEventListener('connection:open', (evt) => {
       const conn = evt.detail
       connections.set(conn.remotePeer, conn)

--- a/packages/libp2p/test/circuit-relay/stop.spec.ts
+++ b/packages/libp2p/test/circuit-relay/stop.spec.ts
@@ -1,6 +1,6 @@
 /* eslint-env mocha */
 
-import { EventEmitter } from '@libp2p/interface/events'
+import { TypedEventEmitter } from '@libp2p/interface/events'
 import { isStartable } from '@libp2p/interface/startable'
 import { mockStream } from '@libp2p/interface-compliance-tests/mocks'
 import { createEd25519PeerId } from '@libp2p/peer-id-factory'
@@ -43,7 +43,7 @@ describe('circuit-relay stop protocol', function () {
       transportManager: stubInterface<TransportManager>(),
       upgrader: stubInterface<Upgrader>(),
       connectionGater: stubInterface<ConnectionGater>(),
-      events: new EventEmitter()
+      events: new TypedEventEmitter()
     }
 
     transport = circuitRelayTransport({

--- a/packages/libp2p/test/connection-manager/auto-dial.spec.ts
+++ b/packages/libp2p/test/connection-manager/auto-dial.spec.ts
@@ -1,6 +1,6 @@
 /* eslint-env mocha */
 
-import { EventEmitter } from '@libp2p/interface/events'
+import { TypedEventEmitter, type TypedEventTarget } from '@libp2p/interface/events'
 import { PeerMap } from '@libp2p/peer-collections'
 import { createEd25519PeerId } from '@libp2p/peer-id-factory'
 import { PersistentPeerStore } from '@libp2p/peer-store'
@@ -23,13 +23,13 @@ import type { ConnectionManager } from '@libp2p/interface-internal/connection-ma
 
 describe('auto-dial', () => {
   let autoDialler: AutoDial
-  let events: EventEmitter<Libp2pEvents>
+  let events: TypedEventTarget<Libp2pEvents>
   let peerStore: PeerStore
   let peerId: PeerId
 
   beforeEach(async () => {
     peerId = await createEd25519PeerId()
-    events = new EventEmitter()
+    events = new TypedEventEmitter()
     peerStore = new PersistentPeerStore({
       datastore: new MemoryDatastore(),
       events,

--- a/packages/libp2p/test/connection-manager/direct.node.ts
+++ b/packages/libp2p/test/connection-manager/direct.node.ts
@@ -6,7 +6,7 @@ import path from 'node:path'
 import { yamux } from '@chainsafe/libp2p-yamux'
 import { type Connection, type ConnectionProtector, isConnection } from '@libp2p/interface/connection'
 import { AbortError } from '@libp2p/interface/errors'
-import { EventEmitter } from '@libp2p/interface/events'
+import { TypedEventEmitter } from '@libp2p/interface/events'
 import { start, stop } from '@libp2p/interface/startable'
 import { mockConnection, mockConnectionGater, mockDuplex, mockMultiaddrConnection, mockUpgrader } from '@libp2p/interface-compliance-tests/mocks'
 import { mplex } from '@libp2p/mplex'
@@ -58,7 +58,7 @@ describe('dialing (direct, TCP)', () => {
       createEd25519PeerId()
     ])
 
-    const remoteEvents = new EventEmitter()
+    const remoteEvents = new TypedEventEmitter()
     remoteComponents = defaultComponents({
       peerId: remotePeerId,
       events: remoteEvents,
@@ -78,7 +78,7 @@ describe('dialing (direct, TCP)', () => {
     remoteTM = remoteComponents.transportManager = new DefaultTransportManager(remoteComponents)
     remoteTM.add(tcp()())
 
-    const localEvents = new EventEmitter()
+    const localEvents = new TypedEventEmitter()
     localComponents = defaultComponents({
       peerId: localPeerId,
       events: localEvents,

--- a/packages/libp2p/test/connection-manager/direct.spec.ts
+++ b/packages/libp2p/test/connection-manager/direct.spec.ts
@@ -2,7 +2,7 @@
 
 import { yamux } from '@chainsafe/libp2p-yamux'
 import { AbortError } from '@libp2p/interface/errors'
-import { EventEmitter } from '@libp2p/interface/events'
+import { TypedEventEmitter } from '@libp2p/interface/events'
 import { mockConnectionGater, mockDuplex, mockMultiaddrConnection, mockUpgrader, mockConnection } from '@libp2p/interface-compliance-tests/mocks'
 import { mplex } from '@libp2p/mplex'
 import { peerIdFromString } from '@libp2p/peer-id'
@@ -45,7 +45,7 @@ describe('dialing (direct, WebSockets)', () => {
   let connectionManager: DefaultConnectionManager
 
   beforeEach(async () => {
-    const localEvents = new EventEmitter()
+    const localEvents = new TypedEventEmitter()
     localComponents = defaultComponents({
       peerId: await createEd25519PeerId(),
       datastore: new MemoryDatastore(),

--- a/packages/libp2p/test/connection-manager/index.node.ts
+++ b/packages/libp2p/test/connection-manager/index.node.ts
@@ -1,6 +1,6 @@
 /* eslint-env mocha */
 
-import { EventEmitter } from '@libp2p/interface/events'
+import { TypedEventEmitter } from '@libp2p/interface/events'
 import { start } from '@libp2p/interface/startable'
 import { mockConnection, mockDuplex, mockMultiaddrConnection } from '@libp2p/interface-compliance-tests/mocks'
 import { expect } from 'aegir/chai'
@@ -53,7 +53,7 @@ describe('Connection Manager', () => {
       peerStore,
       transportManager: stubInterface<TransportManager>(),
       connectionGater: stubInterface<ConnectionGater>(),
-      events: new EventEmitter()
+      events: new TypedEventEmitter()
     })
     const connectionManager = new DefaultConnectionManager(components, {
       maxConnections: 1000,
@@ -91,7 +91,7 @@ describe('Connection Manager', () => {
       peerStore,
       transportManager: stubInterface<TransportManager>(),
       connectionGater: stubInterface<ConnectionGater>(),
-      events: new EventEmitter()
+      events: new TypedEventEmitter()
     })
     const connectionManager = new DefaultConnectionManager(components, {
       maxConnections: 1000,

--- a/packages/libp2p/test/connection-manager/index.spec.ts
+++ b/packages/libp2p/test/connection-manager/index.spec.ts
@@ -1,6 +1,6 @@
 /* eslint-env mocha */
 
-import { EventEmitter } from '@libp2p/interface/events'
+import { TypedEventEmitter } from '@libp2p/interface/events'
 import { KEEP_ALIVE } from '@libp2p/interface/peer-store/tags'
 import { mockConnection, mockDuplex, mockMultiaddrConnection, mockMetrics } from '@libp2p/interface-compliance-tests/mocks'
 import { createEd25519PeerId } from '@libp2p/peer-id-factory'
@@ -365,7 +365,7 @@ describe('Connection Manager', () => {
       peerStore: stubInterface<PeerStore>(),
       transportManager: stubInterface<TransportManager>(),
       connectionGater: stubInterface<ConnectionGater>(),
-      events: new EventEmitter()
+      events: new TypedEventEmitter()
     }, {
       ...defaultOptions,
       deny: [
@@ -393,7 +393,7 @@ describe('Connection Manager', () => {
       peerStore: stubInterface<PeerStore>(),
       transportManager: stubInterface<TransportManager>(),
       connectionGater: stubInterface<ConnectionGater>(),
-      events: new EventEmitter()
+      events: new TypedEventEmitter()
     }, {
       ...defaultOptions,
       maxConnections: 1
@@ -425,7 +425,7 @@ describe('Connection Manager', () => {
       peerStore: stubInterface<PeerStore>(),
       transportManager: stubInterface<TransportManager>(),
       connectionGater: stubInterface<ConnectionGater>(),
-      events: new EventEmitter()
+      events: new TypedEventEmitter()
     }, {
       ...defaultOptions,
       inboundConnectionThreshold: 1
@@ -461,7 +461,7 @@ describe('Connection Manager', () => {
       peerStore: stubInterface<PeerStore>(),
       transportManager: stubInterface<TransportManager>(),
       connectionGater: stubInterface<ConnectionGater>(),
-      events: new EventEmitter()
+      events: new TypedEventEmitter()
     }, {
       ...defaultOptions,
       maxConnections: 1,
@@ -497,7 +497,7 @@ describe('Connection Manager', () => {
       peerStore: stubInterface<PeerStore>(),
       transportManager: stubInterface<TransportManager>(),
       connectionGater: stubInterface<ConnectionGater>(),
-      events: new EventEmitter()
+      events: new TypedEventEmitter()
     }, {
       ...defaultOptions,
       maxIncomingPendingConnections: 1

--- a/packages/libp2p/test/fetch/index.spec.ts
+++ b/packages/libp2p/test/fetch/index.spec.ts
@@ -1,6 +1,6 @@
 /* eslint-env mocha */
 
-import { EventEmitter } from '@libp2p/interface/events'
+import { TypedEventEmitter } from '@libp2p/interface/events'
 import { start, stop } from '@libp2p/interface/startable'
 import { mockRegistrar, mockUpgrader, connectionPair } from '@libp2p/interface-compliance-tests/mocks'
 import { createEd25519PeerId } from '@libp2p/peer-id-factory'
@@ -27,7 +27,7 @@ const defaultInit: FetchServiceInit = {
 async function createComponents (index: number): Promise<Components> {
   const peerId = await createEd25519PeerId()
 
-  const events = new EventEmitter()
+  const events = new TypedEventEmitter()
   const components = defaultComponents({
     peerId,
     registrar: mockRegistrar(),

--- a/packages/libp2p/test/identify/index.spec.ts
+++ b/packages/libp2p/test/identify/index.spec.ts
@@ -1,7 +1,7 @@
 /* eslint-env mocha */
 /* eslint max-nested-callbacks: ["error", 6] */
 
-import { EventEmitter } from '@libp2p/interface/events'
+import { TypedEventEmitter } from '@libp2p/interface/events'
 import { start, stop } from '@libp2p/interface/startable'
 import { mockConnectionGater, mockRegistrar, mockUpgrader, connectionPair } from '@libp2p/interface-compliance-tests/mocks'
 import { createEd25519PeerId } from '@libp2p/peer-id-factory'
@@ -51,7 +51,7 @@ const protocols = [MULTICODEC_IDENTIFY, MULTICODEC_IDENTIFY_PUSH]
 async function createComponents (index: number): Promise<Components> {
   const peerId = await createEd25519PeerId()
 
-  const events = new EventEmitter()
+  const events = new TypedEventEmitter()
   const components = defaultComponents({
     peerId,
     datastore: new MemoryDatastore(),

--- a/packages/libp2p/test/identify/push.spec.ts
+++ b/packages/libp2p/test/identify/push.spec.ts
@@ -1,6 +1,6 @@
 /* eslint-env mocha */
 
-import { EventEmitter } from '@libp2p/interface/events'
+import { TypedEventEmitter } from '@libp2p/interface/events'
 import { start, stop } from '@libp2p/interface/startable'
 import { mockConnectionGater, mockRegistrar, mockUpgrader, connectionPair } from '@libp2p/interface-compliance-tests/mocks'
 import { createEd25519PeerId } from '@libp2p/peer-id-factory'
@@ -42,7 +42,7 @@ const protocols = [MULTICODEC_IDENTIFY, MULTICODEC_IDENTIFY_PUSH]
 async function createComponents (index: number): Promise<Components> {
   const peerId = await createEd25519PeerId()
 
-  const events = new EventEmitter()
+  const events = new TypedEventEmitter()
   const components = defaultComponents({
     peerId,
     datastore: new MemoryDatastore(),

--- a/packages/libp2p/test/peer-discovery/index.node.ts
+++ b/packages/libp2p/test/peer-discovery/index.node.ts
@@ -2,7 +2,7 @@
 
 import { bootstrap } from '@libp2p/bootstrap'
 import { randomBytes } from '@libp2p/crypto'
-import { EventEmitter } from '@libp2p/interface/events'
+import { TypedEventEmitter } from '@libp2p/interface/events'
 import { peerDiscovery } from '@libp2p/interface/peer-discovery'
 import { kadDHT } from '@libp2p/kad-dht'
 import { mdns } from '@libp2p/mdns'
@@ -22,7 +22,7 @@ import type { KadDHT } from '@libp2p/kad-dht'
 
 const listenAddr = multiaddr('/ip4/127.0.0.1/tcp/0')
 
-class TestPeerDiscovery extends EventEmitter<PeerDiscoveryEvents> implements PeerDiscovery {
+class TestPeerDiscovery extends TypedEventEmitter<PeerDiscoveryEvents> implements PeerDiscovery {
   get [peerDiscovery] (): PeerDiscovery {
     return this
   }

--- a/packages/libp2p/test/ping/index.spec.ts
+++ b/packages/libp2p/test/ping/index.spec.ts
@@ -1,6 +1,6 @@
 /* eslint-env mocha */
 
-import { EventEmitter } from '@libp2p/interface/events'
+import { TypedEventEmitter } from '@libp2p/interface/events'
 import { start, stop } from '@libp2p/interface/startable'
 import { mockRegistrar, mockUpgrader, connectionPair } from '@libp2p/interface-compliance-tests/mocks'
 import { createEd25519PeerId } from '@libp2p/peer-id-factory'
@@ -28,7 +28,7 @@ const defaultInit: PingServiceInit = {
 async function createComponents (index: number): Promise<Components> {
   const peerId = await createEd25519PeerId()
 
-  const events = new EventEmitter()
+  const events = new TypedEventEmitter()
   const components = defaultComponents({
     peerId,
     registrar: mockRegistrar(),

--- a/packages/libp2p/test/registrar/registrar.spec.ts
+++ b/packages/libp2p/test/registrar/registrar.spec.ts
@@ -2,7 +2,7 @@
 
 import { yamux } from '@chainsafe/libp2p-yamux'
 import { CodeError } from '@libp2p/interface/errors'
-import { EventEmitter } from '@libp2p/interface/events'
+import { TypedEventEmitter, type TypedEventTarget } from '@libp2p/interface/events'
 import { mockDuplex, mockMultiaddrConnection, mockUpgrader, mockConnection } from '@libp2p/interface-compliance-tests/mocks'
 import { mplex } from '@libp2p/mplex'
 import { createEd25519PeerId } from '@libp2p/peer-id-factory'
@@ -43,7 +43,7 @@ describe('registrar', () => {
 
   describe('errors', () => {
     beforeEach(() => {
-      const events = new EventEmitter()
+      const events = new TypedEventEmitter()
       components = defaultComponents({
         peerId,
         events,
@@ -81,13 +81,13 @@ describe('registrar', () => {
     let peerId: PeerId
     let connectionManager: StubbedInstance<ConnectionManager>
     let peerStore: StubbedInstance<PeerStore>
-    let events: EventEmitter<Libp2pEvents>
+    let events: TypedEventTarget<Libp2pEvents>
 
     beforeEach(async () => {
       peerId = await createEd25519PeerId()
       connectionManager = stubInterface<ConnectionManager>()
       peerStore = stubInterface<PeerStore>()
-      events = new EventEmitter<Libp2pEvents>()
+      events = new TypedEventEmitter<Libp2pEvents>()
 
       registrar = new DefaultRegistrar({
         peerId,

--- a/packages/libp2p/test/transports/transport-manager.node.ts
+++ b/packages/libp2p/test/transports/transport-manager.node.ts
@@ -1,6 +1,6 @@
 /* eslint-env mocha */
 
-import { EventEmitter } from '@libp2p/interface/events'
+import { TypedEventEmitter } from '@libp2p/interface/events'
 import { start, stop } from '@libp2p/interface/startable'
 import { FaultTolerance } from '@libp2p/interface/transport'
 import { mockUpgrader } from '@libp2p/interface-compliance-tests/mocks'
@@ -33,7 +33,7 @@ describe('Transport Manager (TCP)', () => {
   })
 
   beforeEach(async () => {
-    const events = new EventEmitter()
+    const events = new TypedEventEmitter()
     components = defaultComponents({
       peerId: localPeer,
       events,

--- a/packages/libp2p/test/transports/transport-manager.spec.ts
+++ b/packages/libp2p/test/transports/transport-manager.spec.ts
@@ -1,6 +1,6 @@
 /* eslint-env mocha */
 
-import { EventEmitter } from '@libp2p/interface/events'
+import { TypedEventEmitter } from '@libp2p/interface/events'
 import { start, stop } from '@libp2p/interface/startable'
 import { FaultTolerance } from '@libp2p/interface/transport'
 import { mockUpgrader } from '@libp2p/interface-compliance-tests/mocks'
@@ -26,7 +26,7 @@ describe('Transport Manager (WebSockets)', () => {
   let components: Components
 
   beforeEach(async () => {
-    const events = new EventEmitter()
+    const events = new TypedEventEmitter()
     components = {
       peerId: await createEd25519PeerId(),
       events,

--- a/packages/libp2p/test/upgrading/upgrader.spec.ts
+++ b/packages/libp2p/test/upgrading/upgrader.spec.ts
@@ -1,7 +1,7 @@
 /* eslint-env mocha */
 
 import { yamux } from '@chainsafe/libp2p-yamux'
-import { EventEmitter } from '@libp2p/interface/events'
+import { TypedEventEmitter } from '@libp2p/interface/events'
 import { mockConnectionGater, mockConnectionManager, mockMultiaddrConnPair, mockRegistrar, mockStream, mockMuxer } from '@libp2p/interface-compliance-tests/mocks'
 import { mplex } from '@libp2p/mplex'
 import { createEd25519PeerId } from '@libp2p/peer-id-factory'
@@ -76,7 +76,7 @@ describe('Upgrader', () => {
       registrar: mockRegistrar(),
       datastore: new MemoryDatastore(),
       connectionProtector: localConnectionProtector,
-      events: new EventEmitter()
+      events: new TypedEventEmitter()
     })
     localComponents.peerStore = new PersistentPeerStore(localComponents)
     localComponents.connectionManager = mockConnectionManager(localComponents)
@@ -103,7 +103,7 @@ describe('Upgrader', () => {
       registrar: mockRegistrar(),
       datastore: new MemoryDatastore(),
       connectionProtector: remoteConnectionProtector,
-      events: new EventEmitter()
+      events: new TypedEventEmitter()
     })
     remoteComponents.peerStore = new PersistentPeerStore(remoteComponents)
     remoteComponents.connectionManager = mockConnectionManager(remoteComponents)

--- a/packages/libp2p/test/upnp-nat/upnp-nat.node.ts
+++ b/packages/libp2p/test/upnp-nat/upnp-nat.node.ts
@@ -1,6 +1,6 @@
 /* eslint-env mocha */
 
-import { EventEmitter } from '@libp2p/interface/events'
+import { TypedEventEmitter } from '@libp2p/interface/events'
 import { start, stop } from '@libp2p/interface/startable'
 import { FaultTolerance } from '@libp2p/interface/transport'
 import { mockUpgrader } from '@libp2p/interface-compliance-tests/mocks'
@@ -31,7 +31,7 @@ describe('UPnP NAT (TCP)', () => {
   let client: StubbedInstance<NatAPI>
 
   async function createNatManager (addrs = DEFAULT_ADDRESSES, natManagerOptions = {}): Promise<{ natManager: any, components: Components }> {
-    const events = new EventEmitter()
+    const events = new TypedEventEmitter()
     const components: any = defaultComponents({
       peerId: await createEd25519PeerId(),
       upgrader: mockUpgrader({ events }),

--- a/packages/peer-discovery-bootstrap/src/index.ts
+++ b/packages/peer-discovery-bootstrap/src/index.ts
@@ -1,4 +1,4 @@
-import { EventEmitter } from '@libp2p/interface/events'
+import { TypedEventEmitter } from '@libp2p/interface/events'
 import { peerDiscovery } from '@libp2p/interface/peer-discovery'
 import { logger } from '@libp2p/logger'
 import { peerIdFromString } from '@libp2p/peer-id'
@@ -50,7 +50,7 @@ export interface BootstrapComponents {
 /**
  * Emits 'peer' events on a regular interval for each peer in the provided list.
  */
-class Bootstrap extends EventEmitter<PeerDiscoveryEvents> implements PeerDiscovery, Startable {
+class Bootstrap extends TypedEventEmitter<PeerDiscoveryEvents> implements PeerDiscovery, Startable {
   static tag = 'bootstrap'
 
   private timer?: ReturnType<typeof setTimeout>

--- a/packages/peer-discovery-mdns/src/index.ts
+++ b/packages/peer-discovery-mdns/src/index.ts
@@ -1,4 +1,4 @@
-import { CustomEvent, EventEmitter } from '@libp2p/interface/events'
+import { CustomEvent, TypedEventEmitter } from '@libp2p/interface/events'
 import { peerDiscovery } from '@libp2p/interface/peer-discovery'
 import { logger } from '@libp2p/logger'
 import multicastDNS from 'multicast-dns'
@@ -24,7 +24,7 @@ export interface MulticastDNSComponents {
   addressManager: AddressManager
 }
 
-class MulticastDNS extends EventEmitter<PeerDiscoveryEvents> implements PeerDiscovery, Startable {
+class MulticastDNS extends TypedEventEmitter<PeerDiscoveryEvents> implements PeerDiscovery, Startable {
   public mdns?: multicastDNS.MulticastDNS
 
   private readonly broadcast: boolean

--- a/packages/peer-store/src/index.ts
+++ b/packages/peer-store/src/index.ts
@@ -3,7 +3,7 @@ import { RecordEnvelope, PeerRecord } from '@libp2p/peer-record'
 import all from 'it-all'
 import { PersistentStore, type PeerUpdate } from './store.js'
 import type { Libp2pEvents } from '@libp2p/interface'
-import type { EventEmitter } from '@libp2p/interface/events'
+import type { TypedEventTarget } from '@libp2p/interface/events'
 import type { PeerId } from '@libp2p/interface/peer-id'
 import type { PeerStore, Peer, PeerData, PeerQuery } from '@libp2p/interface/peer-store'
 import type { Multiaddr } from '@multiformats/multiaddr'
@@ -14,7 +14,7 @@ const log = logger('libp2p:peer-store')
 export interface PersistentPeerStoreComponents {
   peerId: PeerId
   datastore: Datastore
-  events: EventEmitter<Libp2pEvents>
+  events: TypedEventTarget<Libp2pEvents>
 }
 
 /**
@@ -33,7 +33,7 @@ export interface PersistentPeerStoreInit {
  */
 export class PersistentPeerStore implements PeerStore {
   private readonly store: PersistentStore
-  private readonly events: EventEmitter<Libp2pEvents>
+  private readonly events: TypedEventTarget<Libp2pEvents>
   private readonly peerId: PeerId
 
   constructor (components: PersistentPeerStoreComponents, init: PersistentPeerStoreInit = {}) {

--- a/packages/peer-store/test/index.spec.ts
+++ b/packages/peer-store/test/index.spec.ts
@@ -1,7 +1,7 @@
 /* eslint-env mocha */
 /* eslint max-nested-callbacks: ["error", 6] */
 
-import { EventEmitter } from '@libp2p/interface/events'
+import { TypedEventEmitter, type TypedEventTarget } from '@libp2p/interface/events'
 import { createEd25519PeerId } from '@libp2p/peer-id-factory'
 import { RecordEnvelope, PeerRecord } from '@libp2p/peer-record'
 import { multiaddr } from '@multiformats/multiaddr'
@@ -18,12 +18,12 @@ describe('PersistentPeerStore', () => {
   let peerId: PeerId
   let otherPeerId: PeerId
   let peerStore: PersistentPeerStore
-  let events: EventEmitter<Libp2pEvents>
+  let events: TypedEventTarget<Libp2pEvents>
 
   beforeEach(async () => {
     peerId = await createEd25519PeerId()
     otherPeerId = await createEd25519PeerId()
-    events = new EventEmitter()
+    events = new TypedEventEmitter()
     peerStore = new PersistentPeerStore({ peerId, events, datastore: new MemoryDatastore() })
   })
 

--- a/packages/peer-store/test/merge.spec.ts
+++ b/packages/peer-store/test/merge.spec.ts
@@ -1,7 +1,7 @@
 /* eslint-env mocha */
 /* eslint max-nested-callbacks: ["error", 6] */
 
-import { EventEmitter } from '@libp2p/interface/events'
+import { TypedEventEmitter, type TypedEventTarget } from '@libp2p/interface/events'
 import { createEd25519PeerId } from '@libp2p/peer-id-factory'
 import { multiaddr } from '@multiformats/multiaddr'
 import { expect } from 'aegir/chai'
@@ -20,12 +20,12 @@ describe('merge', () => {
   let peerId: PeerId
   let otherPeerId: PeerId
   let peerStore: PersistentPeerStore
-  let events: EventEmitter<Libp2pEvents>
+  let events: TypedEventTarget<Libp2pEvents>
 
   beforeEach(async () => {
     peerId = await createEd25519PeerId()
     otherPeerId = await createEd25519PeerId()
-    events = new EventEmitter()
+    events = new TypedEventEmitter()
     peerStore = new PersistentPeerStore({ peerId, events, datastore: new MemoryDatastore() })
   })
 

--- a/packages/peer-store/test/patch.spec.ts
+++ b/packages/peer-store/test/patch.spec.ts
@@ -1,7 +1,7 @@
 /* eslint-env mocha */
 /* eslint max-nested-callbacks: ["error", 6] */
 
-import { EventEmitter } from '@libp2p/interface/events'
+import { TypedEventEmitter, type TypedEventTarget } from '@libp2p/interface/events'
 import { createEd25519PeerId } from '@libp2p/peer-id-factory'
 import { multiaddr } from '@multiformats/multiaddr'
 import { expect } from 'aegir/chai'
@@ -20,12 +20,12 @@ describe('patch', () => {
   let peerId: PeerId
   let otherPeerId: PeerId
   let peerStore: PersistentPeerStore
-  let events: EventEmitter<Libp2pEvents>
+  let events: TypedEventTarget<Libp2pEvents>
 
   beforeEach(async () => {
     peerId = await createEd25519PeerId()
     otherPeerId = await createEd25519PeerId()
-    events = new EventEmitter()
+    events = new TypedEventEmitter()
     peerStore = new PersistentPeerStore({ peerId, events, datastore: new MemoryDatastore() })
   })
 

--- a/packages/peer-store/test/save.spec.ts
+++ b/packages/peer-store/test/save.spec.ts
@@ -1,7 +1,7 @@
 /* eslint-env mocha */
 /* eslint max-nested-callbacks: ["error", 6] */
 
-import { EventEmitter } from '@libp2p/interface/events'
+import { TypedEventEmitter, type TypedEventTarget } from '@libp2p/interface/events'
 import { createEd25519PeerId, createRSAPeerId, createSecp256k1PeerId } from '@libp2p/peer-id-factory'
 import { multiaddr } from '@multiformats/multiaddr'
 import { expect } from 'aegir/chai'
@@ -23,12 +23,12 @@ describe('save', () => {
   let peerId: PeerId
   let otherPeerId: PeerId
   let peerStore: PersistentPeerStore
-  let events: EventEmitter<Libp2pEvents>
+  let events: TypedEventTarget<Libp2pEvents>
 
   beforeEach(async () => {
     peerId = await createEd25519PeerId()
     otherPeerId = await createEd25519PeerId()
-    events = new EventEmitter()
+    events = new TypedEventEmitter()
     peerStore = new PersistentPeerStore({ peerId, events, datastore: new MemoryDatastore() })
   })
 

--- a/packages/protocol-perf/test/index.spec.ts
+++ b/packages/protocol-perf/test/index.spec.ts
@@ -1,6 +1,6 @@
 /* eslint-env mocha */
 
-import { EventEmitter } from '@libp2p/interface/events'
+import { TypedEventEmitter } from '@libp2p/interface/events'
 import { start, stop } from '@libp2p/interface/startable'
 import { connectionPair, mockRegistrar, type MockNetworkComponents, mockConnectionManager } from '@libp2p/interface-compliance-tests/mocks'
 import { createEd25519PeerId } from '@libp2p/peer-id-factory'
@@ -11,7 +11,7 @@ export async function createComponents (): Promise<MockNetworkComponents> {
   const components: any = {
     peerId: await createEd25519PeerId(),
     registrar: mockRegistrar(),
-    events: new EventEmitter()
+    events: new TypedEventEmitter()
   }
 
   components.connectionManager = mockConnectionManager(components)

--- a/packages/pubsub/src/index.ts
+++ b/packages/pubsub/src/index.ts
@@ -1,5 +1,5 @@
 import { CodeError } from '@libp2p/interface/errors'
-import { EventEmitter, CustomEvent } from '@libp2p/interface/events'
+import { TypedEventEmitter, CustomEvent } from '@libp2p/interface/events'
 import { type PubSub, type Message, type StrictNoSign, type StrictSign, type PubSubInit, type PubSubEvents, type PeerStreams, type PubSubRPCMessage, type PubSubRPC, type PubSubRPCSubscription, type SubscriptionChangeData, type PublishResult, type TopicValidatorFn, TopicValidatorResult } from '@libp2p/interface/pubsub'
 import { logger } from '@libp2p/logger'
 import { PeerMap, PeerSet } from '@libp2p/peer-collections'
@@ -28,7 +28,7 @@ export interface PubSubComponents {
  * PubSubBaseProtocol handles the peers and connections logic for pubsub routers
  * and specifies the API that pubsub routers should have.
  */
-export abstract class PubSubBaseProtocol<Events extends Record<string, any> = PubSubEvents> extends EventEmitter<Events> implements PubSub<Events> {
+export abstract class PubSubBaseProtocol<Events extends Record<string, any> = PubSubEvents> extends TypedEventEmitter<Events> implements PubSub<Events> {
   public started: boolean
   /**
    * Map of topics to which peers are subscribed to

--- a/packages/pubsub/src/peer-streams.ts
+++ b/packages/pubsub/src/peer-streams.ts
@@ -1,4 +1,4 @@
-import { EventEmitter, CustomEvent } from '@libp2p/interface/events'
+import { TypedEventEmitter, CustomEvent } from '@libp2p/interface/events'
 import { logger } from '@libp2p/logger'
 import { abortableSource } from 'abortable-iterator'
 import * as lp from 'it-length-prefixed'
@@ -20,7 +20,7 @@ export interface PeerStreamsInit {
 /**
  * Thin wrapper around a peer's inbound / outbound pubsub streams
  */
-export class PeerStreams extends EventEmitter<PeerStreamEvents> {
+export class PeerStreams extends TypedEventEmitter<PeerStreamEvents> {
   public readonly id: PeerId
   public readonly protocol: string
   /**

--- a/packages/transport-tcp/src/listener.ts
+++ b/packages/transport-tcp/src/listener.ts
@@ -1,6 +1,6 @@
 import net from 'net'
 import { CodeError } from '@libp2p/interface/errors'
-import { EventEmitter, CustomEvent } from '@libp2p/interface/events'
+import { TypedEventEmitter, CustomEvent } from '@libp2p/interface/events'
 import { logger } from '@libp2p/logger'
 import { CODE_P2P } from './constants.js'
 import { toMultiaddrConnection } from './socket-to-conn.js'
@@ -71,7 +71,7 @@ type Status = { code: TCPListenerStatusCode.INACTIVE } | {
   netConfig: NetConfig
 }
 
-export class TCPListener extends EventEmitter<ListenerEvents> implements Listener {
+export class TCPListener extends TypedEventEmitter<ListenerEvents> implements Listener {
   private readonly server: net.Server
   /** Keep track of open connections to destroy in case of timeout */
   private readonly connections = new Set<MultiaddrConnection>()

--- a/packages/transport-tcp/test/connection-limits.spec.ts
+++ b/packages/transport-tcp/test/connection-limits.spec.ts
@@ -1,6 +1,6 @@
 import net from 'node:net'
 import { promisify } from 'util'
-import { EventEmitter } from '@libp2p/interface/events'
+import { TypedEventEmitter } from '@libp2p/interface/events'
 import { mockUpgrader } from '@libp2p/interface-compliance-tests/mocks'
 import { multiaddr } from '@multiformats/multiaddr'
 import { expect } from 'aegir/chai'
@@ -88,7 +88,7 @@ describe('closeAbove/listenBelow', () => {
     const trasnport = tcp({ closeServerOnMaxConnections: { listenBelow, closeAbove } })()
 
     const upgrader = mockUpgrader({
-      events: new EventEmitter()
+      events: new TypedEventEmitter()
     })
     const listener = trasnport.createListener({ upgrader }) as TCPListener
     // eslint-disable-next-line @typescript-eslint/promise-function-async
@@ -115,7 +115,7 @@ describe('closeAbove/listenBelow', () => {
     const trasnport = tcp({ closeServerOnMaxConnections: { listenBelow, closeAbove } })()
 
     const upgrader = mockUpgrader({
-      events: new EventEmitter()
+      events: new TypedEventEmitter()
     })
     const listener = trasnport.createListener({ upgrader }) as TCPListener
     // eslint-disable-next-line @typescript-eslint/promise-function-async
@@ -150,7 +150,7 @@ describe('closeAbove/listenBelow', () => {
     const trasnport = tcp({ closeServerOnMaxConnections: { listenBelow, closeAbove } })()
 
     const upgrader = mockUpgrader({
-      events: new EventEmitter()
+      events: new TypedEventEmitter()
     })
     const listener = trasnport.createListener({ upgrader }) as TCPListener
     // eslint-disable-next-line @typescript-eslint/promise-function-async
@@ -181,7 +181,7 @@ describe('closeAbove/listenBelow', () => {
     const trasnport = tcp({ closeServerOnMaxConnections: { listenBelow, closeAbove } })()
 
     const upgrader = mockUpgrader({
-      events: new EventEmitter()
+      events: new TypedEventEmitter()
     })
     const listener = trasnport.createListener({ upgrader }) as TCPListener
     // eslint-disable-next-line @typescript-eslint/promise-function-async

--- a/packages/transport-tcp/test/connection.spec.ts
+++ b/packages/transport-tcp/test/connection.spec.ts
@@ -1,4 +1,4 @@
-import { EventEmitter } from '@libp2p/interface/events'
+import { TypedEventEmitter } from '@libp2p/interface/events'
 import { mockUpgrader } from '@libp2p/interface-compliance-tests/mocks'
 import { multiaddr } from '@multiformats/multiaddr'
 import { expect } from 'aegir/chai'
@@ -13,7 +13,7 @@ describe('valid localAddr and remoteAddr', () => {
   beforeEach(() => {
     transport = tcp()()
     upgrader = mockUpgrader({
-      events: new EventEmitter()
+      events: new TypedEventEmitter()
     })
   })
 

--- a/packages/transport-tcp/test/listen-dial.spec.ts
+++ b/packages/transport-tcp/test/listen-dial.spec.ts
@@ -1,6 +1,6 @@
 import os from 'os'
 import path from 'path'
-import { EventEmitter } from '@libp2p/interface/events'
+import { TypedEventEmitter } from '@libp2p/interface/events'
 import { mockRegistrar, mockUpgrader } from '@libp2p/interface-compliance-tests/mocks'
 import { multiaddr } from '@multiformats/multiaddr'
 import { expect } from 'aegir/chai'
@@ -22,7 +22,7 @@ describe('listen', () => {
   beforeEach(() => {
     transport = tcp()()
     upgrader = mockUpgrader({
-      events: new EventEmitter()
+      events: new TypedEventEmitter()
     })
   })
 
@@ -175,7 +175,7 @@ describe('dial', () => {
     })
     upgrader = mockUpgrader({
       registrar,
-      events: new EventEmitter()
+      events: new TypedEventEmitter()
     })
 
     transport = tcp()()

--- a/packages/transport-tcp/test/max-connections.spec.ts
+++ b/packages/transport-tcp/test/max-connections.spec.ts
@@ -1,6 +1,6 @@
 import net from 'node:net'
 import { promisify } from 'node:util'
-import { EventEmitter } from '@libp2p/interface/events'
+import { TypedEventEmitter } from '@libp2p/interface/events'
 import { mockUpgrader } from '@libp2p/interface-compliance-tests/mocks'
 import { multiaddr } from '@multiformats/multiaddr'
 import { expect } from 'aegir/chai'
@@ -22,7 +22,7 @@ describe('maxConnections', () => {
     const transport = tcp({ maxConnections })()
 
     const upgrader = mockUpgrader({
-      events: new EventEmitter()
+      events: new TypedEventEmitter()
     })
     const listener = transport.createListener({ upgrader })
     // eslint-disable-next-line @typescript-eslint/promise-function-async

--- a/packages/transport-webrtc/src/private-to-private/listener.ts
+++ b/packages/transport-webrtc/src/private-to-private/listener.ts
@@ -1,4 +1,4 @@
-import { EventEmitter } from '@libp2p/interface/events'
+import { TypedEventEmitter } from '@libp2p/interface/events'
 import { Circuit } from '@multiformats/mafmt'
 import type { PeerId } from '@libp2p/interface/peer-id'
 import type { ListenerEvents, Listener } from '@libp2p/interface/transport'
@@ -14,7 +14,7 @@ export interface WebRTCPeerListenerInit {
   shutdownController: AbortController
 }
 
-export class WebRTCPeerListener extends EventEmitter<ListenerEvents> implements Listener {
+export class WebRTCPeerListener extends TypedEventEmitter<ListenerEvents> implements Listener {
   private readonly peerId: PeerId
   private readonly transportManager: TransportManager
   private readonly shutdownController: AbortController

--- a/packages/transport-websockets/.aegir.js
+++ b/packages/transport-websockets/.aegir.js
@@ -6,7 +6,7 @@ export default {
     async before () {
       const { multiaddr } = await import('@multiformats/multiaddr')
       const { mockRegistrar, mockUpgrader } = await import('@libp2p/interface-compliance-tests/mocks')
-      const { EventEmitter } = await import('@libp2p/interface/events')
+      const { TypedEventEmitter } = await import('@libp2p/interface/events')
       const { webSockets } = await import('./dist/src/index.js')
 
       const protocol = '/echo/1.0.0'
@@ -19,7 +19,7 @@ export default {
       })
       const upgrader = mockUpgrader({
         registrar,
-        events: new EventEmitter()
+        events: new TypedEventEmitter()
       })
 
       const ws = webSockets()()

--- a/packages/transport-websockets/src/listener.ts
+++ b/packages/transport-websockets/src/listener.ts
@@ -1,5 +1,5 @@
 import os from 'os'
-import { EventEmitter, CustomEvent } from '@libp2p/interface/events'
+import { TypedEventEmitter, CustomEvent } from '@libp2p/interface/events'
 import { logger } from '@libp2p/logger'
 import { ipPortToMultiaddr as toMultiaddr } from '@libp2p/utils/ip-port-to-multiaddr'
 import { multiaddr, protocols } from '@multiformats/multiaddr'
@@ -14,7 +14,7 @@ import type { WebSocketServer } from 'it-ws/server'
 
 const log = logger('libp2p:websockets:listener')
 
-class WebSocketListener extends EventEmitter<ListenerEvents> implements Listener {
+class WebSocketListener extends TypedEventEmitter<ListenerEvents> implements Listener {
   private readonly connections: Set<DuplexWebSocket>
   private listeningMultiaddr?: Multiaddr
   private readonly server: WebSocketServer

--- a/packages/transport-websockets/test/browser.ts
+++ b/packages/transport-websockets/test/browser.ts
@@ -1,6 +1,6 @@
 /* eslint-env mocha */
 
-import { EventEmitter } from '@libp2p/interface/events'
+import { TypedEventEmitter } from '@libp2p/interface/events'
 import { mockUpgrader } from '@libp2p/interface-compliance-tests/mocks'
 import { multiaddr } from '@multiformats/multiaddr'
 import { expect } from 'aegir/chai'
@@ -23,7 +23,7 @@ describe('libp2p-websockets', () => {
     ws = webSockets()()
     conn = await ws.dial(ma, {
       upgrader: mockUpgrader({
-        events: new EventEmitter()
+        events: new TypedEventEmitter()
       })
     })
   })

--- a/packages/transport-websockets/test/node.ts
+++ b/packages/transport-websockets/test/node.ts
@@ -4,7 +4,7 @@
 import fs from 'fs'
 import http from 'http'
 import https from 'https'
-import { EventEmitter } from '@libp2p/interface/events'
+import { TypedEventEmitter } from '@libp2p/interface/events'
 import { mockRegistrar, mockUpgrader } from '@libp2p/interface-compliance-tests/mocks'
 import { multiaddr } from '@multiformats/multiaddr'
 import { expect } from 'aegir/chai'
@@ -41,7 +41,7 @@ void registrar.handle(protocol, (evt) => {
 })
 const upgrader = mockUpgrader({
   registrar,
-  events: new EventEmitter()
+  events: new TypedEventEmitter()
 })
 
 describe('instantiate the transport', () => {


### PR DESCRIPTION
We add types to a `EventEmitter` class which extends the plain js `EventTarget`.

The name is chosen to give familiarity to node developers but it's not generally a good idea.

This refactor:

1. Exports a new `TypedEventTarget` interface which adds types to `EventTarget`
2. Renames `EventEmitter` to `TypedEventEmitter` to draw a distinction between them
3. Re-exports `TypedEventEmitter` as `EventEmitter` to preserve backwards compatibility

In the future all consuming code should rely on the `TypedEventTarget` interface while implementing code uses `TypedEventEmitter` as an implementation of a `TypedEventEmitter`.

By depending on the interface and not the implementation consuming code is isolated from problems that arise when two versions of `@libp2p/interface` is in the dependency tree and the event subsystems would otherwise be compatible due to type overlap.

This manifests as an error message about incompatible implementations of the private `#listeners` field in EventEmitter.

Backwards compatibility is achieved by exporting the `TypedEventEmitter` class as the older `EventEmitter` name.  This should be removed in a future PR to the v1.0 branch once external modules (e.g. Gossipsub) have been updated to use the new `TypedEventEmitter` symbol.

## Change checklist

- [x] I have performed a self-review of my own code
- [ ] I have made corresponding changes to the documentation if necessary (this includes comments as well)
- [ ] I have added tests that prove my fix is effective or that my feature works