### PR TITLE
chore: fix ping tests

### DIFF
--- a/packages/libp2p/test/ping/ping.node.ts
+++ b/packages/libp2p/test/ping/ping.node.ts
@@ -17,6 +17,11 @@ describe('ping', () => {
     nodes = await Promise.all([
       createNode({
         config: createBaseOptions({
+          addresses: {
+            listen: [
+              '/ip4/0.0.0.0/tcp/0'
+            ]
+          },
           services: {
             ping: pingService()
           }
@@ -24,6 +29,11 @@ describe('ping', () => {
       }),
       createNode({
         config: createBaseOptions({
+          addresses: {
+            listen: [
+              '/ip4/0.0.0.0/tcp/0'
+            ]
+          },
           services: {
             ping: pingService()
           }
@@ -31,6 +41,11 @@ describe('ping', () => {
       }),
       createNode({
         config: createBaseOptions({
+          addresses: {
+            listen: [
+              '/ip4/0.0.0.0/tcp/0'
+            ]
+          },
           services: {
             ping: pingService()
           }


### PR DESCRIPTION
The ping tests run over transient connections which can hit relay limits.

Instead listen on tcp connections so the tests only run over direct connections.

## Change checklist

- [x] I have performed a self-review of my own code
- [ ] I have made corresponding changes to the documentation if necessary (this includes comments as well)
- [x] I have added tests that prove my fix is effective or that my feature works