### PR TITLE
feat: add component logger

### DIFF
--- a/packages/interface/src/index.ts
+++ b/packages/interface/src/index.ts
@@ -107,6 +107,23 @@ export interface IdentifyResult {
 }
 
 /**
+ * Logger component for libp2p
+ */
+export interface Logger {
+  (formatter: any, ...args: any[]): void
+  error(formatter: any, ...args: any[]): void
+  trace(formatter: any, ...args: any[]): void
+  enabled: boolean
+}
+
+/**
+ * Peer logger component for libp2p
+ */
+export interface ComponentLogger {
+  forComponent(name: string): Logger
+}
+
+/**
  * Once you have a libp2p instance, you can listen to several events it emits,
  * so that you can be notified of relevant network events.
  *
@@ -408,6 +425,8 @@ export interface Libp2p<T extends ServiceMap = ServiceMap> extends Startable, Ty
    */
   metrics?: Metrics
 
+  logger: ComponentLogger
+
   /**
    * Get a deduplicated list of peer advertising multiaddrs by concatenating
    * the listen addresses used by transports with any configured
@@ -624,6 +643,13 @@ export interface Libp2p<T extends ServiceMap = ServiceMap> extends Startable, Ty
  */
 export interface AbortOptions {
   signal?: AbortSignal
+}
+
+/**
+ * An object that contains a Logger as the `log` property.
+ */
+export interface LoggerOptions {
+  log: Logger
 }
 
 /**

--- a/packages/libp2p/src/components.ts
+++ b/packages/libp2p/src/components.ts
@@ -1,6 +1,7 @@
 import { CodeError } from '@libp2p/interface/errors'
 import { isStartable, type Startable } from '@libp2p/interface/startable'
-import type { Libp2pEvents } from '@libp2p/interface'
+import { defaultLogger } from '@libp2p/logger'
+import type { Libp2pEvents, ComponentLogger } from '@libp2p/interface'
 import type { ConnectionProtector } from '@libp2p/interface/connection'
 import type { ConnectionGater } from '@libp2p/interface/connection-gater'
 import type { ContentRouting } from '@libp2p/interface/content-routing'
@@ -18,6 +19,7 @@ import type { Datastore } from 'interface-datastore'
 
 export interface Components extends Record<string, any>, Startable {
   peerId: PeerId
+  logger: ComponentLogger
   events: TypedEventTarget<Libp2pEvents>
   addressManager: AddressManager
   peerStore: PeerStore
@@ -35,6 +37,7 @@ export interface Components extends Record<string, any>, Startable {
 
 export interface ComponentsInit {
   peerId?: PeerId
+  logger?: ComponentLogger
   events?: TypedEventTarget<Libp2pEvents>
   addressManager?: AddressManager
   peerStore?: PeerStore
@@ -59,6 +62,10 @@ class DefaultComponents implements Startable {
 
     for (const [key, value] of Object.entries(init)) {
       this.components[key] = value
+    }
+
+    if (this.components.logger == null) {
+      this.components.logger = defaultLogger()
     }
   }
 

--- a/packages/libp2p/src/connection-manager/auto-dial.ts
+++ b/packages/libp2p/src/connection-manager/auto-dial.ts
@@ -1,15 +1,12 @@
-import { logger } from '@libp2p/logger'
 import { PeerMap, PeerSet } from '@libp2p/peer-collections'
 import { toString as uint8ArrayToString } from 'uint8arrays/to-string'
 import { PeerJobQueue } from '../utils/peer-job-queue.js'
 import { AUTO_DIAL_CONCURRENCY, AUTO_DIAL_DISCOVERED_PEERS_DEBOUNCE, AUTO_DIAL_INTERVAL, AUTO_DIAL_MAX_QUEUE_LENGTH, AUTO_DIAL_PEER_RETRY_THRESHOLD, AUTO_DIAL_PRIORITY, LAST_DIAL_FAILURE_KEY, MIN_CONNECTIONS } from './constants.js'
-import type { Libp2pEvents } from '@libp2p/interface'
+import type { Libp2pEvents, Logger, ComponentLogger } from '@libp2p/interface'
 import type { TypedEventTarget } from '@libp2p/interface/events'
 import type { PeerStore } from '@libp2p/interface/peer-store'
 import type { Startable } from '@libp2p/interface/startable'
 import type { ConnectionManager } from '@libp2p/interface-internal/connection-manager'
-
-const log = logger('libp2p:connection-manager:auto-dial')
 
 interface AutoDialInit {
   minConnections?: number
@@ -25,6 +22,7 @@ interface AutoDialComponents {
   connectionManager: ConnectionManager
   peerStore: PeerStore
   events: TypedEventTarget<Libp2pEvents>
+  logger: ComponentLogger
 }
 
 const defaultOptions = {
@@ -50,6 +48,7 @@ export class AutoDial implements Startable {
   private autoDialInterval?: ReturnType<typeof setInterval>
   private started: boolean
   private running: boolean
+  readonly #log: Logger
 
   /**
    * Proactively tries to connect to known peers stored in the PeerStore.
@@ -65,20 +64,21 @@ export class AutoDial implements Startable {
     this.autoDialMaxQueueLength = init.maxQueueLength ?? defaultOptions.maxQueueLength
     this.autoDialPeerRetryThresholdMs = init.autoDialPeerRetryThreshold ?? defaultOptions.autoDialPeerRetryThreshold
     this.autoDialDiscoveredPeersDebounce = init.autoDialDiscoveredPeersDebounce ?? defaultOptions.autoDialDiscoveredPeersDebounce
+    this.#log = components.logger.forComponent('libp2p:connection-manager:auto-dial')
     this.started = false
     this.running = false
     this.queue = new PeerJobQueue({
       concurrency: init.autoDialConcurrency ?? defaultOptions.autoDialConcurrency
     })
     this.queue.addListener('error', (err) => {
-      log.error('error during auto-dial', err)
+      this.#log.error('error during auto-dial', err)
     })
 
     // check the min connection limit whenever a peer disconnects
     components.events.addEventListener('connection:close', () => {
       this.autoDial()
         .catch(err => {
-          log.error(err)
+          this.#log.error(err)
         })
     })
 
@@ -93,7 +93,7 @@ export class AutoDial implements Startable {
       debounce = setTimeout(() => {
         this.autoDial()
           .catch(err => {
-            log.error(err)
+            this.#log.error(err)
           })
       }, this.autoDialDiscoveredPeersDebounce)
     })
@@ -107,7 +107,7 @@ export class AutoDial implements Startable {
     this.autoDialInterval = setTimeout(() => {
       this.autoDial()
         .catch(err => {
-          log.error('error while autodialing', err)
+          this.#log.error('error while autodialing', err)
         })
     }, this.autoDialIntervalMs)
     this.started = true
@@ -116,7 +116,7 @@ export class AutoDial implements Startable {
   afterStart (): void {
     this.autoDial()
       .catch(err => {
-        log.error('error while autodialing', err)
+        this.#log.error('error while autodialing', err)
       })
   }
 
@@ -139,24 +139,24 @@ export class AutoDial implements Startable {
     // Already has enough connections
     if (numConnections >= this.minConnections) {
       if (this.minConnections > 0) {
-        log.trace('have enough connections %d/%d', numConnections, this.minConnections)
+        this.#log.trace('have enough connections %d/%d', numConnections, this.minConnections)
       }
       return
     }
 
     if (this.queue.size > this.autoDialMaxQueueLength) {
-      log('not enough connections %d/%d but auto dial queue is full', numConnections, this.minConnections)
+      this.#log('not enough connections %d/%d but auto dial queue is full', numConnections, this.minConnections)
       return
     }
 
     if (this.running) {
-      log('not enough connections %d/%d - but skipping autodial as it is already running', numConnections, this.minConnections)
+      this.#log('not enough connections %d/%d - but skipping autodial as it is already running', numConnections, this.minConnections)
       return
     }
 
     this.running = true
 
-    log('not enough connections %d/%d - will dial peers to increase the number of connections', numConnections, this.minConnections)
+    this.#log('not enough connections %d/%d - will dial peers to increase the number of connections', numConnections, this.minConnections)
 
     const dialQueue = new PeerSet(
       // @ts-expect-error boolean filter removes falsy peer IDs
@@ -172,25 +172,25 @@ export class AutoDial implements Startable {
         (peer) => {
           // Remove peers without addresses
           if (peer.addresses.length === 0) {
-            log.trace('not autodialing %p because they have no addresses', peer.id)
+            this.#log.trace('not autodialing %p because they have no addresses', peer.id)
             return false
           }
 
           // remove peers we are already connected to
           if (connections.has(peer.id)) {
-            log.trace('not autodialing %p because they are already connected', peer.id)
+            this.#log.trace('not autodialing %p because they are already connected', peer.id)
             return false
           }
 
           // remove peers we are already dialling
           if (dialQueue.has(peer.id)) {
-            log.trace('not autodialing %p because they are already being dialed', peer.id)
+            this.#log.trace('not autodialing %p because they are already being dialed', peer.id)
             return false
           }
 
           // remove peers already in the autodial queue
           if (this.queue.hasJob(peer.id)) {
-            log.trace('not autodialing %p because they are already being autodialed', peer.id)
+            this.#log.trace('not autodialing %p because they are already being autodialed', peer.id)
             return false
           }
 
@@ -249,7 +249,7 @@ export class AutoDial implements Startable {
       return Date.now() - lastDialFailureTimestamp > this.autoDialPeerRetryThresholdMs
     })
 
-    log('selected %d/%d peers to dial', peersThatHaveNotFailed.length, peers.length)
+    this.#log('selected %d/%d peers to dial', peersThatHaveNotFailed.length, peers.length)
 
     for (const peer of peersThatHaveNotFailed) {
       this.queue.add(async () => {
@@ -257,19 +257,19 @@ export class AutoDial implements Startable {
 
         // Check to see if we still need to auto dial
         if (numConnections >= this.minConnections) {
-          log('got enough connections now %d/%d', numConnections, this.minConnections)
+          this.#log('got enough connections now %d/%d', numConnections, this.minConnections)
           this.queue.clear()
           return
         }
 
-        log('connecting to a peerStore stored peer %p', peer.id)
+        this.#log('connecting to a peerStore stored peer %p', peer.id)
         await this.connectionManager.openConnection(peer.id, {
           priority: this.autoDialPriority
         })
       }, {
         peerId: peer.id
       }).catch(err => {
-        log.error('could not connect to peerStore stored peer', err)
+        this.#log.error('could not connect to peerStore stored peer', err)
       })
     }
 
@@ -279,7 +279,7 @@ export class AutoDial implements Startable {
       this.autoDialInterval = setTimeout(() => {
         this.autoDial()
           .catch(err => {
-            log.error('error while autodialing', err)
+            this.#log.error('error while autodialing', err)
           })
       }, this.autoDialIntervalMs)
     }

--- a/packages/libp2p/src/connection-manager/utils.ts
+++ b/packages/libp2p/src/connection-manager/utils.ts
@@ -1,14 +1,12 @@
 import { setMaxListeners } from '@libp2p/interface/events'
-import { logger } from '@libp2p/logger'
 import { type AbortOptions, multiaddr, type Multiaddr } from '@multiformats/multiaddr'
 import { type ClearableSignal, anySignal } from 'any-signal'
-
-const log = logger('libp2p:connection-manager:utils')
+import type { LoggerOptions } from '@libp2p/interface'
 
 /**
  * Resolve multiaddr recursively
  */
