### PR TITLE
refactor: extract DCUtR utils

### DIFF
--- a/packages/libp2p/src/dcutr/dcutr.ts
+++ b/packages/libp2p/src/dcutr/dcutr.ts
@@ -1,12 +1,11 @@
 import { CodeError } from '@libp2p/interface/errors'
 import { logger } from '@libp2p/logger'
 import { type Multiaddr, multiaddr } from '@multiformats/multiaddr'
-import { Circuit, IP, DNS } from '@multiformats/multiaddr-matcher'
 import delay from 'delay'
 import { pbStream } from 'it-protobuf-stream'
-import isPrivate from 'private-ip'
 import { codes } from '../errors.js'
 import { HolePunch } from './pb/message.js'
+import { isPublicAndDialable } from './utils.js'
 import { multicodec } from './index.js'
 import type { DCUtRServiceComponents, DCUtRServiceInit } from './index.js'
 import type { Connection, Stream } from '@libp2p/interface/connection'
@@ -242,7 +241,7 @@ export class DefaultDCUtRService implements Startable {
         return ma
       })
       .filter(ma => {
-        return this.isPublicAndDialable(ma)
+        return isPublicAndDialable(ma, this.transportManager)
       })
 
     if (publicAddresses.length > 0) {
@@ -366,7 +365,7 @@ export class DefaultDCUtRService implements Startable {
       try {
         const ma = multiaddr(addr)
 
-        if (!this.isPublicAndDialable(ma)) {
+        if (!isPublicAndDialable(ma, this.transportManager)) {
           continue
         }
 
@@ -375,36 +374,5 @@ export class DefaultDCUtRService implements Startable {
     }
 
     return output
-  }
-
-  /**
-   * Returns true if the passed multiaddr is public, not relayed and we have a
-   * transport that can dial it
-   */
-  isPublicAndDialable (ma: Multiaddr): boolean {
-    // ignore circuit relay
-    if (Circuit.matches(ma)) {
-      return false
-    }
-
-    // dns addresses are probably public?
-    if (DNS.matches(ma)) {
-      return true
-    }
-
-    // ensure we have only IPv4/IPv6 addresses
-    if (!IP.matches(ma)) {
-      return false
-    }
-
-    const transport = this.transportManager.transportForMultiaddr(ma)
-
-    if (transport == null) {
-      return false
-    }
-
-    const options = ma.toOptions()
-
-    return isPrivate(options.host) === false
   }
 }

--- a/packages/libp2p/src/dcutr/utils.ts
+++ b/packages/libp2p/src/dcutr/utils.ts
@@ -1,0 +1,33 @@
+import { type Multiaddr } from '@multiformats/multiaddr'
+import { Circuit, IP, DNS } from '@multiformats/multiaddr-matcher'
+import isPrivate from 'private-ip'
+import type { TransportManager } from '@libp2p/interface-internal/src/transport-manager'
+
+/**
+ * Returns true if the passed multiaddr is public, not relayed and we have a
+ * transport that can dial it
+ */
+export function isPublicAndDialable (ma: Multiaddr, transportManager: TransportManager): boolean {
+  // ignore circuit relay
+  if (Circuit.matches(ma)) {
+    return false
+  }
+
+  const transport = transportManager.transportForMultiaddr(ma)
+
+  if (transport == null) {
+    return false
+  }
+
+  // dns addresses are probably public?
+  if (DNS.matches(ma)) {
+    return true
+  }
+
+  // ensure we have only IPv4/IPv6 addresses
+  if (!IP.matches(ma)) {
+    return false
+  }
+
+  return isPrivate(ma.toOptions().host) === false
+}

--- a/packages/libp2p/test/dcutr/utils.spec.ts
+++ b/packages/libp2p/test/dcutr/utils.spec.ts
@@ -1,0 +1,39 @@
+/* eslint-env mocha */
+
+import { multiaddr } from '@multiformats/multiaddr'
+import { expect } from 'aegir/chai'
+import { stubInterface } from 'sinon-ts'
+import { isPublicAndDialable } from '../../src/dcutr/utils.js'
+import type { Transport } from '@libp2p/interface/transport'
+import type { TransportManager } from '@libp2p/interface-internal/transport-manager'
+
+describe('dcutr utils', () => {
+  describe('isPublicAndDialable', () => {
+    const testCases = {
+      // good addresses
+      '/ip4/123.123.123.123/tcp/80/p2p/12D3KooWbtp1AcgweFSArD7dbKWYpAr8MZR1tofwNwLFLjeNGLWa': true,
+      '/dnsaddr/example.com/p2p/12D3KooWbtp1AcgweFSArD7dbKWYpAr8MZR1tofwNwLFLjeNGLWa': true,
+      '/ip4/123.123.123.123/tcp/80/p2p/12D3KooWbtp1AcgweFSArD7dbKWYpAr8MZR1tofwNwLFLjeNGLWa/p2p-circuit/webrtc/p2p/QmNnooDu7bfjPFoTZYxMNLWUQJyrVwtbZg5gBMjTezGAJN': true,
+
+      // bad addresses
+      '/dnsaddr/example.com/p2p/12D3KooWbtp1AcgweFSArD7dbKWYpAr8MZR1tofwNwLFLjeNGLWa/p2p-circuit/p2p/QmNnooDu7bfjPFoTZYxMNLWUQJyrVwtbZg5gBMjTezGAJN': false,
+      '/ip4/10.0.0.1/tcp/123/p2p/12D3KooWbtp1AcgweFSArD7dbKWYpAr8MZR1tofwNwLFLjeNGLWa': false
+    }
+
+    for (const [key, value] of Object.entries(testCases)) {
+      it(`should ${value ? '' : 'not '}allow ${key}`, () => {
+        const transportManager = stubInterface<TransportManager>({
+          transportForMultiaddr: stubInterface<Transport>()
+        })
+
+        expect(isPublicAndDialable(multiaddr(key), transportManager)).to.equal(value)
+      })
+    }
+
+    it('should not allow addresses for which there is no transport', () => {
+      const transportManager = stubInterface<TransportManager>()
+
+      expect(isPublicAndDialable(multiaddr('/ip4/123.123.123.123/p2p/12D3KooWbtp1AcgweFSArD7dbKWYpAr8MZR1tofwNwLFLjeNGLWa'), transportManager)).to.be.false()
+    })
+  })
+})


### PR DESCRIPTION
In order to get a better view on testing DCUtR, split the utility functions out to test them separately starting with `isPublicAndDialable`.

## Change checklist

- [x] I have performed a self-review of my own code
- [ ] I have made corresponding changes to the documentation if necessary (this includes comments as well)
- [x] I have added tests that prove my fix is effective or that my feature works