### PR TITLE
fix: export DHT record class

### DIFF
--- a/packages/kad-dht/src/index.ts
+++ b/packages/kad-dht/src/index.ts
@@ -13,6 +13,8 @@ import type { Datastore } from 'interface-datastore'
 import type { CID } from 'multiformats/cid'
 import type { ProgressOptions, ProgressEvent } from 'progress-events'
 
+export { Libp2pRecord as Record } from './record/index.js'
+
 /**
  * The types of events emitted during DHT queries
  */


### PR DESCRIPTION
This needs to be exported for reuse by things that create DHT records such as IPNS.  Previously it was imported from the `@libp2p/record` module.

Exported as `Record` because it's a KAD-DHT specific record and `KAD-DHT` in a class name is redundant within the scope of the KAD-DHT module.

## Change checklist

- [x] I have performed a self-review of my own code
- [ ] I have made corresponding changes to the documentation if necessary (this includes comments as well)
- [ ] I have added tests that prove my fix is effective or that my feature works