### PR TITLE
chore: fix pubsub interop tests

### DIFF
--- a/packages/libp2p/test/interop.ts
+++ b/packages/libp2p/test/interop.ts
@@ -129,7 +129,10 @@ async function createJsPeer (options: SpawnOptions): Promise<Daemon> {
     },
     transports: [tcp(), circuitRelayTransport()],
     streamMuxers: [],
-    connectionEncryption: [noise()]
+    connectionEncryption: [noise()],
+    connectionManager: {
+      minConnections: 0
+    }
   }
 
   const services: ServiceFactoryMap = {


### PR DESCRIPTION
When opening outbound streams, only make sure no outbound pubsub streams exist on the connection, not just any pubsub streams.

Improves logging:
- Disables autodial during interop tests to make logs quieter
- Makes logging why we can't send an RPC message to a peer clearer

Fixes a race condition where the remote peer can open streams before us which then prevents us opening streams.

## Change checklist

- [x] I have performed a self-review of my own code
- [ ] I have made corresponding changes to the documentation if necessary (this includes comments as well)
- [ ] I have added tests that prove my fix is effective or that my feature works