### PR TITLE
fix: close early WebRTC streams properly

### DIFF
--- a/packages/transport-webrtc/src/private-to-private/transport.ts
+++ b/packages/transport-webrtc/src/private-to-private/transport.ts
@@ -121,10 +121,6 @@ export class WebRTCTransport implements Transport, Startable {
     log.trace('dialing address: %a', ma)
 
     const peerConnection = new RTCPeerConnection(this.init.rtcConfiguration)
-    const muxerFactory = new DataChannelMuxerFactory({
-      peerConnection,
-      dataChannelOptions: this.init.dataChannel
-    })
 
     const { remoteAddress } = await initiateConnection({
       peerConnection,
@@ -145,7 +141,10 @@ export class WebRTCTransport implements Transport, Startable {
     const connection = await options.upgrader.upgradeOutbound(webRTCConn, {
       skipProtection: true,
       skipEncryption: true,
-      muxerFactory
+      muxerFactory: new DataChannelMuxerFactory({
+        peerConnection,
+        dataChannelOptions: this.init.dataChannel
+      })
     })
 
     // close the connection on shut down
@@ -157,7 +156,6 @@ export class WebRTCTransport implements Transport, Startable {
   async _onProtocol ({ connection, stream }: IncomingStreamData): Promise<void> {
     const signal = AbortSignal.timeout(this.init.inboundConnectionTimeout ?? INBOUND_CONNECTION_TIMEOUT)
     const peerConnection = new RTCPeerConnection(this.init.rtcConfiguration)
-    const muxerFactory = new DataChannelMuxerFactory({ peerConnection, dataChannelOptions: this.init.dataChannel })
 
     try {
       const { remoteAddress } = await handleIncomingStream({
@@ -180,7 +178,7 @@ export class WebRTCTransport implements Transport, Startable {
       await this.components.upgrader.upgradeInbound(webRTCConn, {
         skipEncryption: true,
         skipProtection: true,
-        muxerFactory
+        muxerFactory: new DataChannelMuxerFactory({ peerConnection, dataChannelOptions: this.init.dataChannel })
       })
 
       // close the stream if SDP messages have been exchanged successfully

--- a/packages/transport-webrtc/src/stream.ts
+++ b/packages/transport-webrtc/src/stream.ts
@@ -84,7 +84,6 @@ export class WebRTCStream extends AbstractStream {
    */
   private readonly receiveFinAck: DeferredPromise<void>
   private readonly finAckTimeout: number
-  //  private sentFinAck: boolean
 
   constructor (init: WebRTCStreamInit) {
     // override onEnd to send/receive FIN_ACK before closing the stream


### PR DESCRIPTION
A race condition exists where a remote can start opening streams over WebRTC before we have finished the connection upgrade.

When this happens we need to be able to gracefully close the stream the same as ones opened after the upgrade.

This PR makes the action taken on stream close reconfigurable after the muxer factory has been created.

## Change checklist

- [x] I have performed a self-review of my own code
- [ ] I have made corresponding changes to the documentation if necessary (this includes comments as well)
- [ ] I have added tests that prove my fix is effective or that my feature works