### PR TITLE
refactor!: rename perf exports to remove Service

### DIFF
--- a/doc/migrations/v0.46-v1.0.0.md
+++ b/doc/migrations/v0.46-v1.0.0.md
@@ -12,6 +12,7 @@ A migration guide for refactoring your application code from libp2p `v0.46` to `
 - [Fetch](#fetch)
 - [KeyChain](#keychain)
 - [UPnPNat](#upnpnat)
+- [Perf](#perf)
 - [Plaintext](#plaintext)
 - [Pnet](#pnet)
 - [Metrics](#metrics)
@@ -221,6 +222,37 @@ import { uPnPNAT } from '@libp2p/upnp-nat'
 const node = await createLibp2p({
   services: {
     uPnPNAT: uPnPNAT()
+  }
+})
+```
+
+## Perf
+
+The Perf service module exports have been renamed in line with the other changes
+here.
+
+**Before**
+
+```ts
+import { createLibp2p } from 'libp2p'
+import { perService } from '@libp2p/perf'
+
+const node = await createLibp2p({
+  services: {
+    perf: perService()
+  }
+})
+```
+
+**After**
+
+```ts
+import { createLibp2p } from 'libp2p'
+import { perf } from '@libp2p/perf'
+
+const node = await createLibp2p({
+  services: {
+    perf: perf()
   }
 })
 ```

--- a/packages/protocol-perf/README.md
+++ b/packages/protocol-perf/README.md
@@ -18,13 +18,13 @@ import { mplex } from '@libp2p/mplex'
 import { tcp } from '@libp2p/tcp'
 import { createLibp2p, type Libp2p } from 'libp2p'
 import { plaintext } from '@libp2p/plaintext'
-import { perfService, type PerfService } from '@libp2p/perf'
+import { perf, type Perf } from '@libp2p/perf'
 
 const ONE_MEG = 1024 * 1024
 const UPLOAD_BYTES = ONE_MEG * 1024
 const DOWNLOAD_BYTES = ONE_MEG * 1024
 