-export async function resolveMultiaddrs (ma: Multiaddr, options: AbortOptions): Promise<Multiaddr[]> {
+export async function resolveMultiaddrs (ma: Multiaddr, options: AbortOptions & LoggerOptions): Promise<Multiaddr[]> {
   // TODO: recursive logic should live in multiaddr once dns4/dns6 support is in place
   // Now only supporting resolve for dnsaddr
   const resolvableProto = ma.protoNames().includes('dnsaddr')
@@ -31,7 +29,7 @@ export async function resolveMultiaddrs (ma: Multiaddr, options: AbortOptions): 
     return array
   }, ([]))
 
-  log('resolved %s to', ma, output.map(ma => ma.toString()))
+  options.log('resolved %s to', ma, output.map(ma => ma.toString()))
 
   return output
 }
@@ -39,13 +37,13 @@ export async function resolveMultiaddrs (ma: Multiaddr, options: AbortOptions): 
 /**
  * Resolve a given multiaddr. If this fails, an empty array will be returned
  */
-async function resolveRecord (ma: Multiaddr, options: AbortOptions): Promise<Multiaddr[]> {
+async function resolveRecord (ma: Multiaddr, options: AbortOptions & LoggerOptions): Promise<Multiaddr[]> {
   try {
     ma = multiaddr(ma.toString()) // Use current multiaddr module
     const multiaddrs = await ma.resolve(options)
     return multiaddrs
   } catch (err) {
-    log.error(`multiaddr ${ma.toString()} could not be resolved`, err)
+    options.log.error(`multiaddr ${ma.toString()} could not be resolved`, err)
     return []
   }
 }

--- a/packages/libp2p/src/identify/index.ts
+++ b/packages/libp2p/src/identify/index.ts
@@ -4,7 +4,7 @@ import {
 } from './consts.js'
 import { DefaultIdentifyService } from './identify.js'
 import { Identify } from './pb/message.js'
-import type { AbortOptions, IdentifyResult, Libp2pEvents } from '@libp2p/interface'
+import type { AbortOptions, IdentifyResult, Libp2pEvents, ComponentLogger } from '@libp2p/interface'
 import type { TypedEventTarget } from '@libp2p/interface/events'
 import type { PeerId } from '@libp2p/interface/peer-id'
 import type { PeerStore } from '@libp2p/interface/peer-store'
@@ -59,6 +59,7 @@ export interface IdentifyServiceComponents {
   registrar: Registrar
   addressManager: AddressManager
   events: TypedEventTarget<Libp2pEvents>
+  logger: ComponentLogger
 }
 
 /**

--- a/packages/libp2p/src/index.ts
+++ b/packages/libp2p/src/index.ts
@@ -19,7 +19,7 @@ import type { AddressManagerInit } from './address-manager/index.js'
 import type { Components } from './components.js'
 import type { ConnectionManagerInit } from './connection-manager/index.js'
 import type { TransportManagerInit } from './transport-manager.js'
-import type { Libp2p, ServiceMap, RecursivePartial } from '@libp2p/interface'
+import type { Libp2p, ServiceMap, RecursivePartial, ComponentLogger } from '@libp2p/interface'
 import type { ConnectionProtector } from '@libp2p/interface/connection'
 import type { ConnectionEncrypter } from '@libp2p/interface/connection-encrypter'
 import type { ConnectionGater } from '@libp2p/interface/connection-gater'
@@ -108,6 +108,27 @@ export interface Libp2pInit<T extends ServiceMap = { x: Record<string, unknown> 
    * Arbitrary libp2p modules
    */
   services: ServiceFactoryMap<T>
+
+  /**
+   * An optional logging implementation that can be used to write runtime logs.
+   *
+   * Set the `DEBUG` env var or the `debug` key on LocalStorage to see logs.
+   *
+   * @example
+   *
+   * Node.js:
+   *
+   * ```console
+   * $ DEBUG="*libp2p:*" node myscript.js
+   * ```
+   *
+   * Browsers:
+   *
+   * ```javascript
+   * localStorage.setItem('debug', '*libp2p:*')
+   * ```
+   */
+  logger?: ComponentLogger
 }
 
 export type { Libp2p }

