### PR TITLE
fix!: remove event emitter type from interfaces

### DIFF
--- a/packages/interface/src/events.ts
+++ b/packages/interface/src/events.ts
@@ -117,9 +117,6 @@ class CustomEventPolyfill<T = any> extends Event {
 
 export const CustomEvent = globalThis.CustomEvent ?? CustomEventPolyfill
 
-// TODO: remove this in v1
-export { TypedEventEmitter as EventEmitter }
-
 // create a setMaxListeners that doesn't break browser usage
 export const setMaxListeners: typeof nodeSetMaxListeners = (n, ...eventTargets) => {
   try {

--- a/packages/peer-discovery-mdns/src/mdns.ts
+++ b/packages/peer-discovery-mdns/src/mdns.ts
@@ -1,4 +1,4 @@
-import { CustomEvent, EventEmitter } from '@libp2p/interface/events'
+import { CustomEvent, TypedEventEmitter } from '@libp2p/interface/events'
 import { peerDiscovery } from '@libp2p/interface/peer-discovery'
 import multicastDNS from 'multicast-dns'
 import * as query from './query.js'
@@ -23,7 +23,7 @@ export interface MulticastDNSComponents {
   logger: ComponentLogger
 }
 
-export class MulticastDNS extends EventEmitter<PeerDiscoveryEvents> implements PeerDiscovery, Startable {
+export class MulticastDNS extends TypedEventEmitter<PeerDiscoveryEvents> implements PeerDiscovery, Startable {
   public mdns?: multicastDNS.MulticastDNS
 
   private readonly log: Logger


### PR DESCRIPTION
All code should be using `TypedEventEmitter` instead of `EventEmitter` so remove the re-export from the interfaces package.
    
BREAKING CHANGE: removed EventEmitter re-export - please use TypedEventEmitter instead

## Change checklist

- [x] I have performed a self-review of my own code
- [ ] I have made corresponding changes to the documentation if necessary (this includes comments as well)
- [ ] I have added tests that prove my fix is effective or that my feature works