### PR TITLE
fix: allow DHT self-query to time out

### DIFF
--- a/packages/kad-dht/src/dual-kad-dht.ts
+++ b/packages/kad-dht/src/dual-kad-dht.ts
@@ -103,7 +103,7 @@ function multiaddrIsPublic (multiaddr: Multiaddr): boolean {
 
   // dns4 or dns6 or dnsaddr
   if (tuples[0][0] === DNS4_CODE || tuples[0][0] === DNS6_CODE || tuples[0][0] === DNSADDR_CODE) {
-    log('%m is public %s', multiaddr, true)
+    log('%a is public %s', multiaddr, true)
 
     return true
   }
@@ -113,7 +113,7 @@ function multiaddrIsPublic (multiaddr: Multiaddr): boolean {
     const result = isPrivate(`${tuples[0][1]}`)
     const isPublic = result == null || !result
 
-    log('%m is public %s', multiaddr, isPublic)
+    log('%a is public %s', multiaddr, isPublic)
 
     return isPublic
   }
@@ -173,7 +173,7 @@ export class DefaultDualKadDHT extends EventEmitter<PeerDiscoveryEvents> impleme
           .some(({ multiaddr }) => {
             const isPublic = multiaddrIsPublic(multiaddr)
 
-            log('%m is public %s', multiaddr, isPublic)
+            log('%a is public %s', multiaddr, isPublic)
 
             return isPublic
           })

--- a/packages/kad-dht/src/dual-kad-dht.ts
+++ b/packages/kad-dht/src/dual-kad-dht.ts
@@ -103,8 +103,6 @@ function multiaddrIsPublic (multiaddr: Multiaddr): boolean {
 
   // dns4 or dns6 or dnsaddr
   if (tuples[0][0] === DNS4_CODE || tuples[0][0] === DNS6_CODE || tuples[0][0] === DNSADDR_CODE) {
-    log('%a is public %s', multiaddr, true)
-
     return true
   }
 
@@ -112,8 +110,6 @@ function multiaddrIsPublic (multiaddr: Multiaddr): boolean {
   if (tuples[0][0] === IP4_CODE || tuples[0][0] === IP6_CODE) {
     const result = isPrivate(`${tuples[0][1]}`)
     const isPublic = result == null || !result
-
-    log('%a is public %s', multiaddr, isPublic)
 
     return isPublic
   }
@@ -170,13 +166,7 @@ export class DefaultDualKadDHT extends EventEmitter<PeerDiscoveryEvents> impleme
       components.events.addEventListener('self:peer:update', (evt) => {
         log('received update of self-peer info')
         const hasPublicAddress = evt.detail.peer.addresses
-          .some(({ multiaddr }) => {
-            const isPublic = multiaddrIsPublic(multiaddr)
-
-            log('%a is public %s', multiaddr, isPublic)
-
-            return isPublic
-          })
+          .some(({ multiaddr }) => multiaddrIsPublic(multiaddr))
 
         this.getMode()
           .then(async mode => {

--- a/packages/kad-dht/src/record/selectors.ts
+++ b/packages/kad-dht/src/record/selectors.ts
@@ -24,7 +24,7 @@ export function bestRecord (selectors: Selectors, k: Uint8Array, records: Uint8A
   const selector = selectors[parts[1].toString()]
 
   if (selector == null) {
-    const errMsg = `Unrecognized key prefix: ${parts[1]}`
+    const errMsg = `No selector function configured for key type "${parts[1]}"`
 
     throw new CodeError(errMsg, 'ERR_UNRECOGNIZED_KEY_PREFIX')
   }

--- a/packages/kad-dht/src/record/validators.ts
+++ b/packages/kad-dht/src/record/validators.ts
@@ -23,7 +23,7 @@ export async function verifyRecord (validators: Validators, record: Libp2pRecord
   const validator = validators[parts[1].toString()]
 
   if (validator == null) {
-    const errMsg = 'Invalid record keytype'
+    const errMsg = `No validator available for key type "${parts[1]}"`
 
     throw new CodeError(errMsg, 'ERR_INVALID_RECORD_KEY_TYPE')
   }

--- a/packages/kad-dht/test/record/selection.spec.ts
+++ b/packages/kad-dht/test/record/selection.spec.ts
@@ -13,26 +13,20 @@ describe('selection', () => {
     it('throws no records given when no records received', () => {
       expect(
         () => selection.bestRecord({}, uint8ArrayFromString('/'), [])
-      ).to.throw(
-        /No records given/
-      )
+      ).to.throw().with.property('code', 'ERR_NO_RECORDS_RECEIVED')
     })
 
     it('throws on missing selector in the record key', () => {
       expect(
         () => selection.bestRecord({}, uint8ArrayFromString('/'), records)
-      ).to.throw(
-        /Record key does not have a selector function/
-      )
+      ).to.throw().with.property('code', 'ERR_NO_SELECTOR_FUNCTION_FOR_RECORD_KEY')
     })
 
     it('throws on unknown key prefix', () => {
       expect(
         // @ts-expect-error invalid input
         () => selection.bestRecord({ world () {} }, uint8ArrayFromString('/hello/'), records)
-      ).to.throw(
-        /Unrecognized key prefix: hello/
-      )
+      ).to.throw().with.property('code', 'ERR_UNRECOGNIZED_KEY_PREFIX')
     })
 
     it('returns the index from the matching selector', () => {

--- a/packages/kad-dht/test/record/validator.spec.ts
+++ b/packages/kad-dht/test/record/validator.spec.ts
@@ -86,9 +86,7 @@ describe('validator', () => {
         }
       }
       await expect(validator.verifyRecord(validators, rec))
-        .to.eventually.rejectedWith(
-          /Invalid record keytype/
-        )
+        .to.eventually.rejected.with.property('code', 'ERR_INVALID_RECORD_KEY_TYPE')
     })
   })
 


### PR DESCRIPTION
When we run our first self-query we first check the routing table to see if it has peers.

If not we wait for some peers to be discovered before continuing.

The change here is to use the general query AbortSignal to abort waiting for peers to be discovered.  If they are not discovered allow other queries to continue and fail with eaiser to understand error messages.

Also fixes some logging typos and makes error messages more understandable.

## Change checklist

- [x] I have performed a self-review of my own code
- [ ] I have made corresponding changes to the documentation if necessary (this includes comments as well)
- [ ] I have added tests that prove my fix is effective or that my feature works