### PR TITLE
fix: append peer id to dial addresses before filtering

### DIFF
--- a/packages/libp2p/src/connection-manager/dial-queue.ts
+++ b/packages/libp2p/src/connection-manager/dial-queue.ts
@@ -368,7 +368,6 @@ export class DialQueue {
     if (peerId != null) {
       const peerIdMultiaddr = `/p2p/${peerId.toString()}`
       resolvedAddresses = resolvedAddresses.map(addr => {
-        const addressPeerId = addr.multiaddr.getPeerId()
         const lastProto = addr.multiaddr.protos().pop()
 
         // do not append peer id to path multiaddrs
@@ -377,7 +376,7 @@ export class DialQueue {
         }
 
         // append peer id to multiaddr if it is not already present
-        if (addressPeerId !== peerId.toString()) {
+        if (addr.multiaddr.getPeerId() == null) {
           return {
             multiaddr: addr.multiaddr.encapsulate(peerIdMultiaddr),
             isCertified: addr.isCertified


### PR DESCRIPTION
Some transports like WebRTC require the target peer id to be present on the multiaddr, so append the peer id before filtering by supported transport.

## Change checklist

- [x] I have performed a self-review of my own code
- [ ] I have made corresponding changes to the documentation if necessary (this includes comments as well)
- [x] I have added tests that prove my fix is effective or that my feature works