### PR TITLE
fix: make initiator webrtc address dialable

### DIFF
--- a/packages/transport-webrtc/src/private-to-private/initiate-connection.ts
+++ b/packages/transport-webrtc/src/private-to-private/initiate-connection.ts
@@ -1,18 +1,18 @@
 import { CodeError } from '@libp2p/interface/errors'
 import { logger } from '@libp2p/logger'
 import { peerIdFromString } from '@libp2p/peer-id'
-import { multiaddr, type Multiaddr } from '@multiformats/multiaddr'
 import { pbStream } from 'it-protobuf-stream'
 import pDefer, { type DeferredPromise } from 'p-defer'
 import { type RTCPeerConnection, RTCSessionDescription } from '../webrtc/index.js'
 import { Message } from './pb/message.js'
 import { SIGNALING_PROTO_ID, splitAddr, type WebRTCTransportMetrics } from './transport.js'
-import { parseRemoteAddress, readCandidatesUntilConnected, resolveOnConnected } from './util.js'
+import { readCandidatesUntilConnected, resolveOnConnected } from './util.js'
 import type { DataChannelOptions } from '../index.js'
 import type { Connection } from '@libp2p/interface/connection'
 import type { ConnectionManager } from '@libp2p/interface-internal/connection-manager'
 import type { IncomingStreamData } from '@libp2p/interface-internal/registrar'
 import type { TransportManager } from '@libp2p/interface-internal/transport-manager'
+import type { Multiaddr } from '@multiformats/multiaddr'
 
 const log = logger('libp2p:webrtc:initiate-connection')
 
