### PR TITLE
chore: cache interop build files

### DIFF
--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -181,6 +181,10 @@ jobs:
         with:
           node-version: lts/*
       - uses: ipfs/aegir/actions/cache-node-modules@master
+        with:
+          directories: |
+            ./interop/dist
+            ./interop/node_modules
       - name: Build images
         run: (cd interop && make -j 4)
       - name: Save package-lock.json as artifact

--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -17,6 +17,10 @@ jobs:
       with:
         node-version: lts/*
     - uses: ipfs/aegir/actions/cache-node-modules@master
+      with:
+        directories: |
+          ./interop/dist
+          ./interop/node_modules
 
   check:
     needs: build


### PR DESCRIPTION
Add the interop output dirs to the npm/build cache
