### PR TITLE
fix: do not overwrite addresses on identify push when none are sent

### DIFF
--- a/packages/libp2p/src/identify/identify.ts
+++ b/packages/libp2p/src/identify/identify.ts
@@ -490,6 +490,17 @@ export class DefaultIdentifyService implements Startable, IdentifyService {
       peer.metadata.set('ProtocolVersion', uint8ArrayFromString(message.protocolVersion))
     }
 
+    // if the remote has not sent addresses, preserve the existing ones.
+    // this can happen during an identify-push triggered by a supported protocol
+    // change but the protobuf format makes it impossible to know if the remote
+    // was telling us they have no addresses (unlikely) or if they meant to send
+    // a partial update and omit the list entirely
+    if (peer.addresses.length === 0) {
+      // @ts-expect-error addresses is not optional
+      delete peer.addresses
+    }
+
+    log('patching %p with', peer)
     await this.peerStore.patch(connection.remotePeer, peer)
 
     const result: IdentifyResult = {

--- a/packages/libp2p/src/identify/identify.ts
+++ b/packages/libp2p/src/identify/identify.ts
@@ -23,7 +23,7 @@ import type { Libp2pEvents, IdentifyResult, SignedPeerRecord, AbortOptions } fro
 import type { Connection, Stream } from '@libp2p/interface/connection'
 import type { TypedEventTarget } from '@libp2p/interface/events'
 import type { PeerId } from '@libp2p/interface/peer-id'
-import type { Peer, PeerStore } from '@libp2p/interface/peer-store'
+import type { Peer, PeerData, PeerStore } from '@libp2p/interface/peer-store'
 import type { Startable } from '@libp2p/interface/startable'
 import type { AddressManager } from '@libp2p/interface-internal/address-manager'
 import type { ConnectionManager } from '@libp2p/interface-internal/connection-manager'
@@ -404,17 +404,30 @@ export class DefaultIdentifyService implements Startable, IdentifyService {
     log('received identify from %p', connection.remotePeer)
 
     if (message == null) {
-      throw new Error('Message was null or undefined')
+      throw new CodeError('message was null or undefined', 'ERR_INVALID_MESSAGE')
     }
 
-    const peer = {
-      addresses: message.listenAddrs.map(buf => ({
+    const peer: PeerData = {}
+
+    if (message.listenAddrs.length > 0) {
+      peer.addresses = message.listenAddrs.map(buf => ({
         isCertified: false,
         multiaddr: multiaddr(buf)
-      })),
-      protocols: message.protocols,
-      metadata: new Map(),
-      peerRecordEnvelope: message.signedPeerRecord
+      }))
+    }
+
+    if (message.protocols.length > 0) {
+      peer.protocols = message.protocols
+    }
+
+    if (message.publicKey != null) {
+      peer.publicKey = message.publicKey
+
+      const peerId = await peerIdFromKeys(message.publicKey)
+
+      if (!peerId.equals(connection.remotePeer)) {
+        throw new CodeError('public key did not match remote PeerId', 'ERR_INVALID_PUBLIC_KEY')
+      }
     }
 
     let output: SignedPeerRecord | undefined
@@ -429,12 +442,12 @@ export class DefaultIdentifyService implements Startable, IdentifyService {
 
       // Verify peerId
       if (!peerRecord.peerId.equals(envelope.peerId)) {
-        throw new Error('signing key does not match PeerId in the PeerRecord')
+        throw new CodeError('signing key does not match PeerId in the PeerRecord', 'ERR_INVALID_SIGNING_KEY')
       }
 
       // Make sure remote peer is the one sending the record
       if (!connection.remotePeer.equals(peerRecord.peerId)) {
-        throw new Error('signing key does not match remote PeerId')
+        throw new CodeError('signing key does not match remote PeerId', 'ERR_INVALID_PEER_RECORD_KEY')
       }
 
       let existingPeer: Peer | undefined
@@ -482,26 +495,25 @@ export class DefaultIdentifyService implements Startable, IdentifyService {
       log('%p did not send a signed peer record', connection.remotePeer)
     }
 
-    if (message.agentVersion != null) {
-      peer.metadata.set('AgentVersion', uint8ArrayFromString(message.agentVersion))
-    }
-
-    if (message.protocolVersion != null) {
-      peer.metadata.set('ProtocolVersion', uint8ArrayFromString(message.protocolVersion))
-    }
-
-    // if the remote has not sent addresses, preserve the existing ones.
-    // this can happen during an identify-push triggered by a supported protocol
-    // change but the protobuf format makes it impossible to know if the remote
-    // was telling us they have no addresses (unlikely) or if they meant to send
-    // a partial update and omit the list entirely
-    if (peer.addresses.length === 0) {
-      // @ts-expect-error addresses is not optional
-      delete peer.addresses
-    }
-
     log('patching %p with', peer)
     await this.peerStore.patch(connection.remotePeer, peer)
+
+    if (message.agentVersion != null || message.protocolVersion != null) {
+      const metadata: Record<string, Uint8Array> = {}
+
+      if (message.agentVersion != null) {
+        metadata.AgentVersion = uint8ArrayFromString(message.agentVersion)
+      }
+
+      if (message.protocolVersion != null) {
+        metadata.ProtocolVersion = uint8ArrayFromString(message.protocolVersion)
+      }
+
+      log('updating %p metadata', peer)
+      await this.peerStore.merge(connection.remotePeer, {
+        metadata
+      })
+    }
 
     const result: IdentifyResult = {
       peerId: connection.remotePeer,

--- a/packages/libp2p/test/identify/index.spec.ts
+++ b/packages/libp2p/test/identify/index.spec.ts
@@ -85,7 +85,7 @@ async function createComponents (index: number): Promise<Components> {
   return components
 }
 
-describe.only('identify', () => {
+describe('identify', () => {
   let localComponents: Components
   let remoteComponents: Components
 

--- a/packages/libp2p/test/identify/index.spec.ts
+++ b/packages/libp2p/test/identify/index.spec.ts
@@ -3,7 +3,7 @@
 
 import { TypedEventEmitter } from '@libp2p/interface/events'
 import { start, stop } from '@libp2p/interface/startable'
-import { mockConnectionGater, mockRegistrar, mockUpgrader, connectionPair } from '@libp2p/interface-compliance-tests/mocks'
+import { mockConnectionGater, mockRegistrar, mockUpgrader, connectionPair, mockStream } from '@libp2p/interface-compliance-tests/mocks'
 import { createEd25519PeerId } from '@libp2p/peer-id-factory'
 import { PeerRecord, RecordEnvelope } from '@libp2p/peer-record'
 import { PersistentPeerStore } from '@libp2p/peer-store'
@@ -15,6 +15,7 @@ import drain from 'it-drain'
 import * as lp from 'it-length-prefixed'
 import { pipe } from 'it-pipe'
 import { pbStream } from 'it-protobuf-stream'
+import { pushable } from 'it-pushable'
 import pDefer from 'p-defer'
 import sinon from 'sinon'
 import { stubInterface } from 'sinon-ts'
@@ -31,8 +32,10 @@ import { DefaultIdentifyService } from '../../src/identify/identify.js'
 import { identifyService, type IdentifyServiceInit, Message } from '../../src/identify/index.js'
 import { Identify } from '../../src/identify/pb/message.js'
 import { DefaultTransportManager } from '../../src/transport-manager.js'
+import type { Connection } from '@libp2p/interface/connection'
 import type { IncomingStreamData } from '@libp2p/interface-internal/registrar'
 import type { TransportManager } from '@libp2p/interface-internal/transport-manager'
+import type { Duplex, Source } from 'it-stream-types'
 
 const listenMaddrs = [multiaddr('/ip4/127.0.0.1/tcp/15002/ws')]
 
@@ -503,5 +506,61 @@ describe('identify', () => {
       multiaddr: multiaddr('/ip4/127.0.0.1/tcp/5678')
     }])
     expect(peer.id.publicKey).to.equalBytes(remoteComponents.peerId.publicKey)
+  })
+
+  it('should not overwrite addresses when none are sent', async () => {
+    const localIdentify = new DefaultIdentifyService(localComponents, defaultInit)
+    await start(localIdentify)
+
+    const duplex: Duplex<any, Source<any>, any> = {
+      source: pushable(),
+      sink: async (source) => {
+        await drain(source)
+      }
+    }
+
+    duplex.source.push(lp.encode.single(Identify.encode({
+      listenAddrs: [
+        multiaddr('/ip4/127.0.0.1/tcp/4001').bytes
+      ],
+      protocols: [
+        '/proto/1'
+      ]
+    })))
+
+    await localIdentify._handlePush({
+      stream: mockStream(duplex),
+      connection: stubInterface<Connection>({
+        remotePeer: remoteComponents.peerId
+      })
+    })
+
+    const peerData = await localComponents.peerStore.get(remoteComponents.peerId)
+    expect(peerData.addresses[0].multiaddr.toString()).to.equal('/ip4/127.0.0.1/tcp/4001')
+    expect(peerData.protocols).to.deep.equal(['/proto/1'])
+
+    const updateDuplex: Duplex<any, Source<any>, any> = {
+      source: pushable(),
+      sink: async (source) => {
+        await drain(source)
+      }
+    }
+
+    updateDuplex.source.push(lp.encode.single(Identify.encode({
+      protocols: [
+        '/proto/2'
+      ]
+    })))
+
+    await localIdentify._handlePush({
+      stream: mockStream(updateDuplex),
+      connection: stubInterface<Connection>({
+        remotePeer: remoteComponents.peerId
+      })
+    })
+
+    const updatedPeerData = await localComponents.peerStore.get(remoteComponents.peerId)
+    expect(updatedPeerData.addresses[0].multiaddr.toString()).to.equal('/ip4/127.0.0.1/tcp/4001')
+    expect(updatedPeerData.protocols).to.deep.equal(['/proto/2'])
   })
 })


### PR DESCRIPTION
During identify-push in response to a protocol update go-libp2p does not send a signed peer record or the current list of listen addresses.

This manifests in intermittent interop test failures where we have no valid addresses for a dial, when we dial a peer ID after adding multiaddrs for it to the peer store.
    
Protobuf does not let us differentiate between an empty list and no list items at all because the field is just `repeated` - an absence of repeated fields doesn't mean the list was omitted.
    