-async function createNode (): Promise<Libp2p<{ perf: PerfService }>> {
+async function createNode (): Promise<Libp2p<{ perf: Perf }>> {
   return createLibp2p({
     addresses: {
       listen: [
@@ -41,7 +41,7 @@ async function createNode (): Promise<Libp2p<{ perf: PerfService }>> {
       yamux(), mplex()
     ],
     services: {
-      perf: perfService()
+      perf: perf()
     }
   })
 }

--- a/packages/protocol-perf/src/index.ts
+++ b/packages/protocol-perf/src/index.ts
@@ -12,13 +12,13 @@
  * import { tcp } from '@libp2p/tcp'
  * import { createLibp2p, type Libp2p } from 'libp2p'
  * import { plaintext } from '@libp2p/plaintext'
- * import { perfService, type PerfService } from '@libp2p/perf'
+ * import { perf, type Perf } from '@libp2p/perf'
  *
  * const ONE_MEG = 1024 * 1024
  * const UPLOAD_BYTES = ONE_MEG * 1024
  * const DOWNLOAD_BYTES = ONE_MEG * 1024
  *
- * async function createNode (): Promise<Libp2p<{ perf: PerfService }>> {
+ * async function createNode (): Promise<Libp2p<{ perf: Perf }>> {
  *   return createLibp2p({
  *     addresses: {
  *       listen: [
@@ -35,7 +35,7 @@
  *       yamux(), mplex()
  *     ],
  *     services: {
- *       perf: perfService()
+ *       perf: perf()
  *     }
  *   })
  * }
@@ -52,7 +52,7 @@
  * ```
  */
 
-import { PerfService as PerfServiceClass } from './perf-service.js'
+import { Perf as PerfClass } from './perf-service.js'
 import type { AbortOptions } from '@libp2p/interface'
 import type { ConnectionManager } from '@libp2p/interface-internal/connection-manager'
 import type { Registrar } from '@libp2p/interface-internal/registrar'
@@ -69,7 +69,7 @@ export interface PerfOptions extends AbortOptions {
   reuseExistingConnection?: boolean
 }
 
-export interface PerfService {
+export interface Perf {
   measurePerformance(multiaddr: Multiaddr, sendBytes: number, recvBytes: number, options?: PerfOptions): AsyncGenerator<PerfOutput>
 }
 
@@ -80,7 +80,7 @@ export interface PerfOutput {
   downloadBytes: number
 }
 
-export interface PerfServiceInit {
+export interface PerfInit {
   protocolName?: string
   maxInboundStreams?: number
   maxOutboundStreams?: number
@@ -92,11 +92,11 @@ export interface PerfServiceInit {
   writeBlockSize?: number
 }
 
-export interface PerfServiceComponents {
+export interface PerfComponents {
   registrar: Registrar
   connectionManager: ConnectionManager
 }
 
-export function perfService (init: PerfServiceInit = {}): (components: PerfServiceComponents) => PerfService {
-  return (components) => new PerfServiceClass(components, init)
+export function perf (init: PerfInit = {}): (components: PerfComponents) => Perf {
+  return (components) => new PerfClass(components, init)
 }

--- a/packages/protocol-perf/src/perf-service.ts
+++ b/packages/protocol-perf/src/perf-service.ts
@@ -1,16 +1,16 @@
 import { logger } from '@libp2p/logger'
 import { pushable } from 'it-pushable'
 import { MAX_INBOUND_STREAMS, MAX_OUTBOUND_STREAMS, PROTOCOL_NAME, RUN_ON_TRANSIENT_CONNECTION, WRITE_BLOCK_SIZE } from './constants.js'
-import type { PerfOptions, PerfOutput, PerfServiceComponents, PerfServiceInit, PerfService as PerfServiceInterface } from './index.js'
+import type { PerfOptions, PerfOutput, PerfComponents, PerfInit, Perf as PerfInterface } from './index.js'
 import type { Startable } from '@libp2p/interface/startable'
 import type { IncomingStreamData } from '@libp2p/interface-internal/registrar'
 import type { Multiaddr } from '@multiformats/multiaddr'
 
 const log = logger('libp2p:perf')
 
-export class PerfService implements Startable, PerfServiceInterface {
+export class Perf implements Startable, PerfInterface {
   public readonly protocol: string
-  private readonly components: PerfServiceComponents
+  private readonly components: PerfComponents
   private started: boolean
   private readonly databuf: ArrayBuffer
   private readonly writeBlockSize: number
@@ -18,7 +18,7 @@ export class PerfService implements Startable, PerfServiceInterface {
   private readonly maxOutboundStreams: number
   private readonly runOnTransientConnection: boolean
 
-  constructor (components: PerfServiceComponents, init: PerfServiceInit = {}) {
+  constructor (components: PerfComponents, init: PerfInit = {}) {
     this.components = components
     this.started = false
     this.protocol = init.protocolName ?? PROTOCOL_NAME

--- a/packages/protocol-perf/test/index.spec.ts
+++ b/packages/protocol-perf/test/index.spec.ts
@@ -7,17 +7,17 @@ import { expect } from 'aegir/chai'
 import last from 'it-last'
 import { duplexPair } from 'it-pair/duplex'
 import { stubInterface, type StubbedInstance } from 'sinon-ts'
-import { PerfService } from '../src/perf-service.js'
+import { Perf } from '../src/perf-service.js'
 import type { Connection } from '@libp2p/interface/connection'
 import type { ConnectionManager } from '@libp2p/interface-internal/connection-manager'
 import type { Registrar } from '@libp2p/interface-internal/registrar'
 
-interface StubbedPerfServiceComponents {
+interface StubbedPerfComponents {
   registrar: StubbedInstance<Registrar>
   connectionManager: StubbedInstance<ConnectionManager>
 }
 
-export function createComponents (): StubbedPerfServiceComponents {
+export function createComponents (): StubbedPerfComponents {
   return {
     registrar: stubInterface<Registrar>(),
     connectionManager: stubInterface<ConnectionManager>()
@@ -25,8 +25,8 @@ export function createComponents (): StubbedPerfServiceComponents {
 }
 
 describe('perf', () => {
-  let localComponents: StubbedPerfServiceComponents
-  let remoteComponents: StubbedPerfServiceComponents
+  let localComponents: StubbedPerfComponents
+  let remoteComponents: StubbedPerfComponents
 
   beforeEach(async () => {
     localComponents = createComponents()
@@ -46,8 +46,8 @@ describe('perf', () => {
   })
 
   it('should run perf', async () => {
-    const client = new PerfService(localComponents)
-    const server = new PerfService(remoteComponents)
+    const client = new Perf(localComponents)
+    const server = new Perf(remoteComponents)
 
     await start(client)
     await start(server)
@@ -77,8 +77,8 @@ describe('perf', () => {
   })
 
   it('should reuse existing connection', async () => {
-    const client = new PerfService(localComponents)
-    const server = new PerfService(remoteComponents)
+    const client = new Perf(localComponents)
+    const server = new Perf(remoteComponents)
 
     await start(client)
     await start(server)


### PR DESCRIPTION
Removes the redundant `Service` from perf exports in line with other changes to modules in v1.

BREAKING CHANGE: the `perfService` export is now just `perf`

## Change checklist

- [x] I have performed a self-review of my own code
- [x] I have made corresponding changes to the documentation if necessary (this includes comments as well)
- [ ] I have added tests that prove my fix is effective or that my feature works