### PR TITLE
fix: datachannel label should be an empty string

### DIFF
--- a/packages/transport-webrtc/src/muxer.ts
+++ b/packages/transport-webrtc/src/muxer.ts
@@ -38,8 +38,6 @@ interface BufferedStream {
   onEnd(err?: Error): void
 }
 
-let streamIndex = 0
-
 export class DataChannelMuxerFactory implements StreamMuxerFactory {
   public readonly protocol: string
 
@@ -190,10 +188,8 @@ export class DataChannelMuxer implements StreamMuxer {
   sink: Sink<Source<Uint8Array | Uint8ArrayList>, Promise<void>> = nopSink
 
   newStream (): Stream {
-    streamIndex++
-
     // The spec says the label SHOULD be an empty string: https://github.com/libp2p/specs/blob/master/webrtc/README.md#rtcdatachannel-label
-    const channel = this.peerConnection.createDataChannel(`stream-${streamIndex}`)
+    const channel = this.peerConnection.createDataChannel('')
     const stream = createStream({
       channel,
       direction: 'outbound',


### PR DESCRIPTION
Fixes regession introduced by #2200

## Change checklist

- [x] I have performed a self-review of my own code
- [ ] I have made corresponding changes to the documentation if necessary (this includes comments as well)
- [ ] I have added tests that prove my fix is effective or that my feature works