### PR TITLE
fix: only send ip/domain observed address in identify

### DIFF
--- a/packages/libp2p/src/identify/identify.ts
+++ b/packages/libp2p/src/identify/identify.ts
@@ -4,6 +4,7 @@ import { logger } from '@libp2p/logger'
 import { peerIdFromKeys } from '@libp2p/peer-id'
 import { RecordEnvelope, PeerRecord } from '@libp2p/peer-record'
 import { type Multiaddr, multiaddr, protocols } from '@multiformats/multiaddr'
+import { IP_OR_DOMAIN } from '@multiformats/multiaddr-matcher'
 import { pbStream } from 'it-protobuf-stream'
 import { fromString as uint8ArrayFromString } from 'uint8arrays/from-string'
 import { toString as uint8ArrayToString } from 'uint8arrays/to-string'
@@ -345,6 +346,12 @@ export class DefaultIdentifyService implements Startable, IdentifyService {
         signedPeerRecord = envelope.marshal().subarray()
       }
 
+      let observedAddr: Uint8Array | undefined = connection.remoteAddr.bytes
+
+      if (!IP_OR_DOMAIN.matches(connection.remoteAddr)) {
+        observedAddr = undefined
+      }
+
       const pb = pbStream(stream).pb(Identify)
 
       await pb.write({
@@ -353,7 +360,7 @@ export class DefaultIdentifyService implements Startable, IdentifyService {
         publicKey,
         listenAddrs: multiaddrs.map(addr => addr.bytes),
         signedPeerRecord,
-        observedAddr: connection.remoteAddr.bytes,
+        observedAddr,
         protocols: peerData.protocols
       }, {
         signal

--- a/packages/libp2p/src/upgrader.ts
+++ b/packages/libp2p/src/upgrader.ts
@@ -432,7 +432,7 @@ export class DefaultUpgrader implements Upgrader {
           throw new CodeError('Stream is not multiplexed', codes.ERR_MUXER_UNAVAILABLE)
         }
 
-        log('%s: starting new stream on %s', direction, protocols)
+        log('%s-%s: starting new stream on %s', connection.id, direction, protocols)
         const muxedStream = await muxer.newStream()
 
         try {


### PR DESCRIPTION
Some addresses are not naturally routable - for example incoming webrtc addresses, so do not send them as observed addresses in identify responses.

## Change checklist

- [x] I have performed a self-review of my own code
- [ ] I have made corresponding changes to the documentation if necessary (this includes comments as well)
- [x] I have added tests that prove my fix is effective or that my feature works