@@ -33,7 +33,7 @@ export interface ConnectOptions {
 }
 
 export async function initiateConnection ({ peerConnection, signal, metrics, multiaddr: ma, connectionManager, transportManager }: ConnectOptions): Promise<{ remoteAddress: Multiaddr }> {
-  const { baseAddr, peerId } = splitAddr(ma)
+  const { baseAddr } = splitAddr(ma)
 
   metrics?.dialerEvents.increment({ open: true })
 
@@ -158,12 +158,10 @@ export async function initiateConnection ({ peerConnection, signal, metrics, mul
         signal
       })
 
-      const remoteAddress = parseRemoteAddress(peerConnection.currentRemoteDescription?.sdp ?? '')
-
-      log.trace('initiator connected to remote address %s', remoteAddress)
+      log.trace('initiator connected to remote address %s', ma)
 
       return {
-        remoteAddress: multiaddr(remoteAddress).encapsulate(`/p2p/${peerId.toString()}`)
+        remoteAddress: ma
       }
     } catch (err: any) {
       peerConnection.close()

--- a/packages/transport-webrtc/src/private-to-private/signaling-stream-handler.ts
+++ b/packages/transport-webrtc/src/private-to-private/signaling-stream-handler.ts
@@ -1,10 +1,11 @@
 import { CodeError } from '@libp2p/interface/errors'
 import { logger } from '@libp2p/logger'
+import { multiaddr, type Multiaddr } from '@multiformats/multiaddr'
 import { pbStream } from 'it-protobuf-stream'
 import pDefer, { type DeferredPromise } from 'p-defer'
 import { type RTCPeerConnection, RTCSessionDescription } from '../webrtc/index.js'
 import { Message } from './pb/message.js'
-import { parseRemoteAddress, readCandidatesUntilConnected, resolveOnConnected } from './util.js'
+import { readCandidatesUntilConnected, resolveOnConnected } from './util.js'
 import type { IncomingStreamData } from '@libp2p/interface-internal/registrar'
 
 const log = logger('libp2p:webrtc:signaling-stream-handler')
@@ -14,7 +15,7 @@ export interface IncomingStreamOpts extends IncomingStreamData {
   signal: AbortSignal
 }
 
-export async function handleIncomingStream ({ peerConnection, stream, signal, connection }: IncomingStreamOpts): Promise<{ remoteAddress: string }> {
+export async function handleIncomingStream ({ peerConnection, stream, signal, connection }: IncomingStreamOpts): Promise<{ remoteAddress: Multiaddr }> {
   log.trace('new inbound signaling stream')
 
   const messageStream = pbStream(stream).pb(Message)
@@ -121,7 +122,7 @@ export async function handleIncomingStream ({ peerConnection, stream, signal, co
     }
   }
 
-  const remoteAddress = parseRemoteAddress(peerConnection.currentRemoteDescription?.sdp ?? '')
+  const remoteAddress = multiaddr(`/webrtc/p2p/${connection.remoteAddr.getPeerId()}`)
 
   log.trace('recipient connected to remote address %s', remoteAddress)
 

--- a/packages/transport-webrtc/src/private-to-private/transport.ts
+++ b/packages/transport-webrtc/src/private-to-private/transport.ts
@@ -170,7 +170,7 @@ export class WebRTCTransport implements Transport, Startable {
       const webRTCConn = new WebRTCMultiaddrConnection({
         peerConnection,
         timeline: { open: (new Date()).getTime() },
-        remoteAddr: multiaddr(remoteAddress).encapsulate(`/p2p/${connection.remotePeer.toString()}`),
+        remoteAddr: remoteAddress,
         metrics: this.metrics?.listenerEvents
       })
 

--- a/packages/transport-webrtc/src/private-to-private/util.ts
+++ b/packages/transport-webrtc/src/private-to-private/util.ts
@@ -110,16 +110,3 @@ export function resolveOnConnected (pc: RTCPeerConnection, promise: DeferredProm
     }
   }
 }
-
-export function parseRemoteAddress (sdp: string): string {
-  // 'a=candidate:1746876089 1 udp 2113937151 0614fbad-b...ocal 54882 typ host generation 0 network-cost 999'
-  const candidateLine = sdp.split('\r\n').filter(line => line.startsWith('a=candidate')).pop()
-  const candidateParts = candidateLine?.split(' ')
-
-  if (candidateLine == null || candidateParts == null || candidateParts.length < 5) {
-    log('could not parse remote address from', candidateLine)
-    return '/webrtc'
-  }
-
-  return `/dnsaddr/${candidateParts[4]}/${candidateParts[2].toLowerCase()}/${candidateParts[5]}/webrtc`
-}

--- a/packages/transport-webrtc/test/basics.spec.ts
+++ b/packages/transport-webrtc/test/basics.spec.ts
@@ -122,6 +122,15 @@ describe('basics', () => {
     expect(output).to.equalBytes(toBuffer(input))
   })
 
+  it('reports remote addresses correctly', async () => {
+    const initatorConnection = await connectNodes()
+    expect(initatorConnection.remoteAddr.toString()).to.equal(`${process.env.RELAY_MULTIADDR}/p2p-circuit/webrtc/p2p/${remoteNode.peerId}`)
+
+    const receiverConnections = remoteNode.getConnections(localNode.peerId)
+    expect(receiverConnections).to.have.lengthOf(1)
+    expect(receiverConnections[0].remoteAddr.toString()).to.equal(`/webrtc/p2p/${localNode.peerId}`)
+  })
+
   it('can send a large file', async () => {
     const connection = await connectNodes()
 

--- a/packages/transport-webrtc/test/peer.browser.spec.ts
+++ b/packages/transport-webrtc/test/peer.browser.spec.ts
@@ -38,6 +38,7 @@ interface PrivateToPrivateComponents {
 
 async function getComponents (): Promise<PrivateToPrivateComponents> {
   const relayPeerId = await createEd25519PeerId()
+  const initiatorPeerId = await createEd25519PeerId()
   const receiverPeerId = await createEd25519PeerId()
   const receiverMultiaddr = multiaddr(`/ip4/123.123.123.123/tcp/123/p2p/${relayPeerId}/p2p-circuit/webrtc/p2p/${receiverPeerId}`)
   const [initiatorToReceiver, receiverToInitiator] = duplexPair<any>()
@@ -66,7 +67,9 @@ async function getComponents (): Promise<PrivateToPrivateComponents> {
     },
     recipient: {
       peerConnection: new RTCPeerConnection(),
-      connection: stubInterface<Connection>(),
+      connection: stubInterface<Connection>({
+        remoteAddr: multiaddr(`/ip4/123.123.123.123/tcp/123/p2p/${relayPeerId}/p2p-circuit/p2p/${initiatorPeerId}`)
+      }),
       abortController: recipientAbortController,
       signal: recipientAbortController.signal,
       stream: receiverStream


### PR DESCRIPTION
Updates the reported remote address of webrtc connections to be the address that was dialed, so it can be treated as an opaque value and shared with other interested parties.

The recipient remote address is just `/webrtc/p2p/QmInitiator` as there is no guarantee that the intiator has a reservation anywhere.

## Change checklist

- [x] I have performed a self-review of my own code
- [ ] I have made corresponding changes to the documentation if necessary (this includes comments as well)
- [x] I have added tests that prove my fix is effective or that my feature works