### PR TITLE
fix: log peer data in identify correctly

### DIFF
--- a/packages/libp2p/src/identify/identify.ts
+++ b/packages/libp2p/src/identify/identify.ts
@@ -495,7 +495,7 @@ export class DefaultIdentifyService implements Startable, IdentifyService {
       log('%p did not send a signed peer record', connection.remotePeer)
     }
 
-    log('patching %p with', peer)
+    log('patching %p with', connection.remotePeer, peer)
     await this.peerStore.patch(connection.remotePeer, peer)
 
     if (message.agentVersion != null || message.protocolVersion != null) {
@@ -509,7 +509,7 @@ export class DefaultIdentifyService implements Startable, IdentifyService {
         metadata.ProtocolVersion = uint8ArrayFromString(message.protocolVersion)
       }
 
-      log('updating %p metadata', peer)
+      log('merging %p metadata', connection.remotePeer, metadata)
       await this.peerStore.merge(connection.remotePeer, {
         metadata
       })


### PR DESCRIPTION
When logging peer data, pass the peer id and the update to the logger instead of just the update values, otherwise the values get logged as `[object Object]`.

## Change checklist

- [x] I have performed a self-review of my own code
- [ ] I have made corresponding changes to the documentation if necessary (this includes comments as well)
- [ ] I have added tests that prove my fix is effective or that my feature works