--- a/packages/libp2p/test/connection-manager/auto-dial.spec.ts
+++ b/packages/libp2p/test/connection-manager/auto-dial.spec.ts
@@ -12,6 +12,7 @@ import pWaitFor from 'p-wait-for'
 import Sinon from 'sinon'
 import { stubInterface } from 'sinon-ts'
 import { fromString as uint8ArrayFromString } from 'uint8arrays/from-string'
+import { defaultComponents } from '../../src/components.js'
 import { AutoDial } from '../../src/connection-manager/auto-dial.js'
 import { LAST_DIAL_FAILURE_KEY } from '../../src/connection-manager/constants.js'
 import { matchPeerId } from '../fixtures/match-peer-id.js'
@@ -73,11 +74,11 @@ describe('auto-dial', () => {
       getDialQueue: Sinon.stub().returns([])
     })
 
-    autoDialler = new AutoDial({
+    autoDialler = new AutoDial(defaultComponents({
       peerStore,
       connectionManager,
       events
-    }, {
+    }), {
       minConnections: 10,
       autoDialInterval: 10000
     })
@@ -127,11 +128,11 @@ describe('auto-dial', () => {
       getDialQueue: Sinon.stub().returns([])
     })
 
-    autoDialler = new AutoDial({
+    autoDialler = new AutoDial(defaultComponents({
       peerStore,
       connectionManager,
       events
-    }, {
+    }), {
       minConnections: 10
     })
     autoDialler.start()
@@ -181,11 +182,11 @@ describe('auto-dial', () => {
       }])
     })
 
-    autoDialler = new AutoDial({
+    autoDialler = new AutoDial(defaultComponents({
       peerStore,
       connectionManager,
       events
-    }, {
+    }), {
       minConnections: 10
     })
     autoDialler.start()
@@ -207,11 +208,11 @@ describe('auto-dial', () => {
       getDialQueue: Sinon.stub().returns([])
     })
 
-    autoDialler = new AutoDial({
+    autoDialler = new AutoDial(defaultComponents({
       peerStore,
       connectionManager,
       events
-    }, {
+    }), {
       minConnections: 10,
       autoDialInterval: 10000
     })
@@ -258,11 +259,11 @@ describe('auto-dial', () => {
       getDialQueue: Sinon.stub().returns([])
     })
 
-    autoDialler = new AutoDial({
+    autoDialler = new AutoDial(defaultComponents({
       peerStore,
       connectionManager,
       events
-    }, {
+    }), {
       minConnections: 10,
       autoDialPeerRetryThreshold: 2000
     })

--- a/packages/libp2p/test/connection-manager/dial-queue.spec.ts
+++ b/packages/libp2p/test/connection-manager/dial-queue.spec.ts
@@ -1,6 +1,7 @@
 /* eslint-env mocha */
 
 import { mockConnection, mockDuplex, mockMultiaddrConnection } from '@libp2p/interface-compliance-tests/mocks'
+import { peerLogger } from '@libp2p/logger'
 import { createEd25519PeerId } from '@libp2p/peer-id-factory'
 import { multiaddr, resolvers } from '@multiformats/multiaddr'
 import { WebRTC } from '@multiformats/multiaddr-matcher'
@@ -10,6 +11,7 @@ import pDefer from 'p-defer'
 import sinon from 'sinon'
 import { type StubbedInstance, stubInterface } from 'sinon-ts'
 import { DialQueue } from '../../src/connection-manager/dial-queue.js'
+import type { ComponentLogger } from '@libp2p/interface'
 import type { Connection } from '@libp2p/interface/connection'
 import type { ConnectionGater } from '@libp2p/interface/connection-gater'
 import type { PeerId } from '@libp2p/interface/peer-id'
@@ -23,15 +25,19 @@ describe('dial queue', () => {
     peerStore: StubbedInstance<PeerStore>
     transportManager: StubbedInstance<TransportManager>
     connectionGater: StubbedInstance<ConnectionGater>
+    logger: ComponentLogger
   }
   let dialer: DialQueue
 
   beforeEach(async () => {
+    const peerId = await createEd25519PeerId()
+
     components = {
-      peerId: await createEd25519PeerId(),
+      peerId,
       peerStore: stubInterface<PeerStore>(),
       transportManager: stubInterface<TransportManager>(),
-      connectionGater: stubInterface<ConnectionGater>()
+      connectionGater: stubInterface<ConnectionGater>(),
+      logger: peerLogger(peerId)
     }
   })
 

--- a/packages/libp2p/test/connection-manager/index.spec.ts
+++ b/packages/libp2p/test/connection-manager/index.spec.ts
@@ -3,6 +3,7 @@
 import { TypedEventEmitter } from '@libp2p/interface/events'
 import { KEEP_ALIVE } from '@libp2p/interface/peer-store/tags'
 import { mockConnection, mockDuplex, mockMultiaddrConnection, mockMetrics } from '@libp2p/interface-compliance-tests/mocks'
+import { defaultLogger } from '@libp2p/logger'
 import { createEd25519PeerId } from '@libp2p/peer-id-factory'
 import { multiaddr } from '@multiformats/multiaddr'
 import { expect } from 'aegir/chai'
@@ -365,7 +366,8 @@ describe('Connection Manager', () => {
       peerStore: stubInterface<PeerStore>(),
       transportManager: stubInterface<TransportManager>(),
       connectionGater: stubInterface<ConnectionGater>(),
-      events: new TypedEventEmitter()
+      events: new TypedEventEmitter(),
+      logger: defaultLogger()
     }, {
       ...defaultOptions,
       deny: [
@@ -393,7 +395,8 @@ describe('Connection Manager', () => {
       peerStore: stubInterface<PeerStore>(),
       transportManager: stubInterface<TransportManager>(),
       connectionGater: stubInterface<ConnectionGater>(),
-      events: new TypedEventEmitter()
+      events: new TypedEventEmitter(),
+      logger: defaultLogger()
     }, {
       ...defaultOptions,
       maxConnections: 1
@@ -425,7 +428,8 @@ describe('Connection Manager', () => {
       peerStore: stubInterface<PeerStore>(),
       transportManager: stubInterface<TransportManager>(),
       connectionGater: stubInterface<ConnectionGater>(),
-      events: new TypedEventEmitter()
+      events: new TypedEventEmitter(),
+      logger: defaultLogger()
     }, {
       ...defaultOptions,
       inboundConnectionThreshold: 1
@@ -461,7 +465,8 @@ describe('Connection Manager', () => {
       peerStore: stubInterface<PeerStore>(),
       transportManager: stubInterface<TransportManager>(),
       connectionGater: stubInterface<ConnectionGater>(),
-      events: new TypedEventEmitter()
+      events: new TypedEventEmitter(),
+      logger: defaultLogger()
     }, {
       ...defaultOptions,
       maxConnections: 1,
@@ -497,7 +502,8 @@ describe('Connection Manager', () => {
       peerStore: stubInterface<PeerStore>(),
       transportManager: stubInterface<TransportManager>(),
       connectionGater: stubInterface<ConnectionGater>(),
-      events: new TypedEventEmitter()
+      events: new TypedEventEmitter(),
+      logger: defaultLogger()
     }, {
       ...defaultOptions,
       maxIncomingPendingConnections: 1
@@ -543,7 +549,8 @@ describe('Connection Manager', () => {
       peerStore: stubInterface<PeerStore>(),
       transportManager: stubInterface<TransportManager>(),
       connectionGater: stubInterface<ConnectionGater>(),
-      events: new TypedEventEmitter()
+      events: new TypedEventEmitter(),
+      logger: defaultLogger()
     }, {
       ...defaultOptions,
       maxIncomingPendingConnections: 1

--- a/packages/libp2p/test/connection/compliance.spec.ts
+++ b/packages/libp2p/test/connection/compliance.spec.ts
@@ -1,5 +1,6 @@
 import tests from '@libp2p/interface-compliance-tests/connection'
 import peers from '@libp2p/interface-compliance-tests/peers'
+import { peerLogger } from '@libp2p/logger'
 import * as PeerIdFactory from '@libp2p/peer-id-factory'
 import { multiaddr } from '@multiformats/multiaddr'
 import { createConnection } from '../../src/connection/index.js'
@@ -13,6 +14,7 @@ describe('connection compliance', () => {
      * certain values for testing.
      */
     async setup (properties) {
+      const localPeer = await PeerIdFactory.createEd25519PeerId()
       const remoteAddr = multiaddr('/ip4/127.0.0.1/tcp/8081')
       const remotePeer = await PeerIdFactory.createFromJSON(peers[0])
       let openStreams: Stream[] = []
@@ -29,6 +31,7 @@ describe('connection compliance', () => {
         encryption: '/secio/1.0.0',
         multiplexer: '/mplex/6.7.0',
         status: 'open',
+        logger: peerLogger(localPeer),
         newStream: async (protocols) => {
           const id = `${streamId++}`
           const stream: Stream = {

--- a/packages/libp2p/test/connection/index.spec.ts
+++ b/packages/libp2p/test/connection/index.spec.ts
@@ -1,3 +1,4 @@
+import { defaultLogger } from '@libp2p/logger'
 import { createEd25519PeerId } from '@libp2p/peer-id-factory'
 import { multiaddr } from '@multiformats/multiaddr'
 import { expect } from 'aegir/chai'
@@ -17,7 +18,8 @@ function defaultConnectionInit (): any {
     newStream: Sinon.stub(),
     close: Sinon.stub(),
     abort: Sinon.stub(),
-    getStreams: Sinon.stub()
+    getStreams: Sinon.stub(),
+    logger: defaultLogger()
   }
 }
 

--- a/packages/logger/src/index.ts
+++ b/packages/logger/src/index.ts
@@ -1,9 +1,8 @@
 /**
  * @packageDocumentation
  *
- * A map that reports it's size to the libp2p [Metrics](https://github.com/libp2p/js-libp2p-interfaces/tree/master/packages/libp2p-interfaces/src/metrics#readme) system.
- *
- * If metrics are disabled a regular map is used.
+ * A logger for libp2p based on the venerable [debug](https://www.npmjs.com/package/debug)
+ * module.
  *
  * @example
  *
@@ -33,6 +32,7 @@ import debug from 'debug'
 import { base32 } from 'multiformats/bases/base32'
 import { base58btc } from 'multiformats/bases/base58'
 import { base64 } from 'multiformats/bases/base64'
+import { truncatePeerId } from './utils.js'
 import type { PeerId } from '@libp2p/interface/peer-id'
 import type { Multiaddr } from '@multiformats/multiaddr'
 import type { Key } from 'interface-datastore'
@@ -80,6 +80,10 @@ export interface Logger {
   enabled: boolean
 }
 
+export interface ComponentLogger {
+  forComponent(name: string): Logger
+}
+
 function createDisabledLogger (namespace: string): debug.Debugger {
   const logger = (): void => {}
   logger.enabled = false
@@ -93,6 +97,94 @@ function createDisabledLogger (namespace: string): debug.Debugger {
   return logger
 }
 
+export interface PeerLoggerOptions {
+  prefixLength: number
+  suffixLength: number
+}
+
+/**
+ * Create a component logger that will prefix any log messages with a truncated
+ * peer id.
+ *
+ * @example
+ *
+ * ```TypeScript
+ * import { peerLogger } from '@libp2p/logger'
+ * import { peerIdFromString } from '@libp2p/peer-id'
+ *
+ * const peerId = peerIdFromString('12D3FooBar')
+ * const logger = peerLogger(peerId)
+ *
+ * const log = logger.forComponent('my-component')
+ * log.info('hello world')
+ * // logs "12…oBar:my-component hello world"
+ * ```
+ */
+export function peerLogger (peerId: PeerId, options: Partial<PeerLoggerOptions> = {}): ComponentLogger {
+  return prefixLogger(truncatePeerId(peerId, options))
+}
+
+/**
+ * Create a component logger that will prefix any log messages with the passed
+ * string.
+ *
+ * @example
+ *
+ * ```TypeScript
+ * import { prefixLogger } from '@libp2p/logger'
+ *
+ * const logger = prefixLogger('my-node')
+ *
+ * const log = logger.forComponent('my-component')
+ * log.info('hello world')
+ * // logs "my-node:my-component hello world"
+ * ```
+ */
+export function prefixLogger (prefix: string): ComponentLogger {
+  return {
+    forComponent (name: string) {
+      return logger(`${prefix}:${name}`)
+    }
+  }
+}
+
+/**
+ * Create a component logger
+ *
+ * @example
+ *
+ * ```TypeScript
+ * import { defaultLogger } from '@libp2p/logger'
+ * import { peerIdFromString } from '@libp2p/peer-id'
+ *
+ * const logger = defaultLogger()
+ *
+ * const log = logger.forComponent('my-component')
+ * log.info('hello world')
+ * // logs "my-component hello world"
+ * ```
+ */
+export function defaultLogger (): ComponentLogger {
+  return {
+    forComponent (name: string) {
+      return logger(name)
+    }
+  }
+}
+
+/**
+ * Creates a logger for the passed component name.
+ *
+ * @example
+ *
+ * ```TypeScript
+ * import { logger } from '@libp2p/logger'
+ *
+ * const log = logger('my-component')
+ * log.info('hello world')
+ * // logs "my-component hello world"
+ * ```
+ */
 export function logger (name: string): Logger {
   // trace logging is a no-op by default
   let trace: debug.Debugger = createDisabledLogger(`${name}:trace`)

--- a/packages/logger/src/utils.ts
+++ b/packages/logger/src/utils.ts
@@ -1,0 +1,10 @@
+import type { PeerLoggerOptions } from './index.js'
+import type { PeerId } from '@libp2p/interface/peer-id'
+
+export function truncatePeerId (peerId: PeerId, options: Partial<PeerLoggerOptions> = {}): string {
+  const prefixLength = options.prefixLength ?? 2
+  const suffixLength = options.suffixLength ?? 4
+
+  const peerIdString = peerId.toString()
+  return `${peerIdString.substring(0, prefixLength)}…${peerIdString.substring(peerIdString.length, peerIdString.length - suffixLength)}`
+}

--- a/packages/logger/test/index.spec.ts
+++ b/packages/logger/test/index.spec.ts
@@ -9,11 +9,24 @@ import { base64 } from 'multiformats/bases/base64'
 import sinon from 'sinon'
 import { fromString as uint8ArrayFromString } from 'uint8arrays/from-string'
 import { toString as unint8ArrayToString } from 'uint8arrays/to-string'
-import { logger } from '../src/index.js'
+import { logger, peerLogger } from '../src/index.js'
 
 describe('logger', () => {
   it('creates a logger', () => {
     const log = logger('hello')
+
+    expect(log).to.be.a('function')
+    expect(log).to.a.property('enabled').that.is.not.true()
+    expect(log).to.have.property('error').that.is.a('function')
+    expect(log).to.have.nested.property('error.enabled').that.is.not.true()
+    expect(log).to.have.property('trace').that.is.a('function')
+    expect(log).to.have.nested.property('trace.enabled').that.is.not.true()
+  })
+
+  it('creates a peer logger', () => {
+    const peerId = peerIdFromString('12D3KooWLkHeUp6r5unBZKbYwV54CgKVxHuJDroFoigr8mF11CKW')
+    const logger = peerLogger(peerId)
+    const log = logger.forComponent('hello')
 
     expect(log).to.be.a('function')
     expect(log).to.a.property('enabled').that.is.not.true()

--- a/packages/logger/test/utils.spec.ts
+++ b/packages/logger/test/utils.spec.ts
@@ -1,0 +1,11 @@
+import { peerIdFromString } from '@libp2p/peer-id'
+import { expect } from 'aegir/chai'
+import { truncatePeerId } from '../src/utils.js'
+
+describe('utils', () => {
+  it('should truncate a peer id', () => {
+    const peerId = peerIdFromString('QmZ8eiDPqQqWR17EPxiwCDgrKPVhCHLcyn6xSCNpFAdAZb')
+
+    expect(truncatePeerId(peerId)).to.equal('Qm…dAZb')
+  })
+})


### PR DESCRIPTION
When running multiple libp2p instances simultaneously it's often hard to work out which log messages come from which instance. This PR solves the problem.

- Adds a `ComponentLogger` interface to libp2p which is an object that lets a component get a logger specific to that component.
- Adds an optional `logger` config key to libp2p which is an implementation of `ComponentLogger`.
- Adds three implementations of `ComponentLogger`
  - `defaultLogger` - this preserves existing logging behaviour
  - `peerLogger` - this prefixes all log lines with a truncated peer id
  - `prefixLogger` - this prefixes all log lines with an arbitrary string

`libp2p` uses the passed logger if one is configured, otherwise it uses `defaultLogger` to make this change backwards compatible.

The logger is added to the `components` map so libp2p components can accept it as part of their required components and use the `forComponent` function to create a component-specific logger.

It will take a bit of time to thread the use of `ComponentLogger` throughout the monorepo, but this can be done in follow-up PRs since the existing logging behaviour is maintained by the changes here.

For v1.x we may switch to `peerLogger`.

Refs #2105

## Change checklist

- [x] I have performed a self-review of my own code
- [x] I have made corresponding changes to the documentation if necessary (this includes comments as well)
- [x] I have added tests that prove my fix is effective or that my feature works