### PR TITLE
fix: use logging component everywhere

### DIFF
--- a/packages/connection-encrypter-plaintext/package.json
+++ b/packages/connection-encrypter-plaintext/package.json
@@ -59,7 +59,7 @@
   },
   "devDependencies": {
     "@libp2p/interface-compliance-tests": "^4.1.5",
-    "@libp2p/logger": "^3.0.2",
+    "@libp2p/logger": "^3.1.0",
     "@libp2p/peer-id-factory": "^3.0.8",
     "aegir": "^41.0.2",
     "protons": "^7.3.0",

--- a/packages/connection-encrypter-plaintext/src/index.ts
+++ b/packages/connection-encrypter-plaintext/src/index.ts
@@ -46,10 +46,10 @@ export interface PlaintextComponents {
 
 class Plaintext implements ConnectionEncrypter {
   public protocol: string = PROTOCOL
-  readonly #log: Logger
+  private readonly log: Logger
 
   constructor (components: PlaintextComponents) {
-    this.#log = components.logger.forComponent('libp2p:plaintext')
+    this.log = components.logger.forComponent('libp2p:plaintext')
   }
 
   async secureInbound (localId: PeerId, conn: Duplex<AsyncGenerator<Uint8Array>, Source<Uint8Array>, Promise<void>>, remoteId?: PeerId): Promise<SecuredConnection> {
@@ -85,7 +85,7 @@ class Plaintext implements ConnectionEncrypter {
       }).subarray()
     )
 
-    this.#log('write pubkey exchange to peer %p', remoteId)
+    this.log('write pubkey exchange to peer %p', remoteId)
 
     // Get the Exchange message
     const response = (await lp.decode.fromReader(shake.reader).next()).value
@@ -95,7 +95,7 @@ class Plaintext implements ConnectionEncrypter {
     }
 
     const id = Exchange.decode(response)
-    this.#log('read pubkey exchange from peer %p', remoteId)
+    this.log('read pubkey exchange from peer %p', remoteId)
 
     let peerId
     try {
@@ -117,7 +117,7 @@ class Plaintext implements ConnectionEncrypter {
         throw new Error('Public key did not match id')
       }
     } catch (err: any) {
-      this.#log.error(err)
+      this.log.error(err)
       throw new InvalidCryptoExchangeError('Remote did not provide its public key')
     }
 
@@ -125,7 +125,7 @@ class Plaintext implements ConnectionEncrypter {
       throw new UnexpectedPeerError()
     }
 
-    this.#log('plaintext key exchange completed successfully with peer %p', peerId)
+    this.log('plaintext key exchange completed successfully with peer %p', peerId)
 
     shake.rest()
 

--- a/packages/connection-encrypter-plaintext/src/index.ts
+++ b/packages/connection-encrypter-plaintext/src/index.ts
@@ -21,18 +21,17 @@
  */
 
 import { UnexpectedPeerError, InvalidCryptoExchangeError } from '@libp2p/interface/errors'
-import { logger } from '@libp2p/logger'
 import { peerIdFromBytes, peerIdFromKeys } from '@libp2p/peer-id'
 import { handshake } from 'it-handshake'
 import * as lp from 'it-length-prefixed'
 import map from 'it-map'
 import { Exchange, KeyType } from './pb/proto.js'
+import type { ComponentLogger, Logger } from '@libp2p/interface'
 import type { ConnectionEncrypter, SecuredConnection } from '@libp2p/interface/connection-encrypter'
 import type { PeerId } from '@libp2p/interface/peer-id'
 import type { Duplex, Source } from 'it-stream-types'
 import type { Uint8ArrayList } from 'uint8arraylist'
 
-const log = logger('libp2p:plaintext')
 const PROTOCOL = '/plaintext/2.0.0'
 
 function lpEncodeExchange (exchange: Exchange): Uint8ArrayList {
@@ -41,96 +40,105 @@ function lpEncodeExchange (exchange: Exchange): Uint8ArrayList {
   return lp.encode.single(pb)
 }
 
-/**
- * Encrypt connection
- */
-async function encrypt (localId: PeerId, conn: Duplex<AsyncGenerator<Uint8Array>, Source<Uint8Array>, Promise<void>>, remoteId?: PeerId): Promise<SecuredConnection> {
-  const shake = handshake(conn)
-
-  let type = KeyType.RSA
-
-  if (localId.type === 'Ed25519') {
-    type = KeyType.Ed25519
-  } else if (localId.type === 'secp256k1') {
-    type = KeyType.Secp256k1
-  }
-
-  // Encode the public key and write it to the remote peer
-  shake.write(
-    lpEncodeExchange({
-      id: localId.toBytes(),
-      pubkey: {
-        Type: type,
-        Data: localId.publicKey ?? new Uint8Array(0)
-      }
-    }).subarray()
-  )
-
-  log('write pubkey exchange to peer %p', remoteId)
-
-  // Get the Exchange message
-  const response = (await lp.decode.fromReader(shake.reader).next()).value
-
-  if (response == null) {
-    throw new Error('Did not read response')
-  }
-
-  const id = Exchange.decode(response)
-  log('read pubkey exchange from peer %p', remoteId)
-
-  let peerId
-  try {
-    if (id.pubkey == null) {
-      throw new Error('Public key missing')
-    }
-
-    if (id.pubkey.Data.length === 0) {
-      throw new Error('Public key data too short')
-    }
-
-    if (id.id == null) {
-      throw new Error('Remote id missing')
-    }
-
-    peerId = await peerIdFromKeys(id.pubkey.Data)
-
-    if (!peerId.equals(peerIdFromBytes(id.id))) {
-      throw new Error('Public key did not match id')
-    }
-  } catch (err: any) {
-    log.error(err)
-    throw new InvalidCryptoExchangeError('Remote did not provide its public key')
-  }
-
-  if (remoteId != null && !peerId.equals(remoteId)) {
-    throw new UnexpectedPeerError()
-  }
-
-  log('plaintext key exchange completed successfully with peer %p', peerId)
-
-  shake.rest()
-
-  return {
-    conn: {
-      sink: shake.stream.sink,
-      source: map(shake.stream.source, (buf) => buf.subarray())
-    },
-    remotePeer: peerId
-  }
+export interface PlaintextComponents {
+  logger: ComponentLogger
 }
 
 class Plaintext implements ConnectionEncrypter {
   public protocol: string = PROTOCOL
+  readonly #log: Logger
+
+  constructor (components: PlaintextComponents) {
+    this.#log = components.logger.forComponent('libp2p:plaintext')
+  }
 
   async secureInbound (localId: PeerId, conn: Duplex<AsyncGenerator<Uint8Array>, Source<Uint8Array>, Promise<void>>, remoteId?: PeerId): Promise<SecuredConnection> {
-    return encrypt(localId, conn, remoteId)
+    return this._encrypt(localId, conn, remoteId)
   }
 
   async secureOutbound (localId: PeerId, conn: Duplex<AsyncGenerator<Uint8Array>, Source<Uint8Array>, Promise<void>>, remoteId?: PeerId): Promise<SecuredConnection> {
-    return encrypt(localId, conn, remoteId)
+    return this._encrypt(localId, conn, remoteId)
+  }
+
+  /**
+   * Encrypt connection
+   */
+  async _encrypt (localId: PeerId, conn: Duplex<AsyncGenerator<Uint8Array>, Source<Uint8Array>, Promise<void>>, remoteId?: PeerId): Promise<SecuredConnection> {
+    const shake = handshake(conn)
+
+    let type = KeyType.RSA
+
+    if (localId.type === 'Ed25519') {
+      type = KeyType.Ed25519
+    } else if (localId.type === 'secp256k1') {
+      type = KeyType.Secp256k1
+    }
+
+    // Encode the public key and write it to the remote peer
+    shake.write(
+      lpEncodeExchange({
+        id: localId.toBytes(),
+        pubkey: {
+          Type: type,
+          Data: localId.publicKey ?? new Uint8Array(0)
+        }
+      }).subarray()
+    )
+
+    this.#log('write pubkey exchange to peer %p', remoteId)
+
+    // Get the Exchange message
+    const response = (await lp.decode.fromReader(shake.reader).next()).value
+
+    if (response == null) {
+      throw new Error('Did not read response')
+    }
+
+    const id = Exchange.decode(response)
+    this.#log('read pubkey exchange from peer %p', remoteId)
+
+    let peerId
+    try {
+      if (id.pubkey == null) {
+        throw new Error('Public key missing')
+      }
+
+      if (id.pubkey.Data.length === 0) {
+        throw new Error('Public key data too short')
+      }
+
+      if (id.id == null) {
+        throw new Error('Remote id missing')
+      }
+
+      peerId = await peerIdFromKeys(id.pubkey.Data)
+
+      if (!peerId.equals(peerIdFromBytes(id.id))) {
+        throw new Error('Public key did not match id')
+      }
+    } catch (err: any) {
+      this.#log.error(err)
+      throw new InvalidCryptoExchangeError('Remote did not provide its public key')
+    }
+
+    if (remoteId != null && !peerId.equals(remoteId)) {
+      throw new UnexpectedPeerError()
+    }
+
+    this.#log('plaintext key exchange completed successfully with peer %p', peerId)
+
+    shake.rest()
+
+    return {
+      conn: {
+        sink: shake.stream.sink,
+        source: map(shake.stream.source, (buf) => buf.subarray())
+      },
+      remotePeer: peerId
+    }
   }
 }
 
-export function plaintext (): () => ConnectionEncrypter {
-  return () => new Plaintext()
+export function plaintext (): (components: PlaintextComponents) => ConnectionEncrypter {
+  return (components) => new Plaintext(components)
 }

--- a/packages/connection-encrypter-plaintext/test/compliance.spec.ts
+++ b/packages/connection-encrypter-plaintext/test/compliance.spec.ts
@@ -1,12 +1,15 @@
 /* eslint-env mocha */
 
 import suite from '@libp2p/interface-compliance-tests/connection-encryption'
+import { defaultLogger } from '@libp2p/logger'
 import { plaintext } from '../src/index.js'
 
 describe('plaintext compliance', () => {
   suite({
     async setup () {
-      return plaintext()()
+      return plaintext()({
+        logger: defaultLogger()
+      })
     },
     async teardown () {
 

--- a/packages/connection-encrypter-plaintext/test/index.spec.ts
+++ b/packages/connection-encrypter-plaintext/test/index.spec.ts
@@ -5,6 +5,7 @@ import {
   UnexpectedPeerError
 } from '@libp2p/interface/errors'
 import { mockMultiaddrConnPair } from '@libp2p/interface-compliance-tests/mocks'
+import { defaultLogger } from '@libp2p/logger'
 import { peerIdFromBytes } from '@libp2p/peer-id'
 import { createEd25519PeerId, createRSAPeerId } from '@libp2p/peer-id-factory'
 import { multiaddr } from '@multiformats/multiaddr'
@@ -27,7 +28,9 @@ describe('plaintext', () => {
       createEd25519PeerId()
     ])
 
-    encrypter = plaintext()()
+    encrypter = plaintext()({
+      logger: defaultLogger()
+    })
   })
 
   afterEach(() => {

--- a/packages/interface-compliance-tests/src/mocks/connection-manager.ts
+++ b/packages/interface-compliance-tests/src/mocks/connection-manager.ts
@@ -4,7 +4,7 @@ import { PeerMap } from '@libp2p/peer-collections'
 import { peerIdFromString } from '@libp2p/peer-id'
 import { isMultiaddr, type Multiaddr } from '@multiformats/multiaddr'
 import { connectionPair } from './connection.js'
-import type { Libp2pEvents, PendingDial } from '@libp2p/interface'
+import type { ComponentLogger, Libp2pEvents, PendingDial } from '@libp2p/interface'
 import type { Connection } from '@libp2p/interface/connection'
 import type { TypedEventTarget } from '@libp2p/interface/events'
 import type { PubSub } from '@libp2p/interface/pubsub'
@@ -18,6 +18,7 @@ export interface MockNetworkComponents {
   connectionManager: ConnectionManager
   events: TypedEventTarget<Libp2pEvents>
   pubsub?: PubSub
+  logger: ComponentLogger
 }
 
 class MockNetwork {

--- a/packages/interface-compliance-tests/src/pubsub/index.ts
+++ b/packages/interface-compliance-tests/src/pubsub/index.ts
@@ -5,6 +5,7 @@ import messagesTest from './messages.js'
 import multipleNodesTest from './multiple-nodes.js'
 import twoNodesTest from './two-nodes.js'
 import type { TestSetup } from '../index.js'
+import type { ComponentLogger } from '@libp2p/interface'
 import type { PeerId } from '@libp2p/interface/peer-id'
 import type { PubSub, PubSubInit } from '@libp2p/interface/pubsub'
 import type { ConnectionManager } from '@libp2p/interface-internal/connection-manager'
@@ -15,6 +16,7 @@ export interface PubSubComponents {
   registrar: Registrar
   connectionManager: ConnectionManager
   pubsub?: PubSub
+  logger: ComponentLogger
 }
 
 export interface PubSubArgs {

--- a/packages/interface-compliance-tests/src/pubsub/utils.ts
+++ b/packages/interface-compliance-tests/src/pubsub/utils.ts
@@ -1,4 +1,5 @@
 import { TypedEventEmitter } from '@libp2p/interface/events'
+import { defaultLogger } from '@libp2p/logger'
 import { createEd25519PeerId } from '@libp2p/peer-id-factory'
 import { pEvent } from 'p-event'
 import pWaitFor from 'p-wait-for'
@@ -19,7 +20,8 @@ export async function createComponents (): Promise<MockNetworkComponents> {
   const components: any = {
     peerId: await createEd25519PeerId(),
     registrar: mockRegistrar(),
-    events: new TypedEventEmitter()
+    events: new TypedEventEmitter(),
+    logger: defaultLogger()
   }
   components.connectionManager = mockConnectionManager(components)
 

--- a/packages/kad-dht/package.json
+++ b/packages/kad-dht/package.json
@@ -55,7 +55,6 @@
     "@libp2p/crypto": "^2.0.8",
     "@libp2p/interface": "^0.1.6",
     "@libp2p/interface-internal": "^0.1.9",
-    "@libp2p/logger": "^3.1.0",
     "@libp2p/peer-collections": "^4.0.8",
     "@libp2p/peer-id": "^3.0.6",
     "@multiformats/multiaddr": "^12.1.10",
@@ -90,6 +89,7 @@
   },
   "devDependencies": {
     "@libp2p/interface-compliance-tests": "^4.1.5",
+    "@libp2p/logger": "^3.1.0",
     "@libp2p/peer-id-factory": "^3.0.8",
     "@libp2p/peer-store": "^9.0.9",
     "@types/lodash.random": "^3.2.6",

--- a/packages/kad-dht/src/content-fetching/index.ts
+++ b/packages/kad-dht/src/content-fetching/index.ts
@@ -32,7 +32,7 @@ export interface ContentFetchingInit {
 }
 
 export class ContentFetching {
-  readonly #log: Logger
+  private readonly log: Logger
   private readonly components: KadDHTComponents
   private readonly validators: Validators
   private readonly selectors: Selectors
@@ -44,7 +44,7 @@ export class ContentFetching {
     const { validators, selectors, peerRouting, queryManager, network, lan } = init
 
     this.components = components
-    this.#log = components.logger.forComponent(`libp2p:kad-dht:${lan ? 'lan' : 'wan'}:content-fetching`)
+    this.log = components.logger.forComponent(`libp2p:kad-dht:${lan ? 'lan' : 'wan'}:content-fetching`)
     this.validators = validators
     this.selectors = selectors
     this.peerRouting = peerRouting
@@ -62,14 +62,14 @@ export class ContentFetching {
    * the local datastore
    */
   async getLocal (key: Uint8Array): Promise<Libp2pRecord> {
-    this.#log('getLocal %b', key)
+    this.log('getLocal %b', key)
 
     const dsKey = bufferToRecordKey(key)
 
-    this.#log('fetching record for key %k', dsKey)
+    this.log('fetching record for key %k', dsKey)
 
     const raw = await this.components.datastore.get(dsKey)
-    this.#log('found %k in local datastore', dsKey)
+    this.log('found %k in local datastore', dsKey)
 
     const rec = Libp2pRecord.deserialize(raw)
 
@@ -82,13 +82,13 @@ export class ContentFetching {
    * Send the best record found to any peers that have an out of date record
    */
   async * sendCorrectionRecord (key: Uint8Array, vals: ValueEvent[], best: Uint8Array, options: AbortOptions = {}): AsyncGenerator<QueryEvent> {
-    this.#log('sendCorrection for %b', key)
+    this.log('sendCorrection for %b', key)
     const fixupRec = createPutRecord(key, best)
 
     for (const { value, from } of vals) {
       // no need to do anything
       if (uint8ArrayEquals(value, best)) {
-        this.#log('record was ok')
+        this.log('record was ok')
         continue
       }
 
@@ -96,10 +96,10 @@ export class ContentFetching {
       if (this.components.peerId.equals(from)) {
         try {
           const dsKey = bufferToRecordKey(key)
-          this.#log(`Storing corrected record for key ${dsKey.toString()}`)
+          this.log(`Storing corrected record for key ${dsKey.toString()}`)
           await this.components.datastore.put(dsKey, fixupRec.subarray())
         } catch (err: any) {
-          this.#log.error('Failed error correcting self', err)
+          this.log.error('Failed error correcting self', err)
         }
 
         continue
@@ -122,7 +122,7 @@ export class ContentFetching {
         yield queryErrorEvent({ from, error: new CodeError('value not put correctly', 'ERR_PUT_VALUE_INVALID') }, options)
       }
 
-      this.#log.error('Failed error correcting entry')
+      this.log.error('Failed error correcting entry')
     }
   }
 
@@ -130,14 +130,14 @@ export class ContentFetching {
    * Store the given key/value pair in the DHT
    */
   async * put (key: Uint8Array, value: Uint8Array, options: AbortOptions = {}): AsyncGenerator<unknown, void, undefined> {
-    this.#log('put key %b value %b', key, value)
+    this.log('put key %b value %b', key, value)
 
     // create record in the dht format
     const record = createPutRecord(key, value)
 
     // store the record locally
     const dsKey = bufferToRecordKey(key)
-    this.#log(`storing record for key ${dsKey.toString()}`)
+    this.log(`storing record for key ${dsKey.toString()}`)
     await this.components.datastore.put(dsKey, record.subarray())
 
     // put record to the closest peers
@@ -154,7 +154,7 @@ export class ContentFetching {
           const msg = new Message(MESSAGE_TYPE.PUT_VALUE, key, 0)
           msg.record = Libp2pRecord.deserialize(record)
 
-          this.#log('send put to %p', event.peer.id)
+          this.log('send put to %p', event.peer.id)
           for await (const putEvent of this.network.sendRequest(event.peer.id, msg, options)) {
             events.push(putEvent)
 
@@ -186,7 +186,7 @@ export class ContentFetching {
    * Get the value to the given key
    */
   async * get (key: Uint8Array, options: QueryOptions = {}): AsyncGenerator<QueryEvent | ValueEvent> {
-    this.#log('get %b', key)
+    this.log('get %b', key)
 
     const vals: ValueEvent[] = []
 
@@ -215,7 +215,7 @@ export class ContentFetching {
     }
 
     const best = records[i]
-    this.#log('GetValue %b %b', key, best)
+    this.log('GetValue %b %b', key, best)
 
     if (best == null) {
       throw new CodeError('best value was not found', 'ERR_NOT_FOUND')
@@ -230,7 +230,7 @@ export class ContentFetching {
    * Get the `n` values to the given key without sorting
    */
   async * getMany (key: Uint8Array, options: QueryOptions = {}): AsyncGenerator<QueryEvent> {
-    this.#log('getMany values for %b', key)
+    this.log('getMany values for %b', key)
 
     try {
       const localRec = await this.getLocal(key)
@@ -240,7 +240,7 @@ export class ContentFetching {
         from: this.components.peerId
       }, options)
     } catch (err: any) {
-      this.#log('error getting local value for %b', key, err)
+      this.log('error getting local value for %b', key, err)
     }
 
     const self = this // eslint-disable-line @typescript-eslint/no-this-alias

--- a/packages/kad-dht/src/content-routing/index.ts
+++ b/packages/kad-dht/src/content-routing/index.ts
@@ -30,7 +30,7 @@ export interface ContentRoutingInit {
 }
 
 export class ContentRouting {
-  readonly #log: Logger
+  private readonly log: Logger
   private readonly components: KadDHTComponents
   private readonly network: Network
   private readonly peerRouting: PeerRouting
@@ -42,7 +42,7 @@ export class ContentRouting {
     const { network, peerRouting, queryManager, routingTable, providers, lan } = init
 
     this.components = components
-    this.#log = components.logger.forComponent(`libp2p:kad-dht:${lan ? 'lan' : 'wan'}:content-routing`)
+    this.log = components.logger.forComponent(`libp2p:kad-dht:${lan ? 'lan' : 'wan'}:content-routing`)
     this.network = network
     this.peerRouting = peerRouting
     this.queryManager = queryManager
@@ -55,7 +55,7 @@ export class ContentRouting {
    * are contactable on the given multiaddrs
    */
   async * provide (key: CID, multiaddrs: Multiaddr[], options: QueryOptions = {}): AsyncGenerator<QueryEvent, void, undefined> {
-    this.#log('provide %s', key)
+    this.log('provide %s', key)
 
     // Add peer as provider
     await this.providers.addProvider(key, this.components.peerId)
@@ -76,21 +76,21 @@ export class ContentRouting {
 
         const events = []
 
-        this.#log('putProvider %s to %p', key, event.peer.id)
+        this.log('putProvider %s to %p', key, event.peer.id)
 
         try {
-          this.#log('sending provider record for %s to %p', key, event.peer.id)
+          this.log('sending provider record for %s to %p', key, event.peer.id)
 
           for await (const sendEvent of this.network.sendMessage(event.peer.id, msg, options)) {
             if (sendEvent.name === 'PEER_RESPONSE') {
-              this.#log('sent provider record for %s to %p', key, event.peer.id)
+              this.log('sent provider record for %s to %p', key, event.peer.id)
               sent++
             }
 
             events.push(sendEvent)
           }
         } catch (err: any) {
-          this.#log.error('error sending provide record to peer %p', event.peer.id, err)
+          this.log.error('error sending provide record to peer %p', event.peer.id, err)
           events.push(queryErrorEvent({ from: event.peer.id, error: err }, options))
         }
 
@@ -113,7 +113,7 @@ export class ContentRouting {
       }
     )
 
-    this.#log('sent provider records to %d peers', sent)
+    this.log('sent provider records to %d peers', sent)
   }
 
   /**
@@ -124,7 +124,7 @@ export class ContentRouting {
     const target = key.multihash.bytes
     const self = this // eslint-disable-line @typescript-eslint/no-this-alias
 
-    this.#log('findProviders %c', key)
+    this.log('findProviders %c', key)
 
     const provs = await this.providers.getProviders(key)
 
@@ -145,7 +145,7 @@ export class ContentRouting {
             throw err
           }
 
-          this.#log('no peer store entry for %p', peerId)
+          this.log('no peer store entry for %p', peerId)
         }
       }
 
@@ -176,7 +176,7 @@ export class ContentRouting {
       yield event
 
       if (event.name === 'PEER_RESPONSE') {
-        this.#log('Found %d provider entries for %c and %d closer peers', event.providers.length, key, event.closer.length)
+        this.log('Found %d provider entries for %c and %d closer peers', event.providers.length, key, event.closer.length)
 
         const newProviders = []
 

--- a/packages/kad-dht/src/dual-kad-dht.ts
+++ b/packages/kad-dht/src/dual-kad-dht.ts
@@ -125,13 +125,13 @@ export class DefaultDualKadDHT extends TypedEventEmitter<PeerDiscoveryEvents> im
   public readonly components: KadDHTComponents
   private readonly contentRouting: ContentRouting
   private readonly peerRouting: PeerRouting
-  readonly #log: Logger
+  private readonly log: Logger
 
   constructor (components: KadDHTComponents, init: KadDHTInit = {}) {
     super()
 
     this.components = components
-    this.#log = components.logger.forComponent('libp2p:kad-dht')
+    this.log = components.logger.forComponent('libp2p:kad-dht')
 
     this.wan = new DefaultKadDHT(components, {
       protocolPrefix: '/ipfs',
@@ -164,7 +164,7 @@ export class DefaultDualKadDHT extends TypedEventEmitter<PeerDiscoveryEvents> im
     // mode when the node's peer data is updated with publicly dialable addresses
     if (init.clientMode == null) {
       components.events.addEventListener('self:peer:update', (evt) => {
-        this.#log('received update of self-peer info')
+        this.log('received update of self-peer info')
         const hasPublicAddress = evt.detail.peer.addresses
           .some(({ multiaddr }) => multiaddrIsPublic(multiaddr))
 
@@ -177,7 +177,7 @@ export class DefaultDualKadDHT extends TypedEventEmitter<PeerDiscoveryEvents> im
             }
           })
           .catch(err => {
-            this.#log.error('error setting dht server mode', err)
+            this.log.error('error setting dht server mode', err)
           })
       })
     }
@@ -322,7 +322,7 @@ export class DefaultDualKadDHT extends TypedEventEmitter<PeerDiscoveryEvents> im
       }
 
       if (event.name === 'PEER_RESPONSE' && event.messageName === 'ADD_PROVIDER') {
-        this.#log('sent provider record for %s to %p', key, event.from)
+        this.log('sent provider record for %s to %p', key, event.from)
         success++
       }
     }

--- a/packages/kad-dht/src/dual-kad-dht.ts
+++ b/packages/kad-dht/src/dual-kad-dht.ts
@@ -3,19 +3,17 @@ import { CodeError } from '@libp2p/interface/errors'
 import { TypedEventEmitter, CustomEvent } from '@libp2p/interface/events'
 import { type PeerDiscovery, peerDiscovery, type PeerDiscoveryEvents } from '@libp2p/interface/peer-discovery'
 import { type PeerRouting, peerRouting } from '@libp2p/interface/peer-routing'
-import { logger } from '@libp2p/logger'
 import drain from 'it-drain'
 import merge from 'it-merge'
 import isPrivate from 'private-ip'
 import { DefaultKadDHT } from './kad-dht.js'
 import { queryErrorEvent } from './query/events.js'
 import type { DualKadDHT, KadDHT, KadDHTComponents, KadDHTInit, QueryEvent, QueryOptions } from './index.js'
+import type { Logger } from '@libp2p/interface'
 import type { PeerId } from '@libp2p/interface/peer-id'
 import type { PeerInfo } from '@libp2p/interface/peer-info'
 import type { Multiaddr } from '@multiformats/multiaddr'
 import type { CID } from 'multiformats/cid'
-
-const log = logger('libp2p:kad-dht')
 
 /**
  * Wrapper class to convert events into returned values
@@ -127,11 +125,13 @@ export class DefaultDualKadDHT extends TypedEventEmitter<PeerDiscoveryEvents> im
   public readonly components: KadDHTComponents
   private readonly contentRouting: ContentRouting
   private readonly peerRouting: PeerRouting
+  readonly #log: Logger
 
   constructor (components: KadDHTComponents, init: KadDHTInit = {}) {
     super()
 
     this.components = components
+    this.#log = components.logger.forComponent('libp2p:kad-dht')
 
     this.wan = new DefaultKadDHT(components, {
       protocolPrefix: '/ipfs',
@@ -164,7 +164,7 @@ export class DefaultDualKadDHT extends TypedEventEmitter<PeerDiscoveryEvents> im
     // mode when the node's peer data is updated with publicly dialable addresses
     if (init.clientMode == null) {
       components.events.addEventListener('self:peer:update', (evt) => {
-        log('received update of self-peer info')
+        this.#log('received update of self-peer info')
         const hasPublicAddress = evt.detail.peer.addresses
           .some(({ multiaddr }) => multiaddrIsPublic(multiaddr))
 
@@ -177,7 +177,7 @@ export class DefaultDualKadDHT extends TypedEventEmitter<PeerDiscoveryEvents> im
             }
           })
           .catch(err => {
-            log.error('error setting dht server mode', err)
+            this.#log.error('error setting dht server mode', err)
           })
       })
     }
@@ -322,7 +322,7 @@ export class DefaultDualKadDHT extends TypedEventEmitter<PeerDiscoveryEvents> im
       }
 
       if (event.name === 'PEER_RESPONSE' && event.messageName === 'ADD_PROVIDER') {
-        log('sent provider record for %s to %p', key, event.from)
+        this.#log('sent provider record for %s to %p', key, event.from)
         success++
       }
     }

--- a/packages/kad-dht/src/index.ts
+++ b/packages/kad-dht/src/index.ts
@@ -1,6 +1,6 @@
 import { DefaultDualKadDHT } from './dual-kad-dht.js'
 import type { ProvidersInit } from './providers.js'
-import type { Libp2pEvents, AbortOptions } from '@libp2p/interface'
+import type { Libp2pEvents, AbortOptions, ComponentLogger } from '@libp2p/interface'
 import type { TypedEventTarget } from '@libp2p/interface/events'
 import type { Metrics } from '@libp2p/interface/metrics'
 import type { PeerId } from '@libp2p/interface/peer-id'
@@ -315,6 +315,7 @@ export interface KadDHTComponents {
   connectionManager: ConnectionManager
   datastore: Datastore
   events: TypedEventTarget<Libp2pEvents>
+  logger: ComponentLogger
 }
 
 export function kadDHT (init?: KadDHTInit): (components: KadDHTComponents) => DualKadDHT {

--- a/packages/kad-dht/src/kad-dht.ts
+++ b/packages/kad-dht/src/kad-dht.ts
@@ -1,5 +1,4 @@
 import { CustomEvent, TypedEventEmitter } from '@libp2p/interface/events'
-import { type Logger, logger } from '@libp2p/logger'
 import pDefer from 'p-defer'
 import { PROTOCOL_DHT, PROTOCOL_PREFIX, LAN_PREFIX } from './constants.js'
 import { ContentFetching } from './content-fetching/index.js'
@@ -20,6 +19,7 @@ import {
   removePublicAddresses
 } from './utils.js'
 import type { KadDHTComponents, KadDHTInit, QueryOptions, Validators, Selectors, KadDHT, QueryEvent } from './index.js'
+import type { Logger } from '@libp2p/interface'
 import type { PeerDiscoveryEvents } from '@libp2p/interface/peer-discovery'
 import type { PeerId } from '@libp2p/interface/peer-id'
 import type { PeerInfo } from '@libp2p/interface/peer-info'
@@ -47,7 +47,7 @@ export class DefaultKadDHT extends TypedEventEmitter<PeerDiscoveryEvents> implem
   public peerRouting: PeerRouting
 
   public readonly components: KadDHTComponents
-  private readonly log: Logger
+  readonly #log: Logger
   private running: boolean
   private readonly kBucketSize: number
   private clientMode: boolean
@@ -88,7 +88,7 @@ export class DefaultKadDHT extends TypedEventEmitter<PeerDiscoveryEvents> implem
     this.running = false
     this.components = components
     this.lan = Boolean(lan)
-    this.log = logger(`libp2p:kad-dht:${lan === true ? 'lan' : 'wan'}`)
+    this.#log = components.logger.forComponent(`libp2p:kad-dht:${lan === true ? 'lan' : 'wan'}`)
     this.protocol = `${protocolPrefix ?? PROTOCOL_PREFIX}${lan === true ? LAN_PREFIX : ''}${PROTOCOL_DHT}`
     this.kBucketSize = kBucketSize ?? 20
     this.clientMode = clientMode ?? true
@@ -159,7 +159,7 @@ export class DefaultKadDHT extends TypedEventEmitter<PeerDiscoveryEvents> implem
       providers: this.providers,
       lan: this.lan
     })
-    this.routingTableRefresh = new RoutingTableRefresh({
+    this.routingTableRefresh = new RoutingTableRefresh(components, {
       peerRouting: this.peerRouting,
       routingTable: this.routingTable,
       lan: this.lan
@@ -189,7 +189,7 @@ export class DefaultKadDHT extends TypedEventEmitter<PeerDiscoveryEvents> implem
       const peerData = evt.detail
 
       this.onPeerConnect(peerData).catch(err => {
-        this.log.error('could not add %p to routing table', peerData.id, err)
+        this.#log.error('could not add %p to routing table', peerData.id, err)
       })
 
       this.dispatchEvent(new CustomEvent('peer', {
@@ -212,13 +212,13 @@ export class DefaultKadDHT extends TypedEventEmitter<PeerDiscoveryEvents> implem
 
         await this.onPeerConnect(peerData)
       }).catch(err => {
-        this.log.error('could not add %p to routing table', peerId, err)
+        this.#log.error('could not add %p to routing table', peerId, err)
       })
     })
   }
 
   async onPeerConnect (peerData: PeerInfo): Promise<void> {
-    this.log('peer %p connected', peerData.id)
+    this.#log('peer %p connected', peerData.id)
 
     if (this.lan) {
       peerData = removePublicAddresses(peerData)
@@ -227,14 +227,14 @@ export class DefaultKadDHT extends TypedEventEmitter<PeerDiscoveryEvents> implem
     }
 
     if (peerData.multiaddrs.length === 0) {
-      this.log('ignoring %p as they do not have any %s addresses in %s', peerData.id, this.lan ? 'private' : 'public', peerData.multiaddrs.map(addr => addr.toString()))
+      this.#log('ignoring %p as they do not have any %s addresses in %s', peerData.id, this.lan ? 'private' : 'public', peerData.multiaddrs.map(addr => addr.toString()))
       return
     }
 
     try {
       await this.routingTable.add(peerData.id)
     } catch (err: any) {
-      this.log.error('could not add %p to routing table', peerData.id, err)
+      this.#log.error('could not add %p to routing table', peerData.id, err)
     }
   }
 
@@ -259,10 +259,10 @@ export class DefaultKadDHT extends TypedEventEmitter<PeerDiscoveryEvents> implem
     await this.components.registrar.unhandle(this.protocol)
 
     if (mode === 'client') {
-      this.log('enabling client mode')
+      this.#log('enabling client mode')
       this.clientMode = true
     } else {
-      this.log('enabling server mode')
+      this.#log('enabling server mode')
       this.clientMode = false
       await this.components.registrar.handle(this.protocol, this.rpc.onIncomingStream.bind(this.rpc), {
         maxInboundStreams: this.maxInboundStreams,

--- a/packages/kad-dht/src/kad-dht.ts
+++ b/packages/kad-dht/src/kad-dht.ts
@@ -47,7 +47,7 @@ export class DefaultKadDHT extends TypedEventEmitter<PeerDiscoveryEvents> implem
   public peerRouting: PeerRouting
 
   public readonly components: KadDHTComponents
-  readonly #log: Logger
+  private readonly log: Logger
   private running: boolean
   private readonly kBucketSize: number
   private clientMode: boolean
@@ -88,7 +88,7 @@ export class DefaultKadDHT extends TypedEventEmitter<PeerDiscoveryEvents> implem
     this.running = false
     this.components = components
     this.lan = Boolean(lan)
-    this.#log = components.logger.forComponent(`libp2p:kad-dht:${lan === true ? 'lan' : 'wan'}`)
+    this.log = components.logger.forComponent(`libp2p:kad-dht:${lan === true ? 'lan' : 'wan'}`)
     this.protocol = `${protocolPrefix ?? PROTOCOL_PREFIX}${lan === true ? LAN_PREFIX : ''}${PROTOCOL_DHT}`
     this.kBucketSize = kBucketSize ?? 20
     this.clientMode = clientMode ?? true
@@ -189,7 +189,7 @@ export class DefaultKadDHT extends TypedEventEmitter<PeerDiscoveryEvents> implem
       const peerData = evt.detail
 
       this.onPeerConnect(peerData).catch(err => {
-        this.#log.error('could not add %p to routing table', peerData.id, err)
+        this.log.error('could not add %p to routing table', peerData.id, err)
       })
 
       this.dispatchEvent(new CustomEvent('peer', {
@@ -212,13 +212,13 @@ export class DefaultKadDHT extends TypedEventEmitter<PeerDiscoveryEvents> implem
 
         await this.onPeerConnect(peerData)
       }).catch(err => {
-        this.#log.error('could not add %p to routing table', peerId, err)
+        this.log.error('could not add %p to routing table', peerId, err)
       })
     })
   }
 
   async onPeerConnect (peerData: PeerInfo): Promise<void> {
-    this.#log('peer %p connected', peerData.id)
+    this.log('peer %p connected', peerData.id)
 
     if (this.lan) {
       peerData = removePublicAddresses(peerData)
@@ -227,14 +227,14 @@ export class DefaultKadDHT extends TypedEventEmitter<PeerDiscoveryEvents> implem
     }
 
     if (peerData.multiaddrs.length === 0) {
-      this.#log('ignoring %p as they do not have any %s addresses in %s', peerData.id, this.lan ? 'private' : 'public', peerData.multiaddrs.map(addr => addr.toString()))
+      this.log('ignoring %p as they do not have any %s addresses in %s', peerData.id, this.lan ? 'private' : 'public', peerData.multiaddrs.map(addr => addr.toString()))
       return
     }
 
     try {
       await this.routingTable.add(peerData.id)
     } catch (err: any) {
-      this.#log.error('could not add %p to routing table', peerData.id, err)
+      this.log.error('could not add %p to routing table', peerData.id, err)
     }
   }
 
@@ -259,10 +259,10 @@ export class DefaultKadDHT extends TypedEventEmitter<PeerDiscoveryEvents> implem
     await this.components.registrar.unhandle(this.protocol)
 
     if (mode === 'client') {
-      this.#log('enabling client mode')
+      this.log('enabling client mode')
       this.clientMode = true
     } else {
-      this.#log('enabling server mode')
+      this.log('enabling server mode')
       this.clientMode = false
       await this.components.registrar.handle(this.protocol, this.rpc.onIncomingStream.bind(this.rpc), {
         maxInboundStreams: this.maxInboundStreams,

--- a/packages/kad-dht/src/network.ts
+++ b/packages/kad-dht/src/network.ts
@@ -1,6 +1,5 @@
 import { CodeError } from '@libp2p/interface/errors'
 import { TypedEventEmitter, CustomEvent } from '@libp2p/interface/events'
-import { logger } from '@libp2p/logger'
 import { abortableDuplex } from 'abortable-iterator'
 import drain from 'it-drain'
 import first from 'it-first'
@@ -14,12 +13,11 @@ import {
   queryErrorEvent
 } from './query/events.js'
 import type { KadDHTComponents, QueryEvent, QueryOptions } from './index.js'
-import type { AbortOptions } from '@libp2p/interface'
+import type { AbortOptions, Logger } from '@libp2p/interface'
 import type { Stream } from '@libp2p/interface/connection'
 import type { PeerId } from '@libp2p/interface/peer-id'
 import type { PeerInfo } from '@libp2p/interface/peer-info'
 import type { Startable } from '@libp2p/interface/startable'
-import type { Logger } from '@libp2p/logger'
 import type { Duplex, Source } from 'it-stream-types'
 import type { Uint8ArrayList } from 'uint8arraylist'
 
@@ -36,7 +34,7 @@ interface NetworkEvents {
  * Handle network operations for the dht
  */
 export class Network extends TypedEventEmitter<NetworkEvents> implements Startable {
-  private readonly log: Logger
+  readonly #log: Logger
   private readonly protocol: string
   private running: boolean
   private readonly components: KadDHTComponents
@@ -49,7 +47,7 @@ export class Network extends TypedEventEmitter<NetworkEvents> implements Startab
 
     const { protocol, lan } = init
     this.components = components
-    this.log = logger(`libp2p:kad-dht:${lan ? 'lan' : 'wan'}:network`)
+    this.#log = components.logger.forComponent(`libp2p:kad-dht:${lan ? 'lan' : 'wan'}:network`)
     this.running = false
     this.protocol = protocol
   }
@@ -87,7 +85,7 @@ export class Network extends TypedEventEmitter<NetworkEvents> implements Startab
       return
     }
 
-    this.log('sending %s to %p', msg.type, to)
+    this.#log('sending %s to %p', msg.type, to)
     yield dialPeerEvent({ peer: to }, options)
     yield sendQueryEvent({ to, type: msg.type }, options)
 
@@ -123,7 +121,7 @@ export class Network extends TypedEventEmitter<NetworkEvents> implements Startab
       return
     }
 
-    this.log('sending %s to %p', msg.type, to)
+    this.#log('sending %s to %p', msg.type, to)
     yield dialPeerEvent({ peer: to }, options)
     yield sendQueryEvent({ to, type: msg.type }, options)
 

--- a/packages/kad-dht/src/network.ts
+++ b/packages/kad-dht/src/network.ts
@@ -34,7 +34,7 @@ interface NetworkEvents {
  * Handle network operations for the dht
  */
 export class Network extends TypedEventEmitter<NetworkEvents> implements Startable {
-  readonly #log: Logger
+  private readonly log: Logger
   private readonly protocol: string
   private running: boolean
   private readonly components: KadDHTComponents
@@ -47,7 +47,7 @@ export class Network extends TypedEventEmitter<NetworkEvents> implements Startab
 
     const { protocol, lan } = init
     this.components = components
-    this.#log = components.logger.forComponent(`libp2p:kad-dht:${lan ? 'lan' : 'wan'}:network`)
+    this.log = components.logger.forComponent(`libp2p:kad-dht:${lan ? 'lan' : 'wan'}:network`)
     this.running = false
     this.protocol = protocol
   }
@@ -85,7 +85,7 @@ export class Network extends TypedEventEmitter<NetworkEvents> implements Startab
       return
     }
 
-    this.#log('sending %s to %p', msg.type, to)
+    this.log('sending %s to %p', msg.type, to)
     yield dialPeerEvent({ peer: to }, options)
     yield sendQueryEvent({ to, type: msg.type }, options)
 
@@ -121,7 +121,7 @@ export class Network extends TypedEventEmitter<NetworkEvents> implements Startab
       return
     }
 
-    this.#log('sending %s to %p', msg.type, to)
+    this.log('sending %s to %p', msg.type, to)
     yield dialPeerEvent({ peer: to }, options)
     yield sendQueryEvent({ to, type: msg.type }, options)
 

--- a/packages/kad-dht/src/peer-routing/index.ts
+++ b/packages/kad-dht/src/peer-routing/index.ts
@@ -1,6 +1,5 @@
 import { keys } from '@libp2p/crypto'
 import { CodeError } from '@libp2p/interface/errors'
-import { logger } from '@libp2p/logger'
 import { peerIdFromKeys } from '@libp2p/peer-id'
 import { toString as uint8ArrayToString } from 'uint8arrays/to-string'
 import { Message, MESSAGE_TYPE } from '../message/index.js'
@@ -18,10 +17,10 @@ import type { Network } from '../network.js'
 import type { QueryManager, QueryOptions } from '../query/manager.js'
 import type { QueryFunc } from '../query/types.js'
 import type { RoutingTable } from '../routing-table/index.js'
-import type { AbortOptions } from '@libp2p/interface'
+import type { AbortOptions, Logger } from '@libp2p/interface'
 import type { PeerId } from '@libp2p/interface/peer-id'
 import type { PeerInfo } from '@libp2p/interface/peer-info'
-import type { Logger } from '@libp2p/logger'
+import type { PeerStore } from '@libp2p/interface/src/peer-store/index.js'
 
 export interface PeerRoutingInit {
   routingTable: RoutingTable
@@ -32,22 +31,24 @@ export interface PeerRoutingInit {
 }
 
 export class PeerRouting {
-  private readonly components: KadDHTComponents
-  private readonly log: Logger
+  readonly #log: Logger
   private readonly routingTable: RoutingTable
   private readonly network: Network
   private readonly validators: Validators
   private readonly queryManager: QueryManager
+  private readonly peerStore: PeerStore
+  private readonly peerId: PeerId
 
   constructor (components: KadDHTComponents, init: PeerRoutingInit) {
     const { routingTable, network, validators, queryManager, lan } = init
 
-    this.components = components
     this.routingTable = routingTable
     this.network = network
     this.validators = validators
     this.queryManager = queryManager
-    this.log = logger(`libp2p:kad-dht:${lan ? 'lan' : 'wan'}:peer-routing`)
+    this.peerStore = components.peerStore
+    this.peerId = components.peerId
+    this.#log = components.logger.forComponent(`libp2p:kad-dht:${lan ? 'lan' : 'wan'}:peer-routing`)
   }
 
   /**
@@ -59,10 +60,10 @@ export class PeerRouting {
     const p = await this.routingTable.find(peer)
 
     if (p != null) {
-      this.log('findPeerLocal found %p in routing table', peer)
+      this.#log('findPeerLocal found %p in routing table', peer)
 
       try {
-        peerData = await this.components.peerStore.get(p)
+        peerData = await this.peerStore.get(p)
       } catch (err: any) {
         if (err.code !== 'ERR_NOT_FOUND') {
           throw err
@@ -72,7 +73,7 @@ export class PeerRouting {
 
     if (peerData == null) {
       try {
-        peerData = await this.components.peerStore.get(peer)
+        peerData = await this.peerStore.get(peer)
       } catch (err: any) {
         if (err.code !== 'ERR_NOT_FOUND') {
           throw err
@@ -81,7 +82,7 @@ export class PeerRouting {
     }
 
     if (peerData != null) {
-      this.log('findPeerLocal found %p in peer store', peer)
+      this.#log('findPeerLocal found %p in peer store', peer)
 
       return {
         id: peerData.id,
@@ -132,16 +133,16 @@ export class PeerRouting {
    * Search for a peer with the given ID
    */
   async * findPeer (id: PeerId, options: QueryOptions = {}): AsyncGenerator<FinalPeerEvent | QueryEvent> {
-    this.log('findPeer %p', id)
+    this.#log('findPeer %p', id)
 
     // Try to find locally
     const pi = await this.findPeerLocal(id)
 
     // already got it
     if (pi != null) {
-      this.log('found local')
+      this.#log('found local')
       yield finalPeerEvent({
-        from: this.components.peerId,
+        from: this.peerId,
         peer: pi
       }, options)
       return
@@ -180,7 +181,7 @@ export class PeerRouting {
     }
 
     if (!foundPeer) {
-      yield queryErrorEvent({ from: this.components.peerId, error: new CodeError('Not found', 'ERR_NOT_FOUND') }, options)
+      yield queryErrorEvent({ from: this.peerId, error: new CodeError('Not found', 'ERR_NOT_FOUND') }, options)
     }
   }
 
@@ -189,7 +190,7 @@ export class PeerRouting {
    * bytes from a multihash or a peer ID
    */
   async * getClosestPeers (key: Uint8Array, options: QueryOptions = {}): AsyncGenerator<DialPeerEvent | QueryEvent> {
-    this.log('getClosestPeers to %b', key)
+    this.#log('getClosestPeers to %b', key)
     const id = await utils.convertBuffer(key)
     const tablePeers = this.routingTable.closestPeers(id)
     const self = this // eslint-disable-line @typescript-eslint/no-this-alias
@@ -198,7 +199,7 @@ export class PeerRouting {
     await Promise.all(tablePeers.map(async peer => { await peers.add(peer) }))
 
     const getCloserPeersQuery: QueryFunc = async function * ({ peer, signal }) {
-      self.log('closerPeersSingle %s from %p', uint8ArrayToString(key, 'base32'), peer)
+      self.#log('closerPeersSingle %s from %p', uint8ArrayToString(key, 'base32'), peer)
       const request = new Message(MESSAGE_TYPE.FIND_NODE, key, 0)
 
       yield * self.network.sendRequest(peer, request, {
@@ -215,14 +216,14 @@ export class PeerRouting {
       }
     }
 
-    this.log('found %d peers close to %b', peers.length, key)
+    this.#log('found %d peers close to %b', peers.length, key)
 
     for (const peerId of peers.peers) {
       try {
-        const peer = await this.components.peerStore.get(peerId)
+        const peer = await this.peerStore.get(peerId)
 
         yield finalPeerEvent({
-          from: this.components.peerId,
+          from: this.peerId,
           peer: {
             id: peerId,
             multiaddrs: peer.addresses.map(({ multiaddr }) => multiaddr)
@@ -251,7 +252,7 @@ export class PeerRouting {
             await this._verifyRecordOnline(event.record)
           } catch (err: any) {
             const errMsg = 'invalid record received, discarded'
-            this.log(errMsg)
+            this.#log(errMsg)
 
             yield queryErrorEvent({ from: event.from, error: new CodeError(errMsg, 'ERR_INVALID_RECORD') }, options)
             continue
@@ -290,7 +291,7 @@ export class PeerRouting {
       }
 
       try {
-        const peer = await this.components.peerStore.get(peerId)
+        const peer = await this.peerStore.get(peerId)
 
         output.push({
           id: peerId,
@@ -304,9 +305,9 @@ export class PeerRouting {
     }
 
     if (output.length > 0) {
-      this.log('getCloserPeersOffline found %d peer(s) closer to %b than %p', output.length, key, closerThan)
+      this.#log('getCloserPeersOffline found %d peer(s) closer to %b than %p', output.length, key, closerThan)
     } else {
-      this.log('getCloserPeersOffline could not find peer closer to %b than %p', key, closerThan)
+      this.#log('getCloserPeersOffline could not find peer closer to %b than %p', key, closerThan)
     }
 
     return output

--- a/packages/kad-dht/src/query-self.ts
+++ b/packages/kad-dht/src/query-self.ts
@@ -33,7 +33,7 @@ export interface QuerySelfComponents {
  * Receives notifications of new peers joining the network that support the DHT protocol
  */
 export class QuerySelf implements Startable {
-  readonly #log: Logger
+  private readonly log: Logger
   private readonly peerId: PeerId
   private readonly peerRouting: PeerRouting
   private readonly routingTable: RoutingTable
@@ -51,7 +51,7 @@ export class QuerySelf implements Startable {
     const { peerRouting, lan, count, interval, queryTimeout, routingTable } = init
 
     this.peerId = components.peerId
-    this.#log = components.logger.forComponent(`libp2p:kad-dht:${lan ? 'lan' : 'wan'}:query-self`)
+    this.log = components.logger.forComponent(`libp2p:kad-dht:${lan ? 'lan' : 'wan'}:query-self`)
     this.started = false
     this.peerRouting = peerRouting
     this.routingTable = routingTable
@@ -76,7 +76,7 @@ export class QuerySelf implements Startable {
     this.timeoutId = setTimeout(() => {
       this.querySelf()
         .catch(err => {
-          this.#log.error('error running self-query', err)
+          this.log.error('error running self-query', err)
         })
     }, this.initialInterval)
   }
@@ -95,12 +95,12 @@ export class QuerySelf implements Startable {
 
   async querySelf (): Promise<void> {
     if (!this.started) {
-      this.#log('skip self-query because we are not started')
+      this.log('skip self-query because we are not started')
       return
     }
 
     if (this.querySelfPromise != null) {
-      this.#log('joining existing self query')
+      this.log('joining existing self query')
       return this.querySelfPromise.promise
     }
 
@@ -115,14 +115,14 @@ export class QuerySelf implements Startable {
 
       try {
         if (this.routingTable.size === 0) {
-          this.#log('routing table was empty, waiting for some peers before running query')
+          this.log('routing table was empty, waiting for some peers before running query')
           // wait to discover at least one DHT peer
           await pEvent(this.routingTable, 'peer:add', {
             signal
           })
         }
 
-        this.#log('run self-query, look for %d peers timing out after %dms', this.count, this.queryTimeout)
+        this.log('run self-query, look for %d peers timing out after %dms', this.count, this.queryTimeout)
         const start = Date.now()
 
         const found = await pipe(
@@ -134,9 +134,9 @@ export class QuerySelf implements Startable {
           async (source) => length(source)
         )
 
-        this.#log('self-query found %d peers in %dms', found, Date.now() - start)
+        this.log('self-query found %d peers in %dms', found, Date.now() - start)
       } catch (err: any) {
-        this.#log.error('self-query error', err)
+        this.log.error('self-query error', err)
       } finally {
         signal.clear()
 
@@ -157,7 +157,7 @@ export class QuerySelf implements Startable {
     this.timeoutId = setTimeout(() => {
       this.querySelf()
         .catch(err => {
-          this.#log.error('error running self-query', err)
+          this.log.error('error running self-query', err)
         })
     }, this.interval)
   }

--- a/packages/kad-dht/src/query-self.ts
+++ b/packages/kad-dht/src/query-self.ts
@@ -1,5 +1,4 @@
 import { setMaxListeners } from '@libp2p/interface/events'
-import { logger, type Logger } from '@libp2p/logger'
 import { anySignal } from 'any-signal'
 import length from 'it-length'
 import { pipe } from 'it-pipe'
@@ -9,6 +8,7 @@ import { pEvent } from 'p-event'
 import { QUERY_SELF_INTERVAL, QUERY_SELF_TIMEOUT, K, QUERY_SELF_INITIAL_INTERVAL } from './constants.js'
 import type { PeerRouting } from './peer-routing/index.js'
 import type { RoutingTable } from './routing-table/index.js'
+import type { ComponentLogger, Logger } from '@libp2p/interface'
 import type { PeerId } from '@libp2p/interface/peer-id'
 import type { Startable } from '@libp2p/interface/startable'
 import type { DeferredPromise } from 'p-defer'
@@ -26,14 +26,15 @@ export interface QuerySelfInit {
 
 export interface QuerySelfComponents {
   peerId: PeerId
+  logger: ComponentLogger
 }
 
 /**
  * Receives notifications of new peers joining the network that support the DHT protocol
  */
 export class QuerySelf implements Startable {
-  private readonly log: Logger
-  private readonly components: QuerySelfComponents
+  readonly #log: Logger
+  private readonly peerId: PeerId
   private readonly peerRouting: PeerRouting
   private readonly routingTable: RoutingTable
   private readonly count: number
@@ -49,8 +50,8 @@ export class QuerySelf implements Startable {
   constructor (components: QuerySelfComponents, init: QuerySelfInit) {
     const { peerRouting, lan, count, interval, queryTimeout, routingTable } = init
 
-    this.components = components
-    this.log = logger(`libp2p:kad-dht:${lan ? 'lan' : 'wan'}:query-self`)
+    this.peerId = components.peerId
+    this.#log = components.logger.forComponent(`libp2p:kad-dht:${lan ? 'lan' : 'wan'}:query-self`)
     this.started = false
     this.peerRouting = peerRouting
     this.routingTable = routingTable
@@ -75,7 +76,7 @@ export class QuerySelf implements Startable {
     this.timeoutId = setTimeout(() => {
       this.querySelf()
         .catch(err => {
-          this.log.error('error running self-query', err)
+          this.#log.error('error running self-query', err)
         })
     }, this.initialInterval)
   }
@@ -94,12 +95,12 @@ export class QuerySelf implements Startable {
 
   async querySelf (): Promise<void> {
     if (!this.started) {
-      this.log('skip self-query because we are not started')
+      this.#log('skip self-query because we are not started')
       return
     }
 
     if (this.querySelfPromise != null) {
-      this.log('joining existing self query')
+      this.#log('joining existing self query')
       return this.querySelfPromise.promise
     }
 
@@ -114,18 +115,18 @@ export class QuerySelf implements Startable {
 
       try {
         if (this.routingTable.size === 0) {
-          this.log('routing table was empty, waiting for some peers before running query')
+          this.#log('routing table was empty, waiting for some peers before running query')
           // wait to discover at least one DHT peer
           await pEvent(this.routingTable, 'peer:add', {
             signal
           })
         }
 
-        this.log('run self-query, look for %d peers timing out after %dms', this.count, this.queryTimeout)
+        this.#log('run self-query, look for %d peers timing out after %dms', this.count, this.queryTimeout)
         const start = Date.now()
 
         const found = await pipe(
-          this.peerRouting.getClosestPeers(this.components.peerId.toBytes(), {
+          this.peerRouting.getClosestPeers(this.peerId.toBytes(), {
             signal,
             isSelfQuery: true
           }),
@@ -133,9 +134,9 @@ export class QuerySelf implements Startable {
           async (source) => length(source)
         )
 
-        this.log('self-query found %d peers in %dms', found, Date.now() - start)
+        this.#log('self-query found %d peers in %dms', found, Date.now() - start)
       } catch (err: any) {
-        this.log.error('self-query error', err)
+        this.#log.error('self-query error', err)
       } finally {
         signal.clear()
 
@@ -156,7 +157,7 @@ export class QuerySelf implements Startable {
     this.timeoutId = setTimeout(() => {
       this.querySelf()
         .catch(err => {
-          this.log.error('error running self-query', err)
+          this.#log.error('error running self-query', err)
         })
     }, this.interval)
   }

--- a/packages/kad-dht/src/query/query-path.ts
+++ b/packages/kad-dht/src/query/query-path.ts
@@ -8,9 +8,9 @@ import { queueToGenerator } from './utils.js'
 import type { CleanUpEvents } from './manager.js'
 import type { QueryEvent, QueryOptions } from '../index.js'
 import type { QueryFunc } from '../query/types.js'
+import type { Logger } from '@libp2p/interface'
 import type { TypedEventTarget } from '@libp2p/interface/events'
 import type { PeerId } from '@libp2p/interface/peer-id'
-import type { Logger } from '@libp2p/logger'
 import type { PeerSet } from '@libp2p/peer-collections'
 
 const MAX_XOR = BigInt('0xFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFF')

--- a/packages/kad-dht/src/query/utils.ts
+++ b/packages/kad-dht/src/query/utils.ts
@@ -2,8 +2,8 @@ import { CodeError } from '@libp2p/interface/errors'
 import { pushable } from 'it-pushable'
 import type { CleanUpEvents } from './manager.js'
 import type { QueryEvent } from '../index.js'
+import type { Logger } from '@libp2p/interface'
 import type { TypedEventTarget } from '@libp2p/interface/events'
-import type { Logger } from '@libp2p/logger'
 import type Queue from 'p-queue'
 
 export async function * queueToGenerator (queue: Queue, signal: AbortSignal, cleanUp: TypedEventTarget<CleanUpEvents>, log: Logger): AsyncGenerator<QueryEvent, void, undefined> {

--- a/packages/kad-dht/src/routing-table/index.ts
+++ b/packages/kad-dht/src/routing-table/index.ts
@@ -1,15 +1,14 @@
 import { TypedEventEmitter } from '@libp2p/interface/events'
-import { logger } from '@libp2p/logger'
 import { PeerSet } from '@libp2p/peer-collections'
 import Queue from 'p-queue'
 import * as utils from '../utils.js'
 import { KBucket, type PingEventDetails } from './k-bucket.js'
+import type { ComponentLogger, Logger } from '@libp2p/interface'
 import type { Metric, Metrics } from '@libp2p/interface/metrics'
 import type { PeerId } from '@libp2p/interface/peer-id'
 import type { PeerStore } from '@libp2p/interface/peer-store'
 import type { Startable } from '@libp2p/interface/startable'
 import type { ConnectionManager } from '@libp2p/interface-internal/connection-manager'
-import type { Logger } from '@libp2p/logger'
 
 export const KAD_CLOSE_TAG_NAME = 'kad-close'
 export const KAD_CLOSE_TAG_VALUE = 50
@@ -32,6 +31,7 @@ export interface RoutingTableComponents {
   peerStore: PeerStore
   connectionManager: ConnectionManager
   metrics?: Metrics
+  logger: ComponentLogger
 }
 
 export interface RoutingTableEvents {
@@ -48,7 +48,7 @@ export class RoutingTable extends TypedEventEmitter<RoutingTableEvents> implemen
   public kb?: KBucket
   public pingQueue: Queue
 
-  private readonly log: Logger
+  readonly #log: Logger
   private readonly components: RoutingTableComponents
   private readonly lan: boolean
   private readonly pingTimeout: number
@@ -69,7 +69,7 @@ export class RoutingTable extends TypedEventEmitter<RoutingTableEvents> implemen
     const { kBucketSize, pingTimeout, lan, pingConcurrency, protocol, tagName, tagValue } = init
 
     this.components = components
-    this.log = logger(`libp2p:kad-dht:${lan ? 'lan' : 'wan'}:routing-table`)
+    this.#log = components.logger.forComponent(`libp2p:kad-dht:${lan ? 'lan' : 'wan'}:routing-table`)
     this.kBucketSize = kBucketSize ?? KBUCKET_SIZE
     this.pingTimeout = pingTimeout ?? PING_TIMEOUT
     this.pingConcurrency = pingConcurrency ?? PING_CONCURRENCY
@@ -162,7 +162,7 @@ export class RoutingTable extends TypedEventEmitter<RoutingTableEvents> implemen
           }
         })
         .catch(err => {
-          this.log.error('Could not update peer tags', err)
+          this.#log.error('Could not update peer tags', err)
         })
 
       kClosest = newClosest
@@ -214,7 +214,7 @@ export class RoutingTable extends TypedEventEmitter<RoutingTableEvents> implemen
                 signal: AbortSignal.timeout(this.pingTimeout)
               }
 
-              this.log('pinging old contact %p', oldContact.peer)
+              this.#log('pinging old contact %p', oldContact.peer)
               const connection = await this.components.connectionManager.openConnection(oldContact.peer, options)
               const stream = await connection.newStream(this.protocol, options)
               await stream.close()
@@ -223,8 +223,8 @@ export class RoutingTable extends TypedEventEmitter<RoutingTableEvents> implemen
               if (this.running && this.kb != null) {
                 // only evict peers if we are still running, otherwise we evict when dialing is
                 // cancelled due to shutdown in progress
-                this.log.error('could not ping peer %p', oldContact.peer, err)
-                this.log('evicting old contact after ping failed %p', oldContact.peer)
+                this.#log.error('could not ping peer %p', oldContact.peer, err)
+                this.#log('evicting old contact after ping failed %p', oldContact.peer)
                 this.kb.remove(oldContact.id)
               }
             } finally {
@@ -234,15 +234,15 @@ export class RoutingTable extends TypedEventEmitter<RoutingTableEvents> implemen
         )
 
         if (this.running && responded < oldContacts.length && this.kb != null) {
-          this.log('adding new contact %p', newContact.peer)
+          this.#log('adding new contact %p', newContact.peer)
           this.kb.add(newContact)
         }
       } catch (err: any) {
-        this.log.error('could not process k-bucket ping event', err)
+        this.#log.error('could not process k-bucket ping event', err)
       }
     })
       .catch(err => {
-        this.log.error('could not process k-bucket ping event', err)
+        this.#log.error('could not process k-bucket ping event', err)
       })
   }
 
@@ -311,7 +311,7 @@ export class RoutingTable extends TypedEventEmitter<RoutingTableEvents> implemen
 
     this.kb.add({ id, peer })
 
-    this.log('added %p with kad id %b', peer, id)
+    this.#log('added %p with kad id %b', peer, id)
 
     this.metrics?.routingTableSize.update(this.size)
   }

--- a/packages/kad-dht/src/routing-table/index.ts
+++ b/packages/kad-dht/src/routing-table/index.ts
@@ -48,7 +48,7 @@ export class RoutingTable extends TypedEventEmitter<RoutingTableEvents> implemen
   public kb?: KBucket
   public pingQueue: Queue
 
-  readonly #log: Logger
+  private readonly log: Logger
   private readonly components: RoutingTableComponents
   private readonly lan: boolean
   private readonly pingTimeout: number
@@ -69,7 +69,7 @@ export class RoutingTable extends TypedEventEmitter<RoutingTableEvents> implemen
     const { kBucketSize, pingTimeout, lan, pingConcurrency, protocol, tagName, tagValue } = init
 
     this.components = components
-    this.#log = components.logger.forComponent(`libp2p:kad-dht:${lan ? 'lan' : 'wan'}:routing-table`)
+    this.log = components.logger.forComponent(`libp2p:kad-dht:${lan ? 'lan' : 'wan'}:routing-table`)
     this.kBucketSize = kBucketSize ?? KBUCKET_SIZE
     this.pingTimeout = pingTimeout ?? PING_TIMEOUT
     this.pingConcurrency = pingConcurrency ?? PING_CONCURRENCY
@@ -162,7 +162,7 @@ export class RoutingTable extends TypedEventEmitter<RoutingTableEvents> implemen
           }
         })
         .catch(err => {
-          this.#log.error('Could not update peer tags', err)
+          this.log.error('Could not update peer tags', err)
         })
 
       kClosest = newClosest
@@ -214,7 +214,7 @@ export class RoutingTable extends TypedEventEmitter<RoutingTableEvents> implemen
                 signal: AbortSignal.timeout(this.pingTimeout)
               }
 
-              this.#log('pinging old contact %p', oldContact.peer)
+              this.log('pinging old contact %p', oldContact.peer)
               const connection = await this.components.connectionManager.openConnection(oldContact.peer, options)
               const stream = await connection.newStream(this.protocol, options)
               await stream.close()
@@ -223,8 +223,8 @@ export class RoutingTable extends TypedEventEmitter<RoutingTableEvents> implemen
               if (this.running && this.kb != null) {
                 // only evict peers if we are still running, otherwise we evict when dialing is
                 // cancelled due to shutdown in progress
-                this.#log.error('could not ping peer %p', oldContact.peer, err)
-                this.#log('evicting old contact after ping failed %p', oldContact.peer)
+                this.log.error('could not ping peer %p', oldContact.peer, err)
+                this.log('evicting old contact after ping failed %p', oldContact.peer)
                 this.kb.remove(oldContact.id)
               }
             } finally {
@@ -234,15 +234,15 @@ export class RoutingTable extends TypedEventEmitter<RoutingTableEvents> implemen
         )
 
         if (this.running && responded < oldContacts.length && this.kb != null) {
-          this.#log('adding new contact %p', newContact.peer)
+          this.log('adding new contact %p', newContact.peer)
           this.kb.add(newContact)
         }
       } catch (err: any) {
-        this.#log.error('could not process k-bucket ping event', err)
+        this.log.error('could not process k-bucket ping event', err)
       }
     })
       .catch(err => {
-        this.#log.error('could not process k-bucket ping event', err)
+        this.log.error('could not process k-bucket ping event', err)
       })
   }
 
@@ -311,7 +311,7 @@ export class RoutingTable extends TypedEventEmitter<RoutingTableEvents> implemen
 
     this.kb.add({ id, peer })
 
-    this.#log('added %p with kad id %b', peer, id)
+    this.log('added %p with kad id %b', peer, id)
 
     this.metrics?.routingTableSize.update(this.size)
   }

--- a/packages/kad-dht/src/rpc/handlers/add-provider.ts
+++ b/packages/kad-dht/src/rpc/handlers/add-provider.ts
@@ -16,15 +16,15 @@ export interface AddProviderHandlerInit {
 
 export class AddProviderHandler implements DHTMessageHandler {
   private readonly providers: Providers
-  #log: Logger
+  private readonly log: Logger
 
   constructor (components: AddProviderComponents, init: AddProviderHandlerInit) {
-    this.#log = components.logger.forComponent('libp2p:kad-dht:rpc:handlers:add-provider')
+    this.log = components.logger.forComponent('libp2p:kad-dht:rpc:handlers:add-provider')
     this.providers = init.providers
   }
 
   async handle (peerId: PeerId, msg: Message): Promise<Message | undefined> {
-    this.#log('start')
+    this.log('start')
 
     if (msg.key == null || msg.key.length === 0) {
       throw new CodeError('Missing key', 'ERR_MISSING_KEY')
@@ -39,23 +39,23 @@ export class AddProviderHandler implements DHTMessageHandler {
     }
 
     if (msg.providerPeers == null || msg.providerPeers.length === 0) {
-      this.#log.error('no providers found in message')
+      this.log.error('no providers found in message')
     }
 
     await Promise.all(
       msg.providerPeers.map(async (pi) => {
         // Ignore providers not from the originator
         if (!pi.id.equals(peerId)) {
-          this.#log('invalid provider peer %p from %p', pi.id, peerId)
+          this.log('invalid provider peer %p from %p', pi.id, peerId)
           return
         }
 
         if (pi.multiaddrs.length < 1) {
-          this.#log('no valid addresses for provider %p. Ignore', peerId)
+          this.log('no valid addresses for provider %p. Ignore', peerId)
           return
         }
 
-        this.#log('received provider %p for %s (addrs %s)', peerId, cid, pi.multiaddrs.map((m) => m.toString()))
+        this.log('received provider %p for %s (addrs %s)', peerId, cid, pi.multiaddrs.map((m) => m.toString()))
 
         await this.providers.addProvider(cid, pi.id)
       })

--- a/packages/kad-dht/src/rpc/handlers/add-provider.ts
+++ b/packages/kad-dht/src/rpc/handlers/add-provider.ts
@@ -1,12 +1,14 @@
 import { CodeError } from '@libp2p/interface/errors'
-import { logger } from '@libp2p/logger'
 import { CID } from 'multiformats/cid'
 import type { Message } from '../../message/index.js'
 import type { Providers } from '../../providers'
 import type { DHTMessageHandler } from '../index.js'
+import type { ComponentLogger, Logger } from '@libp2p/interface'
 import type { PeerId } from '@libp2p/interface/peer-id'
 
-const log = logger('libp2p:kad-dht:rpc:handlers:add-provider')
+export interface AddProviderComponents {
+  logger: ComponentLogger
+}
 
 export interface AddProviderHandlerInit {
   providers: Providers
@@ -14,14 +16,15 @@ export interface AddProviderHandlerInit {
 
 export class AddProviderHandler implements DHTMessageHandler {
   private readonly providers: Providers
+  #log: Logger
 
-  constructor (init: AddProviderHandlerInit) {
-    const { providers } = init
-    this.providers = providers
+  constructor (components: AddProviderComponents, init: AddProviderHandlerInit) {
+    this.#log = components.logger.forComponent('libp2p:kad-dht:rpc:handlers:add-provider')
+    this.providers = init.providers
   }
 
   async handle (peerId: PeerId, msg: Message): Promise<Message | undefined> {
-    log('start')
+    this.#log('start')
 
     if (msg.key == null || msg.key.length === 0) {
       throw new CodeError('Missing key', 'ERR_MISSING_KEY')
@@ -36,23 +39,23 @@ export class AddProviderHandler implements DHTMessageHandler {
     }
 
     if (msg.providerPeers == null || msg.providerPeers.length === 0) {
-      log.error('no providers found in message')
+      this.#log.error('no providers found in message')
     }
 
     await Promise.all(
       msg.providerPeers.map(async (pi) => {
         // Ignore providers not from the originator
         if (!pi.id.equals(peerId)) {
-          log('invalid provider peer %p from %p', pi.id, peerId)
+          this.#log('invalid provider peer %p from %p', pi.id, peerId)
           return
         }
 
         if (pi.multiaddrs.length < 1) {
-          log('no valid addresses for provider %p. Ignore', peerId)
+          this.#log('no valid addresses for provider %p. Ignore', peerId)
           return
         }
 
-        log('received provider %p for %s (addrs %s)', peerId, cid, pi.multiaddrs.map((m) => m.toString()))
+        this.#log('received provider %p for %s (addrs %s)', peerId, cid, pi.multiaddrs.map((m) => m.toString()))
 
         await this.providers.addProvider(cid, pi.id)
       })

--- a/packages/kad-dht/src/rpc/handlers/find-node.ts
+++ b/packages/kad-dht/src/rpc/handlers/find-node.ts
@@ -1,4 +1,3 @@
-import { logger } from '@libp2p/logger'
 import { protocols } from '@multiformats/multiaddr'
 import { equals as uint8ArrayEquals } from 'uint8arrays'
 import { Message } from '../../message/index.js'
@@ -8,11 +7,10 @@ import {
 } from '../../utils.js'
 import type { PeerRouting } from '../../peer-routing/index.js'
 import type { DHTMessageHandler } from '../index.js'
+import type { ComponentLogger, Logger } from '@libp2p/interface'
 import type { PeerId } from '@libp2p/interface/peer-id'
 import type { PeerInfo } from '@libp2p/interface/peer-info'
 import type { AddressManager } from '@libp2p/interface-internal/address-manager'
-
-const log = logger('libp2p:kad-dht:rpc:handlers:find-node')
 
 export interface FindNodeHandlerInit {
   peerRouting: PeerRouting
@@ -22,17 +20,22 @@ export interface FindNodeHandlerInit {
 export interface FindNodeHandlerComponents {
   peerId: PeerId
   addressManager: AddressManager
+  logger: ComponentLogger
 }
 
 export class FindNodeHandler implements DHTMessageHandler {
   private readonly peerRouting: PeerRouting
   private readonly lan: boolean
-  private readonly components: FindNodeHandlerComponents
+  private readonly peerId: PeerId
+  private readonly addressManager: AddressManager
+  readonly #log: Logger
 
   constructor (components: FindNodeHandlerComponents, init: FindNodeHandlerInit) {
     const { peerRouting, lan } = init
 
-    this.components = components
+    this.#log = components.logger.forComponent('libp2p:kad-dht:rpc:handlers:find-node')
+    this.peerId = components.peerId
+    this.addressManager = components.addressManager
     this.peerRouting = peerRouting
     this.lan = Boolean(lan)
   }
@@ -41,14 +44,14 @@ export class FindNodeHandler implements DHTMessageHandler {
    * Process `FindNode` DHT messages
    */
   async handle (peerId: PeerId, msg: Message): Promise<Message> {
-    log('incoming request from %p for peers closer to %b', peerId, msg.key)
+    this.#log('incoming request from %p for peers closer to %b', peerId, msg.key)
 
     let closer: PeerInfo[] = []
 
-    if (uint8ArrayEquals(this.components.peerId.toBytes(), msg.key)) {
+    if (uint8ArrayEquals(this.peerId.toBytes(), msg.key)) {
       closer = [{
-        id: this.components.peerId,
-        multiaddrs: this.components.addressManager.getAddresses().map(ma => ma.decapsulateCode(protocols('p2p').code))
+        id: this.peerId,
+        multiaddrs: this.addressManager.getAddresses().map(ma => ma.decapsulateCode(protocols('p2p').code))
       }]
     } else {
       closer = await this.peerRouting.getCloserPeersOffline(msg.key, peerId)
@@ -63,7 +66,7 @@ export class FindNodeHandler implements DHTMessageHandler {
     if (closer.length > 0) {
       response.closerPeers = closer
     } else {
-      log('could not find any peers closer to %b than %p', msg.key, peerId)
+      this.#log('could not find any peers closer to %b than %p', msg.key, peerId)
     }
 
     return response

--- a/packages/kad-dht/src/rpc/handlers/find-node.ts
+++ b/packages/kad-dht/src/rpc/handlers/find-node.ts
@@ -28,12 +28,12 @@ export class FindNodeHandler implements DHTMessageHandler {
   private readonly lan: boolean
   private readonly peerId: PeerId
   private readonly addressManager: AddressManager
-  readonly #log: Logger
+  private readonly log: Logger
 
   constructor (components: FindNodeHandlerComponents, init: FindNodeHandlerInit) {
     const { peerRouting, lan } = init
 
-    this.#log = components.logger.forComponent('libp2p:kad-dht:rpc:handlers:find-node')
+    this.log = components.logger.forComponent('libp2p:kad-dht:rpc:handlers:find-node')
     this.peerId = components.peerId
     this.addressManager = components.addressManager
     this.peerRouting = peerRouting
@@ -44,7 +44,7 @@ export class FindNodeHandler implements DHTMessageHandler {
    * Process `FindNode` DHT messages
    */
   async handle (peerId: PeerId, msg: Message): Promise<Message> {
-    this.#log('incoming request from %p for peers closer to %b', peerId, msg.key)
+    this.log('incoming request from %p for peers closer to %b', peerId, msg.key)
 
     let closer: PeerInfo[] = []
 
@@ -66,7 +66,7 @@ export class FindNodeHandler implements DHTMessageHandler {
     if (closer.length > 0) {
       response.closerPeers = closer
     } else {
-      this.#log('could not find any peers closer to %b than %p', msg.key, peerId)
+      this.log('could not find any peers closer to %b than %p', msg.key, peerId)
     }
 
     return response

--- a/packages/kad-dht/src/rpc/handlers/get-providers.ts
+++ b/packages/kad-dht/src/rpc/handlers/get-providers.ts
@@ -30,12 +30,12 @@ export class GetProvidersHandler implements DHTMessageHandler {
   private readonly providers: Providers
   private readonly lan: boolean
   private readonly peerStore: PeerStore
-  readonly #log: Logger
+  private readonly log: Logger
 
   constructor (components: GetProvidersHandlerComponents, init: GetProvidersHandlerInit) {
     const { peerRouting, providers, lan } = init
 
-    this.#log = components.logger.forComponent('libp2p:kad-dht:rpc:handlers:get-providers')
+    this.log = components.logger.forComponent('libp2p:kad-dht:rpc:handlers:get-providers')
     this.peerStore = components.peerStore
     this.peerRouting = peerRouting
     this.providers = providers
@@ -50,7 +50,7 @@ export class GetProvidersHandler implements DHTMessageHandler {
       throw new CodeError('Invalid CID', 'ERR_INVALID_CID')
     }
 
-    this.#log('%p asking for providers for %s', peerId, cid)
+    this.log('%p asking for providers for %s', peerId, cid)
 
     const [peers, closer] = await Promise.all([
       this.providers.getProviders(cid),
@@ -69,7 +69,7 @@ export class GetProvidersHandler implements DHTMessageHandler {
       response.closerPeers = closerPeers
     }
 
-    this.#log('got %s providers %s closerPeers', providerPeers.length, closerPeers.length)
+    this.log('got %s providers %s closerPeers', providerPeers.length, closerPeers.length)
     return response
   }
 

--- a/packages/kad-dht/src/rpc/handlers/get-value.ts
+++ b/packages/kad-dht/src/rpc/handlers/get-value.ts
@@ -1,5 +1,4 @@
 import { CodeError } from '@libp2p/interface/errors'
-import { logger } from '@libp2p/logger'
 import {
   MAX_RECORD_AGE
 } from '../../constants.js'
@@ -8,11 +7,10 @@ import { Libp2pRecord } from '../../record/index.js'
 import { bufferToRecordKey, isPublicKeyKey, fromPublicKeyKey } from '../../utils.js'
 import type { PeerRouting } from '../../peer-routing/index.js'
 import type { DHTMessageHandler } from '../index.js'
+import type { ComponentLogger, Logger } from '@libp2p/interface'
 import type { PeerId } from '@libp2p/interface/peer-id'
 import type { PeerStore } from '@libp2p/interface/peer-store'
 import type { Datastore } from 'interface-datastore'
-
-const log = logger('libp2p:kad-dht:rpc:handlers:get-value')
 
 export interface GetValueHandlerInit {
   peerRouting: PeerRouting
@@ -21,23 +19,26 @@ export interface GetValueHandlerInit {
 export interface GetValueHandlerComponents {
   peerStore: PeerStore
   datastore: Datastore
+  logger: ComponentLogger
 }
 
 export class GetValueHandler implements DHTMessageHandler {
-  private readonly components: GetValueHandlerComponents
+  private readonly peerStore: PeerStore
+  private readonly datastore: Datastore
   private readonly peerRouting: PeerRouting
+  readonly #log: Logger
 
   constructor (components: GetValueHandlerComponents, init: GetValueHandlerInit) {
-    const { peerRouting } = init
-
-    this.components = components
-    this.peerRouting = peerRouting
+    this.#log = components.logger.forComponent('libp2p:kad-dht:rpc:handlers:get-value')
+    this.peerStore = components.peerStore
+    this.datastore = components.datastore
+    this.peerRouting = init.peerRouting
   }
 
   async handle (peerId: PeerId, msg: Message): Promise<Message> {
     const key = msg.key
 
-    log('%p asked for key %b', peerId, key)
+    this.#log('%p asked for key %b', peerId, key)
 
     if (key == null || key.length === 0) {
       throw new CodeError('Invalid key', 'ERR_INVALID_KEY')
@@ -46,12 +47,12 @@ export class GetValueHandler implements DHTMessageHandler {
     const response = new Message(MESSAGE_TYPE.GET_VALUE, key, msg.clusterLevel)
 
     if (isPublicKeyKey(key)) {
-      log('is public key')
+      this.#log('is public key')
       const idFromKey = fromPublicKeyKey(key)
       let pubKey: Uint8Array | undefined
 
       try {
-        const peer = await this.components.peerStore.get(idFromKey)
+        const peer = await this.peerStore.get(idFromKey)
 
         if (peer.id.publicKey == null) {
           throw new CodeError('No public key found in key book', 'ERR_NOT_FOUND')
@@ -65,7 +66,7 @@ export class GetValueHandler implements DHTMessageHandler {
       }
 
       if (pubKey != null) {
-        log('returning found public key')
+        this.#log('returning found public key')
         response.record = new Libp2pRecord(key, pubKey, new Date())
         return response
       }
@@ -77,12 +78,12 @@ export class GetValueHandler implements DHTMessageHandler {
     ])
 
     if (record != null) {
-      log('had record for %b in local datastore', key)
+      this.#log('had record for %b in local datastore', key)
       response.record = record
     }
 
     if (closer.length > 0) {
-      log('had %s closer peers in routing table', closer.length)
+      this.#log('had %s closer peers in routing table', closer.length)
       response.closerPeers = closer
     }
 
@@ -96,13 +97,13 @@ export class GetValueHandler implements DHTMessageHandler {
    * - it was received less than `MAX_RECORD_AGE` ago.
    */
   async _checkLocalDatastore (key: Uint8Array): Promise<Libp2pRecord | undefined> {
-    log('checkLocalDatastore looking for %b', key)
+    this.#log('checkLocalDatastore looking for %b', key)
     const dsKey = bufferToRecordKey(key)
 
     // Fetch value from ds
     let rawRecord
     try {
-      rawRecord = await this.components.datastore.get(dsKey)
+      rawRecord = await this.datastore.get(dsKey)
     } catch (err: any) {
       if (err.code === 'ERR_NOT_FOUND') {
         return undefined
@@ -121,7 +122,7 @@ export class GetValueHandler implements DHTMessageHandler {
     if (record.timeReceived == null ||
       Date.now() - record.timeReceived.getTime() > MAX_RECORD_AGE) {
       // If record is bad delete it and return
-      await this.components.datastore.delete(dsKey)
+      await this.datastore.delete(dsKey)
       return undefined
     }
 

--- a/packages/kad-dht/src/rpc/handlers/get-value.ts
+++ b/packages/kad-dht/src/rpc/handlers/get-value.ts
@@ -26,10 +26,10 @@ export class GetValueHandler implements DHTMessageHandler {
   private readonly peerStore: PeerStore
   private readonly datastore: Datastore
   private readonly peerRouting: PeerRouting
-  readonly #log: Logger
+  private readonly log: Logger
 
   constructor (components: GetValueHandlerComponents, init: GetValueHandlerInit) {
-    this.#log = components.logger.forComponent('libp2p:kad-dht:rpc:handlers:get-value')
+    this.log = components.logger.forComponent('libp2p:kad-dht:rpc:handlers:get-value')
     this.peerStore = components.peerStore
     this.datastore = components.datastore
     this.peerRouting = init.peerRouting
@@ -38,7 +38,7 @@ export class GetValueHandler implements DHTMessageHandler {
   async handle (peerId: PeerId, msg: Message): Promise<Message> {
     const key = msg.key
 
-    this.#log('%p asked for key %b', peerId, key)
+    this.log('%p asked for key %b', peerId, key)
 
     if (key == null || key.length === 0) {
       throw new CodeError('Invalid key', 'ERR_INVALID_KEY')
@@ -47,7 +47,7 @@ export class GetValueHandler implements DHTMessageHandler {
     const response = new Message(MESSAGE_TYPE.GET_VALUE, key, msg.clusterLevel)
 
     if (isPublicKeyKey(key)) {
-      this.#log('is public key')
+      this.log('is public key')
       const idFromKey = fromPublicKeyKey(key)
       let pubKey: Uint8Array | undefined
 
@@ -66,7 +66,7 @@ export class GetValueHandler implements DHTMessageHandler {
       }
 
       if (pubKey != null) {
-        this.#log('returning found public key')
+        this.log('returning found public key')
         response.record = new Libp2pRecord(key, pubKey, new Date())
         return response
       }
@@ -78,12 +78,12 @@ export class GetValueHandler implements DHTMessageHandler {
     ])
 
     if (record != null) {
-      this.#log('had record for %b in local datastore', key)
+      this.log('had record for %b in local datastore', key)
       response.record = record
     }
 
     if (closer.length > 0) {
-      this.#log('had %s closer peers in routing table', closer.length)
+      this.log('had %s closer peers in routing table', closer.length)
       response.closerPeers = closer
     }
 
@@ -97,7 +97,7 @@ export class GetValueHandler implements DHTMessageHandler {
    * - it was received less than `MAX_RECORD_AGE` ago.
    */
   async _checkLocalDatastore (key: Uint8Array): Promise<Libp2pRecord | undefined> {
-    this.#log('checkLocalDatastore looking for %b', key)
+    this.log('checkLocalDatastore looking for %b', key)
     const dsKey = bufferToRecordKey(key)
 
     // Fetch value from ds

--- a/packages/kad-dht/src/rpc/handlers/ping.ts
+++ b/packages/kad-dht/src/rpc/handlers/ping.ts
@@ -1,13 +1,21 @@
-import { logger } from '@libp2p/logger'
 import type { Message } from '../../message/index.js'
 import type { DHTMessageHandler } from '../index.js'
+import type { ComponentLogger, Logger } from '@libp2p/interface'
 import type { PeerId } from '@libp2p/interface/peer-id'
 
-const log = logger('libp2p:kad-dht:rpc:handlers:ping')
+export interface PingComponents {
+  logger: ComponentLogger
+}
 
 export class PingHandler implements DHTMessageHandler {
+  readonly #log: Logger
+
+  constructor (components: PingComponents) {
+    this.#log = components.logger.forComponent('libp2p:kad-dht:rpc:handlers:ping')
+  }
+
   async handle (peerId: PeerId, msg: Message): Promise<Message> {
-    log('ping from %p', peerId)
+    this.#log('ping from %p', peerId)
     return msg
   }
 }

--- a/packages/kad-dht/src/rpc/handlers/ping.ts
+++ b/packages/kad-dht/src/rpc/handlers/ping.ts
@@ -8,14 +8,14 @@ export interface PingComponents {
 }
 
 export class PingHandler implements DHTMessageHandler {
-  readonly #log: Logger
+  private readonly log: Logger
 
   constructor (components: PingComponents) {
-    this.#log = components.logger.forComponent('libp2p:kad-dht:rpc:handlers:ping')
+    this.log = components.logger.forComponent('libp2p:kad-dht:rpc:handlers:ping')
   }
 
   async handle (peerId: PeerId, msg: Message): Promise<Message> {
-    this.#log('ping from %p', peerId)
+    this.log('ping from %p', peerId)
     return msg
   }
 }

--- a/packages/kad-dht/src/rpc/handlers/put-value.ts
+++ b/packages/kad-dht/src/rpc/handlers/put-value.ts
@@ -1,10 +1,10 @@
 import { CodeError } from '@libp2p/interface/errors'
-import { type Logger, logger } from '@libp2p/logger'
 import { verifyRecord } from '../../record/validators.js'
 import { bufferToRecordKey } from '../../utils.js'
 import type { Validators } from '../../index.js'
 import type { Message } from '../../message/index.js'
 import type { DHTMessageHandler } from '../index.js'
+import type { ComponentLogger, Logger } from '@libp2p/interface'
 import type { PeerId } from '@libp2p/interface/peer-id'
 import type { Datastore } from 'interface-datastore'
 
@@ -14,31 +14,32 @@ export interface PutValueHandlerInit {
 
 export interface PutValueHandlerComponents {
   datastore: Datastore
+  logger: ComponentLogger
 }
 
 export class PutValueHandler implements DHTMessageHandler {
-  private readonly log: Logger
   private readonly components: PutValueHandlerComponents
   private readonly validators: Validators
+  readonly #log: Logger
 
   constructor (components: PutValueHandlerComponents, init: PutValueHandlerInit) {
     const { validators } = init
 
     this.components = components
-    this.log = logger('libp2p:kad-dht:rpc:handlers:put-value')
+    this.#log = components.logger.forComponent('libp2p:kad-dht:rpc:handlers:put-value')
     this.validators = validators
   }
 
   async handle (peerId: PeerId, msg: Message): Promise<Message> {
     const key = msg.key
-    this.log('%p asked us to store value for key %b', peerId, key)
+    this.#log('%p asked us to store value for key %b', peerId, key)
 
     const record = msg.record
 
     if (record == null) {
       const errMsg = `Empty record from: ${peerId.toString()}`
 
-      this.log.error(errMsg)
+      this.#log.error(errMsg)
       throw new CodeError(errMsg, 'ERR_EMPTY_RECORD')
     }
 
@@ -48,9 +49,9 @@ export class PutValueHandler implements DHTMessageHandler {
       record.timeReceived = new Date()
       const recordKey = bufferToRecordKey(record.key)
       await this.components.datastore.put(recordKey, record.serialize().subarray())
-      this.log('put record for %b into datastore under key %k', key, recordKey)
+      this.#log('put record for %b into datastore under key %k', key, recordKey)
     } catch (err: any) {
-      this.log('did not put record for key %b into datastore %o', key, err)
+      this.#log('did not put record for key %b into datastore %o', key, err)
     }
 
     return msg

--- a/packages/kad-dht/src/rpc/handlers/put-value.ts
+++ b/packages/kad-dht/src/rpc/handlers/put-value.ts
@@ -20,26 +20,26 @@ export interface PutValueHandlerComponents {
 export class PutValueHandler implements DHTMessageHandler {
   private readonly components: PutValueHandlerComponents
   private readonly validators: Validators
-  readonly #log: Logger
+  private readonly log: Logger
 
   constructor (components: PutValueHandlerComponents, init: PutValueHandlerInit) {
     const { validators } = init
 
     this.components = components
-    this.#log = components.logger.forComponent('libp2p:kad-dht:rpc:handlers:put-value')
+    this.log = components.logger.forComponent('libp2p:kad-dht:rpc:handlers:put-value')
     this.validators = validators
   }
 
   async handle (peerId: PeerId, msg: Message): Promise<Message> {
     const key = msg.key
-    this.#log('%p asked us to store value for key %b', peerId, key)
+    this.log('%p asked us to store value for key %b', peerId, key)
 
     const record = msg.record
 
     if (record == null) {
       const errMsg = `Empty record from: ${peerId.toString()}`
 
-      this.#log.error(errMsg)
+      this.log.error(errMsg)
       throw new CodeError(errMsg, 'ERR_EMPTY_RECORD')
     }
 
@@ -49,9 +49,9 @@ export class PutValueHandler implements DHTMessageHandler {
       record.timeReceived = new Date()
       const recordKey = bufferToRecordKey(record.key)
       await this.components.datastore.put(recordKey, record.serialize().subarray())
-      this.#log('put record for %b into datastore under key %k', key, recordKey)
+      this.log('put record for %b into datastore under key %k', key, recordKey)
     } catch (err: any) {
-      this.#log('did not put record for key %b into datastore %o', key, err)
+      this.log('did not put record for key %b into datastore %o', key, err)
     }
 
     return msg

--- a/packages/kad-dht/src/rpc/index.ts
+++ b/packages/kad-dht/src/rpc/index.ts
@@ -1,4 +1,3 @@
-import { type Logger, logger } from '@libp2p/logger'
 import * as lp from 'it-length-prefixed'
 import { pipe } from 'it-pipe'
 import { Message, MESSAGE_TYPE } from '../message/index.js'
@@ -12,6 +11,7 @@ import type { Validators } from '../index.js'
 import type { PeerRouting } from '../peer-routing'
 import type { Providers } from '../providers'
 import type { RoutingTable } from '../routing-table'
+import type { Logger } from '@libp2p/interface'
 import type { PeerId } from '@libp2p/interface/peer-id'
 import type { IncomingStreamData } from '@libp2p/interface-internal/registrar'
 
@@ -34,20 +34,20 @@ export interface RPCComponents extends GetValueHandlerComponents, PutValueHandle
 export class RPC {
   private readonly handlers: Record<string, DHTMessageHandler>
   private readonly routingTable: RoutingTable
-  private readonly log: Logger
+  readonly #log: Logger
 
   constructor (components: RPCComponents, init: RPCInit) {
     const { providers, peerRouting, validators, lan } = init
 
-    this.log = logger('libp2p:kad-dht:rpc')
+    this.#log = components.logger.forComponent('libp2p:kad-dht:rpc')
     this.routingTable = init.routingTable
     this.handlers = {
       [MESSAGE_TYPE.GET_VALUE]: new GetValueHandler(components, { peerRouting }),
       [MESSAGE_TYPE.PUT_VALUE]: new PutValueHandler(components, { validators }),
       [MESSAGE_TYPE.FIND_NODE]: new FindNodeHandler(components, { peerRouting, lan }),
-      [MESSAGE_TYPE.ADD_PROVIDER]: new AddProviderHandler({ providers }),
+      [MESSAGE_TYPE.ADD_PROVIDER]: new AddProviderHandler(components, { providers }),
       [MESSAGE_TYPE.GET_PROVIDERS]: new GetProvidersHandler(components, { peerRouting, providers, lan }),
-      [MESSAGE_TYPE.PING]: new PingHandler()
+      [MESSAGE_TYPE.PING]: new PingHandler(components)
     }
   }
 
@@ -58,14 +58,14 @@ export class RPC {
     try {
       await this.routingTable.add(peerId)
     } catch (err: any) {
-      this.log.error('Failed to update the kbucket store', err)
+      this.#log.error('Failed to update the kbucket store', err)
     }
 
     // get handler & execute it
     const handler = this.handlers[msg.type]
 
     if (handler == null) {
-      this.log.error(`no handler found for message type: ${msg.type}`)
+      this.#log.error(`no handler found for message type: ${msg.type}`)
       return
     }
 
@@ -83,7 +83,7 @@ export class RPC {
       try {
         await this.routingTable.add(peerId)
       } catch (err: any) {
-        this.log.error(err)
+        this.#log.error(err)
       }
 
       const self = this // eslint-disable-line @typescript-eslint/no-this-alias
@@ -95,7 +95,7 @@ export class RPC {
           for await (const msg of source) {
             // handle the message
             const desMessage = Message.deserialize(msg)
-            self.log('incoming %s from %p', desMessage.type, peerId)
+            self.#log('incoming %s from %p', desMessage.type, peerId)
             const res = await self.handleMessage(peerId, desMessage)
 
             // Not all handlers will return a response
@@ -109,7 +109,7 @@ export class RPC {
       )
     })
       .catch(err => {
-        this.log.error(err)
+        this.#log.error(err)
       })
   }
 }

--- a/packages/kad-dht/src/rpc/index.ts
+++ b/packages/kad-dht/src/rpc/index.ts
@@ -34,12 +34,12 @@ export interface RPCComponents extends GetValueHandlerComponents, PutValueHandle
 export class RPC {
   private readonly handlers: Record<string, DHTMessageHandler>
   private readonly routingTable: RoutingTable
-  readonly #log: Logger
+  private readonly log: Logger
 
   constructor (components: RPCComponents, init: RPCInit) {
     const { providers, peerRouting, validators, lan } = init
 
-    this.#log = components.logger.forComponent('libp2p:kad-dht:rpc')
+    this.log = components.logger.forComponent('libp2p:kad-dht:rpc')
     this.routingTable = init.routingTable
     this.handlers = {
       [MESSAGE_TYPE.GET_VALUE]: new GetValueHandler(components, { peerRouting }),
@@ -58,14 +58,14 @@ export class RPC {
     try {
       await this.routingTable.add(peerId)
     } catch (err: any) {
-      this.#log.error('Failed to update the kbucket store', err)
+      this.log.error('Failed to update the kbucket store', err)
     }
 
     // get handler & execute it
     const handler = this.handlers[msg.type]
 
     if (handler == null) {
-      this.#log.error(`no handler found for message type: ${msg.type}`)
+      this.log.error(`no handler found for message type: ${msg.type}`)
       return
     }
 
@@ -83,7 +83,7 @@ export class RPC {
       try {
         await this.routingTable.add(peerId)
       } catch (err: any) {
-        this.#log.error(err)
+        this.log.error(err)
       }
 
       const self = this // eslint-disable-line @typescript-eslint/no-this-alias
@@ -95,7 +95,7 @@ export class RPC {
           for await (const msg of source) {
             // handle the message
             const desMessage = Message.deserialize(msg)
-            self.#log('incoming %s from %p', desMessage.type, peerId)
+            self.log('incoming %s from %p', desMessage.type, peerId)
             const res = await self.handleMessage(peerId, desMessage)
 
             // Not all handlers will return a response
@@ -109,7 +109,7 @@ export class RPC {
       )
     })
       .catch(err => {
-        this.#log.error(err)
+        this.log.error(err)
       })
   }
 }

--- a/packages/kad-dht/src/topology-listener.ts
+++ b/packages/kad-dht/src/topology-listener.ts
@@ -17,7 +17,7 @@ export interface TopologyListenerEvents {
  * Receives notifications of new peers joining the network that support the DHT protocol
  */
 export class TopologyListener extends TypedEventEmitter<TopologyListenerEvents> implements Startable {
-  readonly #log: Logger
+  private readonly log: Logger
   private readonly components: KadDHTComponents
   private readonly protocol: string
   private running: boolean
@@ -29,7 +29,7 @@ export class TopologyListener extends TypedEventEmitter<TopologyListenerEvents> 
     const { protocol, lan } = init
 
     this.components = components
-    this.#log = components.logger.forComponent(`libp2p:kad-dht:topology-listener:${lan ? 'lan' : 'wan'}`)
+    this.log = components.logger.forComponent(`libp2p:kad-dht:topology-listener:${lan ? 'lan' : 'wan'}`)
     this.running = false
     this.protocol = protocol
   }
@@ -51,7 +51,7 @@ export class TopologyListener extends TypedEventEmitter<TopologyListenerEvents> 
     // register protocol with topology
     this.registrarId = await this.components.registrar.register(this.protocol, {
       onConnect: (peerId) => {
-        this.#log('observed peer %p with protocol %s', peerId, this.protocol)
+        this.log('observed peer %p with protocol %s', peerId, this.protocol)
         this.dispatchEvent(new CustomEvent('peer', {
           detail: peerId
         }))

--- a/packages/kad-dht/src/topology-listener.ts
+++ b/packages/kad-dht/src/topology-listener.ts
@@ -1,9 +1,8 @@
 import { CustomEvent, TypedEventEmitter } from '@libp2p/interface/events'
-import { logger } from '@libp2p/logger'
 import type { KadDHTComponents } from '.'
+import type { Logger } from '@libp2p/interface'
 import type { PeerId } from '@libp2p/interface/peer-id'
 import type { Startable } from '@libp2p/interface/startable'
-import type { Logger } from '@libp2p/logger'
 
 export interface TopologyListenerInit {
   protocol: string
@@ -18,7 +17,7 @@ export interface TopologyListenerEvents {
  * Receives notifications of new peers joining the network that support the DHT protocol
  */
 export class TopologyListener extends TypedEventEmitter<TopologyListenerEvents> implements Startable {
-  private readonly log: Logger
+  readonly #log: Logger
   private readonly components: KadDHTComponents
   private readonly protocol: string
   private running: boolean
@@ -30,7 +29,7 @@ export class TopologyListener extends TypedEventEmitter<TopologyListenerEvents> 
     const { protocol, lan } = init
 
     this.components = components
-    this.log = logger(`libp2p:kad-dht:topology-listener:${lan ? 'lan' : 'wan'}`)
+    this.#log = components.logger.forComponent(`libp2p:kad-dht:topology-listener:${lan ? 'lan' : 'wan'}`)
     this.running = false
     this.protocol = protocol
   }
@@ -52,7 +51,7 @@ export class TopologyListener extends TypedEventEmitter<TopologyListenerEvents> 
     // register protocol with topology
     this.registrarId = await this.components.registrar.register(this.protocol, {
       onConnect: (peerId) => {
-        this.log('observed peer %p with protocol %s', peerId, this.protocol)
+        this.#log('observed peer %p with protocol %s', peerId, this.protocol)
         this.dispatchEvent(new CustomEvent('peer', {
           detail: peerId
         }))

--- a/packages/kad-dht/test/generate-peers/generate-peers.node.ts
+++ b/packages/kad-dht/test/generate-peers/generate-peers.node.ts
@@ -1,6 +1,7 @@
 /* eslint-env mocha */
 import path from 'path'
 import { fileURLToPath } from 'url'
+import { defaultLogger } from '@libp2p/logger'
 import { createRSAPeerId } from '@libp2p/peer-id-factory'
 import { expect } from 'aegir/chai'
 import { execa } from 'execa'
@@ -55,7 +56,8 @@ describe.skip('generate peers', function () {
     const components = {
       peerId: id,
       connectionManager: stubInterface<ConnectionManager>(),
-      peerStore: stubInterface<PeerStore>()
+      peerStore: stubInterface<PeerStore>(),
+      logger: defaultLogger()
     }
     const table = new RoutingTable(components, {
       kBucketSize: 20,
@@ -63,6 +65,8 @@ describe.skip('generate peers', function () {
       protocol: '/ipfs/kad/1.0.0'
     })
     refresh = new RoutingTableRefresh({
+      logger: defaultLogger()
+    }, {
       routingTable: table,
       // @ts-expect-error not a full implementation
       peerRouting: {},

--- a/packages/kad-dht/test/providers.node.ts
+++ b/packages/kad-dht/test/providers.node.ts
@@ -2,6 +2,7 @@
 
 import os from 'os'
 import path from 'path'
+import { defaultLogger } from '@libp2p/logger'
 import { MemoryDatastore } from 'datastore-core/memory'
 import { LevelDatastore } from 'datastore-level'
 import { Providers } from '../src/providers.js'
@@ -27,7 +28,8 @@ describe('Providers', () => {
     const store = new LevelDatastore(p)
     await store.open()
     providers = new Providers({
-      datastore: new MemoryDatastore()
+      datastore: new MemoryDatastore(),
+      logger: defaultLogger()
     }, {
       cacheSize: 10
     })

--- a/packages/kad-dht/test/providers.spec.ts
+++ b/packages/kad-dht/test/providers.spec.ts
@@ -1,5 +1,6 @@
 /* eslint-env mocha */
 
+import { defaultLogger } from '@libp2p/logger'
 import { expect } from 'aegir/chai'
 import { MemoryDatastore } from 'datastore-core/memory'
 import delay from 'delay'
@@ -25,7 +26,8 @@ describe('Providers', () => {
 
   it('simple add and get of providers', async () => {
     providers = new Providers({
-      datastore: new MemoryDatastore()
+      datastore: new MemoryDatastore(),
+      logger: defaultLogger()
     })
 
     const cid = CID.parse('QmdfTbBqBPQ7VNxZEYEj14VmRuZBkqFbiwReogJgS1zR1n')
@@ -42,7 +44,8 @@ describe('Providers', () => {
 
   it('duplicate add of provider is deduped', async () => {
     providers = new Providers({
-      datastore: new MemoryDatastore()
+      datastore: new MemoryDatastore(),
+      logger: defaultLogger()
     })
 
     const cid = CID.parse('QmdfTbBqBPQ7VNxZEYEj14VmRuZBkqFbiwReogJgS1zR1n')
@@ -63,7 +66,8 @@ describe('Providers', () => {
 
   it('more providers than space in the lru cache', async () => {
     providers = new Providers({
-      datastore: new MemoryDatastore()
+      datastore: new MemoryDatastore(),
+      logger: defaultLogger()
     }, {
       cacheSize: 10
     })
@@ -85,7 +89,8 @@ describe('Providers', () => {
 
   it('expires', async () => {
     providers = new Providers({
-      datastore: new MemoryDatastore()
+      datastore: new MemoryDatastore(),
+      logger: defaultLogger()
     }, {
       cleanupInterval: 100,
       provideValidity: 200

--- a/packages/kad-dht/test/query-self.spec.ts
+++ b/packages/kad-dht/test/query-self.spec.ts
@@ -1,6 +1,7 @@
 /* eslint-env mocha */
 
 import { CustomEvent } from '@libp2p/interface/events'
+import { defaultLogger } from '@libp2p/logger'
 import { createEd25519PeerId } from '@libp2p/peer-id-factory'
 import { expect } from 'aegir/chai'
 import pDefer from 'p-defer'
@@ -26,7 +27,8 @@ describe('Query Self', () => {
     peerRouting = stubInterface<PeerRouting>()
 
     const components = {
-      peerId
+      peerId,
+      logger: defaultLogger()
     }
 
     const init = {

--- a/packages/kad-dht/test/query.spec.ts
+++ b/packages/kad-dht/test/query.spec.ts
@@ -1,5 +1,6 @@
 /* eslint-env mocha */
 
+import { defaultLogger } from '@libp2p/logger'
 import { expect } from 'aegir/chai'
 import delay from 'delay'
 import all from 'it-all'
@@ -123,7 +124,8 @@ describe('QueryManager', () => {
 
   it('does not run queries before start', async () => {
     const manager = new QueryManager({
-      peerId: ourPeerId
+      peerId: ourPeerId,
+      logger: defaultLogger()
     }, {
       ...defaultInit(),
       disjointPaths: 1
@@ -135,7 +137,8 @@ describe('QueryManager', () => {
 
   it('does not run queries after stop', async () => {
     const manager = new QueryManager({
-      peerId: ourPeerId
+      peerId: ourPeerId,
+      logger: defaultLogger()
     }, {
       ...defaultInit(),
       disjointPaths: 1
@@ -150,7 +153,8 @@ describe('QueryManager', () => {
 
   it('should pass query context', async () => {
     const manager = new QueryManager({
-      peerId: ourPeerId
+      peerId: ourPeerId,
+      logger: defaultLogger()
     }, {
       ...defaultInit(),
       disjointPaths: 1
@@ -183,7 +187,8 @@ describe('QueryManager', () => {
 
   it('simple run - succeed finding value', async () => {
     const manager = new QueryManager({
-      peerId: ourPeerId
+      peerId: ourPeerId,
+      logger: defaultLogger()
     }, {
       ...defaultInit(),
       disjointPaths: 1,
@@ -235,7 +240,8 @@ describe('QueryManager', () => {
 
   it('simple run - fail to find value', async () => {
     const manager = new QueryManager({
-      peerId: ourPeerId
+      peerId: ourPeerId,
+      logger: defaultLogger()
     }, {
       ...defaultInit(),
       disjointPaths: 1,
@@ -277,7 +283,8 @@ describe('QueryManager', () => {
 
   it('should abort a query', async () => {
     const manager = new QueryManager({
-      peerId: ourPeerId
+      peerId: ourPeerId,
+      logger: defaultLogger()
     }, {
       ...defaultInit(),
       disjointPaths: 2,
@@ -322,7 +329,8 @@ describe('QueryManager', () => {
 
   it('should allow a sub-query to timeout without aborting the whole query', async () => {
     const manager = new QueryManager({
-      peerId: ourPeerId
+      peerId: ourPeerId,
+      logger: defaultLogger()
     }, {
       ...defaultInit(),
       disjointPaths: 2,
@@ -373,7 +381,8 @@ describe('QueryManager', () => {
 
   it('does not return an error if only some queries error', async () => {
     const manager = new QueryManager({
-      peerId: ourPeerId
+      peerId: ourPeerId,
+      logger: defaultLogger()
     }, {
       ...defaultInit(),
       disjointPaths: 10
@@ -411,7 +420,8 @@ describe('QueryManager', () => {
 
   it('returns empty run if initial peer list is empty', async () => {
     const manager = new QueryManager({
-      peerId: ourPeerId
+      peerId: ourPeerId,
+      logger: defaultLogger()
     }, {
       ...defaultInit(),
       disjointPaths: 10
@@ -432,7 +442,8 @@ describe('QueryManager', () => {
 
   it('should query closer peers first', async () => {
     const manager = new QueryManager({
-      peerId: ourPeerId
+      peerId: ourPeerId,
+      logger: defaultLogger()
     }, {
       ...defaultInit(),
       disjointPaths: 1,
@@ -484,7 +495,8 @@ describe('QueryManager', () => {
 
   it('should stop when passing through the same node twice', async () => {
     const manager = new QueryManager({
-      peerId: ourPeerId
+      peerId: ourPeerId,
+      logger: defaultLogger()
     }, {
       ...defaultInit(),
       disjointPaths: 20,
@@ -520,7 +532,8 @@ describe('QueryManager', () => {
 
   it('only closerPeers', async () => {
     const manager = new QueryManager({
-      peerId: ourPeerId
+      peerId: ourPeerId,
+      logger: defaultLogger()
     }, {
       ...defaultInit(),
       disjointPaths: 1,
@@ -551,7 +564,8 @@ describe('QueryManager', () => {
 
   it('only closerPeers concurrent', async () => {
     const manager = new QueryManager({
-      peerId: ourPeerId
+      peerId: ourPeerId,
+      logger: defaultLogger()
     }, {
       ...defaultInit(),
       disjointPaths: 3
@@ -586,7 +600,8 @@ describe('QueryManager', () => {
 
   it('queries stop after shutdown', async () => {
     const manager = new QueryManager({
-      peerId: ourPeerId
+      peerId: ourPeerId,
+      logger: defaultLogger()
     }, {
       ...defaultInit(),
       disjointPaths: 1,
@@ -639,7 +654,8 @@ describe('QueryManager', () => {
 
   it('disjoint path values', async () => {
     const manager = new QueryManager({
-      peerId: ourPeerId
+      peerId: ourPeerId,
+      logger: defaultLogger()
     }, {
       ...defaultInit(),
       disjointPaths: 2
@@ -680,7 +696,8 @@ describe('QueryManager', () => {
 
   it('disjoint path continue other paths after error on one path', async () => {
     const manager = new QueryManager({
-      peerId: ourPeerId
+      peerId: ourPeerId,
+      logger: defaultLogger()
     }, {
       ...defaultInit(),
       disjointPaths: 2
@@ -718,7 +735,8 @@ describe('QueryManager', () => {
 
   it('should allow the self-query query to run', async () => {
     const manager = new QueryManager({
-      peerId: ourPeerId
+      peerId: ourPeerId,
+      logger: defaultLogger()
     }, {
       initialQuerySelfHasRun: pDefer<any>(),
       routingTable
@@ -751,7 +769,8 @@ describe('QueryManager', () => {
     const initialQuerySelfHasRun = pDefer<any>()
 
     const manager = new QueryManager({
-      peerId: ourPeerId
+      peerId: ourPeerId,
+      logger: defaultLogger()
     }, {
       initialQuerySelfHasRun,
       alpha: 2,
@@ -803,7 +822,8 @@ describe('QueryManager', () => {
 
   it('should end paths when they have no closer peers to those already queried', async () => {
     const manager = new QueryManager({
-      peerId: ourPeerId
+      peerId: ourPeerId,
+      logger: defaultLogger()
     }, {
       ...defaultInit(),
       disjointPaths: 1,

--- a/packages/kad-dht/test/routing-table.spec.ts
+++ b/packages/kad-dht/test/routing-table.spec.ts
@@ -2,6 +2,7 @@
 
 import { TypedEventEmitter, CustomEvent } from '@libp2p/interface/events'
 import { mockConnectionManager } from '@libp2p/interface-compliance-tests/mocks'
+import { defaultLogger } from '@libp2p/logger'
 import { PeerSet } from '@libp2p/peer-collections'
 import { peerIdFromString } from '@libp2p/peer-id'
 import { createEd25519PeerId } from '@libp2p/peer-id-factory'
@@ -38,7 +39,8 @@ describe('Routing Table', () => {
     components = {
       peerId: await createPeerId(),
       connectionManager: stubInterface<ConnectionManager>(),
-      peerStore: stubInterface<PeerStore>()
+      peerStore: stubInterface<PeerStore>(),
+      logger: defaultLogger()
     }
     components.connectionManager = mockConnectionManager({
       ...components,

--- a/packages/kad-dht/test/rpc/handlers/add-provider.spec.ts
+++ b/packages/kad-dht/test/rpc/handlers/add-provider.spec.ts
@@ -1,5 +1,6 @@
 /* eslint-env mocha */
 
+import { defaultLogger } from '@libp2p/logger'
 import { multiaddr } from '@multiformats/multiaddr'
 import { expect } from 'aegir/chai'
 import { MemoryDatastore } from 'datastore-core'
@@ -29,9 +30,14 @@ describe('rpc - handlers - AddProvider', () => {
   beforeEach(async () => {
     const datastore = new MemoryDatastore()
 
-    providers = new Providers({ datastore })
+    providers = new Providers({
+      datastore,
+      logger: defaultLogger()
+    })
 
     handler = new AddProviderHandler({
+      logger: defaultLogger()
+    }, {
       providers
     })
   })

--- a/packages/kad-dht/test/rpc/handlers/find-node.spec.ts
+++ b/packages/kad-dht/test/rpc/handlers/find-node.spec.ts
@@ -1,5 +1,6 @@
 /* eslint-env mocha */
 
+import { defaultLogger } from '@libp2p/logger'
 import { multiaddr } from '@multiformats/multiaddr'
 import { expect } from 'aegir/chai'
 import Sinon, { type SinonStubbedInstance } from 'sinon'
@@ -32,7 +33,8 @@ describe('rpc - handlers - FindNode', () => {
 
     handler = new FindNodeHandler({
       peerId,
-      addressManager
+      addressManager,
+      logger: defaultLogger()
     }, {
       peerRouting,
       lan: false
@@ -113,7 +115,8 @@ describe('rpc - handlers - FindNode', () => {
 
     handler = new FindNodeHandler({
       peerId,
-      addressManager
+      addressManager,
+      logger: defaultLogger()
     }, {
       peerRouting,
       lan: true

--- a/packages/kad-dht/test/rpc/handlers/get-providers.spec.ts
+++ b/packages/kad-dht/test/rpc/handlers/get-providers.spec.ts
@@ -1,6 +1,7 @@
 /* eslint-env mocha */
 
 import { TypedEventEmitter } from '@libp2p/interface/events'
+import { defaultLogger } from '@libp2p/logger'
 import { PersistentPeerStore } from '@libp2p/peer-store'
 import { multiaddr } from '@multiformats/multiaddr'
 import { expect } from 'aegir/chai'
@@ -43,11 +44,13 @@ describe('rpc - handlers - GetProviders', () => {
     peerStore = new PersistentPeerStore({
       peerId,
       datastore: new MemoryDatastore(),
-      events: new TypedEventEmitter<Libp2pEvents>()
+      events: new TypedEventEmitter<Libp2pEvents>(),
+      logger: defaultLogger()
     })
 
     const components: GetProvidersHandlerComponents = {
-      peerStore
+      peerStore,
+      logger: defaultLogger()
     }
 
     handler = new GetProvidersHandler(components, {

--- a/packages/kad-dht/test/rpc/handlers/get-value.spec.ts
+++ b/packages/kad-dht/test/rpc/handlers/get-value.spec.ts
@@ -1,6 +1,7 @@
 /* eslint-env mocha */
 
 import { TypedEventEmitter } from '@libp2p/interface/events'
+import { defaultLogger } from '@libp2p/logger'
 import { PersistentPeerStore } from '@libp2p/peer-store'
 import { expect } from 'aegir/chai'
 import { MemoryDatastore } from 'datastore-core'
@@ -40,12 +41,14 @@ describe('rpc - handlers - GetValue', () => {
     peerStore = new PersistentPeerStore({
       peerId,
       datastore,
-      events: new TypedEventEmitter<Libp2pEvents>()
+      events: new TypedEventEmitter<Libp2pEvents>(),
+      logger: defaultLogger()
     })
 
     const components: GetValueHandlerComponents = {
       datastore,
-      peerStore
+      peerStore,
+      logger: defaultLogger()
     }
 
     handler = new GetValueHandler(components, {

--- a/packages/kad-dht/test/rpc/handlers/ping.spec.ts
+++ b/packages/kad-dht/test/rpc/handlers/ping.spec.ts
@@ -1,5 +1,6 @@
 /* eslint-env mocha */
 
+import { defaultLogger } from '@libp2p/logger'
 import { expect } from 'aegir/chai'
 import { fromString as uint8ArrayFromString } from 'uint8arrays/from-string'
 import { Message, MESSAGE_TYPE } from '../../../src/message/index.js'
@@ -19,7 +20,9 @@ describe('rpc - handlers - Ping', () => {
   })
 
   beforeEach(async () => {
-    handler = new PingHandler()
+    handler = new PingHandler({
+      logger: defaultLogger()
+    })
   })
 
   it('replies with the same message', async () => {

--- a/packages/kad-dht/test/rpc/handlers/put-value.spec.ts
+++ b/packages/kad-dht/test/rpc/handlers/put-value.spec.ts
@@ -1,6 +1,7 @@
 /* eslint-env mocha */
 /* eslint max-nested-callbacks: ["error", 8] */
 
+import { defaultLogger } from '@libp2p/logger'
 import { expect } from 'aegir/chai'
 import { MemoryDatastore } from 'datastore-core'
 import delay from 'delay'
@@ -28,7 +29,8 @@ describe('rpc - handlers - PutValue', () => {
     validators = {}
 
     const components = {
-      datastore
+      datastore,
+      logger: defaultLogger()
     }
 
     handler = new PutValueHandler(components, {

--- a/packages/kad-dht/test/rpc/index.node.ts
+++ b/packages/kad-dht/test/rpc/index.node.ts
@@ -3,6 +3,7 @@
 import { TypedEventEmitter } from '@libp2p/interface/events'
 import { start } from '@libp2p/interface/startable'
 import { mockStream } from '@libp2p/interface-compliance-tests/mocks'
+import { defaultLogger } from '@libp2p/logger'
 import { PersistentPeerStore } from '@libp2p/peer-store'
 import { expect } from 'aegir/chai'
 import { MemoryDatastore } from 'datastore-core'
@@ -47,7 +48,8 @@ describe('rpc', () => {
       peerId,
       datastore,
       peerStore: stubInterface<PeerStore>(),
-      addressManager: stubInterface<AddressManager>()
+      addressManager: stubInterface<AddressManager>(),
+      logger: defaultLogger()
     }
     components.peerStore = new PersistentPeerStore({
       ...components,

--- a/packages/kad-dht/test/utils/test-dht.ts
+++ b/packages/kad-dht/test/utils/test-dht.ts
@@ -1,7 +1,7 @@
 import { TypedEventEmitter } from '@libp2p/interface/events'
 import { start, stop } from '@libp2p/interface/startable'
 import { mockRegistrar, mockConnectionManager, mockNetwork } from '@libp2p/interface-compliance-tests/mocks'
-import { logger } from '@libp2p/logger'
+import { defaultLogger } from '@libp2p/logger'
 import { PersistentPeerStore } from '@libp2p/peer-store'
 import { multiaddr } from '@multiformats/multiaddr'
 import { MemoryDatastore } from 'datastore-core/memory'
@@ -18,8 +18,6 @@ import type { PeerStore } from '@libp2p/interface/peer-store'
 import type { AddressManager } from '@libp2p/interface-internal/address-manager'
 import type { ConnectionManager } from '@libp2p/interface-internal/connection-manager'
 import type { Registrar } from '@libp2p/interface-internal/registrar'
-
-const log = logger('libp2p:kad-dht:test-dht')
 
 export class TestDHT {
   private readonly peers: Map<string, { dht: DualKadDHT, registrar: Registrar }>
@@ -38,7 +36,8 @@ export class TestDHT {
       addressManager: stubInterface<AddressManager>(),
       peerStore: stubInterface<PeerStore>(),
       connectionManager: stubInterface<ConnectionManager>(),
-      events
+      events,
+      logger: defaultLogger()
     }
     components.connectionManager = mockConnectionManager({
       ...components,
@@ -93,10 +92,9 @@ export class TestDHT {
         return
       }
 
-      components.peerStore.merge(peerData.id, {
+      void components.peerStore.merge(peerData.id, {
         multiaddrs: peerData.multiaddrs
       })
-        .catch(err => { log.error(err) })
     })
 
     if (autoStart) {

--- a/packages/keychain/package.json
+++ b/packages/keychain/package.json
@@ -56,7 +56,6 @@
   "dependencies": {
     "@libp2p/crypto": "^2.0.8",
     "@libp2p/interface": "^0.1.6",
-    "@libp2p/logger": "^3.1.0",
     "@libp2p/peer-id": "^3.0.6",
     "interface-datastore": "^8.2.0",
     "merge-options": "^3.0.4",
@@ -64,6 +63,7 @@
     "uint8arrays": "^4.0.6"
   },
   "devDependencies": {
+    "@libp2p/logger": "^3.1.0",
     "@libp2p/peer-id-factory": "^3.0.8",
     "aegir": "^41.0.2",
     "datastore-core": "^9.1.1",

--- a/packages/keychain/src/index.ts
+++ b/packages/keychain/src/index.ts
@@ -51,6 +51,7 @@
  */
 
 import { DefaultKeychain } from './keychain.js'
+import type { ComponentLogger } from '@libp2p/interface'
 import type { KeyType } from '@libp2p/interface/keys'
 import type { PeerId } from '@libp2p/interface/peer-id'
 import type { Datastore } from 'interface-datastore'
@@ -70,6 +71,7 @@ export interface KeychainInit {
 
 export interface KeychainComponents {
   datastore: Datastore
+  logger: ComponentLogger
 }
 
 export interface KeyInfo {

--- a/packages/keychain/src/keychain.ts
+++ b/packages/keychain/src/keychain.ts
@@ -85,14 +85,14 @@ function DsInfoName (name: string): Key {
 export class DefaultKeychain implements Keychain {
   private readonly components: KeychainComponents
   private readonly init: KeychainInit
-  #log: Logger
+  private readonly log: Logger
 
   /**
    * Creates a new instance of a key chain
    */
   constructor (components: KeychainComponents, init: KeychainInit) {
     this.components = components
-    this.#log = components.logger.forComponent('libp2p:keychain')
+    this.log = components.logger.forComponent('libp2p:keychain')
     this.init = mergeOptions(defaultOptions, init)
 
     // Enforce NIST SP 800-132
@@ -263,7 +263,7 @@ export class DefaultKeychain implements Keychain {
       return JSON.parse(uint8ArrayToString(res))
     } catch (err: any) {
       await randomDelay()
-      this.#log.error(err)
+      this.log.error(err)
       throw new CodeError(`Key '${name}' does not exist.`, codes.ERR_KEY_NOT_FOUND)
     }
   }
@@ -501,7 +501,7 @@ export class DefaultKeychain implements Keychain {
       return uint8ArrayToString(res)
     } catch (err: any) {
       await randomDelay()
-      this.#log.error(err)
+      this.log.error(err)
       throw new CodeError(`Key '${name}' does not exist.`, codes.ERR_KEY_NOT_FOUND)
     }
   }
@@ -522,7 +522,7 @@ export class DefaultKeychain implements Keychain {
       await randomDelay()
       throw new CodeError(`Invalid pass length ${newPass.length}`, codes.ERR_INVALID_PASS_LENGTH)
     }
-    this.#log('recreating keychain')
+    this.log('recreating keychain')
     const cached = privates.get(this)
 
     if (cached == null) {
@@ -558,6 +558,6 @@ export class DefaultKeychain implements Keychain {
       batch.put(DsInfoName(key.name), uint8ArrayFromString(JSON.stringify(keyInfo)))
       await batch.commit()
     }
-    this.#log('keychain reconstructed')
+    this.log('keychain reconstructed')
   }
 }

--- a/packages/keychain/src/keychain.ts
+++ b/packages/keychain/src/keychain.ts
@@ -3,7 +3,6 @@
 import { pbkdf2, randomBytes } from '@libp2p/crypto'
 import { generateKeyPair, importKey, unmarshalPrivateKey } from '@libp2p/crypto/keys'
 import { CodeError } from '@libp2p/interface/errors'
-import { logger } from '@libp2p/logger'
 import { peerIdFromKeys } from '@libp2p/peer-id'
 import { Key } from 'interface-datastore/key'
 import mergeOptions from 'merge-options'
@@ -12,10 +11,9 @@ import { fromString as uint8ArrayFromString } from 'uint8arrays/from-string'
 import { toString as uint8ArrayToString } from 'uint8arrays/to-string'
 import { codes } from './errors.js'
 import type { KeychainComponents, KeychainInit, Keychain, KeyInfo } from './index.js'
+import type { Logger } from '@libp2p/interface'
 import type { KeyType } from '@libp2p/interface/keys'
 import type { PeerId } from '@libp2p/interface/peer-id'
-
-const log = logger('libp2p:keychain')
 
 const keyPrefix = '/pkcs8/'
 const infoPrefix = '/info/'
@@ -87,12 +85,14 @@ function DsInfoName (name: string): Key {
 export class DefaultKeychain implements Keychain {
   private readonly components: KeychainComponents
   private readonly init: KeychainInit
+  #log: Logger
 
   /**
    * Creates a new instance of a key chain
    */
   constructor (components: KeychainComponents, init: KeychainInit) {
     this.components = components
+    this.#log = components.logger.forComponent('libp2p:keychain')
     this.init = mergeOptions(defaultOptions, init)
 
     // Enforce NIST SP 800-132
@@ -263,7 +263,7 @@ export class DefaultKeychain implements Keychain {
       return JSON.parse(uint8ArrayToString(res))
     } catch (err: any) {
       await randomDelay()
-      log.error(err)
+      this.#log.error(err)
       throw new CodeError(`Key '${name}' does not exist.`, codes.ERR_KEY_NOT_FOUND)
     }
   }
@@ -501,7 +501,7 @@ export class DefaultKeychain implements Keychain {
       return uint8ArrayToString(res)
     } catch (err: any) {
       await randomDelay()
-      log.error(err)
+      this.#log.error(err)
       throw new CodeError(`Key '${name}' does not exist.`, codes.ERR_KEY_NOT_FOUND)
     }
   }
@@ -522,7 +522,7 @@ export class DefaultKeychain implements Keychain {
       await randomDelay()
       throw new CodeError(`Invalid pass length ${newPass.length}`, codes.ERR_INVALID_PASS_LENGTH)
     }
-    log('recreating keychain')
+    this.#log('recreating keychain')
     const cached = privates.get(this)
 
     if (cached == null) {
@@ -558,6 +558,6 @@ export class DefaultKeychain implements Keychain {
       batch.put(DsInfoName(key.name), uint8ArrayFromString(JSON.stringify(keyInfo)))
       await batch.commit()
     }
-    log('keychain reconstructed')
+    this.#log('keychain reconstructed')
   }
 }

--- a/packages/libp2p/src/address-manager/index.ts
+++ b/packages/libp2p/src/address-manager/index.ts
@@ -73,7 +73,7 @@ function stripPeerId (ma: Multiaddr, peerId: PeerId): Multiaddr {
 }
 
 export class DefaultAddressManager {
-  #log: Logger
+  private readonly log: Logger
   private readonly components: DefaultAddressManagerComponents
   // this is an array to allow for duplicates, e.g. multiples of `/ip4/0.0.0.0/tcp/0`
   private readonly listen: string[]
@@ -91,7 +91,7 @@ export class DefaultAddressManager {
     const { listen = [], announce = [] } = init
 
     this.components = components
-    this.#log = components.logger.forComponent('libp2p:address-manager')
+    this.log = components.logger.forComponent('libp2p:address-manager')
     this.listen = listen.map(ma => ma.toString())
     this.announce = new Set(announce.map(ma => ma.toString()))
     this.observed = new Map()
@@ -132,7 +132,7 @@ export class DefaultAddressManager {
     this.components.peerStore.patch(this.components.peerId, {
       multiaddrs: addrs
     })
-      .catch(err => { this.#log.error('error updating addresses', err) })
+      .catch(err => { this.log.error('error updating addresses', err) })
   }
 
   /**

--- a/packages/libp2p/src/connection-manager/auto-dial.ts
+++ b/packages/libp2p/src/connection-manager/auto-dial.ts
@@ -48,7 +48,7 @@ export class AutoDial implements Startable {
   private autoDialInterval?: ReturnType<typeof setInterval>
   private started: boolean
   private running: boolean
-  readonly #log: Logger
+  private readonly log: Logger
 
   /**
    * Proactively tries to connect to known peers stored in the PeerStore.
@@ -64,21 +64,21 @@ export class AutoDial implements Startable {
     this.autoDialMaxQueueLength = init.maxQueueLength ?? defaultOptions.maxQueueLength
     this.autoDialPeerRetryThresholdMs = init.autoDialPeerRetryThreshold ?? defaultOptions.autoDialPeerRetryThreshold
     this.autoDialDiscoveredPeersDebounce = init.autoDialDiscoveredPeersDebounce ?? defaultOptions.autoDialDiscoveredPeersDebounce
-    this.#log = components.logger.forComponent('libp2p:connection-manager:auto-dial')
+    this.log = components.logger.forComponent('libp2p:connection-manager:auto-dial')
     this.started = false
     this.running = false
     this.queue = new PeerJobQueue({
       concurrency: init.autoDialConcurrency ?? defaultOptions.autoDialConcurrency
     })
     this.queue.addListener('error', (err) => {
-      this.#log.error('error during auto-dial', err)
+      this.log.error('error during auto-dial', err)
     })
 
     // check the min connection limit whenever a peer disconnects
     components.events.addEventListener('connection:close', () => {
       this.autoDial()
         .catch(err => {
-          this.#log.error(err)
+          this.log.error(err)
         })
     })
 
@@ -93,7 +93,7 @@ export class AutoDial implements Startable {
       debounce = setTimeout(() => {
         this.autoDial()
           .catch(err => {
-            this.#log.error(err)
+            this.log.error(err)
           })
       }, this.autoDialDiscoveredPeersDebounce)
     })
@@ -107,7 +107,7 @@ export class AutoDial implements Startable {
     this.autoDialInterval = setTimeout(() => {
       this.autoDial()
         .catch(err => {
-          this.#log.error('error while autodialing', err)
+          this.log.error('error while autodialing', err)
         })
     }, this.autoDialIntervalMs)
     this.started = true
@@ -116,7 +116,7 @@ export class AutoDial implements Startable {
   afterStart (): void {
     this.autoDial()
       .catch(err => {
-        this.#log.error('error while autodialing', err)
+        this.log.error('error while autodialing', err)
       })
   }
 
@@ -139,24 +139,24 @@ export class AutoDial implements Startable {
     // Already has enough connections
     if (numConnections >= this.minConnections) {
       if (this.minConnections > 0) {
-        this.#log.trace('have enough connections %d/%d', numConnections, this.minConnections)
+        this.log.trace('have enough connections %d/%d', numConnections, this.minConnections)
       }
       return
     }
 
     if (this.queue.size > this.autoDialMaxQueueLength) {
-      this.#log('not enough connections %d/%d but auto dial queue is full', numConnections, this.minConnections)
+      this.log('not enough connections %d/%d but auto dial queue is full', numConnections, this.minConnections)
       return
     }
 
     if (this.running) {
-      this.#log('not enough connections %d/%d - but skipping autodial as it is already running', numConnections, this.minConnections)
+      this.log('not enough connections %d/%d - but skipping autodial as it is already running', numConnections, this.minConnections)
       return
     }
 
     this.running = true
 
-    this.#log('not enough connections %d/%d - will dial peers to increase the number of connections', numConnections, this.minConnections)
+    this.log('not enough connections %d/%d - will dial peers to increase the number of connections', numConnections, this.minConnections)
 
     const dialQueue = new PeerSet(
       // @ts-expect-error boolean filter removes falsy peer IDs
@@ -172,25 +172,25 @@ export class AutoDial implements Startable {
         (peer) => {
           // Remove peers without addresses
           if (peer.addresses.length === 0) {
-            this.#log.trace('not autodialing %p because they have no addresses', peer.id)
+            this.log.trace('not autodialing %p because they have no addresses', peer.id)
             return false
           }
 
           // remove peers we are already connected to
           if (connections.has(peer.id)) {
-            this.#log.trace('not autodialing %p because they are already connected', peer.id)
+            this.log.trace('not autodialing %p because they are already connected', peer.id)
             return false
           }
 
           // remove peers we are already dialling
           if (dialQueue.has(peer.id)) {
-            this.#log.trace('not autodialing %p because they are already being dialed', peer.id)
+            this.log.trace('not autodialing %p because they are already being dialed', peer.id)
             return false
           }
 
           // remove peers already in the autodial queue
           if (this.queue.hasJob(peer.id)) {
-            this.#log.trace('not autodialing %p because they are already being autodialed', peer.id)
+            this.log.trace('not autodialing %p because they are already being autodialed', peer.id)
             return false
           }
 
@@ -249,7 +249,7 @@ export class AutoDial implements Startable {
       return Date.now() - lastDialFailureTimestamp > this.autoDialPeerRetryThresholdMs
     })
 
-    this.#log('selected %d/%d peers to dial', peersThatHaveNotFailed.length, peers.length)
+    this.log('selected %d/%d peers to dial', peersThatHaveNotFailed.length, peers.length)
 
     for (const peer of peersThatHaveNotFailed) {
       this.queue.add(async () => {
@@ -257,19 +257,19 @@ export class AutoDial implements Startable {
 
         // Check to see if we still need to auto dial
         if (numConnections >= this.minConnections) {
-          this.#log('got enough connections now %d/%d', numConnections, this.minConnections)
+          this.log('got enough connections now %d/%d', numConnections, this.minConnections)
           this.queue.clear()
           return
         }
 
-        this.#log('connecting to a peerStore stored peer %p', peer.id)
+        this.log('connecting to a peerStore stored peer %p', peer.id)
         await this.connectionManager.openConnection(peer.id, {
           priority: this.autoDialPriority
         })
       }, {
         peerId: peer.id
       }).catch(err => {
-        this.#log.error('could not connect to peerStore stored peer', err)
+        this.log.error('could not connect to peerStore stored peer', err)
       })
     }
 
@@ -279,7 +279,7 @@ export class AutoDial implements Startable {
       this.autoDialInterval = setTimeout(() => {
         this.autoDial()
           .catch(err => {
-            this.#log.error('error while autodialing', err)
+            this.log.error('error while autodialing', err)
           })
       }, this.autoDialIntervalMs)
     }

--- a/packages/libp2p/src/connection-manager/dial-queue.ts
+++ b/packages/libp2p/src/connection-manager/dial-queue.ts
@@ -85,7 +85,7 @@ export class DialQueue {
   private readonly pendingDialCount?: Metric
   private readonly shutDownController: AbortController
   private readonly connections: PeerMap<Connection[]>
-  readonly #log: Logger
+  private readonly log: Logger
 
   constructor (components: DialQueueComponents, init: DialerInit = {}) {
     this.addressSorter = init.addressSorter ?? defaultOptions.addressSorter
@@ -93,7 +93,7 @@ export class DialQueue {
     this.maxParallelDialsPerPeer = init.maxParallelDialsPerPeer ?? defaultOptions.maxParallelDialsPerPeer
     this.dialTimeout = init.dialTimeout ?? defaultOptions.dialTimeout
     this.connections = init.connections ?? new PeerMap()
-    this.#log = components.logger.forComponent('libp2p:connection-manager:dial-queue')
+    this.log = components.logger.forComponent('libp2p:connection-manager:dial-queue')
 
     this.peerId = components.peerId
     this.peerStore = components.peerStore
@@ -133,7 +133,7 @@ export class DialQueue {
     })
     // a started job errored
     this.queue.on('error', (err) => {
-      this.#log.error('error in dial queue', err)
+      this.log.error('error in dial queue', err)
       this.pendingDialCount?.update(this.queue.size)
       this.inProgressDialCount?.update(this.queue.pending)
     })
@@ -205,7 +205,7 @@ export class DialQueue {
     })
 
     if (existingConnection != null) {
-      this.#log('already connected to %a', existingConnection.remoteAddr)
+      this.log('already connected to %a', existingConnection.remoteAddr)
       return existingConnection
     }
 
@@ -226,12 +226,12 @@ export class DialQueue {
     })
 
     if (existingDial != null) {
-      this.#log('joining existing dial target for %p', peerId)
+      this.log('joining existing dial target for %p', peerId)
       signal.clear()
       return existingDial.promise
     }
 
-    this.#log('creating dial target for', addrsToDial.map(({ multiaddr }) => multiaddr.toString()))
+    this.log('creating dial target for', addrsToDial.map(({ multiaddr }) => multiaddr.toString()))
     // @ts-expect-error .promise property is set below
     const pendingDial: PendingDialInternal = {
       id: randomId(),
@@ -252,7 +252,7 @@ export class DialQueue {
         signal.clear()
       })
       .catch(async err => {
-        this.#log.error('dial failed to %s', pendingDial.multiaddrs.map(ma => ma.toString()).join(', '), err)
+        this.log.error('dial failed to %s', pendingDial.multiaddrs.map(ma => ma.toString()).join(', '), err)
 
         if (peerId != null) {
           // record the last failed dial
@@ -263,7 +263,7 @@ export class DialQueue {
               }
             })
           } catch (err: any) {
-            this.#log.error('could not update last dial failure key for %p', peerId, err)
+            this.log.error('could not update last dial failure key for %p', peerId, err)
           }
         }
 
@@ -294,12 +294,12 @@ export class DialQueue {
     })
 
     if (existingConnection != null) {
-      this.#log('already connected to %a', existingConnection.remoteAddr)
+      this.log('already connected to %a', existingConnection.remoteAddr)
       await connection.close()
       return existingConnection
     }
 
-    this.#log('connection opened to %a', connection.remoteAddr)
+    this.log('connection opened to %a', connection.remoteAddr)
     return connection
   }
 
@@ -334,11 +334,11 @@ export class DialQueue {
 
       // if just a peer id was passed, load available multiaddrs for this peer from the address book
       if (addrs.length === 0) {
-        this.#log('loading multiaddrs for %p', peerId)
+        this.log('loading multiaddrs for %p', peerId)
         try {
           const peer = await this.peerStore.get(peerId)
           addrs.push(...peer.addresses)
-          this.#log('loaded multiaddrs for %p', peerId, addrs.map(({ multiaddr }) => multiaddr.toString()))
+          this.log('loaded multiaddrs for %p', peerId, addrs.map(({ multiaddr }) => multiaddr.toString()))
         } catch (err: any) {
           if (err.code !== codes.ERR_NOT_FOUND) {
             throw err
@@ -352,7 +352,7 @@ export class DialQueue {
       addrs.map(async addr => {
         const result = await resolveMultiaddrs(addr.multiaddr, {
           ...options,
-          log: this.#log
+          log: this.log
         })
 
         if (result.length === 1 && result[0].equals(addr.multiaddr)) {
@@ -425,8 +425,8 @@ export class DialQueue {
     const dedupedMultiaddrs = [...dedupedAddrs.values()]
 
     if (dedupedMultiaddrs.length === 0 || dedupedMultiaddrs.length > this.maxPeerAddrsToDial) {
-      this.#log('addresses for %p before filtering', peerId ?? 'unknown peer', resolvedAddresses.map(({ multiaddr }) => multiaddr.toString()))
-      this.#log('addresses for %p after filtering', peerId ?? 'unknown peer', dedupedMultiaddrs.map(({ multiaddr }) => multiaddr.toString()))
+      this.log('addresses for %p before filtering', peerId ?? 'unknown peer', resolvedAddresses.map(({ multiaddr }) => multiaddr.toString()))
+      this.log('addresses for %p after filtering', peerId ?? 'unknown peer', dedupedMultiaddrs.map(({ multiaddr }) => multiaddr.toString()))
     }
 
     // make sure we actually have some addresses to dial
@@ -470,7 +470,7 @@ export class DialQueue {
         concurrency: this.maxParallelDialsPerPeer
       })
       peerDialQueue.on('error', (err) => {
-        this.#log.error('error dialling', err)
+        this.log.error('error dialling', err)
       })
 
       const conn = await Promise.any(pendingDial.multiaddrs.map(async (addr, i) => {
@@ -483,13 +483,13 @@ export class DialQueue {
         // let any signal abort the dial
         const signal = combineSignals(controller.signal, options.signal)
         signal.addEventListener('abort', () => {
-          this.#log('dial to %a aborted', addr)
+          this.log('dial to %a aborted', addr)
         })
         const deferred = pDefer<Connection>()
 
         await peerDialQueue.add(async () => {
           if (signal.aborted) {
-            this.#log('dial to %a was aborted before reaching the head of the peer dial queue', addr)
+            this.log('dial to %a was aborted before reaching the head of the peer dial queue', addr)
             deferred.reject(new AbortError())
             return
           }
@@ -498,7 +498,7 @@ export class DialQueue {
           await this.queue.add(async () => {
             try {
               if (signal.aborted) {
-                this.#log('dial to %a was aborted before reaching the head of the dial queue', addr)
+                this.log('dial to %a was aborted before reaching the head of the dial queue', addr)
                 deferred.reject(new AbortError())
                 return
               }
@@ -513,10 +513,10 @@ export class DialQueue {
 
               if (controller.signal.aborted) {
                 // another dial succeeded faster than this one
-                this.#log('multiple dials succeeded, closing superfluous connection')
+                this.log('multiple dials succeeded, closing superfluous connection')
 
                 conn.close().catch(err => {
-                  this.#log.error('error closing superfluous connection', err)
+                  this.log.error('error closing superfluous connection', err)
                 })
 
                 deferred.reject(new AbortError())
@@ -533,13 +533,13 @@ export class DialQueue {
                 }
               })
 
-              this.#log('dial to %a succeeded', addr)
+              this.log('dial to %a succeeded', addr)
 
               // resolve the connection promise
               deferred.resolve(conn)
             } catch (err: any) {
               // something only went wrong if our signal was not aborted
-              this.#log.error('error during dial of %a', addr, err)
+              this.log.error('error during dial of %a', addr, err)
               deferred.reject(err)
             }
           }, {

--- a/packages/libp2p/src/connection-manager/index.ts
+++ b/packages/libp2p/src/connection-manager/index.ts
@@ -186,7 +186,7 @@ export class DefaultConnectionManager implements ConnectionManager, Startable {
   private readonly peerStore: PeerStore
   private readonly metrics?: Metrics
   private readonly events: TypedEventTarget<Libp2pEvents>
-  readonly #log: Logger
+  private readonly log: Logger
 
   constructor (components: DefaultConnectionManagerComponents, init: ConnectionManagerInit = {}) {
     this.maxConnections = init.maxConnections ?? defaultOptions.maxConnections
@@ -205,7 +205,7 @@ export class DefaultConnectionManager implements ConnectionManager, Startable {
     this.peerStore = components.peerStore
     this.metrics = components.metrics
     this.events = components.events
-    this.#log = components.logger.forComponent('libp2p:connection-manager')
+    this.log = components.logger.forComponent('libp2p:connection-manager')
 
     this.onConnect = this.onConnect.bind(this)
     this.onDisconnect = this.onDisconnect.bind(this)
@@ -359,7 +359,7 @@ export class DefaultConnectionManager implements ConnectionManager, Startable {
     this.autoDial.start()
 
     this.started = true
-    this.#log('started')
+    this.log('started')
   }
 
   async afterStart (): Promise<void> {
@@ -376,13 +376,13 @@ export class DefaultConnectionManager implements ConnectionManager, Startable {
           keepAlivePeers.map(async peer => {
             await this.openConnection(peer.id)
               .catch(err => {
-                this.#log.error(err)
+                this.log.error(err)
               })
           })
         )
       })
       .catch(err => {
-        this.#log.error(err)
+        this.log.error(err)
       })
 
     this.autoDial.afterStart()
@@ -403,22 +403,22 @@ export class DefaultConnectionManager implements ConnectionManager, Startable {
           try {
             await connection.close()
           } catch (err) {
-            this.#log.error(err)
+            this.log.error(err)
           }
         })())
       }
     }
 
-    this.#log('closing %d connections', tasks.length)
+    this.log('closing %d connections', tasks.length)
     await Promise.all(tasks)
     this.connections.clear()
 
-    this.#log('stopped')
+    this.log('stopped')
   }
 
   onConnect (evt: CustomEvent<Connection>): void {
     void this._onConnect(evt).catch(err => {
-      this.#log.error(err)
+      this.log.error(err)
     })
   }
 
@@ -508,12 +508,12 @@ export class DefaultConnectionManager implements ConnectionManager, Startable {
     const { peerId } = getPeerAddress(peerIdOrMultiaddr)
 
     if (peerId != null && options.force !== true) {
-      this.#log('dial %p', peerId)
+      this.log('dial %p', peerId)
       const existingConnection = this.getConnections(peerId)
         .find(conn => !conn.transient)
 
       if (existingConnection != null) {
-        this.#log('had an existing non-transient connection to %p', peerId)
+        this.log('had an existing non-transient connection to %p', peerId)
 
         return existingConnection
       }
@@ -569,7 +569,7 @@ export class DefaultConnectionManager implements ConnectionManager, Startable {
     })
 
     if (denyConnection) {
-      this.#log('connection from %a refused - connection remote address was in deny list', maConn.remoteAddr)
+      this.log('connection from %a refused - connection remote address was in deny list', maConn.remoteAddr)
       return false
     }
 
@@ -586,7 +586,7 @@ export class DefaultConnectionManager implements ConnectionManager, Startable {
 
     // check pending connections
     if (this.incomingPendingConnections === this.maxIncomingPendingConnections) {
-      this.#log('connection from %a refused - incomingPendingConnections exceeded by host', maConn.remoteAddr)
+      this.log('connection from %a refused - incomingPendingConnections exceeded by host', maConn.remoteAddr)
       return false
     }
 
@@ -596,7 +596,7 @@ export class DefaultConnectionManager implements ConnectionManager, Startable {
       try {
         await this.inboundConnectionRateLimiter.consume(host, 1)
       } catch {
-        this.#log('connection from %a refused - inboundConnectionThreshold exceeded by host %s', maConn.remoteAddr, host)
+        this.log('connection from %a refused - inboundConnectionThreshold exceeded by host %s', maConn.remoteAddr, host)
         return false
       }
     }
@@ -607,7 +607,7 @@ export class DefaultConnectionManager implements ConnectionManager, Startable {
       return true
     }
 
-    this.#log('connection from %a refused - maxConnections exceeded', maConn.remoteAddr)
+    this.log('connection from %a refused - maxConnections exceeded', maConn.remoteAddr)
     return false
   }
 

--- a/packages/libp2p/src/connection/index.ts
+++ b/packages/libp2p/src/connection/index.ts
@@ -74,7 +74,7 @@ export class ConnectionImpl implements Connection {
    */
   private readonly _getStreams: () => Stream[]
 
-  readonly #log: Logger
+  private readonly log: Logger
 
   /**
    * An implementation of the js-libp2p connection.
@@ -92,7 +92,7 @@ export class ConnectionImpl implements Connection {
     this.multiplexer = init.multiplexer
     this.encryption = init.encryption
     this.transient = init.transient ?? false
-    this.#log = init.logger.forComponent('libp2p:connection')
+    this.log = init.logger.forComponent('libp2p:connection')
 
     if (this.remoteAddr.getPeerId() == null) {
       this.remoteAddr = this.remoteAddr.encapsulate(`/p2p/${this.remotePeer}`)
@@ -151,7 +151,7 @@ export class ConnectionImpl implements Connection {
       return
     }
 
-    this.#log('closing connection to %a', this.remoteAddr)
+    this.log('closing connection to %a', this.remoteAddr)
 
     this.status = 'closing'
 
@@ -166,35 +166,35 @@ export class ConnectionImpl implements Connection {
     }
 
     try {
-      this.#log.trace('closing all streams')
+      this.log.trace('closing all streams')
 
       // close all streams gracefully - this can throw if we're not multiplexed
       await Promise.all(
         this.streams.map(async s => s.close(options))
       )
 
-      this.#log.trace('closing underlying transport')
+      this.log.trace('closing underlying transport')
 
       // close raw connection
       await this._close(options)
 
-      this.#log.trace('updating timeline with close time')
+      this.log.trace('updating timeline with close time')
 
       this.status = 'closed'
       this.timeline.close = Date.now()
     } catch (err: any) {
-      this.#log.error('error encountered during graceful close of connection to %a', this.remoteAddr, err)
+      this.log.error('error encountered during graceful close of connection to %a', this.remoteAddr, err)
       this.abort(err)
     }
   }
 
   abort (err: Error): void {
-    this.#log.error('aborting connection to %a due to error', this.remoteAddr, err)
+    this.log.error('aborting connection to %a due to error', this.remoteAddr, err)
 
     this.status = 'closing'
     this.streams.forEach(s => { s.abort(err) })
 
-    this.#log.error('all streams aborted', this.streams.length)
+    this.log.error('all streams aborted', this.streams.length)
 
     // Abort raw connection
     this._abort(err)

--- a/packages/libp2p/src/get-peer.ts
+++ b/packages/libp2p/src/get-peer.ts
@@ -1,13 +1,10 @@
 import { CodeError } from '@libp2p/interface/errors'
 import { isPeerId } from '@libp2p/interface/peer-id'
-import { logger } from '@libp2p/logger'
 import { peerIdFromString } from '@libp2p/peer-id'
 import { isMultiaddr } from '@multiformats/multiaddr'
 import { codes } from './errors.js'
 import type { PeerId } from '@libp2p/interface/peer-id'
 import type { Multiaddr } from '@multiformats/multiaddr'
-
-const log = logger('libp2p:get-peer')
 
 export interface PeerAddress {
   peerId?: PeerId
@@ -35,7 +32,6 @@ export function getPeerAddress (peer: PeerId | Multiaddr | Multiaddr[]): PeerAdd
     // ensure PeerId is either not set or is consistent
     peer.forEach(ma => {
       if (!isMultiaddr(ma)) {
-        log.error('multiaddr %s was invalid', ma)
         throw new CodeError('Invalid Multiaddr', codes.ERR_INVALID_MULTIADDR)
       }
 

--- a/packages/libp2p/src/peer-routing.ts
+++ b/packages/libp2p/src/peer-routing.ts
@@ -27,13 +27,13 @@ export interface DefaultPeerRoutingComponents {
 }
 
 export class DefaultPeerRouting implements PeerRouting {
-  readonly #log: Logger
+  private readonly log: Logger
   private readonly peerId: PeerId
   private readonly peerStore: PeerStore
   private readonly routers: PeerRouting[]
 
   constructor (components: DefaultPeerRoutingComponents, init: PeerRoutingInit) {
-    this.#log = components.logger.forComponent('libp2p:peer-routing')
+    this.log = components.logger.forComponent('libp2p:peer-routing')
     this.peerId = components.peerId
     this.peerStore = components.peerStore
     this.routers = init.routers ?? []
@@ -59,7 +59,7 @@ export class DefaultPeerRouting implements PeerRouting {
           try {
             yield await router.findPeer(id, options)
           } catch (err) {
-            self.#log.error(err)
+            self.log.error(err)
           }
         })())
       ),

--- a/packages/libp2p/src/peer-routing.ts
+++ b/packages/libp2p/src/peer-routing.ts
@@ -1,5 +1,4 @@
 import { CodeError } from '@libp2p/interface/errors'
-import { logger } from '@libp2p/logger'
 import filter from 'it-filter'
 import first from 'it-first'
 import merge from 'it-merge'
@@ -10,13 +9,12 @@ import {
   requirePeers
 } from './content-routing/utils.js'
 import { codes, messages } from './errors.js'
-import type { AbortOptions } from '@libp2p/interface'
+import type { AbortOptions, Logger } from '@libp2p/interface'
 import type { PeerId } from '@libp2p/interface/peer-id'
 import type { PeerInfo } from '@libp2p/interface/peer-info'
 import type { PeerRouting } from '@libp2p/interface/peer-routing'
 import type { PeerStore } from '@libp2p/interface/peer-store'
-
-const log = logger('libp2p:peer-routing')
+import type { ComponentLogger } from '@libp2p/logger'
 
 export interface PeerRoutingInit {
   routers?: PeerRouting[]
@@ -25,14 +23,19 @@ export interface PeerRoutingInit {
 export interface DefaultPeerRoutingComponents {
   peerId: PeerId
   peerStore: PeerStore
+  logger: ComponentLogger
 }
 
 export class DefaultPeerRouting implements PeerRouting {
-  private readonly components: DefaultPeerRoutingComponents
+  readonly #log: Logger
+  private readonly peerId: PeerId
+  private readonly peerStore: PeerStore
   private readonly routers: PeerRouting[]
 
   constructor (components: DefaultPeerRoutingComponents, init: PeerRoutingInit) {
-    this.components = components
+    this.#log = components.logger.forComponent('libp2p:peer-routing')
+    this.peerId = components.peerId
+    this.peerStore = components.peerStore
     this.routers = init.routers ?? []
   }
 
@@ -44,9 +47,11 @@ export class DefaultPeerRouting implements PeerRouting {
       throw new CodeError('No peer routers available', codes.ERR_NO_ROUTERS_AVAILABLE)
     }
 
-    if (id.toString() === this.components.peerId.toString()) {
+    if (id.toString() === this.peerId.toString()) {
       throw new CodeError('Should not try to find self', codes.ERR_FIND_SELF)
     }
+
+    const self = this
 
     const output = await pipe(
       merge(
@@ -54,12 +59,12 @@ export class DefaultPeerRouting implements PeerRouting {
           try {
             yield await router.findPeer(id, options)
           } catch (err) {
-            log.error(err)
+            self.#log.error(err)
           }
         })())
       ),
       (source) => filter(source, Boolean),
-      (source) => storeAddresses(source, this.components.peerStore),
+      (source) => storeAddresses(source, this.peerStore),
       async (source) => first(source)
     )
 
@@ -82,7 +87,7 @@ export class DefaultPeerRouting implements PeerRouting {
       merge(
         ...this.routers.map(router => router.getClosestPeers(key, options))
       ),
-      (source) => storeAddresses(source, this.components.peerStore),
+      (source) => storeAddresses(source, this.peerStore),
       (source) => uniquePeers(source),
       (source) => requirePeers(source)
     )

--- a/packages/libp2p/src/registrar.ts
+++ b/packages/libp2p/src/registrar.ts
@@ -25,13 +25,13 @@ export interface RegistrarComponents {
  * Responsible for notifying registered protocols of events in the network.
  */
 export class DefaultRegistrar implements Registrar {
-  readonly #log: Logger
+  private readonly log: Logger
   private readonly topologies: Map<string, Map<string, Topology>>
   private readonly handlers: Map<string, StreamHandlerRecord>
   private readonly components: RegistrarComponents
 
   constructor (components: RegistrarComponents) {
-    this.#log = components.logger.forComponent('libp2p:registrar')
+    this.log = components.logger.forComponent('libp2p:registrar')
     this.topologies = new Map()
     this.handlers = new Map()
     this.components = components
@@ -179,7 +179,7 @@ export class DefaultRegistrar implements Registrar {
           return
         }
 
-        this.#log.error('could not inform topologies of disconnecting peer %p', remotePeer, err)
+        this.log.error('could not inform topologies of disconnecting peer %p', remotePeer, err)
       })
   }
 

--- a/packages/libp2p/src/registrar.ts
+++ b/packages/libp2p/src/registrar.ts
@@ -1,16 +1,14 @@
 import { CodeError } from '@libp2p/interface/errors'
-import { logger } from '@libp2p/logger'
 import merge from 'merge-options'
 import { codes } from './errors.js'
-import type { IdentifyResult, Libp2pEvents, PeerUpdate } from '@libp2p/interface'
+import type { IdentifyResult, Libp2pEvents, Logger, PeerUpdate } from '@libp2p/interface'
 import type { TypedEventTarget } from '@libp2p/interface/events'
 import type { PeerId } from '@libp2p/interface/peer-id'
 import type { PeerStore } from '@libp2p/interface/peer-store'
 import type { Topology } from '@libp2p/interface/topology'
 import type { ConnectionManager } from '@libp2p/interface-internal/connection-manager'
 import type { StreamHandlerOptions, StreamHandlerRecord, Registrar, StreamHandler } from '@libp2p/interface-internal/registrar'
-
-const log = logger('libp2p:registrar')
+import type { ComponentLogger } from '@libp2p/logger'
 
 export const DEFAULT_MAX_INBOUND_STREAMS = 32
 export const DEFAULT_MAX_OUTBOUND_STREAMS = 64
@@ -20,17 +18,20 @@ export interface RegistrarComponents {
   connectionManager: ConnectionManager
   peerStore: PeerStore
   events: TypedEventTarget<Libp2pEvents>
+  logger: ComponentLogger
 }
 
 /**
  * Responsible for notifying registered protocols of events in the network.
  */
 export class DefaultRegistrar implements Registrar {
+  readonly #log: Logger
   private readonly topologies: Map<string, Map<string, Topology>>
   private readonly handlers: Map<string, StreamHandlerRecord>
   private readonly components: RegistrarComponents
 
   constructor (components: RegistrarComponents) {
+    this.#log = components.logger.forComponent('libp2p:registrar')
     this.topologies = new Map()
     this.handlers = new Map()
     this.components = components
@@ -178,7 +179,7 @@ export class DefaultRegistrar implements Registrar {
           return
         }
 
-        log.error('could not inform topologies of disconnecting peer %p', remotePeer, err)
+        this.#log.error('could not inform topologies of disconnecting peer %p', remotePeer, err)
       })
   }
 

--- a/packages/libp2p/src/transport-manager.ts
+++ b/packages/libp2p/src/transport-manager.ts
@@ -25,7 +25,7 @@ export interface DefaultTransportManagerComponents {
 }
 
 export class DefaultTransportManager implements TransportManager, Startable {
-  readonly #log: Logger
+  private readonly log: Logger
   private readonly components: DefaultTransportManagerComponents
   private readonly transports: Map<string, Transport>
   private readonly listeners: Map<string, Listener[]>
@@ -33,7 +33,7 @@ export class DefaultTransportManager implements TransportManager, Startable {
   private started: boolean
 
   constructor (components: DefaultTransportManagerComponents, init: TransportManagerInit = {}) {
-    this.#log = components.logger.forComponent('libp2p:transports')
+    this.log = components.logger.forComponent('libp2p:transports')
     this.components = components
     this.started = false
     this.transports = new Map<string, Transport>()
@@ -58,7 +58,7 @@ export class DefaultTransportManager implements TransportManager, Startable {
       throw new CodeError(`There is already a transport with the tag ${tag}`, codes.ERR_DUPLICATE_TRANSPORT)
     }
 
-    this.#log('adding transport %s', tag)
+    this.log('adding transport %s', tag)
 
     this.transports.set(tag, transport)
 
@@ -88,7 +88,7 @@ export class DefaultTransportManager implements TransportManager, Startable {
   async stop (): Promise<void> {
     const tasks = []
     for (const [key, listeners] of this.listeners) {
-      this.#log('closing listeners for %s', key)
+      this.log('closing listeners for %s', key)
       while (listeners.length > 0) {
         const listener = listeners.pop()
 
@@ -101,7 +101,7 @@ export class DefaultTransportManager implements TransportManager, Startable {
     }
 
     await Promise.all(tasks)
-    this.#log('all listeners closed')
+    this.log('all listeners closed')
     for (const key of this.listeners.keys()) {
       this.listeners.set(key, [])
     }
@@ -182,7 +182,7 @@ export class DefaultTransportManager implements TransportManager, Startable {
     }
 
     if (addrs == null || addrs.length === 0) {
-      this.#log('no addresses were provided for listening, this node is dial only')
+      this.log('no addresses were provided for listening, this node is dial only')
       return
     }
 
@@ -194,7 +194,7 @@ export class DefaultTransportManager implements TransportManager, Startable {
 
       // For each supported multiaddr, create a listener
       for (const addr of supportedAddrs) {
-        this.#log('creating listener for %s on %a', key, addr)
+        this.log('creating listener for %s on %a', key, addr)
         const listener = transport.createListener({
           upgrader: this.components.upgrader
         })
@@ -253,7 +253,7 @@ export class DefaultTransportManager implements TransportManager, Startable {
       if (this.faultTolerance === FaultTolerance.FATAL_ALL) {
         throw new CodeError(message, codes.ERR_NO_VALID_ADDRESSES)
       }
-      this.#log(`libp2p in dial mode only: ${message}`)
+      this.log(`libp2p in dial mode only: ${message}`)
     }
   }
 
@@ -263,11 +263,11 @@ export class DefaultTransportManager implements TransportManager, Startable {
    */
   async remove (key: string): Promise<void> {
     const listeners = this.listeners.get(key) ?? []
-    this.#log.trace('removing transport %s', key)
+    this.log.trace('removing transport %s', key)
 
     // Close any running listeners
     const tasks = []
-    this.#log.trace('closing listeners for %s', key)
+    this.log.trace('closing listeners for %s', key)
     while (listeners.length > 0) {
       const listener = listeners.pop()
 

--- a/packages/libp2p/src/transport-manager.ts
+++ b/packages/libp2p/src/transport-manager.ts
@@ -1,9 +1,8 @@
 import { CodeError } from '@libp2p/interface/errors'
 import { trackedMap } from '@libp2p/interface/metrics/tracked-map'
 import { FaultTolerance } from '@libp2p/interface/transport'
-import { logger } from '@libp2p/logger'
 import { codes } from './errors.js'
-import type { Libp2pEvents, AbortOptions } from '@libp2p/interface'
+import type { Libp2pEvents, AbortOptions, ComponentLogger, Logger } from '@libp2p/interface'
 import type { Connection } from '@libp2p/interface/connection'
 import type { TypedEventTarget } from '@libp2p/interface/events'
 import type { Metrics } from '@libp2p/interface/metrics'
@@ -12,8 +11,6 @@ import type { Listener, Transport, Upgrader } from '@libp2p/interface/transport'
 import type { AddressManager } from '@libp2p/interface-internal/address-manager'
 import type { TransportManager } from '@libp2p/interface-internal/transport-manager'
 import type { Multiaddr } from '@multiformats/multiaddr'
-
-const log = logger('libp2p:transports')
 
 export interface TransportManagerInit {
   faultTolerance?: FaultTolerance
@@ -24,9 +21,11 @@ export interface DefaultTransportManagerComponents {
   addressManager: AddressManager
   upgrader: Upgrader
   events: TypedEventTarget<Libp2pEvents>
+  logger: ComponentLogger
 }
 
 export class DefaultTransportManager implements TransportManager, Startable {
+  readonly #log: Logger
   private readonly components: DefaultTransportManagerComponents
   private readonly transports: Map<string, Transport>
   private readonly listeners: Map<string, Listener[]>
@@ -34,6 +33,7 @@ export class DefaultTransportManager implements TransportManager, Startable {
   private started: boolean
 
   constructor (components: DefaultTransportManagerComponents, init: TransportManagerInit = {}) {
+    this.#log = components.logger.forComponent('libp2p:transports')
     this.components = components
     this.started = false
     this.transports = new Map<string, Transport>()
@@ -58,7 +58,7 @@ export class DefaultTransportManager implements TransportManager, Startable {
       throw new CodeError(`There is already a transport with the tag ${tag}`, codes.ERR_DUPLICATE_TRANSPORT)
     }
 
-    log('adding transport %s', tag)
+    this.#log('adding transport %s', tag)
 
     this.transports.set(tag, transport)
 
@@ -88,7 +88,7 @@ export class DefaultTransportManager implements TransportManager, Startable {
   async stop (): Promise<void> {
     const tasks = []
     for (const [key, listeners] of this.listeners) {
-      log('closing listeners for %s', key)
+      this.#log('closing listeners for %s', key)
       while (listeners.length > 0) {
         const listener = listeners.pop()
 
@@ -101,7 +101,7 @@ export class DefaultTransportManager implements TransportManager, Startable {
     }
 
     await Promise.all(tasks)
-    log('all listeners closed')
+    this.#log('all listeners closed')
     for (const key of this.listeners.keys()) {
       this.listeners.set(key, [])
     }
@@ -182,7 +182,7 @@ export class DefaultTransportManager implements TransportManager, Startable {
     }
 
     if (addrs == null || addrs.length === 0) {
-      log('no addresses were provided for listening, this node is dial only')
+      this.#log('no addresses were provided for listening, this node is dial only')
       return
     }
 
@@ -194,7 +194,7 @@ export class DefaultTransportManager implements TransportManager, Startable {
 
       // For each supported multiaddr, create a listener
       for (const addr of supportedAddrs) {
-        log('creating listener for %s on %a', key, addr)
+        this.#log('creating listener for %s on %a', key, addr)
         const listener = transport.createListener({
           upgrader: this.components.upgrader
         })
@@ -253,7 +253,7 @@ export class DefaultTransportManager implements TransportManager, Startable {
       if (this.faultTolerance === FaultTolerance.FATAL_ALL) {
         throw new CodeError(message, codes.ERR_NO_VALID_ADDRESSES)
       }
-      log(`libp2p in dial mode only: ${message}`)
+      this.#log(`libp2p in dial mode only: ${message}`)
     }
   }
 
@@ -263,11 +263,11 @@ export class DefaultTransportManager implements TransportManager, Startable {
    */
   async remove (key: string): Promise<void> {
     const listeners = this.listeners.get(key) ?? []
-    log.trace('removing transport %s', key)
+    this.#log.trace('removing transport %s', key)
 
     // Close any running listeners
     const tasks = []
-    log.trace('closing listeners for %s', key)
+    this.#log.trace('closing listeners for %s', key)
     while (listeners.length > 0) {
       const listener = listeners.pop()
 

--- a/packages/libp2p/src/upgrader.ts
+++ b/packages/libp2p/src/upgrader.ts
@@ -118,12 +118,12 @@ export class DefaultUpgrader implements Upgrader {
   private readonly inboundUpgradeTimeout: number
   private readonly events: TypedEventTarget<Libp2pEvents>
   private readonly logger: ComponentLogger
-  readonly #log: Logger
+  private readonly log: Logger
 
   constructor (components: DefaultUpgraderComponents, init: UpgraderInit) {
     this.components = components
     this.connectionEncryption = new Map()
-    this.#log = components.logger.forComponent('libp2p:upgrader')
+    this.log = components.logger.forComponent('libp2p:upgrader')
     this.logger = components.logger
 
     init.connectionEncryption.forEach(encrypter => {
@@ -183,7 +183,7 @@ export class DefaultUpgrader implements Upgrader {
 
       this.components.metrics?.trackMultiaddrConnection(maConn)
 
-      this.#log('starting the inbound connection upgrade')
+      this.log('starting the inbound connection upgrade')
 
       // Protect
       let protectedConn = maConn
@@ -192,7 +192,7 @@ export class DefaultUpgrader implements Upgrader {
         const protector = this.components.connectionProtector
 
         if (protector != null) {
-          this.#log('protecting the inbound connection')
+          this.log('protecting the inbound connection')
           protectedConn = await protector.protect(maConn)
         }
       }
@@ -239,13 +239,13 @@ export class DefaultUpgrader implements Upgrader {
           upgradedConn = multiplexed.stream
         }
       } catch (err: any) {
-        this.#log.error('Failed to upgrade inbound connection', err)
+        this.log.error('Failed to upgrade inbound connection', err)
         throw err
       }
 
       await this.shouldBlockConnection(remotePeer, maConn, 'denyInboundUpgradedConnection')
 
-      this.#log('Successfully upgraded inbound connection')
+      this.log('Successfully upgraded inbound connection')
 
       return this._createConnection({
         cryptoProtocol,
@@ -284,7 +284,7 @@ export class DefaultUpgrader implements Upgrader {
 
     this.components.metrics?.trackMultiaddrConnection(maConn)
 
-    this.#log('Starting the outbound connection upgrade')
+    this.log('Starting the outbound connection upgrade')
 
     // If the transport natively supports encryption, skip connection
     // protector and encryption
@@ -337,14 +337,14 @@ export class DefaultUpgrader implements Upgrader {
         upgradedConn = multiplexed.stream
       }
     } catch (err: any) {
-      this.#log.error('Failed to upgrade outbound connection', err)
+      this.log.error('Failed to upgrade outbound connection', err)
       await maConn.close(err)
       throw err
     }
 
     await this.shouldBlockConnection(remotePeer, maConn, 'denyOutboundUpgradedConnection')
 
-    this.#log('Successfully upgraded outbound connection')
+    this.log('Successfully upgraded outbound connection')
 
     return this._createConnection({
       cryptoProtocol,
@@ -389,7 +389,7 @@ export class DefaultUpgrader implements Upgrader {
             .then(async () => {
               const protocols = this.components.registrar.getProtocols()
               const { stream, protocol } = await mss.handle(muxedStream, protocols)
-              this.#log('%s: incoming stream opened on %s', direction, protocol)
+              this.log('%s: incoming stream opened on %s', direction, protocol)
 
               if (connection == null) {
                 return
@@ -422,7 +422,7 @@ export class DefaultUpgrader implements Upgrader {
               this._onStream({ connection, stream: muxedStream, protocol })
             })
             .catch(async err => {
-              this.#log.error(err)
+              this.log.error(err)
 
               if (muxedStream.timeline.close == null) {
                 await muxedStream.close()
@@ -436,12 +436,12 @@ export class DefaultUpgrader implements Upgrader {
           throw new CodeError('Stream is not multiplexed', codes.ERR_MUXER_UNAVAILABLE)
         }
 
-        this.#log('%s-%s: starting new stream on %s', connection.id, direction, protocols)
+        this.log('%s-%s: starting new stream on %s', connection.id, direction, protocols)
         const muxedStream = await muxer.newStream()
 
         try {
           if (options.signal == null) {
-            this.#log('No abort signal was passed while trying to negotiate protocols %s falling back to default timeout', protocols)
+            this.log('No abort signal was passed while trying to negotiate protocols %s falling back to default timeout', protocols)
 
             const signal = AbortSignal.timeout(DEFAULT_PROTOCOL_SELECT_TIMEOUT)
             setMaxListeners(Infinity, signal)
@@ -483,7 +483,7 @@ export class DefaultUpgrader implements Upgrader {
 
           return muxedStream
         } catch (err: any) {
-          this.#log.error('could not create new stream for protocols %s on connection with address %a', protocols, connection.remoteAddr, err)
+          this.log.error('could not create new stream for protocols %s on connection with address %a', protocols, connection.remoteAddr, err)
 
           if (muxedStream.timeline.close == null) {
             muxedStream.abort(err)
@@ -502,7 +502,7 @@ export class DefaultUpgrader implements Upgrader {
         muxer.sink(upgradedConn.source),
         upgradedConn.sink(muxer.source)
       ]).catch(err => {
-        this.#log.error(err)
+        this.log.error(err)
       })
     }
 
@@ -517,14 +517,14 @@ export class DefaultUpgrader implements Upgrader {
                 await connection.close()
               }
             } catch (err: any) {
-              this.#log.error(err)
+              this.log.error(err)
             } finally {
               this.events.safeDispatchEvent('connection:close', {
                 detail: connection
               })
             }
           })().catch(err => {
-            this.#log.error(err)
+            this.log.error(err)
           })
         }
 
@@ -553,14 +553,14 @@ export class DefaultUpgrader implements Upgrader {
       close: async (options?: AbortOptions) => {
         // Ensure remaining streams are closed gracefully
         if (muxer != null) {
-          this.#log.trace('close muxer')
+          this.log.trace('close muxer')
           await muxer.close(options)
         }
 
-        this.#log.trace('close maconn')
+        this.log.trace('close maconn')
         // close the underlying transport
         await maConn.close(options)
-        this.#log.trace('closed maconn')
+        this.log.trace('closed maconn')
       },
       abort: (err) => {
         maConn.abort(err)
@@ -597,7 +597,7 @@ export class DefaultUpgrader implements Upgrader {
    */
   async _encryptInbound (connection: Duplex<AsyncGenerator<Uint8Array>, Source<Uint8Array>>): Promise<CryptoResult> {
     const protocols = Array.from(this.connectionEncryption.keys())
-    this.#log('handling inbound crypto protocol selection', protocols)
+    this.log('handling inbound crypto protocol selection', protocols)
 
     try {
       const { stream, protocol } = await mss.handle(connection, protocols, {
@@ -610,7 +610,7 @@ export class DefaultUpgrader implements Upgrader {
         throw new Error(`no crypto module found for ${protocol}`)
       }
 
-      this.#log('encrypting inbound connection...')
+      this.log('encrypting inbound connection...')
 
       return {
         ...await encrypter.secureInbound(this.components.peerId, stream),
@@ -627,7 +627,7 @@ export class DefaultUpgrader implements Upgrader {
    */
   async _encryptOutbound (connection: MultiaddrConnection, remotePeerId?: PeerId): Promise<CryptoResult> {
     const protocols = Array.from(this.connectionEncryption.keys())
-    this.#log('selecting outbound crypto protocol', protocols)
+    this.log('selecting outbound crypto protocol', protocols)
 
     try {
       const { stream, protocol } = await mss.select(connection, protocols, {
@@ -640,7 +640,7 @@ export class DefaultUpgrader implements Upgrader {
         throw new Error(`no crypto module found for ${protocol}`)
       }
 
-      this.#log('encrypting outbound connection to %p', remotePeerId)
+      this.log('encrypting outbound connection to %p', remotePeerId)
 
       return {
         ...await encrypter.secureOutbound(this.components.peerId, stream, remotePeerId),
@@ -657,18 +657,18 @@ export class DefaultUpgrader implements Upgrader {
    */
   async _multiplexOutbound (connection: MultiaddrConnection, muxers: Map<string, StreamMuxerFactory>): Promise<{ stream: Duplex<AsyncGenerator<Uint8Array>, Source<Uint8Array>, Promise<void>>, muxerFactory?: StreamMuxerFactory }> {
     const protocols = Array.from(muxers.keys())
-    this.#log('outbound selecting muxer %s', protocols)
+    this.log('outbound selecting muxer %s', protocols)
     try {
       const { stream, protocol } = await mss.select(connection, protocols, {
         writeBytes: true,
         log: this.logger.forComponent('libp2p:mss:select')
       })
-      this.#log('%s selected as muxer protocol', protocol)
+      this.log('%s selected as muxer protocol', protocol)
       const muxerFactory = muxers.get(protocol)
 
       return { stream, muxerFactory }
     } catch (err: any) {
-      this.#log.error('error multiplexing outbound stream', err)
+      this.log.error('error multiplexing outbound stream', err)
       throw new CodeError(String(err), codes.ERR_MUXER_UNAVAILABLE)
     }
   }
@@ -679,7 +679,7 @@ export class DefaultUpgrader implements Upgrader {
    */
   async _multiplexInbound (connection: MultiaddrConnection, muxers: Map<string, StreamMuxerFactory>): Promise<{ stream: Duplex<AsyncGenerator<Uint8Array>, Source<Uint8Array>, Promise<void>>, muxerFactory?: StreamMuxerFactory }> {
     const protocols = Array.from(muxers.keys())
-    this.#log('inbound handling muxers %s', protocols)
+    this.log('inbound handling muxers %s', protocols)
     try {
       const { stream, protocol } = await mss.handle(connection, protocols, {
         writeBytes: true,
@@ -689,7 +689,7 @@ export class DefaultUpgrader implements Upgrader {
 
       return { stream, muxerFactory }
     } catch (err: any) {
-      this.#log.error('error multiplexing inbound stream', err)
+      this.log.error('error multiplexing inbound stream', err)
       throw new CodeError(String(err), codes.ERR_MUXER_UNAVAILABLE)
     }
   }

--- a/packages/libp2p/test/addresses/address-manager.spec.ts
+++ b/packages/libp2p/test/addresses/address-manager.spec.ts
@@ -1,6 +1,7 @@
 /* eslint-env mocha */
 
 import { TypedEventEmitter, type TypedEventTarget } from '@libp2p/interface/events'
+import { defaultLogger } from '@libp2p/logger'
 import { createEd25519PeerId } from '@libp2p/peer-id-factory'
 import { multiaddr } from '@multiformats/multiaddr'
 import { expect } from 'aegir/chai'
@@ -34,7 +35,8 @@ describe('Address Manager', () => {
       peerId,
       transportManager: stubInterface<TransportManager>(),
       peerStore,
-      events
+      events,
+      logger: defaultLogger()
     }, {
       announceFilter: stubInterface<AddressFilter>()
     })
@@ -48,7 +50,8 @@ describe('Address Manager', () => {
       peerId,
       transportManager: stubInterface<TransportManager>(),
       peerStore,
-      events
+      events,
+      logger: defaultLogger()
     }, {
       announceFilter: stubInterface<AddressFilter>(),
       listen: listenAddresses
@@ -68,7 +71,8 @@ describe('Address Manager', () => {
       peerId,
       transportManager: stubInterface<TransportManager>(),
       peerStore,
-      events
+      events,
+      logger: defaultLogger()
     }, {
       announceFilter: stubInterface<AddressFilter>(),
       listen: listenAddresses,
@@ -88,7 +92,8 @@ describe('Address Manager', () => {
       peerId,
       transportManager: stubInterface<TransportManager>(),
       peerStore,
-      events
+      events,
+      logger: defaultLogger()
     }, {
       announceFilter: stubInterface<AddressFilter>()
     })
@@ -106,7 +111,8 @@ describe('Address Manager', () => {
       peerId,
       transportManager: stubInterface<TransportManager>(),
       peerStore,
-      events
+      events,
+      logger: defaultLogger()
     }, {
       announceFilter: stubInterface<AddressFilter>(),
       listen: [
@@ -127,7 +133,8 @@ describe('Address Manager', () => {
       peerId,
       transportManager: stubInterface<TransportManager>(),
       peerStore,
-      events
+      events,
+      logger: defaultLogger()
     }, {
       announceFilter: stubInterface<AddressFilter>()
     })
@@ -150,7 +157,8 @@ describe('Address Manager', () => {
         getAddrs: Sinon.stub().returns([])
       }),
       peerStore,
-      events
+      events,
+      logger: defaultLogger()
     })
 
     am.confirmObservedAddr(multiaddr(ma))
@@ -170,7 +178,8 @@ describe('Address Manager', () => {
       peerId,
       transportManager: stubInterface<TransportManager>(),
       peerStore,
-      events
+      events,
+      logger: defaultLogger()
     })
 
     expect(am.getObservedAddrs()).to.be.empty()
@@ -188,7 +197,8 @@ describe('Address Manager', () => {
       peerId,
       transportManager: stubInterface<TransportManager>(),
       peerStore,
-      events
+      events,
+      logger: defaultLogger()
     })
 
     expect(am.getObservedAddrs()).to.be.empty()
@@ -207,7 +217,8 @@ describe('Address Manager', () => {
       peerId,
       transportManager,
       peerStore,
-      events
+      events,
+      logger: defaultLogger()
     }, {
       listen: [ma],
       announce: []

--- a/packages/libp2p/test/connection-manager/auto-dial.spec.ts
+++ b/packages/libp2p/test/connection-manager/auto-dial.spec.ts
@@ -1,6 +1,7 @@
 /* eslint-env mocha */
 
 import { TypedEventEmitter, type TypedEventTarget } from '@libp2p/interface/events'
+import { defaultLogger } from '@libp2p/logger'
 import { PeerMap } from '@libp2p/peer-collections'
 import { createEd25519PeerId } from '@libp2p/peer-id-factory'
 import { PersistentPeerStore } from '@libp2p/peer-store'
@@ -34,7 +35,8 @@ describe('auto-dial', () => {
     peerStore = new PersistentPeerStore({
       datastore: new MemoryDatastore(),
       events,
-      peerId
+      peerId,
+      logger: defaultLogger()
     })
   })
 

--- a/packages/libp2p/test/connection-manager/direct.node.ts
+++ b/packages/libp2p/test/connection-manager/direct.node.ts
@@ -9,6 +9,7 @@ import { AbortError, ERR_TIMEOUT } from '@libp2p/interface/errors'
 import { TypedEventEmitter } from '@libp2p/interface/events'
 import { start, stop } from '@libp2p/interface/startable'
 import { mockConnection, mockConnectionGater, mockDuplex, mockMultiaddrConnection, mockUpgrader } from '@libp2p/interface-compliance-tests/mocks'
+import { defaultLogger } from '@libp2p/logger'
 import { mplex } from '@libp2p/mplex'
 import { peerIdFromString } from '@libp2p/peer-id'
 import { createEd25519PeerId } from '@libp2p/peer-id-factory'
@@ -73,7 +74,9 @@ describe('dialing (direct, TCP)', () => {
       ]
     })
     remoteTM = remoteComponents.transportManager = new DefaultTransportManager(remoteComponents)
-    remoteTM.add(tcp()())
+    remoteTM.add(tcp()({
+      logger: defaultLogger()
+    }))
 
     const localEvents = new TypedEventEmitter()
     localComponents = defaultComponents({
@@ -92,7 +95,9 @@ describe('dialing (direct, TCP)', () => {
     })
     localComponents.addressManager = new DefaultAddressManager(localComponents)
     localTM = localComponents.transportManager = new DefaultTransportManager(localComponents)
-    localTM.add(tcp()())
+    localTM.add(tcp()({
+      logger: defaultLogger()
+    }))
 
     await start(localComponents)
     await start(remoteComponents)

--- a/packages/libp2p/test/connection-manager/direct.spec.ts
+++ b/packages/libp2p/test/connection-manager/direct.spec.ts
@@ -5,6 +5,7 @@ import { type Identify, identify } from '@libp2p/identify'
 import { AbortError, ERR_TIMEOUT } from '@libp2p/interface/errors'
 import { TypedEventEmitter } from '@libp2p/interface/events'
 import { mockConnectionGater, mockDuplex, mockMultiaddrConnection, mockUpgrader, mockConnection } from '@libp2p/interface-compliance-tests/mocks'
+import { defaultLogger } from '@libp2p/logger'
 import { mplex } from '@libp2p/mplex'
 import { peerIdFromString } from '@libp2p/peer-id'
 import { createEd25519PeerId } from '@libp2p/peer-id-factory'
@@ -64,7 +65,9 @@ describe('dialing (direct, WebSockets)', () => {
     })
 
     localTM = new DefaultTransportManager(localComponents)
-    localTM.add(webSockets({ filter: filters.all })())
+    localTM.add(webSockets({ filter: filters.all })({
+      logger: defaultLogger()
+    }))
     localComponents.transportManager = localTM
 
     // this peer is spun up in .aegir.cjs

--- a/packages/libp2p/test/registrar/registrar.spec.ts
+++ b/packages/libp2p/test/registrar/registrar.spec.ts
@@ -3,6 +3,7 @@
 import { yamux } from '@chainsafe/libp2p-yamux'
 import { TypedEventEmitter, type TypedEventTarget } from '@libp2p/interface/events'
 import { mockDuplex, mockMultiaddrConnection, mockUpgrader, mockConnection } from '@libp2p/interface-compliance-tests/mocks'
+import { defaultLogger } from '@libp2p/logger'
 import { mplex } from '@libp2p/mplex'
 import { createEd25519PeerId } from '@libp2p/peer-id-factory'
 import { PersistentPeerStore } from '@libp2p/peer-store'
@@ -91,7 +92,8 @@ describe('registrar', () => {
         peerId,
         connectionManager,
         peerStore,
-        events
+        events,
+        logger: defaultLogger()
       })
     })
 

--- a/packages/libp2p/test/transports/transport-manager.node.ts
+++ b/packages/libp2p/test/transports/transport-manager.node.ts
@@ -4,6 +4,7 @@ import { TypedEventEmitter } from '@libp2p/interface/events'
 import { start, stop } from '@libp2p/interface/startable'
 import { FaultTolerance } from '@libp2p/interface/transport'
 import { mockUpgrader } from '@libp2p/interface-compliance-tests/mocks'
+import { defaultLogger } from '@libp2p/logger'
 import { createEd25519PeerId } from '@libp2p/peer-id-factory'
 import { PersistentPeerStore } from '@libp2p/peer-store'
 import { tcp } from '@libp2p/tcp'
@@ -60,14 +61,18 @@ describe('Transport Manager (TCP)', () => {
 
   it('should be able to add and remove a transport', async () => {
     expect(tm.getTransports()).to.have.lengthOf(0)
-    tm.add(tcp()())
+    tm.add(tcp()({
+      logger: defaultLogger()
+    }))
     expect(tm.getTransports()).to.have.lengthOf(1)
     await tm.remove('@libp2p/tcp')
     expect(tm.getTransports()).to.have.lengthOf(0)
   })
 
   it('should be able to listen', async () => {
-    const transport = tcp()()
+    const transport = tcp()({
+      logger: defaultLogger()
+    })
 
     expect(tm.getTransports()).to.be.empty()
 
@@ -85,7 +90,9 @@ describe('Transport Manager (TCP)', () => {
   })
 
   it('should be able to dial', async () => {
-    tm.add(tcp()())
+    tm.add(tcp()({
+      logger: defaultLogger()
+    }))
     await tm.listen(addrs)
     const addr = tm.getAddrs().shift()
 
@@ -99,7 +106,9 @@ describe('Transport Manager (TCP)', () => {
   })
 
   it('should remove listeners when they stop listening', async () => {
-    const transport = tcp()()
+    const transport = tcp()({
+      logger: defaultLogger()
+    })
     tm.add(transport)
 
     expect(tm.getListeners()).to.have.lengthOf(0)

--- a/packages/libp2p/test/transports/transport-manager.spec.ts
+++ b/packages/libp2p/test/transports/transport-manager.spec.ts
@@ -4,6 +4,7 @@ import { TypedEventEmitter } from '@libp2p/interface/events'
 import { start, stop } from '@libp2p/interface/startable'
 import { FaultTolerance } from '@libp2p/interface/transport'
 import { mockUpgrader } from '@libp2p/interface-compliance-tests/mocks'
+import { defaultLogger } from '@libp2p/logger'
 import { createEd25519PeerId } from '@libp2p/peer-id-factory'
 import { plaintext } from '@libp2p/plaintext'
 import { webSockets } from '@libp2p/websockets'
@@ -30,7 +31,8 @@ describe('Transport Manager (WebSockets)', () => {
     components = {
       peerId: await createEd25519PeerId(),
       events,
-      upgrader: mockUpgrader({ events })
+      upgrader: mockUpgrader({ events }),
+      logger: defaultLogger()
     } as any
     components.addressManager = new DefaultAddressManager(components, { listen: [listenAddr.toString()] })
 
@@ -52,7 +54,9 @@ describe('Transport Manager (WebSockets)', () => {
     })
 
     expect(tm.getTransports()).to.have.lengthOf(0)
-    tm.add(transport())
+    tm.add(transport({
+      logger: defaultLogger()
+    }))
 
     expect(tm.getTransports()).to.have.lengthOf(1)
     await tm.remove('@libp2p/websockets')
@@ -60,17 +64,23 @@ describe('Transport Manager (WebSockets)', () => {
   })
 
   it('should not be able to add a transport twice', async () => {
-    tm.add(webSockets()())
+    tm.add(webSockets()({
+      logger: defaultLogger()
+    }))
 
     expect(() => {
-      tm.add(webSockets()())
+      tm.add(webSockets()({
+        logger: defaultLogger()
+      }))
     })
       .to.throw()
       .and.to.have.property('code', ErrorCodes.ERR_DUPLICATE_TRANSPORT)
   })
 
   it('should be able to dial', async () => {
-    tm.add(webSockets({ filter: filters.all })())
+    tm.add(webSockets({ filter: filters.all })({
+      logger: defaultLogger()
+    }))
     const addr = multiaddr(process.env.RELAY_MULTIADDR)
     const connection = await tm.dial(addr)
     expect(connection).to.exist()
@@ -78,7 +88,9 @@ describe('Transport Manager (WebSockets)', () => {
   })
 
   it('should fail to dial an unsupported address', async () => {
-    tm.add(webSockets({ filter: filters.all })())
+    tm.add(webSockets({ filter: filters.all })({
+      logger: defaultLogger()
+    }))
     const addr = multiaddr('/ip4/127.0.0.1/tcp/0')
     await expect(tm.dial(addr))
       .to.eventually.be.rejected()
@@ -87,7 +99,9 @@ describe('Transport Manager (WebSockets)', () => {
 
   it('should fail to listen with no valid address', async () => {
     tm = new DefaultTransportManager(components)
-    tm.add(webSockets({ filter: filters.all })())
+    tm.add(webSockets({ filter: filters.all })({
+      logger: defaultLogger()
+    }))
 
     await expect(start(tm))
       .to.eventually.be.rejected()

--- a/packages/libp2p/test/upgrading/upgrader.spec.ts
+++ b/packages/libp2p/test/upgrading/upgrader.spec.ts
@@ -78,9 +78,9 @@ describe('Upgrader', () => {
     })
     localComponents.peerStore = new PersistentPeerStore(localComponents)
     localComponents.connectionManager = mockConnectionManager(localComponents)
-    localMuxerFactory = mplex()()
+    localMuxerFactory = mplex()(localComponents)
     localYamuxerFactory = yamux()()
-    localConnectionEncrypter = plaintext()()
+    localConnectionEncrypter = plaintext()(localComponents)
     localUpgrader = new DefaultUpgrader(localComponents, {
       connectionEncryption: [
         localConnectionEncrypter
@@ -105,9 +105,9 @@ describe('Upgrader', () => {
     })
     remoteComponents.peerStore = new PersistentPeerStore(remoteComponents)
     remoteComponents.connectionManager = mockConnectionManager(remoteComponents)
-    remoteMuxerFactory = mplex()()
+    remoteMuxerFactory = mplex()(remoteComponents)
     remoteYamuxerFactory = yamux()()
-    remoteConnectionEncrypter = plaintext()()
+    remoteConnectionEncrypter = plaintext()(remoteComponents)
     remoteUpgrader = new DefaultUpgrader(remoteComponents, {
       connectionEncryption: [
         remoteConnectionEncrypter
@@ -171,14 +171,14 @@ describe('Upgrader', () => {
     // No available muxers
     localUpgrader = new DefaultUpgrader(localComponents, {
       connectionEncryption: [
-        plaintext()()
+        plaintext()(localComponents)
       ],
       muxers: [],
       inboundUpgradeTimeout: 1000
     })
     remoteUpgrader = new DefaultUpgrader(remoteComponents, {
       connectionEncryption: [
-        plaintext()()
+        plaintext()(localComponents)
       ],
       muxers: [],
       inboundUpgradeTimeout: 1000
@@ -285,7 +285,7 @@ describe('Upgrader', () => {
 
     localUpgrader = new DefaultUpgrader(localComponents, {
       connectionEncryption: [
-        plaintext()()
+        plaintext()(localComponents)
       ],
       muxers: [
         yamux()()
@@ -294,7 +294,7 @@ describe('Upgrader', () => {
     })
     remoteUpgrader = new DefaultUpgrader(remoteComponents, {
       connectionEncryption: [
-        plaintext()()
+        plaintext()(localComponents)
       ],
       muxers: [
         yamux()()
@@ -347,7 +347,7 @@ describe('Upgrader', () => {
 
     localUpgrader = new DefaultUpgrader(localComponents, {
       connectionEncryption: [
-        plaintext()()
+        plaintext()(localComponents)
       ],
       muxers: [
         new OtherMuxerFactory()
@@ -356,11 +356,11 @@ describe('Upgrader', () => {
     })
     remoteUpgrader = new DefaultUpgrader(remoteComponents, {
       connectionEncryption: [
-        plaintext()()
+        plaintext()(localComponents)
       ],
       muxers: [
         yamux()(),
-        mplex()()
+        mplex()(localComponents)
       ],
       inboundUpgradeTimeout: 1000
     })

--- a/packages/metrics-prometheus/package.json
+++ b/packages/metrics-prometheus/package.json
@@ -44,13 +44,13 @@
   },
   "dependencies": {
     "@libp2p/interface": "^0.1.6",
-    "@libp2p/logger": "^3.1.0",
     "it-foreach": "^2.0.3",
     "it-stream-types": "^2.0.1",
     "prom-client": "^15.0.0"
   },
   "devDependencies": {
     "@libp2p/interface-compliance-tests": "^4.1.5",
+    "@libp2p/logger": "^3.1.0",
     "@libp2p/peer-id-factory": "^3.0.8",
     "@multiformats/multiaddr": "^12.1.10",
     "aegir": "^41.0.2",

--- a/packages/metrics-prometheus/src/index.ts
+++ b/packages/metrics-prometheus/src/index.ts
@@ -204,29 +204,29 @@ export interface PrometheusMetricsComponents {
 }
 
 class PrometheusMetrics implements Metrics {
-  #log: Logger
+  private readonly log: Logger
   private transferStats: Map<string, number>
   private readonly registry?: Registry
 
   constructor (components: PrometheusMetricsComponents, init?: Partial<PrometheusMetricsInit>) {
-    this.#log = components.logger.forComponent('libp2p:prometheus-metrics')
+    this.log = components.logger.forComponent('libp2p:prometheus-metrics')
     this.registry = init?.registry
 
     if (init?.preserveExistingMetrics !== true) {
-      this.#log('Clearing existing metrics')
+      this.log('Clearing existing metrics')
       metrics.clear()
       ;(this.registry ?? register).clear()
     }
 
     if (init?.collectDefaultMetrics !== false) {
-      this.#log('Collecting default metrics')
+      this.log('Collecting default metrics')
       collectDefaultMetrics({ ...init?.defaultMetrics, register: this.registry ?? init?.defaultMetrics?.register })
     }
 
     // holds global and per-protocol sent/received stats
     this.transferStats = new Map()
 
-    this.#log('Collecting data transfer metrics')
+    this.log('Collecting data transfer metrics')
     this.registerCounterGroup('libp2p_data_transfer_bytes_total', {
       label: 'protocol',
       calculate: () => {
@@ -243,7 +243,7 @@ class PrometheusMetrics implements Metrics {
       }
     })
 
-    this.#log('Collecting memory metrics')
+    this.log('Collecting memory metrics')
     this.registerMetricGroup('nodejs_memory_usage_bytes', {
       label: 'memory',
       calculate: () => {
@@ -308,7 +308,7 @@ class PrometheusMetrics implements Metrics {
     let metric = metrics.get(name)
 
     if (metrics.has(name)) {
-      this.#log('Reuse existing metric', name)
+      this.log('Reuse existing metric', name)
 
       if (opts.calculate != null) {
         metric.addCalculator(opts.calculate)
@@ -317,7 +317,7 @@ class PrometheusMetrics implements Metrics {
       return metrics.get(name)
     }
 
-    this.#log('Register metric', name)
+    this.log('Register metric', name)
     metric = new PrometheusMetric(name, { registry: this.registry, ...opts })
 
     metrics.set(name, metric)
@@ -337,7 +337,7 @@ class PrometheusMetrics implements Metrics {
     let metricGroup = metrics.get(name)
 
     if (metricGroup != null) {
-      this.#log('Reuse existing metric group', name)
+      this.log('Reuse existing metric group', name)
 
       if (opts.calculate != null) {
         metricGroup.addCalculator(opts.calculate)
@@ -346,7 +346,7 @@ class PrometheusMetrics implements Metrics {
       return metricGroup
     }
 
-    this.#log('Register metric group', name)
+    this.log('Register metric group', name)
     metricGroup = new PrometheusMetricGroup(name, { registry: this.registry, ...opts })
 
     metrics.set(name, metricGroup)
@@ -366,7 +366,7 @@ class PrometheusMetrics implements Metrics {
     let counter = metrics.get(name)
 
     if (counter != null) {
-      this.#log('Reuse existing counter', name)
+      this.log('Reuse existing counter', name)
 
       if (opts.calculate != null) {
         counter.addCalculator(opts.calculate)
@@ -375,7 +375,7 @@ class PrometheusMetrics implements Metrics {
       return metrics.get(name)
     }
 
-    this.#log('Register counter', name)
+    this.log('Register counter', name)
     counter = new PrometheusCounter(name, { registry: this.registry, ...opts })
 
     metrics.set(name, counter)
@@ -395,7 +395,7 @@ class PrometheusMetrics implements Metrics {
     let counterGroup = metrics.get(name)
 
     if (counterGroup != null) {
-      this.#log('Reuse existing counter group', name)
+      this.log('Reuse existing counter group', name)
 
       if (opts.calculate != null) {
         counterGroup.addCalculator(opts.calculate)
@@ -404,7 +404,7 @@ class PrometheusMetrics implements Metrics {
       return counterGroup
     }
 
-    this.#log('Register counter group', name)
+    this.log('Register counter group', name)
     counterGroup = new PrometheusCounterGroup(name, { registry: this.registry, ...opts })
 
     metrics.set(name, counterGroup)

--- a/packages/metrics-prometheus/test/counter-groups.spec.ts
+++ b/packages/metrics-prometheus/test/counter-groups.spec.ts
@@ -1,3 +1,4 @@
+import { defaultLogger } from '@libp2p/logger'
 import { expect } from 'aegir/chai'
 import client from 'prom-client'
 import { prometheusMetrics } from '../src/index.js'
@@ -8,7 +9,9 @@ describe('counter groups', () => {
     const metricName = randomMetricName()
     const metricKey = randomMetricName('key_')
     const metricLabel = randomMetricName('label_')
-    const metrics = prometheusMetrics()()
+    const metrics = prometheusMetrics()({
+      logger: defaultLogger()
+    })
     const metric = metrics.registerCounterGroup(metricName, {
       label: metricLabel
     })
@@ -24,7 +27,9 @@ describe('counter groups', () => {
     const metricKey = randomMetricName('key_')
     const metricLabel = randomMetricName('label_')
     const metricValue = 5
-    const metrics = prometheusMetrics()()
+    const metrics = prometheusMetrics()({
+      logger: defaultLogger()
+    })
     const metric = metrics.registerCounterGroup(metricName, {
       label: metricLabel
     })
@@ -40,7 +45,9 @@ describe('counter groups', () => {
     const metricKey = randomMetricName('key_')
     const metricLabel = randomMetricName('label_')
     const metricValue = 5
-    const metrics = prometheusMetrics()()
+    const metrics = prometheusMetrics()({
+      logger: defaultLogger()
+    })
     metrics.registerCounterGroup(metricName, {
       label: metricLabel,
       calculate: () => {
@@ -58,7 +65,9 @@ describe('counter groups', () => {
     const metricKey = randomMetricName('key_')
     const metricLabel = randomMetricName('label_')
     const metricValue = 5
-    const metrics = prometheusMetrics()()
+    const metrics = prometheusMetrics()({
+      logger: defaultLogger()
+    })
     metrics.registerCounterGroup(metricName, {
       label: metricLabel,
       calculate: async () => {
@@ -76,7 +85,9 @@ describe('counter groups', () => {
     const metricKey = randomMetricName('key_')
     const metricLabel = randomMetricName('label_')
     const metricValue = 5
-    const metrics = prometheusMetrics()()
+    const metrics = prometheusMetrics()({
+      logger: defaultLogger()
+    })
     const metric = metrics.registerCounterGroup(metricName, {
       label: metricLabel
     })
@@ -98,7 +109,9 @@ describe('counter groups', () => {
     const metricLabel = randomMetricName('label_')
     const metricValue1 = 5
     const metricValue2 = 7
-    const metrics = prometheusMetrics()()
+    const metrics = prometheusMetrics()({
+      logger: defaultLogger()
+    })
     const metric1 = metrics.registerCounterGroup(metricName, {
       label: metricLabel
     })

--- a/packages/metrics-prometheus/test/counters.spec.ts
+++ b/packages/metrics-prometheus/test/counters.spec.ts
@@ -1,3 +1,4 @@
+import { defaultLogger } from '@libp2p/logger'
 import { expect } from 'aegir/chai'
 import client from 'prom-client'
 import { prometheusMetrics } from '../src/index.js'
@@ -6,7 +7,9 @@ import { randomMetricName } from './fixtures/random-metric-name.js'
 describe('counters', () => {
   it('should set a counter', async () => {
     const metricName = randomMetricName()
-    const metrics = prometheusMetrics()()
+    const metrics = prometheusMetrics()({
+      logger: defaultLogger()
+    })
     const metric = metrics.registerCounter(metricName)
     metric.increment()
 
@@ -18,7 +21,9 @@ describe('counters', () => {
   it('should increment a counter with a value', async () => {
     const metricName = randomMetricName()
     const metricValue = 5
-    const metrics = prometheusMetrics()()
+    const metrics = prometheusMetrics()({
+      logger: defaultLogger()
+    })
     const metric = metrics.registerCounter(metricName)
     metric.increment(metricValue)
 
@@ -28,7 +33,9 @@ describe('counters', () => {
   it('should calculate a counter', async () => {
     const metricName = randomMetricName()
     const metricValue = 5
-    const metrics = prometheusMetrics()()
+    const metrics = prometheusMetrics()({
+      logger: defaultLogger()
+    })
     metrics.registerCounter(metricName, {
       calculate: () => {
         return metricValue
@@ -41,7 +48,9 @@ describe('counters', () => {
   it('should promise to calculate a counter', async () => {
     const metricName = randomMetricName()
     const metricValue = 5
-    const metrics = prometheusMetrics()()
+    const metrics = prometheusMetrics()({
+      logger: defaultLogger()
+    })
     metrics.registerCounter(metricName, {
       calculate: async () => {
         return metricValue
@@ -54,7 +63,9 @@ describe('counters', () => {
   it('should reset a counter', async () => {
     const metricName = randomMetricName()
     const metricValue = 5
-    const metrics = prometheusMetrics()()
+    const metrics = prometheusMetrics()({
+      logger: defaultLogger()
+    })
     const metric = metrics.registerCounter(metricName)
     metric.increment(metricValue)
 
@@ -70,7 +81,9 @@ describe('counters', () => {
     const metricLabel = randomMetricName('label_')
     const metricValue1 = 5
     const metricValue2 = 7
-    const metrics = prometheusMetrics()()
+    const metrics = prometheusMetrics()({
+      logger: defaultLogger()
+    })
     const metric1 = metrics.registerCounter(metricName, {
       label: metricLabel
     })

--- a/packages/metrics-prometheus/test/custom-registry.spec.ts
+++ b/packages/metrics-prometheus/test/custom-registry.spec.ts
@@ -1,3 +1,4 @@
+import { defaultLogger } from '@libp2p/logger'
 import { expect } from 'aegir/chai'
 import client, { Registry } from 'prom-client'
 import { prometheusMetrics } from '../src/index.js'
@@ -8,7 +9,9 @@ describe('custom registry', () => {
     const metricName = randomMetricName()
     const metricValue = 5
     const registry = new Registry()
-    const metrics = prometheusMetrics({ registry })()
+    const metrics = prometheusMetrics({ registry })({
+      logger: defaultLogger()
+    })
     const metric = metrics.registerMetric(metricName)
     metric.update(metricValue)
 

--- a/packages/metrics-prometheus/test/metric-groups.spec.ts
+++ b/packages/metrics-prometheus/test/metric-groups.spec.ts
@@ -1,3 +1,4 @@
+import { defaultLogger } from '@libp2p/logger'
 import { expect } from 'aegir/chai'
 import client from 'prom-client'
 import { prometheusMetrics } from '../src/index.js'
@@ -9,7 +10,9 @@ describe('metric groups', () => {
     const metricKey = randomMetricName('key_')
     const metricLabel = randomMetricName('label_')
     const metricValue = 5
-    const metrics = prometheusMetrics()()
+    const metrics = prometheusMetrics()({
+      logger: defaultLogger()
+    })
     const metric = metrics.registerMetricGroup(metricName, {
       label: metricLabel
     })
@@ -24,7 +27,9 @@ describe('metric groups', () => {
     const metricName = randomMetricName()
     const metricKey = randomMetricName('key_')
     const metricLabel = randomMetricName('label_')
-    const metrics = prometheusMetrics()()
+    const metrics = prometheusMetrics()({
+      logger: defaultLogger()
+    })
     const metric = metrics.registerMetricGroup(metricName, {
       label: metricLabel
     })
@@ -40,7 +45,9 @@ describe('metric groups', () => {
     const metricKey = randomMetricName('key_')
     const metricLabel = randomMetricName('label_')
     const metricValue = 5
-    const metrics = prometheusMetrics()()
+    const metrics = prometheusMetrics()({
+      logger: defaultLogger()
+    })
     const metric = metrics.registerMetricGroup(metricName, {
       label: metricLabel
     })
@@ -55,7 +62,9 @@ describe('metric groups', () => {
     const metricName = randomMetricName()
     const metricKey = randomMetricName('key_')
     const metricLabel = randomMetricName('label_')
-    const metrics = prometheusMetrics()()
+    const metrics = prometheusMetrics()({
+      logger: defaultLogger()
+    })
     const metric = metrics.registerMetricGroup(metricName, {
       label: metricLabel
     })
@@ -71,7 +80,9 @@ describe('metric groups', () => {
     const metricKey = randomMetricName('key_')
     const metricLabel = randomMetricName('label_')
     const metricValue = 5
-    const metrics = prometheusMetrics()()
+    const metrics = prometheusMetrics()({
+      logger: defaultLogger()
+    })
     const metric = metrics.registerMetricGroup(metricName, {
       label: metricLabel
     })
@@ -87,7 +98,9 @@ describe('metric groups', () => {
     const metricKey = randomMetricName('key_')
     const metricLabel = randomMetricName('label_')
     const metricValue = 5
-    const metrics = prometheusMetrics()()
+    const metrics = prometheusMetrics()({
+      logger: defaultLogger()
+    })
     metrics.registerMetricGroup(metricName, {
       label: metricLabel,
       calculate: () => {
@@ -105,7 +118,9 @@ describe('metric groups', () => {
     const metricKey = randomMetricName('key_')
     const metricLabel = randomMetricName('label_')
     const metricValue = 5
-    const metrics = prometheusMetrics()()
+    const metrics = prometheusMetrics()({
+      logger: defaultLogger()
+    })
     metrics.registerMetricGroup(metricName, {
       label: metricLabel,
       calculate: async () => {
@@ -123,7 +138,9 @@ describe('metric groups', () => {
     const metricKey = randomMetricName('key_')
     const metricLabel = randomMetricName('label_')
     const metricValue = 5
-    const metrics = prometheusMetrics()()
+    const metrics = prometheusMetrics()({
+      logger: defaultLogger()
+    })
     const metric = metrics.registerMetricGroup(metricName, {
       label: metricLabel
     })
@@ -145,7 +162,9 @@ describe('metric groups', () => {
     const metricLabel = randomMetricName('label_')
     const metricValue1 = 5
     const metricValue2 = 7
-    const metrics = prometheusMetrics()()
+    const metrics = prometheusMetrics()({
+      logger: defaultLogger()
+    })
     const metric1 = metrics.registerMetricGroup(metricName, {
       label: metricLabel
     })

--- a/packages/metrics-prometheus/test/metrics.spec.ts
+++ b/packages/metrics-prometheus/test/metrics.spec.ts
@@ -1,3 +1,4 @@
+import { defaultLogger } from '@libp2p/logger'
 import { expect } from 'aegir/chai'
 import client from 'prom-client'
 import { prometheusMetrics } from '../src/index.js'
@@ -7,7 +8,9 @@ describe('metrics', () => {
   it('should set a metric', async () => {
     const metricName = randomMetricName()
     const metricValue = 5
-    const metrics = prometheusMetrics()()
+    const metrics = prometheusMetrics()({
+      logger: defaultLogger()
+    })
     const metric = metrics.registerMetric(metricName)
     metric.update(metricValue)
 
@@ -18,7 +21,9 @@ describe('metrics', () => {
 
   it('should increment a metric without a value', async () => {
     const metricName = randomMetricName()
-    const metrics = prometheusMetrics()()
+    const metrics = prometheusMetrics()({
+      logger: defaultLogger()
+    })
     const metric = metrics.registerMetric(metricName)
     metric.increment()
 
@@ -28,7 +33,9 @@ describe('metrics', () => {
   it('should increment a metric with a value', async () => {
     const metricName = randomMetricName()
     const metricValue = 5
-    const metrics = prometheusMetrics()()
+    const metrics = prometheusMetrics()({
+      logger: defaultLogger()
+    })
     const metric = metrics.registerMetric(metricName)
     metric.increment(metricValue)
 
@@ -37,7 +44,9 @@ describe('metrics', () => {
 
   it('should decrement a metric without a value', async () => {
     const metricName = randomMetricName()
-    const metrics = prometheusMetrics()()
+    const metrics = prometheusMetrics()({
+      logger: defaultLogger()
+    })
     const metric = metrics.registerMetric(metricName)
     metric.decrement()
 
@@ -47,7 +56,9 @@ describe('metrics', () => {
   it('should decrement a metric with a value', async () => {
     const metricName = randomMetricName()
     const metricValue = 5
-    const metrics = prometheusMetrics()()
+    const metrics = prometheusMetrics()({
+      logger: defaultLogger()
+    })
     const metric = metrics.registerMetric(metricName)
     metric.decrement(metricValue)
 
@@ -57,7 +68,9 @@ describe('metrics', () => {
   it('should calculate a metric', async () => {
     const metricName = randomMetricName()
     const metricValue = 5
-    const metrics = prometheusMetrics()()
+    const metrics = prometheusMetrics()({
+      logger: defaultLogger()
+    })
     metrics.registerMetric(metricName, {
       calculate: () => {
         return metricValue
@@ -70,7 +83,9 @@ describe('metrics', () => {
   it('should promise to calculate a metric', async () => {
     const metricName = randomMetricName()
     const metricValue = 5
-    const metrics = prometheusMetrics()()
+    const metrics = prometheusMetrics()({
+      logger: defaultLogger()
+    })
     metrics.registerMetric(metricName, {
       calculate: async () => {
         return metricValue
@@ -83,7 +98,9 @@ describe('metrics', () => {
   it('should reset a metric', async () => {
     const metricName = randomMetricName()
     const metricValue = 5
-    const metrics = prometheusMetrics()()
+    const metrics = prometheusMetrics()({
+      logger: defaultLogger()
+    })
     const metric = metrics.registerMetric(metricName)
     metric.update(metricValue)
 
@@ -99,7 +116,9 @@ describe('metrics', () => {
     const metricLabel = randomMetricName('label_')
     const metricValue1 = 5
     const metricValue2 = 7
-    const metrics = prometheusMetrics()()
+    const metrics = prometheusMetrics()({
+      logger: defaultLogger()
+    })
     const metric1 = metrics.registerMetric(metricName, {
       label: metricLabel
     })

--- a/packages/metrics-prometheus/test/streams.spec.ts
+++ b/packages/metrics-prometheus/test/streams.spec.ts
@@ -1,4 +1,5 @@
 import { connectionPair, mockRegistrar, mockMultiaddrConnPair } from '@libp2p/interface-compliance-tests/mocks'
+import { defaultLogger } from '@libp2p/logger'
 import { createEd25519PeerId } from '@libp2p/peer-id-factory'
 import { multiaddr } from '@multiformats/multiaddr'
 import { expect } from 'aegir/chai'
@@ -40,7 +41,9 @@ describe('streams', () => {
       deferred.resolve()
     })
 
-    const metrics = prometheusMetrics()()
+    const metrics = prometheusMetrics()({
+      logger: defaultLogger()
+    })
 
     // track outgoing stream
     metrics.trackMultiaddrConnection(outbound)
@@ -70,7 +73,9 @@ describe('streams', () => {
       remotePeer
     })
 
-    const metrics = prometheusMetrics()()
+    const metrics = prometheusMetrics()({
+      logger: defaultLogger()
+    })
 
     // track incoming stream
     metrics.trackMultiaddrConnection(inbound)
@@ -110,7 +115,9 @@ describe('streams', () => {
     ;[connectionA, connectionB] = connectionPair(peerA, peerB)
     const aToB = await connectionA.newStream(protocol)
 
-    const metrics = prometheusMetrics()()
+    const metrics = prometheusMetrics()({
+      logger: defaultLogger()
+    })
 
     // track outgoing stream
     metrics.trackProtocolStream(aToB, connectionA)
@@ -146,7 +153,9 @@ describe('streams', () => {
       registrar: mockRegistrar()
     }
 
-    const metrics = prometheusMetrics()()
+    const metrics = prometheusMetrics()({
+      logger: defaultLogger()
+    })
 
     ;[connectionA, connectionB] = connectionPair(peerA, peerB)
 

--- a/packages/multistream-select/package.json
+++ b/packages/multistream-select/package.json
@@ -54,7 +54,6 @@
   },
   "dependencies": {
     "@libp2p/interface": "^0.1.6",
-    "@libp2p/logger": "^3.1.0",
     "abortable-iterator": "^5.0.1",
     "it-first": "^3.0.3",
     "it-handshake": "^4.1.3",
@@ -69,6 +68,7 @@
     "uint8arrays": "^4.0.6"
   },
   "devDependencies": {
+    "@libp2p/logger": "^3.1.0",
     "aegir": "^41.0.2",
     "iso-random-stream": "^2.0.2",
     "it-all": "^3.0.3",

--- a/packages/multistream-select/src/handle.ts
+++ b/packages/multistream-select/src/handle.ts
@@ -1,4 +1,3 @@
-import { logger } from '@libp2p/logger'
 import { handshake } from 'it-handshake'
 import { Uint8ArrayList } from 'uint8arraylist'
 import { fromString as uint8ArrayFromString } from 'uint8arrays/from-string'
@@ -6,8 +5,6 @@ import { PROTOCOL_ID } from './constants.js'
 import * as multistream from './multistream.js'
 import type { ByteArrayInit, ByteListInit, MultistreamSelectInit, ProtocolStream } from './index.js'
 import type { Duplex, Source } from 'it-stream-types'
-
-const log = logger('libp2p:mss:handle')
 
 /**
  * Handle multistream protocol selections for the given list of protocols.
@@ -63,17 +60,17 @@ export async function handle (stream: any, protocols: string | string[], options
 
   while (true) {
     const protocol = await multistream.readString(reader, options)
-    log.trace('read "%s"', protocol)
+    options?.log.trace('read "%s"', protocol)
 
     if (protocol === PROTOCOL_ID) {
-      log.trace('respond with "%s" for "%s"', PROTOCOL_ID, protocol)
+      options?.log.trace('respond with "%s" for "%s"', PROTOCOL_ID, protocol)
       multistream.write(writer, uint8ArrayFromString(PROTOCOL_ID), options)
       continue
     }
 
     if (protocols.includes(protocol)) {
       multistream.write(writer, uint8ArrayFromString(protocol), options)
-      log.trace('respond with "%s" for "%s"', protocol, protocol)
+      options?.log.trace('respond with "%s" for "%s"', protocol, protocol)
       rest()
       return { stream: shakeStream, protocol }
     }
@@ -82,11 +79,11 @@ export async function handle (stream: any, protocols: string | string[], options
       // <varint-msg-len><varint-proto-name-len><proto-name>\n<varint-proto-name-len><proto-name>\n\n
       multistream.write(writer, new Uint8ArrayList(...protocols.map(p => multistream.encode(uint8ArrayFromString(p)))), options)
       // multistream.writeAll(writer, protocols.map(p => uint8ArrayFromString(p)))
-      log.trace('respond with "%s" for %s', protocols, protocol)
+      options?.log.trace('respond with "%s" for %s', protocols, protocol)
       continue
     }
 
     multistream.write(writer, uint8ArrayFromString('na'), options)
-    log('respond with "na" for "%s"', protocol)
+    options?.log('respond with "na" for "%s"', protocol)
   }
 }

--- a/packages/multistream-select/src/index.ts
+++ b/packages/multistream-select/src/index.ts
@@ -21,7 +21,7 @@
  */
 
 import { PROTOCOL_ID } from './constants.js'
-import type { AbortOptions } from '@libp2p/interface'
+import type { AbortOptions, LoggerOptions } from '@libp2p/interface'
 import type { Duplex, Source } from 'it-stream-types'
 
 export { PROTOCOL_ID }
@@ -31,15 +31,15 @@ export interface ProtocolStream<TSource, TSink = TSource, RSink = Promise<void>>
   protocol: string
 }
 
-export interface ByteArrayInit extends AbortOptions {
+export interface ByteArrayInit extends AbortOptions, LoggerOptions {
   writeBytes: true
 }
 
-export interface ByteListInit extends AbortOptions {
+export interface ByteListInit extends AbortOptions, LoggerOptions {
   writeBytes?: false
 }
 
-export interface MultistreamSelectInit extends AbortOptions {
+export interface MultistreamSelectInit extends AbortOptions, LoggerOptions {
   writeBytes?: boolean
 }
 

--- a/packages/multistream-select/src/select.ts
+++ b/packages/multistream-select/src/select.ts
@@ -1,5 +1,4 @@
 import { CodeError } from '@libp2p/interface/errors'
-import { logger } from '@libp2p/logger'
 import { handshake } from 'it-handshake'
 import merge from 'it-merge'
 import { pushable } from 'it-pushable'
@@ -10,8 +9,6 @@ import * as multistream from './multistream.js'
 import { PROTOCOL_ID } from './index.js'
 import type { ByteArrayInit, ByteListInit, MultistreamSelectInit, ProtocolStream } from './index.js'
 import type { Duplex, Source } from 'it-stream-types'
-
-const log = logger('libp2p:mss:select')
 
 /**
  * Negotiate a protocol to use from a list of protocols.
@@ -58,7 +55,7 @@ const log = logger('libp2p:mss:select')
  */
 export async function select (stream: Duplex<AsyncGenerator<Uint8Array>, Source<Uint8Array>>, protocols: string | string[], options: ByteArrayInit): Promise<ProtocolStream<Uint8Array>>
 export async function select (stream: Duplex<AsyncGenerator<Uint8ArrayList | Uint8Array>, Source<Uint8ArrayList | Uint8Array>>, protocols: string | string[], options?: ByteListInit): Promise<ProtocolStream<Uint8ArrayList, Uint8ArrayList | Uint8Array>>
-export async function select (stream: any, protocols: string | string[], options: MultistreamSelectInit = {}): Promise<ProtocolStream<any>> {
+export async function select (stream: any, protocols: string | string[], options?: MultistreamSelectInit): Promise<ProtocolStream<any>> {
   protocols = Array.isArray(protocols) ? [...protocols] : [protocols]
   const { reader, writer, rest, stream: shakeStream } = handshake(stream)
 
@@ -68,18 +65,18 @@ export async function select (stream: any, protocols: string | string[], options
     throw new Error('At least one protocol must be specified')
   }
 
-  log.trace('select: write ["%s", "%s"]', PROTOCOL_ID, protocol)
+  options?.log.trace('select: write ["%s", "%s"]', PROTOCOL_ID, protocol)
   const p1 = uint8ArrayFromString(PROTOCOL_ID)
   const p2 = uint8ArrayFromString(protocol)
   multistream.writeAll(writer, [p1, p2], options)
 
   let response = await multistream.readString(reader, options)
-  log.trace('select: read "%s"', response)
+  options?.log.trace('select: read "%s"', response)
 
   // Read the protocol response if we got the protocolId in return
   if (response === PROTOCOL_ID) {
     response = await multistream.readString(reader, options)
-    log.trace('select: read "%s"', response)
+    options?.log.trace('select: read "%s"', response)
   }
 
   // We're done
@@ -90,10 +87,10 @@ export async function select (stream: any, protocols: string | string[], options
 
   // We haven't gotten a valid ack, try the other protocols
   for (const protocol of protocols) {
-    log.trace('select: write "%s"', protocol)
+    options?.log.trace('select: write "%s"', protocol)
     multistream.write(writer, uint8ArrayFromString(protocol), options)
     const response = await multistream.readString(reader, options)
-    log.trace('select: read "%s" for "%s"', response, protocol)
+    options?.log.trace('select: read "%s" for "%s"', response, protocol)
 
     if (response === protocol) {
       rest() // End our writer so others can start writing to stream

--- a/packages/multistream-select/test/dialer.spec.ts
+++ b/packages/multistream-select/test/dialer.spec.ts
@@ -1,6 +1,7 @@
 /* eslint-env mocha */
 /* eslint max-nested-callbacks: ["error", 5] */
 
+import { logger } from '@libp2p/logger'
 import { expect } from 'aegir/chai'
 import randomBytes from 'iso-random-stream/src/random.js'
 import all from 'it-all'
@@ -20,7 +21,8 @@ describe('Dialer', () => {
       const duplex = pair<Uint8Array>()
 
       const selection = await mss.select(duplex, protocol, {
-        writeBytes: true
+        writeBytes: true,
+        log: logger('test')
       })
       expect(selection.protocol).to.equal(protocol)
 
@@ -36,13 +38,15 @@ describe('Dialer', () => {
       const duplex = pair<Uint8Array>()
 
       const selection = await mss.select(duplex, protocol, {
-        writeBytes: true
+        writeBytes: true,
+        log: logger('test')
       })
       expect(selection.protocol).to.equal(protocol)
 
       // A second select will timeout
       await pTimeout(mss.select(duplex, protocol2, {
-        writeBytes: true
+        writeBytes: true,
+        log: logger('test')
       }), {
         milliseconds: 1e3
       })

--- a/packages/multistream-select/test/multistream.spec.ts
+++ b/packages/multistream-select/test/multistream.spec.ts
@@ -1,6 +1,7 @@
 /* eslint-env mocha */
 /* eslint max-nested-callbacks: ["error", 6] */
 
+import { logger } from '@libp2p/logger'
 import { expect } from 'aegir/chai'
 import all from 'it-all'
 import { pushable } from 'it-pushable'
@@ -125,7 +126,8 @@ describe('Multistream', () => {
       controller.abort()
 
       await expect(Multistream.read(source, {
-        signal: controller.signal
+        signal: controller.signal,
+        log: logger('test')
       })).to.eventually.be.rejected().with.property('code', 'ABORT_ERR')
     })
   })

--- a/packages/peer-discovery-bootstrap/package.json
+++ b/packages/peer-discovery-bootstrap/package.json
@@ -50,13 +50,13 @@
   },
   "dependencies": {
     "@libp2p/interface": "^0.1.6",
-    "@libp2p/logger": "^3.1.0",
     "@libp2p/peer-id": "^3.0.6",
     "@multiformats/mafmt": "^12.1.6",
     "@multiformats/multiaddr": "^12.1.10"
   },
   "devDependencies": {
     "@libp2p/interface-compliance-tests": "^4.1.5",
+    "@libp2p/logger": "^3.1.0",
     "aegir": "^41.0.2",
     "sinon-ts": "^2.0.0"
   }

--- a/packages/peer-discovery-bootstrap/src/index.ts
+++ b/packages/peer-discovery-bootstrap/src/index.ts
@@ -42,7 +42,7 @@
  * const libp2p = await createLibp2p(options)
  *
  * libp2p.on('peer:discovery', function (peerId) {
- *   console.this.#log('found peer: ', peerId.toB58String())
+ *   console.this.log('found peer: ', peerId.toB58String())
  * })
  * ```
  */
@@ -101,7 +101,7 @@ export interface BootstrapComponents {
 class Bootstrap extends TypedEventEmitter<PeerDiscoveryEvents> implements PeerDiscovery, Startable {
   static tag = 'bootstrap'
 
-  readonly #log: Logger
+  private readonly log: Logger
   private timer?: ReturnType<typeof setTimeout>
   private readonly list: PeerInfo[]
   private readonly timeout: number
@@ -115,13 +115,13 @@ class Bootstrap extends TypedEventEmitter<PeerDiscoveryEvents> implements PeerDi
     super()
 
     this.components = components
-    this.#log = components.logger.forComponent('libp2p:bootstrap')
+    this.log = components.logger.forComponent('libp2p:bootstrap')
     this.timeout = options.timeout ?? DEFAULT_BOOTSTRAP_DISCOVERY_TIMEOUT
     this.list = []
 
     for (const candidate of options.list) {
       if (!P2P.matches(candidate)) {
-        this.#log.error('Invalid multiaddr')
+        this.log.error('Invalid multiaddr')
         continue
       }
 
@@ -129,7 +129,7 @@ class Bootstrap extends TypedEventEmitter<PeerDiscoveryEvents> implements PeerDi
       const peerIdStr = ma.getPeerId()
 
       if (peerIdStr == null) {
-        this.#log.error('Invalid bootstrap multiaddr without peer id')
+        this.log.error('Invalid bootstrap multiaddr without peer id')
         continue
       }
 
@@ -160,11 +160,11 @@ class Bootstrap extends TypedEventEmitter<PeerDiscoveryEvents> implements PeerDi
       return
     }
 
-    this.#log('Starting bootstrap node discovery, discovering peers after %s ms', this.timeout)
+    this.log('Starting bootstrap node discovery, discovering peers after %s ms', this.timeout)
     this.timer = setTimeout(() => {
       void this._discoverBootstrapPeers()
         .catch(err => {
-          this.#log.error(err)
+          this.log.error(err)
         })
     }, this.timeout)
   }

--- a/packages/peer-discovery-bootstrap/src/index.ts
+++ b/packages/peer-discovery-bootstrap/src/index.ts
@@ -42,23 +42,21 @@
  * const libp2p = await createLibp2p(options)
  *
  * libp2p.on('peer:discovery', function (peerId) {
- *   console.log('found peer: ', peerId.toB58String())
+ *   console.this.#log('found peer: ', peerId.toB58String())
  * })
  * ```
  */
 
 import { TypedEventEmitter } from '@libp2p/interface/events'
 import { peerDiscovery } from '@libp2p/interface/peer-discovery'
-import { logger } from '@libp2p/logger'
 import { peerIdFromString } from '@libp2p/peer-id'
 import { P2P } from '@multiformats/mafmt'
 import { multiaddr } from '@multiformats/multiaddr'
+import type { ComponentLogger, Logger } from '@libp2p/interface'
 import type { PeerDiscovery, PeerDiscoveryEvents } from '@libp2p/interface/peer-discovery'
 import type { PeerInfo } from '@libp2p/interface/peer-info'
 import type { PeerStore } from '@libp2p/interface/peer-store'
 import type { Startable } from '@libp2p/interface/startable'
-
-const log = logger('libp2p:bootstrap')
 
 const DEFAULT_BOOTSTRAP_TAG_NAME = 'bootstrap'
 const DEFAULT_BOOTSTRAP_TAG_VALUE = 50
@@ -94,6 +92,7 @@ export interface BootstrapInit {
 
 export interface BootstrapComponents {
   peerStore: PeerStore
+  logger: ComponentLogger
 }
 
 /**
@@ -102,6 +101,7 @@ export interface BootstrapComponents {
 class Bootstrap extends TypedEventEmitter<PeerDiscoveryEvents> implements PeerDiscovery, Startable {
   static tag = 'bootstrap'
 
+  readonly #log: Logger
   private timer?: ReturnType<typeof setTimeout>
   private readonly list: PeerInfo[]
   private readonly timeout: number
@@ -115,12 +115,13 @@ class Bootstrap extends TypedEventEmitter<PeerDiscoveryEvents> implements PeerDi
     super()
 
     this.components = components
+    this.#log = components.logger.forComponent('libp2p:bootstrap')
     this.timeout = options.timeout ?? DEFAULT_BOOTSTRAP_DISCOVERY_TIMEOUT
     this.list = []
 
     for (const candidate of options.list) {
       if (!P2P.matches(candidate)) {
-        log.error('Invalid multiaddr')
+        this.#log.error('Invalid multiaddr')
         continue
       }
 
@@ -128,7 +129,7 @@ class Bootstrap extends TypedEventEmitter<PeerDiscoveryEvents> implements PeerDi
       const peerIdStr = ma.getPeerId()
 
       if (peerIdStr == null) {
-        log.error('Invalid bootstrap multiaddr without peer id')
+        this.#log.error('Invalid bootstrap multiaddr without peer id')
         continue
       }
 
@@ -159,11 +160,11 @@ class Bootstrap extends TypedEventEmitter<PeerDiscoveryEvents> implements PeerDi
       return
     }
 
-    log('Starting bootstrap node discovery, discovering peers after %s ms', this.timeout)
+    this.#log('Starting bootstrap node discovery, discovering peers after %s ms', this.timeout)
     this.timer = setTimeout(() => {
       void this._discoverBootstrapPeers()
         .catch(err => {
-          log.error(err)
+          this.#log.error(err)
         })
     }, this.timeout)
   }

--- a/packages/peer-discovery-bootstrap/test/bootstrap.spec.ts
+++ b/packages/peer-discovery-bootstrap/test/bootstrap.spec.ts
@@ -2,6 +2,7 @@
 
 import { isPeerId } from '@libp2p/interface/peer-id'
 import { start, stop } from '@libp2p/interface/startable'
+import { defaultLogger } from '@libp2p/logger'
 import { peerIdFromString } from '@libp2p/peer-id'
 import { IPFS } from '@multiformats/mafmt'
 import { multiaddr } from '@multiformats/multiaddr'
@@ -20,7 +21,8 @@ describe('bootstrap', () => {
     peerStore = stubInterface<PeerStore>()
 
     components = {
-      peerStore
+      peerStore,
+      logger: defaultLogger()
     }
   })
 

--- a/packages/peer-discovery-bootstrap/test/compliance.spec.ts
+++ b/packages/peer-discovery-bootstrap/test/compliance.spec.ts
@@ -1,6 +1,7 @@
 /* eslint-env mocha */
 
 import tests from '@libp2p/interface-compliance-tests/peer-discovery'
+import { defaultLogger } from '@libp2p/logger'
 import { stubInterface } from 'sinon-ts'
 import { bootstrap } from '../src/index.js'
 import peerList from './fixtures/default-peers.js'
@@ -10,7 +11,8 @@ describe('compliance tests', () => {
   tests({
     async setup () {
       const components = {
-        peerStore: stubInterface<PeerStore>()
+        peerStore: stubInterface<PeerStore>(),
+        logger: defaultLogger()
       }
 
       return bootstrap({

--- a/packages/peer-discovery-mdns/package.json
+++ b/packages/peer-discovery-mdns/package.json
@@ -46,7 +46,6 @@
   },
   "dependencies": {
     "@libp2p/interface": "^0.1.6",
-    "@libp2p/logger": "^3.1.0",
     "@libp2p/peer-id": "^3.0.6",
     "@libp2p/utils": "^4.0.7",
     "@multiformats/multiaddr": "^12.1.10",
@@ -57,6 +56,7 @@
   "devDependencies": {
     "@libp2p/interface-compliance-tests": "^4.1.5",
     "@libp2p/interface-internal": "^0.1.9",
+    "@libp2p/logger": "^3.1.0",
     "@libp2p/peer-id-factory": "^3.0.8",
     "aegir": "^41.0.2",
     "p-wait-for": "^5.0.2",

--- a/packages/peer-discovery-mdns/src/mdns.ts
+++ b/packages/peer-discovery-mdns/src/mdns.ts
@@ -1,15 +1,13 @@
 import { CustomEvent, EventEmitter } from '@libp2p/interface/events'
 import { peerDiscovery } from '@libp2p/interface/peer-discovery'
-import { logger } from '@libp2p/logger'
 import multicastDNS from 'multicast-dns'
 import * as query from './query.js'
 import { stringGen } from './utils.js'
+import type { ComponentLogger, Logger } from '@libp2p/interface'
 import type { PeerDiscovery, PeerDiscoveryEvents } from '@libp2p/interface/peer-discovery'
 import type { PeerInfo } from '@libp2p/interface/peer-info'
 import type { Startable } from '@libp2p/interface/src/startable.js'
 import type { AddressManager } from '@libp2p/interface-internal/address-manager'
-
-const log = logger('libp2p:mdns')
 
 export interface MulticastDNSInit {
   broadcast?: boolean
@@ -22,11 +20,13 @@ export interface MulticastDNSInit {
 
 export interface MulticastDNSComponents {
   addressManager: AddressManager
+  logger: ComponentLogger
 }
 
 export class MulticastDNS extends EventEmitter<PeerDiscoveryEvents> implements PeerDiscovery, Startable {
   public mdns?: multicastDNS.MulticastDNS
 
+  readonly #log: Logger
   private readonly broadcast: boolean
   private readonly interval: number
   private readonly serviceTag: string
@@ -39,6 +39,7 @@ export class MulticastDNS extends EventEmitter<PeerDiscoveryEvents> implements P
   constructor (components: MulticastDNSComponents, init: MulticastDNSInit = {}) {
     super()
 
+    this.#log = components.logger.forComponent('libp2p:mdns')
     this.broadcast = init.broadcast !== false
     this.interval = init.interval ?? (1e3 * 10)
     this.serviceTag = init.serviceTag ?? '_p2p._udp.local'
@@ -81,7 +82,9 @@ export class MulticastDNS extends EventEmitter<PeerDiscoveryEvents> implements P
     this.mdns.on('warning', this._onMdnsWarning)
     this.mdns.on('error', this._onMdnsError)
 
-    this._queryInterval = query.queryLAN(this.mdns, this.serviceTag, this.interval)
+    this._queryInterval = query.queryLAN(this.mdns, this.serviceTag, this.interval, {
+      log: this.#log
+    })
   }
 
   _onMdnsQuery (event: multicastDNS.QueryPacket): void {
@@ -89,40 +92,45 @@ export class MulticastDNS extends EventEmitter<PeerDiscoveryEvents> implements P
       return
     }
 
-    log.trace('received incoming mDNS query')
+    this.#log.trace('received incoming mDNS query')
     query.gotQuery(
       event,
       this.mdns,
       this.peerName,
       this.components.addressManager.getAddresses(),
       this.serviceTag,
-      this.broadcast)
+      this.broadcast, {
+        log: this.#log
+      }
+    )
   }
 
   _onMdnsResponse (event: multicastDNS.ResponsePacket): void {
-    log.trace('received mDNS query response')
+    this.#log.trace('received mDNS query response')
 
     try {
-      const foundPeer = query.gotResponse(event, this.peerName, this.serviceTag)
+      const foundPeer = query.gotResponse(event, this.peerName, this.serviceTag, {
+        log: this.#log
+      })
 
       if (foundPeer != null) {
-        log('discovered peer in mDNS query response %p', foundPeer.id)
+        this.#log('discovered peer in mDNS query response %p', foundPeer.id)
 
         this.dispatchEvent(new CustomEvent<PeerInfo>('peer', {
           detail: foundPeer
         }))
       }
     } catch (err) {
-      log.error('Error processing peer response', err)
+      this.#log.error('Error processing peer response', err)
     }
   }
 
   _onMdnsWarning (err: Error): void {
-    log.error('mdns warning', err)
+    this.#log.error('mdns warning', err)
   }
 
   _onMdnsError (err: Error): void {
-    log.error('mdns error', err)
+    this.#log.error('mdns error', err)
   }
 
   /**

--- a/packages/peer-discovery-mdns/src/mdns.ts
+++ b/packages/peer-discovery-mdns/src/mdns.ts
@@ -26,7 +26,7 @@ export interface MulticastDNSComponents {
 export class MulticastDNS extends EventEmitter<PeerDiscoveryEvents> implements PeerDiscovery, Startable {
   public mdns?: multicastDNS.MulticastDNS
 
-  readonly #log: Logger
+  private readonly log: Logger
   private readonly broadcast: boolean
   private readonly interval: number
   private readonly serviceTag: string
@@ -39,7 +39,7 @@ export class MulticastDNS extends EventEmitter<PeerDiscoveryEvents> implements P
   constructor (components: MulticastDNSComponents, init: MulticastDNSInit = {}) {
     super()
 
-    this.#log = components.logger.forComponent('libp2p:mdns')
+    this.log = components.logger.forComponent('libp2p:mdns')
     this.broadcast = init.broadcast !== false
     this.interval = init.interval ?? (1e3 * 10)
     this.serviceTag = init.serviceTag ?? '_p2p._udp.local'
@@ -83,7 +83,7 @@ export class MulticastDNS extends EventEmitter<PeerDiscoveryEvents> implements P
     this.mdns.on('error', this._onMdnsError)
 
     this._queryInterval = query.queryLAN(this.mdns, this.serviceTag, this.interval, {
-      log: this.#log
+      log: this.log
     })
   }
 
@@ -92,7 +92,7 @@ export class MulticastDNS extends EventEmitter<PeerDiscoveryEvents> implements P
       return
     }
 
-    this.#log.trace('received incoming mDNS query')
+    this.log.trace('received incoming mDNS query')
     query.gotQuery(
       event,
       this.mdns,
@@ -100,37 +100,37 @@ export class MulticastDNS extends EventEmitter<PeerDiscoveryEvents> implements P
       this.components.addressManager.getAddresses(),
       this.serviceTag,
       this.broadcast, {
-        log: this.#log
+        log: this.log
       }
     )
   }
 
   _onMdnsResponse (event: multicastDNS.ResponsePacket): void {
-    this.#log.trace('received mDNS query response')
+    this.log.trace('received mDNS query response')
 
     try {
       const foundPeer = query.gotResponse(event, this.peerName, this.serviceTag, {
-        log: this.#log
+        log: this.log
       })
 
       if (foundPeer != null) {
-        this.#log('discovered peer in mDNS query response %p', foundPeer.id)
+        this.log('discovered peer in mDNS query response %p', foundPeer.id)
 
         this.dispatchEvent(new CustomEvent<PeerInfo>('peer', {
           detail: foundPeer
         }))
       }
     } catch (err) {
-      this.#log.error('Error processing peer response', err)
+      this.log.error('Error processing peer response', err)
     }
   }
 
   _onMdnsWarning (err: Error): void {
-    this.#log.error('mdns warning', err)
+    this.log.error('mdns warning', err)
   }
 
   _onMdnsError (err: Error): void {
-    this.#log.error('mdns error', err)
+    this.log.error('mdns error', err)
   }
 
   /**

--- a/packages/peer-discovery-mdns/src/query.ts
+++ b/packages/peer-discovery-mdns/src/query.ts
@@ -1,16 +1,14 @@
-import { logger } from '@libp2p/logger'
 import { peerIdFromString } from '@libp2p/peer-id'
 import { isPrivate } from '@libp2p/utils/multiaddr/is-private'
 import { multiaddr, type Multiaddr, protocols } from '@multiformats/multiaddr'
+import type { LoggerOptions } from '@libp2p/interface'
 import type { PeerInfo } from '@libp2p/interface/peer-info'
 import type { Answer, StringAnswer, TxtAnswer } from 'dns-packet'
 import type { MulticastDNS, QueryPacket, ResponsePacket } from 'multicast-dns'
 
-const log = logger('libp2p:mdns:query')
-
-export function queryLAN (mdns: MulticastDNS, serviceTag: string, interval: number): ReturnType<typeof setInterval> {
+export function queryLAN (mdns: MulticastDNS, serviceTag: string, interval: number, options?: LoggerOptions): ReturnType<typeof setInterval> {
   const query = (): void => {
-    log.trace('query', serviceTag)
+    options?.log.trace('query', serviceTag)
 
     mdns.query({
       questions: [{
@@ -25,7 +23,7 @@ export function queryLAN (mdns: MulticastDNS, serviceTag: string, interval: numb
   return setInterval(query, interval)
 }
 
-export function gotResponse (rsp: ResponsePacket, localPeerName: string, serviceTag: string): PeerInfo | undefined {
+export function gotResponse (rsp: ResponsePacket, localPeerName: string, serviceTag: string, options?: LoggerOptions): PeerInfo | undefined {
   if (rsp.answers == null) {
     return
   }
@@ -70,20 +68,20 @@ export function gotResponse (rsp: ResponsePacket, localPeerName: string, service
     if (peerId == null) {
       throw new Error("Multiaddr doesn't contain PeerId")
     }
-    log('peer found %p', peerId)
+    options?.log('peer found %p', peerId)
 
     return {
       id: peerIdFromString(peerId),
       multiaddrs: multiaddrs.map(addr => addr.decapsulateCode(protocols('p2p').code))
     }
   } catch (e) {
-    log.error('failed to parse mdns response', e)
+    options?.log.error('failed to parse mdns response', e)
   }
 }
 
-export function gotQuery (qry: QueryPacket, mdns: MulticastDNS, peerName: string, multiaddrs: Multiaddr[], serviceTag: string, broadcast: boolean): void {
+export function gotQuery (qry: QueryPacket, mdns: MulticastDNS, peerName: string, multiaddrs: Multiaddr[], serviceTag: string, broadcast: boolean, options?: LoggerOptions): void {
   if (!broadcast) {
-    log('not responding to mDNS query as broadcast mode is false')
+    options?.log('not responding to mDNS query as broadcast mode is false')
     return
   }
 
@@ -112,13 +110,13 @@ export function gotQuery (qry: QueryPacket, mdns: MulticastDNS, peerName: string
         // TXT record fields have a max data length of 255 bytes
         // see 6.1 - https://www.ietf.org/rfc/rfc6763.txt
         if (data.length > 255) {
-          log('multiaddr %a is too long to use in mDNS query response', addr)
+          options?.log('multiaddr %a is too long to use in mDNS query response', addr)
           return
         }
 
         // spec mandates multiaddr contains peer id
         if (addr.getPeerId() == null) {
-          log('multiaddr %a did not have a peer ID so cannot be used in mDNS query response', addr)
+          options?.log('multiaddr %a did not have a peer ID so cannot be used in mDNS query response', addr)
           return
         }
 
@@ -131,7 +129,7 @@ export function gotQuery (qry: QueryPacket, mdns: MulticastDNS, peerName: string
         })
       })
 
-    log.trace('responding to query')
+    options?.log.trace('responding to query')
     mdns.respond(answers)
   }
 }

--- a/packages/peer-discovery-mdns/test/compliance.spec.ts
+++ b/packages/peer-discovery-mdns/test/compliance.spec.ts
@@ -2,6 +2,7 @@
 
 import { CustomEvent } from '@libp2p/interface/events'
 import tests from '@libp2p/interface-compliance-tests/peer-discovery'
+import { defaultLogger } from '@libp2p/logger'
 import { createEd25519PeerId } from '@libp2p/peer-id-factory'
 import { multiaddr } from '@multiformats/multiaddr'
 import { stubInterface } from 'ts-sinon'
@@ -24,7 +25,8 @@ describe('compliance tests', () => {
       ])
 
       discovery = new MulticastDNS({
-        addressManager
+        addressManager,
+        logger: defaultLogger()
       }, {
         broadcast: false,
         port: 50001

--- a/packages/peer-discovery-mdns/test/multicast-dns.spec.ts
+++ b/packages/peer-discovery-mdns/test/multicast-dns.spec.ts
@@ -1,6 +1,7 @@
 /* eslint-env mocha */
 
 import { start, stop } from '@libp2p/interface/startable'
+import { defaultLogger } from '@libp2p/logger'
 import { createEd25519PeerId } from '@libp2p/peer-id-factory'
 import { multiaddr } from '@multiformats/multiaddr'
 import { expect } from 'aegir/chai'
@@ -17,7 +18,10 @@ function getComponents (peerId: PeerId, multiaddrs: Multiaddr[]): MulticastDNSCo
   const addressManager = stubInterface<AddressManager>()
   addressManager.getAddresses.returns(multiaddrs.map(ma => ma.encapsulate(`/p2p/${peerId.toString()}`)))
 
-  return { addressManager }
+  return {
+    addressManager,
+    logger: defaultLogger()
+  }
 }
 
 describe('MulticastDNS', () => {

--- a/packages/peer-store/package.json
+++ b/packages/peer-store/package.json
@@ -55,7 +55,6 @@
   },
   "dependencies": {
     "@libp2p/interface": "^0.1.6",
-    "@libp2p/logger": "^3.1.0",
     "@libp2p/peer-collections": "^4.0.8",
     "@libp2p/peer-id": "^3.0.6",
     "@libp2p/peer-id-factory": "^3.0.8",
@@ -70,6 +69,7 @@
     "uint8arrays": "^4.0.6"
   },
   "devDependencies": {
+    "@libp2p/logger": "^3.1.0",
     "@types/sinon": "^17.0.0",
     "aegir": "^41.0.2",
     "datastore-core": "^9.1.1",

--- a/packages/peer-store/src/index.ts
+++ b/packages/peer-store/src/index.ts
@@ -1,20 +1,18 @@
-import { logger } from '@libp2p/logger'
 import { RecordEnvelope, PeerRecord } from '@libp2p/peer-record'
 import all from 'it-all'
 import { PersistentStore, type PeerUpdate } from './store.js'
-import type { Libp2pEvents } from '@libp2p/interface'
+import type { ComponentLogger, Libp2pEvents, Logger } from '@libp2p/interface'
 import type { TypedEventTarget } from '@libp2p/interface/events'
 import type { PeerId } from '@libp2p/interface/peer-id'
 import type { PeerStore, Peer, PeerData, PeerQuery } from '@libp2p/interface/peer-store'
 import type { Multiaddr } from '@multiformats/multiaddr'
 import type { Datastore } from 'interface-datastore'
 
-const log = logger('libp2p:peer-store')
-
 export interface PersistentPeerStoreComponents {
   peerId: PeerId
   datastore: Datastore
   events: TypedEventTarget<Libp2pEvents>
+  logger: ComponentLogger
 }
 
 /**
@@ -35,84 +33,86 @@ export class PersistentPeerStore implements PeerStore {
   private readonly store: PersistentStore
   private readonly events: TypedEventTarget<Libp2pEvents>
   private readonly peerId: PeerId
+  readonly #log: Logger
 
   constructor (components: PersistentPeerStoreComponents, init: PersistentPeerStoreInit = {}) {
+    this.#log = components.logger.forComponent('libp2p:peer-store')
     this.events = components.events
     this.peerId = components.peerId
     this.store = new PersistentStore(components, init)
   }
 
   async forEach (fn: (peer: Peer,) => void, query?: PeerQuery): Promise<void> {
-    log.trace('forEach await read lock')
+    this.#log.trace('forEach await read lock')
     const release = await this.store.lock.readLock()
-    log.trace('forEach got read lock')
+    this.#log.trace('forEach got read lock')
 
     try {
       for await (const peer of this.store.all(query)) {
         fn(peer)
       }
     } finally {
-      log.trace('forEach release read lock')
+      this.#log.trace('forEach release read lock')
       release()
     }
   }
 
   async all (query?: PeerQuery): Promise<Peer[]> {
-    log.trace('all await read lock')
+    this.#log.trace('all await read lock')
     const release = await this.store.lock.readLock()
-    log.trace('all got read lock')
+    this.#log.trace('all got read lock')
 
     try {
       return await all(this.store.all(query))
     } finally {
-      log.trace('all release read lock')
+      this.#log.trace('all release read lock')
       release()
     }
   }
 
   async delete (peerId: PeerId): Promise<void> {
-    log.trace('delete await write lock')
+    this.#log.trace('delete await write lock')
     const release = await this.store.lock.writeLock()
-    log.trace('delete got write lock')
+    this.#log.trace('delete got write lock')
 
     try {
       await this.store.delete(peerId)
     } finally {
-      log.trace('delete release write lock')
+      this.#log.trace('delete release write lock')
       release()
     }
   }
 
   async has (peerId: PeerId): Promise<boolean> {
-    log.trace('has await read lock')
+    this.#log.trace('has await read lock')
     const release = await this.store.lock.readLock()
-    log.trace('has got read lock')
+    this.#log.trace('has got read lock')
 
     try {
       return await this.store.has(peerId)
     } finally {
-      log.trace('has release read lock')
+      this.#log.trace('has release read lock')
       release()
     }
   }
 
   async get (peerId: PeerId): Promise<Peer> {
-    log.trace('get await read lock')
+    this.#log.trace('get await read lock')
     const release = await this.store.lock.readLock()
-    log.trace('get got read lock')
+    this.#log.trace('get got read lock')
 
     try {
       return await this.store.load(peerId)
     } finally {
-      log.trace('get release read lock')
+      this.#log.trace('get release read lock')
       release()
     }
   }
 
   async save (id: PeerId, data: PeerData): Promise<Peer> {
-    log.trace('save await write lock')
+    this.#log.trace('save await write lock')
     const release = await this.store.lock.writeLock()
-    log.trace('save got write lock')
+    this.#log.trace('save got write lock')
 
     try {
       const result = await this.store.save(id, data)
@@ -121,15 +121,15 @@ export class PersistentPeerStore implements PeerStore {
 
       return result.peer
     } finally {
-      log.trace('save release write lock')
+      this.#log.trace('save release write lock')
       release()
     }
   }
 
   async patch (id: PeerId, data: PeerData): Promise<Peer> {
-    log.trace('patch await write lock')
+    this.#log.trace('patch await write lock')
     const release = await this.store.lock.writeLock()
-    log.trace('patch got write lock')
+    this.#log.trace('patch got write lock')
 
     try {
       const result = await this.store.patch(id, data)
@@ -138,15 +138,15 @@ export class PersistentPeerStore implements PeerStore {
 
       return result.peer
     } finally {
-      log.trace('patch release write lock')
+      this.#log.trace('patch release write lock')
       release()
     }
   }
 
   async merge (id: PeerId, data: PeerData): Promise<Peer> {
-    log.trace('merge await write lock')
+    this.#log.trace('merge await write lock')
     const release = await this.store.lock.writeLock()
-    log.trace('merge got write lock')
+    this.#log.trace('merge got write lock')
 
     try {
       const result = await this.store.merge(id, data)
@@ -155,7 +155,7 @@ export class PersistentPeerStore implements PeerStore {
 
       return result.peer
     } finally {
-      log.trace('merge release write lock')
+      this.#log.trace('merge release write lock')
       release()
     }
   }
@@ -164,7 +164,7 @@ export class PersistentPeerStore implements PeerStore {
     const envelope = await RecordEnvelope.openAndCertify(buf, PeerRecord.DOMAIN)
 
     if (expectedPeer?.equals(envelope.peerId) === false) {
-      log('envelope peer id was not the expected peer id - expected: %p received: %p', expectedPeer, envelope.peerId)
+      this.#log('envelope peer id was not the expected peer id - expected: %p received: %p', expectedPeer, envelope.peerId)
       return false
     }
 
@@ -185,7 +185,7 @@ export class PersistentPeerStore implements PeerStore {
       const storedRecord = PeerRecord.createFromProtobuf(storedEnvelope.payload)
 
       if (storedRecord.seqNumber >= peerRecord.seqNumber) {
-        log('sequence number was lower or equal to existing sequence number - stored: %d received: %d', storedRecord.seqNumber, peerRecord.seqNumber)
+        this.#log('sequence number was lower or equal to existing sequence number - stored: %d received: %d', storedRecord.seqNumber, peerRecord.seqNumber)
         return false
       }
     }

--- a/packages/peer-store/src/index.ts
+++ b/packages/peer-store/src/index.ts
@@ -33,86 +33,86 @@ export class PersistentPeerStore implements PeerStore {
   private readonly store: PersistentStore
   private readonly events: TypedEventTarget<Libp2pEvents>
   private readonly peerId: PeerId
-  readonly #log: Logger
+  private readonly log: Logger
 
   constructor (components: PersistentPeerStoreComponents, init: PersistentPeerStoreInit = {}) {
-    this.#log = components.logger.forComponent('libp2p:peer-store')
+    this.log = components.logger.forComponent('libp2p:peer-store')
     this.events = components.events
     this.peerId = components.peerId
     this.store = new PersistentStore(components, init)
   }
 
   async forEach (fn: (peer: Peer,) => void, query?: PeerQuery): Promise<void> {
-    this.#log.trace('forEach await read lock')
+    this.log.trace('forEach await read lock')
     const release = await this.store.lock.readLock()
-    this.#log.trace('forEach got read lock')
+    this.log.trace('forEach got read lock')
 
     try {
       for await (const peer of this.store.all(query)) {
         fn(peer)
       }
     } finally {
-      this.#log.trace('forEach release read lock')
+      this.log.trace('forEach release read lock')
       release()
     }
   }
 
   async all (query?: PeerQuery): Promise<Peer[]> {
-    this.#log.trace('all await read lock')
+    this.log.trace('all await read lock')
     const release = await this.store.lock.readLock()
-    this.#log.trace('all got read lock')
+    this.log.trace('all got read lock')
 
     try {
       return await all(this.store.all(query))
     } finally {
-      this.#log.trace('all release read lock')
+      this.log.trace('all release read lock')
       release()
     }
   }
 
   async delete (peerId: PeerId): Promise<void> {
-    this.#log.trace('delete await write lock')
+    this.log.trace('delete await write lock')
     const release = await this.store.lock.writeLock()
-    this.#log.trace('delete got write lock')
+    this.log.trace('delete got write lock')
 
     try {
       await this.store.delete(peerId)
     } finally {
-      this.#log.trace('delete release write lock')
+      this.log.trace('delete release write lock')
       release()
     }
   }
 
   async has (peerId: PeerId): Promise<boolean> {
-    this.#log.trace('has await read lock')
+    this.log.trace('has await read lock')
     const release = await this.store.lock.readLock()
-    this.#log.trace('has got read lock')
+    this.log.trace('has got read lock')
 
     try {
       return await this.store.has(peerId)
     } finally {
-      this.#log.trace('has release read lock')
+      this.log.trace('has release read lock')
       release()
     }
   }
 
   async get (peerId: PeerId): Promise<Peer> {
-    this.#log.trace('get await read lock')
+    this.log.trace('get await read lock')
     const release = await this.store.lock.readLock()
-    this.#log.trace('get got read lock')
+    this.log.trace('get got read lock')
 
     try {
       return await this.store.load(peerId)
     } finally {
-      this.#log.trace('get release read lock')
+      this.log.trace('get release read lock')
       release()
     }
   }
 
   async save (id: PeerId, data: PeerData): Promise<Peer> {
-    this.#log.trace('save await write lock')
+    this.log.trace('save await write lock')
     const release = await this.store.lock.writeLock()
-    this.#log.trace('save got write lock')
+    this.log.trace('save got write lock')
 
     try {
       const result = await this.store.save(id, data)
@@ -121,15 +121,15 @@ export class PersistentPeerStore implements PeerStore {
 
       return result.peer
     } finally {
-      this.#log.trace('save release write lock')
+      this.log.trace('save release write lock')
       release()
     }
   }
 
   async patch (id: PeerId, data: PeerData): Promise<Peer> {
-    this.#log.trace('patch await write lock')
+    this.log.trace('patch await write lock')
     const release = await this.store.lock.writeLock()
-    this.#log.trace('patch got write lock')
+    this.log.trace('patch got write lock')
 
     try {
       const result = await this.store.patch(id, data)
@@ -138,15 +138,15 @@ export class PersistentPeerStore implements PeerStore {
 
       return result.peer
     } finally {
-      this.#log.trace('patch release write lock')
+      this.log.trace('patch release write lock')
       release()
     }
   }
 
   async merge (id: PeerId, data: PeerData): Promise<Peer> {
-    this.#log.trace('merge await write lock')
+    this.log.trace('merge await write lock')
     const release = await this.store.lock.writeLock()
-    this.#log.trace('merge got write lock')
+    this.log.trace('merge got write lock')
 
     try {
       const result = await this.store.merge(id, data)
@@ -155,7 +155,7 @@ export class PersistentPeerStore implements PeerStore {
 
       return result.peer
     } finally {
-      this.#log.trace('merge release write lock')
+      this.log.trace('merge release write lock')
       release()
     }
   }
@@ -164,7 +164,7 @@ export class PersistentPeerStore implements PeerStore {
     const envelope = await RecordEnvelope.openAndCertify(buf, PeerRecord.DOMAIN)
 
     if (expectedPeer?.equals(envelope.peerId) === false) {
-      this.#log('envelope peer id was not the expected peer id - expected: %p received: %p', expectedPeer, envelope.peerId)
+      this.log('envelope peer id was not the expected peer id - expected: %p received: %p', expectedPeer, envelope.peerId)
       return false
     }
 
@@ -185,7 +185,7 @@ export class PersistentPeerStore implements PeerStore {
       const storedRecord = PeerRecord.createFromProtobuf(storedEnvelope.payload)
 
       if (storedRecord.seqNumber >= peerRecord.seqNumber) {
-        this.#log('sequence number was lower or equal to existing sequence number - stored: %d received: %d', storedRecord.seqNumber, peerRecord.seqNumber)
+        this.log('sequence number was lower or equal to existing sequence number - stored: %d received: %d', storedRecord.seqNumber, peerRecord.seqNumber)
         return false
       }
     }

--- a/packages/peer-store/test/index.spec.ts
+++ b/packages/peer-store/test/index.spec.ts
@@ -2,6 +2,7 @@
 /* eslint max-nested-callbacks: ["error", 6] */
 
 import { TypedEventEmitter, type TypedEventTarget } from '@libp2p/interface/events'
+import { defaultLogger } from '@libp2p/logger'
 import { createEd25519PeerId } from '@libp2p/peer-id-factory'
 import { RecordEnvelope, PeerRecord } from '@libp2p/peer-record'
 import { multiaddr } from '@multiformats/multiaddr'
@@ -24,7 +25,12 @@ describe('PersistentPeerStore', () => {
     peerId = await createEd25519PeerId()
     otherPeerId = await createEd25519PeerId()
     events = new TypedEventEmitter()
-    peerStore = new PersistentPeerStore({ peerId, events, datastore: new MemoryDatastore() })
+    peerStore = new PersistentPeerStore({
+      peerId,
+      events,
+      datastore: new MemoryDatastore(),
+      logger: defaultLogger()
+    })
   })
 
   it('has an empty map of peers', async () => {

--- a/packages/peer-store/test/merge.spec.ts
+++ b/packages/peer-store/test/merge.spec.ts
@@ -2,6 +2,7 @@
 /* eslint max-nested-callbacks: ["error", 6] */
 
 import { TypedEventEmitter, type TypedEventTarget } from '@libp2p/interface/events'
+import { defaultLogger } from '@libp2p/logger'
 import { createEd25519PeerId } from '@libp2p/peer-id-factory'
 import { multiaddr } from '@multiformats/multiaddr'
 import { expect } from 'aegir/chai'
@@ -26,7 +27,12 @@ describe('merge', () => {
     peerId = await createEd25519PeerId()
     otherPeerId = await createEd25519PeerId()
     events = new TypedEventEmitter()
-    peerStore = new PersistentPeerStore({ peerId, events, datastore: new MemoryDatastore() })
+    peerStore = new PersistentPeerStore({
+      peerId,
+      events,
+      datastore: new MemoryDatastore(),
+      logger: defaultLogger()
+    })
   })
 
   it('emits peer:update event on merge', async () => {

--- a/packages/peer-store/test/patch.spec.ts
+++ b/packages/peer-store/test/patch.spec.ts
@@ -2,6 +2,7 @@
 /* eslint max-nested-callbacks: ["error", 6] */
 
 import { TypedEventEmitter, type TypedEventTarget } from '@libp2p/interface/events'
+import { defaultLogger } from '@libp2p/logger'
 import { createEd25519PeerId } from '@libp2p/peer-id-factory'
 import { multiaddr } from '@multiformats/multiaddr'
 import { expect } from 'aegir/chai'
@@ -26,7 +27,12 @@ describe('patch', () => {
     peerId = await createEd25519PeerId()
     otherPeerId = await createEd25519PeerId()
     events = new TypedEventEmitter()
-    peerStore = new PersistentPeerStore({ peerId, events, datastore: new MemoryDatastore() })
+    peerStore = new PersistentPeerStore({
+      peerId,
+      events,
+      datastore: new MemoryDatastore(),
+      logger: defaultLogger()
+    })
   })
 
   it('emits peer:update event on patch', async () => {

--- a/packages/peer-store/test/save.spec.ts
+++ b/packages/peer-store/test/save.spec.ts
@@ -2,6 +2,7 @@
 /* eslint max-nested-callbacks: ["error", 6] */
 
 import { TypedEventEmitter, type TypedEventTarget } from '@libp2p/interface/events'
+import { defaultLogger } from '@libp2p/logger'
 import { createEd25519PeerId, createRSAPeerId, createSecp256k1PeerId } from '@libp2p/peer-id-factory'
 import { multiaddr } from '@multiformats/multiaddr'
 import { expect } from 'aegir/chai'
@@ -29,7 +30,12 @@ describe('save', () => {
     peerId = await createEd25519PeerId()
     otherPeerId = await createEd25519PeerId()
     events = new TypedEventEmitter()
-    peerStore = new PersistentPeerStore({ peerId, events, datastore: new MemoryDatastore() })
+    peerStore = new PersistentPeerStore({
+      peerId,
+      events,
+      datastore: new MemoryDatastore(),
+      logger: defaultLogger()
+    })
   })
 
   it('throws invalid parameters error if invalid PeerId is provided', async () => {

--- a/packages/pnet/package.json
+++ b/packages/pnet/package.json
@@ -47,7 +47,6 @@
   "dependencies": {
     "@libp2p/crypto": "^2.0.5",
     "@libp2p/interface": "^0.1.3",
-    "@libp2p/logger": "^3.0.2",
     "it-handshake": "^4.1.3",
     "it-map": "^3.0.4",
     "it-pair": "^2.0.6",
@@ -58,6 +57,7 @@
   },
   "devDependencies": {
     "@libp2p/interface-compliance-tests": "^4.1.1",
+    "@libp2p/logger": "^3.1.0",
     "@libp2p/peer-id-factory": "^3.0.5",
     "@multiformats/multiaddr": "^12.1.10",
     "@types/xsalsa20": "^1.1.0",

--- a/packages/pnet/src/crypto.ts
+++ b/packages/pnet/src/crypto.ts
@@ -1,12 +1,9 @@
-import { logger } from '@libp2p/logger'
 import { fromString as uint8ArrayFromString } from 'uint8arrays/from-string'
 import { toString as uint8ArrayToString } from 'uint8arrays/to-string'
 import xsalsa20 from 'xsalsa20'
 import * as Errors from './errors.js'
 import { KEY_LENGTH } from './key-generator.js'
 import type { Source } from 'it-stream-types'
-
-const log = logger('libp2p:pnet')
 
 /**
  * Creates a stream iterable to encrypt messages in a private network
@@ -27,7 +24,6 @@ export function createBoxStream (nonce: Uint8Array, psk: Uint8Array): (source: S
 export function createUnboxStream (nonce: Uint8Array, psk: Uint8Array) {
   return (source: Source<Uint8Array>) => (async function * () {
     const xor = xsalsa20(nonce, psk)
-    log.trace('Decryption enabled')
 
     for await (const chunk of source) {
       yield Uint8Array.from(xor.update(chunk.slice()))
@@ -61,7 +57,6 @@ export function decodeV1PSK (pskBuffer: Uint8Array): { tag: string | undefined, 
       psk
     }
   } catch (err: any) {
-    log.error(err)
     throw new Error(Errors.INVALID_PSK)
   }
 }

--- a/packages/pnet/src/index.ts
+++ b/packages/pnet/src/index.ts
@@ -85,7 +85,7 @@ export interface ProtectorComponents {
 
 class PreSharedKeyConnectionProtector implements ConnectionProtector {
   public tag: string
-  readonly #log: Logger
+  private readonly log: Logger
   private readonly psk: Uint8Array
   private readonly enabled: boolean
 
@@ -94,7 +94,7 @@ class PreSharedKeyConnectionProtector implements ConnectionProtector {
    * for wrapping existing connections in a private encryption stream.
    */
   constructor (components: ProtectorComponents, init: ProtectorInit) {
-    this.#log = components.logger.forComponent('libp2p:pnet')
+    this.log = components.logger.forComponent('libp2p:pnet')
     this.enabled = init.enabled !== false
 
     if (this.enabled) {
@@ -122,7 +122,7 @@ class PreSharedKeyConnectionProtector implements ConnectionProtector {
     }
 
     // Exchange nonces
-    this.#log('protecting the connection')
+    this.log('protecting the connection')
     const localNonce = randomBytes(NONCE_LENGTH)
 
     const shake = handshake(connection)
@@ -138,7 +138,7 @@ class PreSharedKeyConnectionProtector implements ConnectionProtector {
     shake.rest()
 
     // Create the boxing/unboxing pipe
-    this.#log('exchanged nonces')
+    this.log('exchanged nonces')
     const [internal, external] = duplexPair<Uint8Array>()
     pipe(
       external,
@@ -149,7 +149,7 @@ class PreSharedKeyConnectionProtector implements ConnectionProtector {
       // Decrypt all inbound traffic
       createUnboxStream(remoteNonce, this.psk),
       external
-    ).catch(this.#log.error)
+    ).catch(this.log.error)
 
     return {
       ...connection,

--- a/packages/pnet/src/index.ts
+++ b/packages/pnet/src/index.ts
@@ -58,7 +58,6 @@
 
 import { randomBytes } from '@libp2p/crypto'
 import { CodeError } from '@libp2p/interface/errors'
-import { logger } from '@libp2p/logger'
 import { handshake } from 'it-handshake'
 import map from 'it-map'
 import { duplexPair } from 'it-pair/duplex'
@@ -70,9 +69,8 @@ import {
 } from './crypto.js'
 import * as Errors from './errors.js'
 import { NONCE_LENGTH } from './key-generator.js'
+import type { ComponentLogger, Logger } from '@libp2p/interface'
 import type { ConnectionProtector, MultiaddrConnection } from '@libp2p/interface/connection'
-
-const log = logger('libp2p:pnet')
 
 export { generateKey } from './key-generator.js'
 
@@ -81,8 +79,13 @@ export interface ProtectorInit {
   psk: Uint8Array
 }
 
+export interface ProtectorComponents {
+  logger: ComponentLogger
+}
+
 class PreSharedKeyConnectionProtector implements ConnectionProtector {
   public tag: string
+  readonly #log: Logger
   private readonly psk: Uint8Array
   private readonly enabled: boolean
 
@@ -90,7 +93,8 @@ class PreSharedKeyConnectionProtector implements ConnectionProtector {
    * Takes a Private Shared Key (psk) and provides a `protect` method
    * for wrapping existing connections in a private encryption stream.
    */
-  constructor (init: ProtectorInit) {
+  constructor (components: ProtectorComponents, init: ProtectorInit) {
+    this.#log = components.logger.forComponent('libp2p:pnet')
     this.enabled = init.enabled !== false
 
     if (this.enabled) {
@@ -118,7 +122,7 @@ class PreSharedKeyConnectionProtector implements ConnectionProtector {
     }
 
     // Exchange nonces
-    log('protecting the connection')
+    this.#log('protecting the connection')
     const localNonce = randomBytes(NONCE_LENGTH)
 
     const shake = handshake(connection)
@@ -134,7 +138,7 @@ class PreSharedKeyConnectionProtector implements ConnectionProtector {
     shake.rest()
 
     // Create the boxing/unboxing pipe
-    log('exchanged nonces')
+    this.#log('exchanged nonces')
     const [internal, external] = duplexPair<Uint8Array>()
     pipe(
       external,
@@ -145,7 +149,7 @@ class PreSharedKeyConnectionProtector implements ConnectionProtector {
       // Decrypt all inbound traffic
       createUnboxStream(remoteNonce, this.psk),
       external
-    ).catch(log.error)
+    ).catch(this.#log.error)
 
     return {
       ...connection,
@@ -154,6 +158,6 @@ class PreSharedKeyConnectionProtector implements ConnectionProtector {
   }
 }
 
-export function preSharedKey (init: ProtectorInit): () => ConnectionProtector {
-  return () => new PreSharedKeyConnectionProtector(init)
+export function preSharedKey (init: ProtectorInit): (components: ProtectorComponents) => ConnectionProtector {
+  return (components) => new PreSharedKeyConnectionProtector(components, init)
 }

--- a/packages/pnet/test/index.spec.ts
+++ b/packages/pnet/test/index.spec.ts
@@ -1,5 +1,6 @@
 /* eslint-env mocha */
 import { mockMultiaddrConnPair } from '@libp2p/interface-compliance-tests/mocks'
+import { defaultLogger } from '@libp2p/logger'
 import { createEd25519PeerId } from '@libp2p/peer-id-factory'
 import { multiaddr } from '@multiformats/multiaddr'
 import { expect } from 'aegir/chai'
@@ -20,7 +21,9 @@ describe('private network', () => {
   it('should accept a valid psk buffer', () => {
     const protector = preSharedKey({
       psk: swarmKeyBuffer
-    })()
+    })({
+      logger: defaultLogger()
+    })
 
     expect(protector).to.have.property('tag', '/key/swarm/psk/1.0.0/')
   })
@@ -35,7 +38,9 @@ describe('private network', () => {
     })
     const protector = preSharedKey({
       psk: swarmKeyBuffer
-    })()
+    })({
+      logger: defaultLogger()
+    })
 
     const [aToB, bToA] = await Promise.all([
       protector.protect(inbound),
@@ -70,11 +75,15 @@ describe('private network', () => {
     })
     const protector = preSharedKey({
       psk: swarmKeyBuffer
-    })()
+    })({
+      logger: defaultLogger()
+    })
     const protectorB = preSharedKey({
       enabled: true,
       psk: wrongSwarmKeyBuffer
-    })()
+    })({
+      logger: defaultLogger()
+    })
 
     const [aToB, bToA] = await Promise.all([
       protector.protect(inbound),
@@ -99,7 +108,9 @@ describe('private network', () => {
       expect(() => {
         return preSharedKey({
           psk: uint8ArrayFromString('not-a-key')
-        })()
+        })({
+          logger: defaultLogger()
+        })
       }).to.throw(INVALID_PSK)
     })
 
@@ -107,7 +118,9 @@ describe('private network', () => {
       expect(() => {
         return preSharedKey({
           psk: uint8ArrayFromString('/key/swarm/psk/1.0.0/\n/base16/\ndffb7e')
-        })()
+        })({
+          logger: defaultLogger()
+        })
       }).to.throw(INVALID_PSK)
     })
   })

--- a/packages/protocol-autonat/package.json
+++ b/packages/protocol-autonat/package.json
@@ -61,7 +61,7 @@
     "uint8arraylist": "^2.4.3"
   },
   "devDependencies": {
-    "@libp2p/logger": "^3.0.2",
+    "@libp2p/logger": "^3.1.0",
     "@libp2p/peer-id-factory": "^3.0.4",
     "aegir": "^41.0.2",
     "it-all": "^3.0.3",

--- a/packages/protocol-perf/package.json
+++ b/packages/protocol-perf/package.json
@@ -50,11 +50,11 @@
   "dependencies": {
     "@libp2p/interface": "^0.1.6",
     "@libp2p/interface-internal": "^0.1.9",
-    "@libp2p/logger": "^3.1.0",
     "@multiformats/multiaddr": "^12.1.10",
     "it-pushable": "^3.2.1"
   },
   "devDependencies": {
+    "@libp2p/logger": "^3.1.0",
     "@libp2p/interface-compliance-tests": "^4.1.5",
     "aegir": "^41.0.2",
     "it-last": "^3.0.3",

--- a/packages/protocol-perf/src/index.ts
+++ b/packages/protocol-perf/src/index.ts
@@ -53,7 +53,7 @@
  */
 
 import { Perf as PerfClass } from './perf-service.js'
-import type { AbortOptions } from '@libp2p/interface'
+import type { AbortOptions, ComponentLogger } from '@libp2p/interface'
 import type { ConnectionManager } from '@libp2p/interface-internal/connection-manager'
 import type { Registrar } from '@libp2p/interface-internal/registrar'
 import type { Multiaddr } from '@multiformats/multiaddr'
@@ -74,7 +74,7 @@ export interface Perf {
 }
 
 export interface PerfOutput {
-  type: 'intermediary' | 'final'
+  type: 'connection' | 'stream' | 'intermediary' | 'final'
   timeSeconds: number
   uploadBytes: number
   downloadBytes: number
@@ -95,6 +95,7 @@ export interface PerfInit {
 export interface PerfComponents {
   registrar: Registrar
   connectionManager: ConnectionManager
+  logger: ComponentLogger
 }
 
 export function perf (init: PerfInit = {}): (components: PerfComponents) => Perf {

--- a/packages/protocol-perf/src/perf-service.ts
+++ b/packages/protocol-perf/src/perf-service.ts
@@ -1,14 +1,13 @@
-import { logger } from '@libp2p/logger'
 import { pushable } from 'it-pushable'
 import { MAX_INBOUND_STREAMS, MAX_OUTBOUND_STREAMS, PROTOCOL_NAME, RUN_ON_TRANSIENT_CONNECTION, WRITE_BLOCK_SIZE } from './constants.js'
 import type { PerfOptions, PerfOutput, PerfComponents, PerfInit, Perf as PerfInterface } from './index.js'
+import type { Logger } from '@libp2p/interface'
 import type { Startable } from '@libp2p/interface/startable'
 import type { IncomingStreamData } from '@libp2p/interface-internal/registrar'
 import type { Multiaddr } from '@multiformats/multiaddr'
 
-const log = logger('libp2p:perf')
-
 export class Perf implements Startable, PerfInterface {
+  readonly #log: Logger
   public readonly protocol: string
   private readonly components: PerfComponents
   private started: boolean
@@ -20,6 +19,7 @@ export class Perf implements Startable, PerfInterface {
 
   constructor (components: PerfComponents, init: PerfInit = {}) {
     this.components = components
+    this.#log = components.logger.forComponent('libp2p:perf')
     this.started = false
     this.protocol = init.protocolName ?? PROTOCOL_NAME
     this.writeBlockSize = init.writeBlockSize ?? WRITE_BLOCK_SIZE
@@ -32,7 +32,7 @@ export class Perf implements Startable, PerfInterface {
   async start (): Promise<void> {
     await this.components.registrar.handle(this.protocol, (data: IncomingStreamData) => {
       void this.handleMessage(data).catch((err) => {
-        log.error('error handling perf protocol message', err)
+        this.#log.error('error handling perf protocol message', err)
       })
     }, {
       maxInboundStreams: this.maxInboundStreams,
@@ -90,21 +90,39 @@ export class Perf implements Startable, PerfInterface {
   }
 
   async * measurePerformance (ma: Multiaddr, sendBytes: number, receiveBytes: number, options: PerfOptions = {}): AsyncGenerator<PerfOutput> {
-    log('opening stream on protocol %s to %a', this.protocol, ma)
+    this.#log('opening stream on protocol %s to %a', this.protocol, ma)
 
     const uint8Buf = new Uint8Array(this.databuf)
     const writeBlockSize = this.writeBlockSize
 
-    // start time should include connection establishment
-    const initialStartTime = Date.now()
+    let lastReportedTime = Date.now()
     const connection = await this.components.connectionManager.openConnection(ma, {
       ...options,
       force: options.reuseExistingConnection !== true
     })
+
+    yield {
+      type: 'connection',
+      timeSeconds: (Date.now() - lastReportedTime) / 1000,
+      uploadBytes: 0,
+      downloadBytes: 0
+    }
+
+    lastReportedTime = Date.now()
+
     const stream = await connection.newStream(this.protocol, options)
 
+    let initialStartTime = Date.now()
+
+    yield {
+      type: 'stream',
+      timeSeconds: (Date.now() - lastReportedTime) / 1000,
+      uploadBytes: 0,
+      downloadBytes: 0
+    }
+
     let lastAmountOfBytesSent = 0
-    let lastReportedTime = Date.now()
+    lastReportedTime = Date.now()
     let totalBytesSent = 0
 
     // tell the remote how many bytes we will send. Up cast to 64 bit number
@@ -112,7 +130,7 @@ export class Perf implements Startable, PerfInterface {
     const view = new DataView(this.databuf)
     view.setBigUint64(0, BigInt(receiveBytes), false)
 
-    log('sending %i bytes to %p', sendBytes, connection.remotePeer)
+    this.#log('sending %i bytes to %p', sendBytes, connection.remotePeer)
 
     try {
       const sendOutput = pushable<PerfOutput>({
@@ -122,6 +140,8 @@ export class Perf implements Startable, PerfInterface {
       void stream.sink(async function * () {
         // Send the number of bytes to receive
         yield uint8Buf.subarray(0, 8)
+
+        initialStartTime = Date.now()
 
         while (sendBytes > 0) {
           options.signal?.throwIfAborted()
@@ -196,10 +216,10 @@ export class Perf implements Startable, PerfInterface {
         downloadBytes: totalBytesReceived
       }
 
-      log('performed %s to %p', this.protocol, connection.remotePeer)
+      this.#log('performed %s to %p', this.protocol, connection.remotePeer)
       await stream.close()
     } catch (err: any) {
-      log('error sending %d/%d bytes to %p: %s', totalBytesSent, sendBytes, connection.remotePeer, err)
+      this.#log('error sending %d/%d bytes to %p: %s', totalBytesSent, sendBytes, connection.remotePeer, err)
       stream.abort(err)
       throw err
     }

--- a/packages/protocol-perf/src/perf-service.ts
+++ b/packages/protocol-perf/src/perf-service.ts
@@ -7,7 +7,7 @@ import type { IncomingStreamData } from '@libp2p/interface-internal/registrar'
 import type { Multiaddr } from '@multiformats/multiaddr'
 
 export class Perf implements Startable, PerfInterface {
-  readonly #log: Logger
+  private readonly log: Logger
   public readonly protocol: string
   private readonly components: PerfComponents
   private started: boolean
@@ -19,7 +19,7 @@ export class Perf implements Startable, PerfInterface {
 
   constructor (components: PerfComponents, init: PerfInit = {}) {
     this.components = components
-    this.#log = components.logger.forComponent('libp2p:perf')
+    this.log = components.logger.forComponent('libp2p:perf')
     this.started = false
     this.protocol = init.protocolName ?? PROTOCOL_NAME
     this.writeBlockSize = init.writeBlockSize ?? WRITE_BLOCK_SIZE
@@ -32,7 +32,7 @@ export class Perf implements Startable, PerfInterface {
   async start (): Promise<void> {
     await this.components.registrar.handle(this.protocol, (data: IncomingStreamData) => {
       void this.handleMessage(data).catch((err) => {
-        this.#log.error('error handling perf protocol message', err)
+        this.log.error('error handling perf protocol message', err)
       })
     }, {
       maxInboundStreams: this.maxInboundStreams,
@@ -90,7 +90,7 @@ export class Perf implements Startable, PerfInterface {
   }
 
   async * measurePerformance (ma: Multiaddr, sendBytes: number, receiveBytes: number, options: PerfOptions = {}): AsyncGenerator<PerfOutput> {
-    this.#log('opening stream on protocol %s to %a', this.protocol, ma)
+    this.log('opening stream on protocol %s to %a', this.protocol, ma)
 
     const uint8Buf = new Uint8Array(this.databuf)
     const writeBlockSize = this.writeBlockSize
@@ -130,7 +130,7 @@ export class Perf implements Startable, PerfInterface {
     const view = new DataView(this.databuf)
     view.setBigUint64(0, BigInt(receiveBytes), false)
 
-    this.#log('sending %i bytes to %p', sendBytes, connection.remotePeer)
+    this.log('sending %i bytes to %p', sendBytes, connection.remotePeer)
 
     try {
       const sendOutput = pushable<PerfOutput>({
@@ -216,10 +216,10 @@ export class Perf implements Startable, PerfInterface {
         downloadBytes: totalBytesReceived
       }
 
-      this.#log('performed %s to %p', this.protocol, connection.remotePeer)
+      this.log('performed %s to %p', this.protocol, connection.remotePeer)
       await stream.close()
     } catch (err: any) {
-      this.#log('error sending %d/%d bytes to %p: %s', totalBytesSent, sendBytes, connection.remotePeer, err)
+      this.log('error sending %d/%d bytes to %p: %s', totalBytesSent, sendBytes, connection.remotePeer, err)
       stream.abort(err)
       throw err
     }

--- a/packages/protocol-perf/test/index.spec.ts
+++ b/packages/protocol-perf/test/index.spec.ts
@@ -2,12 +2,14 @@
 
 import { start, stop } from '@libp2p/interface/startable'
 import { streamPair } from '@libp2p/interface-compliance-tests/mocks'
+import { defaultLogger } from '@libp2p/logger'
 import { multiaddr } from '@multiformats/multiaddr'
 import { expect } from 'aegir/chai'
 import last from 'it-last'
 import { duplexPair } from 'it-pair/duplex'
 import { stubInterface, type StubbedInstance } from 'sinon-ts'
 import { Perf } from '../src/perf-service.js'
+import type { ComponentLogger } from '@libp2p/interface'
 import type { Connection } from '@libp2p/interface/connection'
 import type { ConnectionManager } from '@libp2p/interface-internal/connection-manager'
 import type { Registrar } from '@libp2p/interface-internal/registrar'
@@ -15,12 +17,14 @@ import type { Registrar } from '@libp2p/interface-internal/registrar'
 interface StubbedPerfComponents {
   registrar: StubbedInstance<Registrar>
   connectionManager: StubbedInstance<ConnectionManager>
+  logger: ComponentLogger
 }
 
 export function createComponents (): StubbedPerfComponents {
   return {
     registrar: stubInterface<Registrar>(),
-    connectionManager: stubInterface<ConnectionManager>()
+    connectionManager: stubInterface<ConnectionManager>(),
+    logger: defaultLogger()
   }
 }
 

--- a/packages/protocol-ping/package.json
+++ b/packages/protocol-ping/package.json
@@ -48,7 +48,6 @@
     "@libp2p/crypto": "^2.0.8",
     "@libp2p/interface": "^0.1.2",
     "@libp2p/interface-internal": "^0.1.5",
-    "@libp2p/logger": "^3.1.0",
     "@libp2p/peer-id-factory": "^3.0.8",
     "@multiformats/multiaddr": "^12.1.10",
     "it-first": "^3.0.3",
@@ -56,6 +55,7 @@
     "uint8arrays": "^4.0.6"
   },
   "devDependencies": {
+    "@libp2p/logger": "^3.1.0",
     "aegir": "^41.0.2",
     "it-byte-stream": "^1.0.1",
     "it-pair": "^2.0.6",

--- a/packages/protocol-ping/src/ping.ts
+++ b/packages/protocol-ping/src/ping.ts
@@ -20,11 +20,11 @@ export class PingService implements Startable, PingServiceInterface {
   private readonly maxInboundStreams: number
   private readonly maxOutboundStreams: number
   private readonly runOnTransientConnection: boolean
-  readonly #log: Logger
+  private readonly log: Logger
 
   constructor (components: PingServiceComponents, init: PingServiceInit = {}) {
     this.components = components
-    this.#log = components.logger.forComponent('libp2p:ping')
+    this.log = components.logger.forComponent('libp2p:ping')
     this.started = false
     this.protocol = `/${init.protocolPrefix ?? PROTOCOL_PREFIX}/${PROTOCOL_NAME}/${PROTOCOL_VERSION}`
     this.timeout = init.timeout ?? TIMEOUT
@@ -57,19 +57,19 @@ export class PingService implements Startable, PingServiceInterface {
    * A handler to register with Libp2p to process ping messages
    */
   handleMessage (data: IncomingStreamData): void {
-    this.#log('incoming ping from %p', data.connection.remotePeer)
+    this.log('incoming ping from %p', data.connection.remotePeer)
 
     const { stream } = data
     const start = Date.now()
 
     void pipe(stream, stream)
       .catch(err => {
-        this.#log.error('incoming ping from %p failed with error', data.connection.remotePeer, err)
+        this.log.error('incoming ping from %p failed with error', data.connection.remotePeer, err)
       })
       .finally(() => {
         const ms = Date.now() - start
 
-        this.#log('incoming ping from %p complete in %dms', data.connection.remotePeer, ms)
+        this.log('incoming ping from %p complete in %dms', data.connection.remotePeer, ms)
       })
   }
 
@@ -77,7 +77,7 @@ export class PingService implements Startable, PingServiceInterface {
    * Ping a given peer and wait for its response, getting the operation latency.
    */
   async ping (peer: PeerId | Multiaddr | Multiaddr[], options: AbortOptions = {}): Promise<number> {
-    this.#log('pinging %p', peer)
+    this.log('pinging %p', peer)
 
     const start = Date.now()
     const data = randomBytes(PING_LENGTH)
@@ -123,11 +123,11 @@ export class PingService implements Startable, PingServiceInterface {
         throw new CodeError(`Received wrong ping ack after ${ms}ms`, ERR_WRONG_PING_ACK)
       }
 
-      this.#log('ping %p complete in %dms', connection.remotePeer, ms)
+      this.log('ping %p complete in %dms', connection.remotePeer, ms)
 
       return ms
     } catch (err: any) {
-      this.#log.error('error while pinging %p', connection.remotePeer, err)
+      this.log.error('error while pinging %p', connection.remotePeer, err)
 
       stream?.abort(err)
 

--- a/packages/pubsub-floodsub/package.json
+++ b/packages/pubsub-floodsub/package.json
@@ -56,7 +56,6 @@
   },
   "dependencies": {
     "@libp2p/interface": "^0.1.6",
-    "@libp2p/logger": "^3.1.0",
     "@libp2p/pubsub": "^8.0.10",
     "protons-runtime": "^5.0.0",
     "uint8arraylist": "^2.4.3",
@@ -64,6 +63,7 @@
   },
   "devDependencies": {
     "@libp2p/interface-compliance-tests": "^4.1.5",
+    "@libp2p/logger": "^3.1.0",
     "@libp2p/peer-collections": "^4.0.8",
     "@libp2p/peer-id-factory": "^3.0.8",
     "@multiformats/multiaddr": "^12.1.10",

--- a/packages/pubsub-floodsub/src/config.ts
+++ b/packages/pubsub-floodsub/src/config.ts
@@ -1,5 +1,1 @@
-import { logger } from '@libp2p/logger'
-
-export const log = logger('libp2p:floodsub')
-
 export const multicodec = '/floodsub/1.0.0'

--- a/packages/pubsub-floodsub/src/index.ts
+++ b/packages/pubsub-floodsub/src/index.ts
@@ -23,7 +23,7 @@
  *
  * node.pubsub.subscribe('fruit')
  * node.pubsub.addEventListener('message', (evt) => {
- *   console.this.#log(evt)
+ *   console.this.log(evt)
  * })
  *
  * node.pubsub.publish('fruit', new TextEncoder().encode('banana'))
@@ -35,7 +35,6 @@ import { toString } from 'uint8arrays/to-string'
 import { SimpleTimeCache } from './cache.js'
 import { multicodec } from './config.js'
 import { RPC } from './message/rpc.js'
-import type { Logger } from '@libp2p/interface'
 import type { PeerId } from '@libp2p/interface/peer-id'
 import type { PubSubInit, Message, PubSubRPC, PubSubRPCMessage, PublishResult, PubSub } from '@libp2p/interface/pubsub'
 import type { Uint8ArrayList } from 'uint8arraylist'
@@ -56,7 +55,6 @@ export interface FloodSubComponents extends PubSubComponents {
  * (it just floods the network).
  */
 export class FloodSub extends PubSubBaseProtocol {
-  #log: Logger
   public seenCache: SimpleTimeCache<boolean>
 
   constructor (components: FloodSubComponents, init?: FloodSubInit) {
@@ -66,7 +64,7 @@ export class FloodSub extends PubSubBaseProtocol {
       multicodecs: [multicodec]
     })
 
-    this.#log = components.logger.forComponent('libp2p:floodsub')
+    this.log = components.logger.forComponent('libp2p:floodsub')
 
     /**
      * Cache of seen messages
@@ -126,22 +124,22 @@ export class FloodSub extends PubSubBaseProtocol {
     const recipients: PeerId[] = []
 
     if (peers == null || peers.length === 0) {
-      this.#log('no peers are subscribed to topic %s', message.topic)
+      this.log('no peers are subscribed to topic %s', message.topic)
       return { recipients }
     }
 
     peers.forEach(id => {
       if (this.components.peerId.equals(id)) {
-        this.#log('not sending message on topic %s to myself', message.topic)
+        this.log('not sending message on topic %s to myself', message.topic)
         return
       }
 
       if (id.equals(from)) {
-        this.#log('not sending message on topic %s to sender %p', message.topic, id)
+        this.log('not sending message on topic %s to sender %p', message.topic, id)
         return
       }
 
-      this.#log('publish msgs on topics %s %p', message.topic, id)
+      this.log('publish msgs on topics %s %p', message.topic, id)
 
       recipients.push(id)
       this.send(id, { messages: [message] })

--- a/packages/pubsub-floodsub/src/index.ts
+++ b/packages/pubsub-floodsub/src/index.ts
@@ -23,24 +23,22 @@
  *
  * node.pubsub.subscribe('fruit')
  * node.pubsub.addEventListener('message', (evt) => {
- *   console.log(evt)
+ *   console.this.#log(evt)
  * })
  *
  * node.pubsub.publish('fruit', new TextEncoder().encode('banana'))
  * ```
  */
 
-import { logger } from '@libp2p/logger'
 import { PubSubBaseProtocol, type PubSubComponents } from '@libp2p/pubsub'
 import { toString } from 'uint8arrays/to-string'
 import { SimpleTimeCache } from './cache.js'
 import { multicodec } from './config.js'
 import { RPC } from './message/rpc.js'
+import type { Logger } from '@libp2p/interface'
 import type { PeerId } from '@libp2p/interface/peer-id'
 import type { PubSubInit, Message, PubSubRPC, PubSubRPCMessage, PublishResult, PubSub } from '@libp2p/interface/pubsub'
 import type { Uint8ArrayList } from 'uint8arraylist'
-
-const log = logger('libp2p:floodsub')
 
 export { multicodec }
 
@@ -58,6 +56,7 @@ export interface FloodSubComponents extends PubSubComponents {
  * (it just floods the network).
  */
 export class FloodSub extends PubSubBaseProtocol {
+  #log: Logger
   public seenCache: SimpleTimeCache<boolean>
 
   constructor (components: FloodSubComponents, init?: FloodSubInit) {
@@ -66,6 +65,8 @@ export class FloodSub extends PubSubBaseProtocol {
       canRelayMessage: true,
       multicodecs: [multicodec]
     })
+
+    this.#log = components.logger.forComponent('libp2p:floodsub')
 
     /**
      * Cache of seen messages
@@ -125,22 +126,22 @@ export class FloodSub extends PubSubBaseProtocol {
     const recipients: PeerId[] = []
 
     if (peers == null || peers.length === 0) {
-      log('no peers are subscribed to topic %s', message.topic)
+      this.#log('no peers are subscribed to topic %s', message.topic)
       return { recipients }
     }
 
     peers.forEach(id => {
       if (this.components.peerId.equals(id)) {
-        log('not sending message on topic %s to myself', message.topic)
+        this.#log('not sending message on topic %s to myself', message.topic)
         return
       }
 
       if (id.equals(from)) {
-        log('not sending message on topic %s to sender %p', message.topic, id)
+        this.#log('not sending message on topic %s to sender %p', message.topic, id)
         return
       }
 
-      log('publish msgs on topics %s %p', message.topic, id)
+      this.#log('publish msgs on topics %s %p', message.topic, id)
 
       recipients.push(id)
       this.send(id, { messages: [message] })

--- a/packages/pubsub-floodsub/test/floodsub.spec.ts
+++ b/packages/pubsub-floodsub/test/floodsub.spec.ts
@@ -2,6 +2,7 @@
 
 import { type Message, type PubSubRPC, StrictNoSign } from '@libp2p/interface/pubsub'
 import { mockRegistrar } from '@libp2p/interface-compliance-tests/mocks'
+import { defaultLogger } from '@libp2p/logger'
 import { PeerSet } from '@libp2p/peer-collections'
 import { createEd25519PeerId } from '@libp2p/peer-id-factory'
 import { PeerStreams } from '@libp2p/pubsub/peer-streams'
@@ -24,7 +25,8 @@ describe('floodsub', () => {
 
     floodsub = new FloodSub({
       peerId: await createEd25519PeerId(),
-      registrar: mockRegistrar()
+      registrar: mockRegistrar(),
+      logger: defaultLogger()
     }, {
       emitSelf: true,
       globalSignaturePolicy: StrictNoSign
@@ -47,6 +49,8 @@ describe('floodsub', () => {
     let callCount = 0
 
     const peerStream = new PeerStreams({
+      logger: defaultLogger()
+    }, {
       id: otherPeer,
       protocol: 'test'
     })
@@ -120,6 +124,8 @@ describe('floodsub', () => {
     const sender = await createEd25519PeerId()
 
     const peerStream = new PeerStreams({
+      logger: defaultLogger()
+    }, {
       id: sender,
       protocol: 'test'
     })

--- a/packages/pubsub/package.json
+++ b/packages/pubsub/package.json
@@ -82,7 +82,6 @@
     "@libp2p/crypto": "^2.0.8",
     "@libp2p/interface": "^0.1.6",
     "@libp2p/interface-internal": "^0.1.9",
-    "@libp2p/logger": "^3.1.0",
     "@libp2p/peer-collections": "^4.0.8",
     "@libp2p/peer-id": "^3.0.6",
     "abortable-iterator": "^5.0.1",
@@ -95,6 +94,7 @@
     "uint8arrays": "^4.0.6"
   },
   "devDependencies": {
+    "@libp2p/logger": "^3.1.0",
     "@libp2p/peer-id-factory": "^3.0.8",
     "@types/sinon": "^17.0.0",
     "aegir": "^41.0.2",

--- a/packages/pubsub/src/peer-streams.ts
+++ b/packages/pubsub/src/peer-streams.ts
@@ -46,12 +46,12 @@ export class PeerStreams extends TypedEventEmitter<PeerStreamEvents> {
    */
   private readonly _inboundAbortController: AbortController
   private closed: boolean
-  readonly #log: Logger
+  private readonly log: Logger
 
   constructor (components: PeerStreamsComponents, init: PeerStreamsInit) {
     super()
 
-    this.#log = components.logger.forComponent('libp2p-pubsub:peer-streams')
+    this.log = components.logger.forComponent('libp2p-pubsub:peer-streams')
     this.id = init.id
     this.protocol = init.protocol
 
@@ -127,7 +127,7 @@ export class PeerStreams extends TypedEventEmitter<PeerStreamEvents> {
         if (this._rawOutboundStream != null) { // eslint-disable-line @typescript-eslint/prefer-optional-chain
           this._rawOutboundStream.closeWrite()
             .catch(err => {
-              this.#log('error closing outbound stream', err)
+              this.log('error closing outbound stream', err)
             })
         }
 
@@ -144,7 +144,7 @@ export class PeerStreams extends TypedEventEmitter<PeerStreamEvents> {
       (source) => lp.encode(source),
       this._rawOutboundStream
     ).catch((err: Error) => {
-      this.#log.error(err)
+      this.log.error(err)
     })
 
     // Only emit if the connection is new

--- a/packages/pubsub/test/emit-self.spec.ts
+++ b/packages/pubsub/test/emit-self.spec.ts
@@ -1,3 +1,4 @@
+import { defaultLogger } from '@libp2p/logger'
 import { expect } from 'aegir/chai'
 import delay from 'delay'
 import { fromString as uint8ArrayFromString } from 'uint8arrays/from-string'
@@ -21,7 +22,8 @@ describe('emitSelf', () => {
 
       pubsub = new PubsubImplementation({
         peerId,
-        registrar: new MockRegistrar()
+        registrar: new MockRegistrar(),
+        logger: defaultLogger()
       }, {
         multicodecs: [protocol],
         emitSelf: true
@@ -76,7 +78,8 @@ describe('emitSelf', () => {
 
       pubsub = new PubsubImplementation({
         peerId,
-        registrar: new MockRegistrar()
+        registrar: new MockRegistrar(),
+        logger: defaultLogger()
       }, {
         multicodecs: [protocol],
         emitSelf: false

--- a/packages/pubsub/test/instance.spec.ts
+++ b/packages/pubsub/test/instance.spec.ts
@@ -1,3 +1,4 @@
+import { defaultLogger } from '@libp2p/logger'
 import { createEd25519PeerId } from '@libp2p/peer-id-factory'
 import { expect } from 'aegir/chai'
 import { PubSubBaseProtocol } from '../src/index.js'
@@ -41,7 +42,8 @@ describe('pubsub instance', () => {
     expect(() => {
       return new PubsubProtocol({
         peerId,
-        registrar: new MockRegistrar()
+        registrar: new MockRegistrar(),
+        logger: defaultLogger()
       }, { // eslint-disable-line no-new
         multicodecs: ['/pubsub/1.0.0']
       })

--- a/packages/pubsub/test/lifecycle.spec.ts
+++ b/packages/pubsub/test/lifecycle.spec.ts
@@ -1,3 +1,4 @@
+import { defaultLogger } from '@libp2p/logger'
 import { expect } from 'aegir/chai'
 import delay from 'delay'
 import sinon from 'sinon'
@@ -53,7 +54,8 @@ describe('pubsub base lifecycle', () => {
 
       pubsub = new PubsubProtocol({
         peerId,
-        registrar: sinonMockRegistrar
+        registrar: sinonMockRegistrar,
+        logger: defaultLogger()
       }, {
         multicodecs: ['/pubsub/1.0.0']
       })
@@ -112,13 +114,15 @@ describe('pubsub base lifecycle', () => {
 
       pubsubA = new PubsubImplementation({
         peerId: peerIdA,
-        registrar: registrarA
+        registrar: registrarA,
+        logger: defaultLogger()
       }, {
         multicodecs: [protocol]
       })
       pubsubB = new PubsubImplementation({
         peerId: peerIdB,
-        registrar: registrarB
+        registrar: registrarB,
+        logger: defaultLogger()
       }, {
         multicodecs: [protocol]
       })

--- a/packages/pubsub/test/message.spec.ts
+++ b/packages/pubsub/test/message.spec.ts
@@ -1,4 +1,5 @@
 /* eslint-env mocha */
+import { defaultLogger } from '@libp2p/logger'
 import { expect } from 'aegir/chai'
 import sinon from 'sinon'
 import { fromString as uint8ArrayFromString } from 'uint8arrays/from-string'
@@ -19,7 +20,8 @@ describe('pubsub base messages', () => {
     peerId = await createPeerId()
     pubsub = new PubsubImplementation({
       peerId,
-      registrar: new MockRegistrar()
+      registrar: new MockRegistrar(),
+      logger: defaultLogger()
     }, {
       multicodecs: ['/pubsub/1.0.0']
     })

--- a/packages/pubsub/test/pubsub.spec.ts
+++ b/packages/pubsub/test/pubsub.spec.ts
@@ -1,4 +1,5 @@
 /* eslint max-nested-callbacks: ["error", 6] */
+import { defaultLogger } from '@libp2p/logger'
 import { PeerSet } from '@libp2p/peer-collections'
 import { createEd25519PeerId } from '@libp2p/peer-id-factory'
 import { expect } from 'aegir/chai'
@@ -31,7 +32,8 @@ describe('pubsub base implementation', () => {
       const peerId = await createPeerId()
       pubsub = new PubsubImplementation({
         peerId,
-        registrar: new MockRegistrar()
+        registrar: new MockRegistrar(),
+        logger: defaultLogger()
       }, {
         multicodecs: [protocol],
         emitSelf: true
@@ -104,7 +106,8 @@ describe('pubsub base implementation', () => {
         const peerId = await createPeerId()
         pubsub = new PubsubImplementation({
           peerId,
-          registrar: new MockRegistrar()
+          registrar: new MockRegistrar(),
+          logger: defaultLogger()
         }, {
           multicodecs: [protocol]
         })
@@ -136,13 +139,15 @@ describe('pubsub base implementation', () => {
 
         pubsubA = new PubsubImplementation({
           peerId: peerIdA,
-          registrar: registrarA
+          registrar: registrarA,
+          logger: defaultLogger()
         }, {
           multicodecs: [protocol]
         })
         pubsubB = new PubsubImplementation({
           peerId: peerIdB,
-          registrar: registrarB
+          registrar: registrarB,
+          logger: defaultLogger()
         }, {
           multicodecs: [protocol]
         })
@@ -206,7 +211,8 @@ describe('pubsub base implementation', () => {
         const peerId = await createPeerId()
         pubsub = new PubsubImplementation({
           peerId,
-          registrar: new MockRegistrar()
+          registrar: new MockRegistrar(),
+          logger: defaultLogger()
         }, {
           multicodecs: [protocol]
         })
@@ -242,13 +248,15 @@ describe('pubsub base implementation', () => {
 
         pubsubA = new PubsubImplementation({
           peerId: peerIdA,
-          registrar: registrarA
+          registrar: registrarA,
+          logger: defaultLogger()
         }, {
           multicodecs: [protocol]
         })
         pubsubB = new PubsubImplementation({
           peerId: peerIdB,
-          registrar: registrarB
+          registrar: registrarB,
+          logger: defaultLogger()
         }, {
           multicodecs: [protocol]
         })
@@ -336,7 +344,8 @@ describe('pubsub base implementation', () => {
       peerId = await createPeerId()
       pubsub = new PubsubImplementation({
         peerId,
-        registrar: new MockRegistrar()
+        registrar: new MockRegistrar(),
+        logger: defaultLogger()
       }, {
         multicodecs: [protocol]
       })
@@ -365,7 +374,8 @@ describe('pubsub base implementation', () => {
       peerId = await createPeerId()
       pubsub = new PubsubImplementation({
         peerId,
-        registrar: new MockRegistrar()
+        registrar: new MockRegistrar(),
+        logger: defaultLogger()
       }, {
         multicodecs: [protocol]
       })
@@ -411,7 +421,9 @@ describe('pubsub base implementation', () => {
       expect(peersSubscribed).to.be.empty()
 
       // Set mock peer subscribed
-      const peer = new PeerStreams({ id: peerId, protocol: 'a-protocol' })
+      const peer = new PeerStreams({
+        logger: defaultLogger()
+      }, { id: peerId, protocol: 'a-protocol' })
       const id = peer.id
 
       const set = new PeerSet()
@@ -436,7 +448,8 @@ describe('pubsub base implementation', () => {
       peerId = await createPeerId()
       pubsub = new PubsubImplementation({
         peerId,
-        registrar: new MockRegistrar()
+        registrar: new MockRegistrar(),
+        logger: defaultLogger()
       }, {
         multicodecs: [protocol]
       })
@@ -450,6 +463,8 @@ describe('pubsub base implementation', () => {
       sinon.spy(pubsub, 'validate')
 
       const peerStream = new PeerStreams({
+        logger: defaultLogger()
+      }, {
         id: await createEd25519PeerId(),
         protocol: 'test'
       })
@@ -480,6 +495,8 @@ describe('pubsub base implementation', () => {
       sinon.spy(pubsub, 'validate')
 
       const peerStream = new PeerStreams({
+        logger: defaultLogger()
+      }, {
         id: await createEd25519PeerId(),
         protocol: 'test'
       })

--- a/packages/pubsub/test/topic-validators.spec.ts
+++ b/packages/pubsub/test/topic-validators.spec.ts
@@ -1,4 +1,5 @@
 import { type PubSubRPC, TopicValidatorResult } from '@libp2p/interface/pubsub'
+import { defaultLogger } from '@libp2p/logger'
 import { createEd25519PeerId } from '@libp2p/peer-id-factory'
 import { expect } from 'aegir/chai'
 import pWaitFor from 'p-wait-for'
@@ -25,7 +26,8 @@ describe('topic validators', () => {
 
     pubsub = new PubsubImplementation({
       peerId,
-      registrar: new MockRegistrar()
+      registrar: new MockRegistrar(),
+      logger: defaultLogger()
     }, {
       multicodecs: [protocol],
       globalSignaturePolicy: 'StrictNoSign'
@@ -44,7 +46,9 @@ describe('topic validators', () => {
     // @ts-expect-error not all fields are implemented in return value
     sinon.stub(pubsub.peers, 'get').returns({})
     const filteredTopic = 't'
-    const peer = new PeerStreams({ id: otherPeerId, protocol: 'a-protocol' })
+    const peer = new PeerStreams({
+      logger: defaultLogger()
+    }, { id: otherPeerId, protocol: 'a-protocol' })
 
     // Set a trivial topic validator
     pubsub.topicValidators.set(filteredTopic, async (_otherPeerId, message) => {

--- a/packages/stream-multiplexer-mplex/package.json
+++ b/packages/stream-multiplexer-mplex/package.json
@@ -58,7 +58,6 @@
   },
   "dependencies": {
     "@libp2p/interface": "^0.1.6",
-    "@libp2p/logger": "^3.1.0",
     "abortable-iterator": "^5.0.1",
     "benchmark": "^2.1.4",
     "it-batched-bytes": "^2.0.2",
@@ -71,6 +70,7 @@
   },
   "devDependencies": {
     "@libp2p/interface-compliance-tests": "^4.1.5",
+    "@libp2p/logger": "^3.1.0",
     "aegir": "^41.0.2",
     "cborg": "^4.0.3",
     "delay": "^6.0.0",

--- a/packages/stream-multiplexer-mplex/src/index.ts
+++ b/packages/stream-multiplexer-mplex/src/index.ts
@@ -31,7 +31,7 @@
  * ```
  */
 
-import { MplexStreamMuxer } from './mplex.js'
+import { MplexStreamMuxer, type MplexComponents } from './mplex.js'
 import type { StreamMuxer, StreamMuxerFactory, StreamMuxerInit } from '@libp2p/interface/stream-muxer'
 
 export interface MplexInit {
@@ -96,19 +96,21 @@ export interface MplexInit {
 class Mplex implements StreamMuxerFactory {
   public protocol = '/mplex/6.7.0'
   private readonly _init: MplexInit
+  private readonly components: MplexComponents
 
-  constructor (init: MplexInit = {}) {
+  constructor (components: MplexComponents, init: MplexInit = {}) {
+    this.components = components
     this._init = init
   }
 
   createStreamMuxer (init: StreamMuxerInit = {}): StreamMuxer {
-    return new MplexStreamMuxer({
+    return new MplexStreamMuxer(this.components, {
       ...init,
       ...this._init
     })
   }
 }
 
-export function mplex (init: MplexInit = {}): () => StreamMuxerFactory {
-  return () => new Mplex(init)
+export function mplex (init: MplexInit = {}): (components: MplexComponents) => StreamMuxerFactory {
+  return (components) => new Mplex(components, init)
 }

--- a/packages/stream-multiplexer-mplex/src/mplex.ts
+++ b/packages/stream-multiplexer-mplex/src/mplex.ts
@@ -1,5 +1,4 @@
 import { CodeError } from '@libp2p/interface/errors'
-import { logger } from '@libp2p/logger'
 import { abortableSource } from 'abortable-iterator'
 import { pipe } from 'it-pipe'
 import { type PushableV, pushableV } from 'it-pushable'
@@ -10,13 +9,11 @@ import { encode } from './encode.js'
 import { MessageTypes, MessageTypeNames, type Message } from './message-types.js'
 import { createStream, type MplexStream } from './stream.js'
 import type { MplexInit } from './index.js'
-import type { AbortOptions } from '@libp2p/interface'
+import type { AbortOptions, ComponentLogger, Logger } from '@libp2p/interface'
 import type { Stream } from '@libp2p/interface/connection'
 import type { StreamMuxer, StreamMuxerInit } from '@libp2p/interface/stream-muxer'
 import type { Sink, Source } from 'it-stream-types'
 import type { Uint8ArrayList } from 'uint8arraylist'
-
-const log = logger('libp2p:mplex')
 
 const MAX_STREAMS_INBOUND_STREAMS_PER_CONNECTION = 1024
 const MAX_STREAMS_OUTBOUND_STREAMS_PER_CONNECTION = 1024
@@ -41,6 +38,10 @@ function printMessage (msg: Message): any {
   return output
 }
 
+export interface MplexComponents {
+  logger: ComponentLogger
+}
+
 interface MplexStreamMuxerInit extends MplexInit, StreamMuxerInit {
   /**
    * The default timeout to use in ms when shutting down the muxer.
@@ -54,6 +55,7 @@ export class MplexStreamMuxer implements StreamMuxer {
   public sink: Sink<Source<Uint8ArrayList | Uint8Array>, Promise<void>>
   public source: AsyncGenerator<Uint8Array>
 
+  readonly #log: Logger
   private _streamId: number
   private readonly _streams: { initiators: Map<number, MplexStream>, receivers: Map<number, MplexStream> }
   private readonly _init: MplexStreamMuxerInit
@@ -61,10 +63,13 @@ export class MplexStreamMuxer implements StreamMuxer {
   private readonly closeController: AbortController
   private readonly rateLimiter: RateLimiterMemory
   private readonly closeTimeout: number
+  private readonly logger: ComponentLogger
 
-  constructor (init?: MplexStreamMuxerInit) {
+  constructor (components: MplexComponents, init?: MplexStreamMuxerInit) {
     init = init ?? {}
 
+    this.#log = components.logger.forComponent('libp2p:mplex')
+    this.logger = components.logger
     this._streamId = 0
     this._streams = {
       /**
@@ -199,7 +204,7 @@ export class MplexStreamMuxer implements StreamMuxer {
   _newStream (options: { id: number, name: string, type: 'initiator' | 'receiver', registry: Map<number, MplexStream> }): MplexStream {
     const { id, name, type, registry } = options
 
-    log('new %s stream %s', type, id)
+    this.#log('new %s stream %s', type, id)
 
     if (type === 'initiator' && this._streams.initiators.size === (this._init.maxOutboundStreams ?? MAX_STREAMS_OUTBOUND_STREAMS_PER_CONNECTION)) {
       throw new CodeError('Too many outbound streams open', 'ERR_TOO_MANY_OUTBOUND_STREAMS')
@@ -210,15 +215,15 @@ export class MplexStreamMuxer implements StreamMuxer {
     }
 
     const send = async (msg: Message): Promise<void> => {
-      if (log.enabled) {
-        log.trace('%s stream %s send', type, id, printMessage(msg))
+      if (this.#log.enabled) {
+        this.#log.trace('%s stream %s send', type, id, printMessage(msg))
       }
 
       this._source.push(msg)
     }
 
     const onEnd = (): void => {
-      log('%s stream with id %s and protocol %s ended', type, id, stream.protocol)
+      this.#log('%s stream with id %s and protocol %s ended', type, id, stream.protocol)
       registry.delete(id)
 
       if (this._init.onStreamEnd != null) {
@@ -226,7 +231,7 @@ export class MplexStreamMuxer implements StreamMuxer {
       }
     }
 
-    const stream = createStream({ id, name, send, type, onEnd, maxMsgSize: this._init.maxMsgSize })
+    const stream = createStream({ id, name, send, type, onEnd, maxMsgSize: this._init.maxMsgSize, logger: this.logger })
     registry.set(id, stream)
     return stream
   }
@@ -252,7 +257,7 @@ export class MplexStreamMuxer implements StreamMuxer {
 
         this._source.end()
       } catch (err: any) {
-        log('error in sink', err)
+        this.#log('error in sink', err)
         this._source.end(err) // End the source with an error
       }
     }
@@ -263,14 +268,14 @@ export class MplexStreamMuxer implements StreamMuxer {
   async _handleIncoming (message: Message): Promise<void> {
     const { id, type } = message
 
-    if (log.enabled) {
-      log.trace('incoming message', printMessage(message))
+    if (this.#log.enabled) {
+      this.#log.trace('incoming message', printMessage(message))
     }
 
     // Create a new stream?
     if (message.type === MessageTypes.NEW_STREAM) {
       if (this._streams.receivers.size === (this._init.maxInboundStreams ?? MAX_STREAMS_INBOUND_STREAMS_PER_CONNECTION)) {
-        log('too many inbound streams open')
+        this.#log('too many inbound streams open')
 
         // not going to allow this stream, send the reset message manually
         // instead of setting it up just to tear it down
@@ -285,7 +290,7 @@ export class MplexStreamMuxer implements StreamMuxer {
         try {
           await this.rateLimiter.consume('new-stream', 1)
         } catch {
-          log('rate limit hit when opening too many new streams over the inbound stream limit - closing remote connection')
+          this.#log('rate limit hit when opening too many new streams over the inbound stream limit - closing remote connection')
           // since there's no backpressure in mplex, the only thing we can really do to protect ourselves is close the connection
           this.abort(new Error('Too many open streams'))
           return
@@ -307,7 +312,7 @@ export class MplexStreamMuxer implements StreamMuxer {
     const stream = list.get(id)
 
     if (stream == null) {
-      log('missing stream %s for message type %s', id, MessageTypeNames[type])
+      this.#log('missing stream %s for message type %s', id, MessageTypeNames[type])
 
       // if the remote keeps sending us messages for streams that have been
       // closed or were never opened they may be attacking us so if they do
@@ -315,7 +320,7 @@ export class MplexStreamMuxer implements StreamMuxer {
       try {
         await this.rateLimiter.consume('missing-stream', 1)
       } catch {
-        log('rate limit hit when receiving messages for streams that do not exist - closing remote connection')
+        this.#log('rate limit hit when receiving messages for streams that do not exist - closing remote connection')
         // since there's no backpressure in mplex, the only thing we can really do to protect ourselves is close the connection
         this.abort(new Error('Too many messages for missing streams'))
         return
@@ -355,10 +360,10 @@ export class MplexStreamMuxer implements StreamMuxer {
           stream.reset()
           break
         default:
-          log('unknown message type %s', type)
+          this.#log('unknown message type %s', type)
       }
     } catch (err: any) {
-      log.error('error while processing message', err)
+      this.#log.error('error while processing message', err)
       stream.abort(err)
     }
   }

--- a/packages/stream-multiplexer-mplex/src/stream.ts
+++ b/packages/stream-multiplexer-mplex/src/stream.ts
@@ -1,10 +1,10 @@
 import { AbstractStream, type AbstractStreamInit } from '@libp2p/interface/stream-muxer/stream'
-import { logger } from '@libp2p/logger'
 import { Uint8ArrayList } from 'uint8arraylist'
 import { fromString as uint8ArrayFromString } from 'uint8arrays/from-string'
 import { MAX_MSG_SIZE } from './decode.js'
 import { InitiatorMessageTypes, ReceiverMessageTypes } from './message-types.js'
 import type { Message } from './message-types.js'
+import type { ComponentLogger } from '@libp2p/interface'
 
 export interface Options {
   id: number
@@ -13,6 +13,7 @@ export interface Options {
   onEnd?(err?: Error): void
   type?: 'initiator' | 'receiver'
   maxMsgSize?: number
+  logger: ComponentLogger
 }
 
 interface MplexStreamInit extends AbstractStreamInit {
@@ -87,6 +88,6 @@ export function createStream (options: Options): MplexStream {
     maxDataSize: maxMsgSize,
     onEnd,
     send,
-    log: logger(`libp2p:mplex:stream:${type}:${id}`)
+    log: options.logger.forComponent(`libp2p:mplex:stream:${type}:${id}`)
   })
 }

--- a/packages/stream-multiplexer-mplex/test/compliance.spec.ts
+++ b/packages/stream-multiplexer-mplex/test/compliance.spec.ts
@@ -1,6 +1,7 @@
 /* eslint-env mocha */
 
 import tests from '@libp2p/interface-compliance-tests/stream-muxer'
+import { defaultLogger } from '@libp2p/logger'
 import { mplex } from '../src/index.js'
 
 describe('compliance', () => {
@@ -9,7 +10,9 @@ describe('compliance', () => {
       return mplex({
         maxInboundStreams: Infinity,
         disconnectThreshold: Infinity
-      })()
+      })({
+        logger: defaultLogger()
+      })
     },
     async teardown () {}
   })

--- a/packages/stream-multiplexer-mplex/test/mplex.spec.ts
+++ b/packages/stream-multiplexer-mplex/test/mplex.spec.ts
@@ -1,6 +1,7 @@
 /* eslint-env mocha */
 /* eslint max-nested-callbacks: ["error", 5] */
 
+import { defaultLogger } from '@libp2p/logger'
 import { expect } from 'aegir/chai'
 import delay from 'delay'
 import all from 'it-all'
@@ -20,7 +21,9 @@ describe('mplex', () => {
     const maxOutboundStreams = 10
     const factory = mplex({
       maxOutboundStreams
-    })()
+    })({
+      logger: defaultLogger()
+    })
     const muxer = factory.createStreamMuxer()
 
     // max out the streams for this connection
@@ -40,7 +43,9 @@ describe('mplex', () => {
     const factory = mplex({
       maxInboundStreams,
       disconnectThreshold: Infinity
-    })()
+    })({
+      logger: defaultLogger()
+    })
     const muxer = factory.createStreamMuxer()
     const stream = pushable()
 
@@ -130,7 +135,9 @@ describe('mplex', () => {
     // create the muxer
     const factory = mplex({
       maxStreamBufferSize
-    })()
+    })({
+      logger: defaultLogger()
+    })
     const muxer = factory.createStreamMuxer({
       onIncomingStream () {
         // do nothing with the stream so the buffer fills up
@@ -187,7 +194,9 @@ describe('mplex', () => {
     // create the muxer
     const factory = mplex({
       minSendBytes
-    })()
+    })({
+      logger: defaultLogger()
+    })
     const muxer = factory.createStreamMuxer({})
 
     // collect outgoing mplex messages

--- a/packages/stream-multiplexer-mplex/test/stream.spec.ts
+++ b/packages/stream-multiplexer-mplex/test/stream.spec.ts
@@ -1,5 +1,6 @@
 /* eslint-env mocha */
 
+import { defaultLogger } from '@libp2p/logger'
 import { expect } from 'aegir/chai'
 import * as cborg from 'cborg'
 import randomBytes from 'iso-random-stream/src/random.js'
@@ -71,8 +72,8 @@ async function streamPair (n: number, onInitiatorMessage?: onMessage, onReceiver
 
     initiator.sourcePush(msgToBuffer(msg))
   }
-  const initiator = createStream({ id, send: mockInitiatorSend, type: 'initiator' })
-  const receiver = createStream({ id, send: mockReceiverSend, type: 'receiver' })
+  const initiator = createStream({ id, send: mockInitiatorSend, type: 'initiator', logger: defaultLogger() })
+  const receiver = createStream({ id, send: mockReceiverSend, type: 'receiver', logger: defaultLogger() })
   const input = new Array(n).fill(0).map((_, i) => new Uint8ArrayList(Uint8Array.from([i])))
 
   void pipe(
@@ -127,7 +128,7 @@ describe('stream', () => {
     const msgs: Message[] = []
     const mockSend = async (msg: Message): Promise<void> => { msgs.push(msg) }
     const id = randomInt(1000)
-    const stream = createStream({ id, send: mockSend })
+    const stream = createStream({ id, send: mockSend, logger: defaultLogger() })
     const input = randomInput()
 
     await pipe(input, stream)
@@ -142,7 +143,7 @@ describe('stream', () => {
     const mockSend = async (msg: Message): Promise<void> => { msgs.push(msg) }
     const id = randomInt(1000)
     const name = `STREAM${Date.now()}`
-    const stream = createStream({ id, name, send: mockSend })
+    const stream = createStream({ id, name, send: mockSend, logger: defaultLogger() })
     const input = randomInput()
 
     await pipe(input, stream)
@@ -158,7 +159,7 @@ describe('stream', () => {
     const id = randomInt(1000)
     const name = `STREAM${Date.now()}`
     const deferred = defer()
-    const stream = createStream({ id, name, onEnd: deferred.resolve, send: mockSend })
+    const stream = createStream({ id, name, onEnd: deferred.resolve, send: mockSend, logger: defaultLogger() })
 
     const error = new Error('boom')
     stream.abort(error)
@@ -173,7 +174,7 @@ describe('stream', () => {
     const id = randomInt(1000)
     const name = `STREAM${Date.now()}`
     const deferred = defer()
-    const stream = createStream({ id, name, onEnd: deferred.resolve, send: mockSend })
+    const stream = createStream({ id, name, onEnd: deferred.resolve, send: mockSend, logger: defaultLogger() })
 
     stream.reset()
 
@@ -187,7 +188,7 @@ describe('stream', () => {
     const mockSend = async (msg: Message): Promise<void> => { msgs.push(msg) }
     const id = randomInt(1000)
     const name = id.toString()
-    const stream = createStream({ id, name, send: mockSend, type: 'initiator' })
+    const stream = createStream({ id, name, send: mockSend, type: 'initiator', logger: defaultLogger() })
     const input = randomInput()
 
     await pipe(input, stream)
@@ -208,7 +209,7 @@ describe('stream', () => {
     const mockSend = async (msg: Message): Promise<void> => { msgs.push(msg) }
     const id = randomInt(1000)
     const name = id.toString()
-    const stream = createStream({ id, name, send: mockSend, type: 'receiver' })
+    const stream = createStream({ id, name, send: mockSend, type: 'receiver', logger: defaultLogger() })
     const input = randomInput()
 
     await pipe(input, stream)
@@ -229,7 +230,7 @@ describe('stream', () => {
     const mockSend = async (msg: Message): Promise<void> => { msgs.push(msg) }
     const id = randomInt(1000)
     const name = id.toString()
-    const stream = createStream({ id, name, send: mockSend, type: 'initiator' })
+    const stream = createStream({ id, name, send: mockSend, type: 'initiator', logger: defaultLogger() })
     const input = randomInput()
 
     await pipe(input, stream)
@@ -246,7 +247,7 @@ describe('stream', () => {
     const mockSend = async (msg: Message): Promise<void> => { msgs.push(msg) }
     const id = randomInt(1000)
     const name = id.toString()
-    const stream = createStream({ id, name, send: mockSend, type: 'receiver' })
+    const stream = createStream({ id, name, send: mockSend, type: 'receiver', logger: defaultLogger() })
     const input = randomInput()
 
     await pipe(input, stream)
@@ -263,7 +264,7 @@ describe('stream', () => {
     const mockSend = async (msg: Message): Promise<void> => { msgs.push(msg) }
     const id = randomInt(1000)
     const name = id.toString()
-    const stream = createStream({ id, name, send: mockSend, type: 'initiator' })
+    const stream = createStream({ id, name, send: mockSend, type: 'initiator', logger: defaultLogger() })
     const error = new Error(`Boom ${Date.now()}`)
     const input = {
       [Symbol.iterator]: function * () {
@@ -289,7 +290,7 @@ describe('stream', () => {
     const mockSend = async (msg: Message): Promise<void> => { msgs.push(msg) }
     const id = randomInt(1000)
     const name = id.toString()
-    const stream = createStream({ id, name, send: mockSend, type: 'receiver' })
+    const stream = createStream({ id, name, send: mockSend, type: 'receiver', logger: defaultLogger() })
     const error = new Error(`Boom ${Date.now()}`)
     const input = {
       [Symbol.iterator]: function * () {
@@ -481,7 +482,7 @@ describe('stream', () => {
     const name = id.toString()
     const deferred = defer()
     const onEnd = (err?: any): void => { err != null ? deferred.reject(err) : deferred.resolve() }
-    const stream = createStream({ id, name, send, onEnd })
+    const stream = createStream({ id, name, send, onEnd, logger: defaultLogger() })
     const input = randomInput()
 
     void pipe(
@@ -500,7 +501,7 @@ describe('stream', () => {
     const id = randomInt(1000)
     const deferred = defer()
     const onEnd = (err?: any): void => { err != null ? deferred.reject(err) : deferred.resolve() }
-    const stream = createStream({ id, send, onEnd })
+    const stream = createStream({ id, send, onEnd, logger: defaultLogger() })
     const input = randomInput()
 
     pipe(
@@ -524,7 +525,7 @@ describe('stream', () => {
     }
     const maxMsgSize = 10
     const id = randomInt(1000)
-    const stream = createStream({ id, send, maxMsgSize })
+    const stream = createStream({ id, send, maxMsgSize, logger: defaultLogger() })
 
     await pipe(
       [
@@ -542,7 +543,7 @@ describe('stream', () => {
   it('should error on double sink', async () => {
     const send = async (): Promise<void> => {}
     const id = randomInt(1000)
-    const stream = createStream({ id, send })
+    const stream = createStream({ id, send, logger: defaultLogger() })
 
     // first sink is ok
     void stream.sink([])
@@ -555,7 +556,7 @@ describe('stream', () => {
   it('should error on double sink after sink has ended', async () => {
     const send = async (): Promise<void> => {}
     const id = randomInt(1000)
-    const stream = createStream({ id, send })
+    const stream = createStream({ id, send, logger: defaultLogger() })
 
     // first sink is ok
     await stream.sink([])
@@ -571,7 +572,7 @@ describe('stream', () => {
     const id = randomInt(1000)
     const name = `STREAM${Date.now()}`
     const maxMsgSize = 10
-    const stream = createStream({ id, name, send: mockSend, maxMsgSize })
+    const stream = createStream({ id, name, send: mockSend, maxMsgSize, logger: defaultLogger() })
     const input = [
       new Uint8Array(1024).map(() => randomInt(0, 255))
     ]

--- a/packages/transport-circuit-relay-v2/package.json
+++ b/packages/transport-circuit-relay-v2/package.json
@@ -68,7 +68,7 @@
   },
   "devDependencies": {
     "@libp2p/interface-compliance-tests": "^4.1.5",
-    "@libp2p/logger": "^3.0.2",
+    "@libp2p/logger": "^3.1.0",
     "@libp2p/peer-id-factory": "^3.0.8",
     "aegir": "^41.0.2",
     "it-drain": "^3.0.3",

--- a/packages/transport-circuit-relay-v2/src/server/advert-service.ts
+++ b/packages/transport-circuit-relay-v2/src/server/advert-service.ts
@@ -35,7 +35,7 @@ export class AdvertService extends TypedEventEmitter<AdvertServiceEvents> implem
   private timeout?: any
   private started: boolean
   private readonly bootDelay: number
-  readonly #log: Logger
+  private readonly log: Logger
 
   /**
    * Creates an instance of Relay
@@ -43,7 +43,7 @@ export class AdvertService extends TypedEventEmitter<AdvertServiceEvents> implem
   constructor (components: AdvertServiceComponents, init?: AdvertServiceInit) {
     super()
 
-    this.#log = components.logger.forComponent('libp2p:circuit-relay:advert-service')
+    this.log = components.logger.forComponent('libp2p:circuit-relay:advert-service')
     this.contentRouting = components.contentRouting
     this.bootDelay = init?.bootDelay ?? DEFAULT_ADVERT_BOOT_DELAY
     this.started = false
@@ -64,7 +64,7 @@ export class AdvertService extends TypedEventEmitter<AdvertServiceEvents> implem
     // Advertise service if HOP enabled and advertising enabled
     this.timeout = setTimeout(() => {
       this._advertiseService().catch(err => {
-        this.#log.error('could not advertise service', err)
+        this.log.error('could not advertise service', err)
       })
     }, this.bootDelay)
 
@@ -96,12 +96,12 @@ export class AdvertService extends TypedEventEmitter<AdvertServiceEvents> implem
         this.safeDispatchEvent('advert:error', { detail: err })
 
         if (err.code === ERR_NO_ROUTERS_AVAILABLE) {
-          this.#log.error('a content router, such as a DHT, must be provided in order to advertise the relay service', err)
+          this.log.error('a content router, such as a DHT, must be provided in order to advertise the relay service', err)
           this.stop()
           return
         }
 
-        this.#log.error('could not advertise service', err)
+        this.log.error('could not advertise service', err)
         throw err
       }
     })

--- a/packages/transport-circuit-relay-v2/src/transport/discovery.ts
+++ b/packages/transport-circuit-relay-v2/src/transport/discovery.ts
@@ -38,12 +38,12 @@ export class RelayDiscovery extends TypedEventEmitter<RelayDiscoveryEvents> impl
   private readonly registrar: Registrar
   private started: boolean
   private topologyId?: string
-  readonly #log: Logger
+  private readonly log: Logger
 
   constructor (components: RelayDiscoveryComponents) {
     super()
 
-    this.#log = components.logger.forComponent('libp2p:circuit-relay:discover-relays')
+    this.log = components.logger.forComponent('libp2p:circuit-relay:discover-relays')
     this.started = false
     this.peerId = components.peerId
     this.peerStore = components.peerStore
@@ -67,7 +67,7 @@ export class RelayDiscovery extends TypedEventEmitter<RelayDiscoveryEvents> impl
 
     void this.discover()
       .catch(err => {
-        this.#log.error('error listening on relays', err)
+        this.log.error('error listening on relays', err)
       })
 
     this.started = true
@@ -90,7 +90,7 @@ export class RelayDiscovery extends TypedEventEmitter<RelayDiscoveryEvents> impl
    * 3. Search the network
    */
   async discover (): Promise<void> {
-    this.#log('searching peer store for relays')
+    this.log('searching peer store for relays')
     const peers = (await this.peerStore.all({
       filters: [
         // filter by a list of peers supporting RELAY_V2_HOP and ones we are not listening on
@@ -104,14 +104,14 @@ export class RelayDiscovery extends TypedEventEmitter<RelayDiscoveryEvents> impl
     }))
 
     for (const peer of peers) {
-      this.#log('found relay peer %p in content peer store', peer.id)
+      this.log('found relay peer %p in content peer store', peer.id)
       this.safeDispatchEvent('relay:discover', { detail: peer.id })
     }
 
-    this.#log('found %d relay peers in peer store', peers.length)
+    this.log('found %d relay peers in peer store', peers.length)
 
     try {
-      this.#log('searching content routing for relays')
+      this.log('searching content routing for relays')
       const cid = await namespaceToCid(RELAY_RENDEZVOUS_NS)
 
       let found = 0
@@ -125,14 +125,14 @@ export class RelayDiscovery extends TypedEventEmitter<RelayDiscoveryEvents> impl
             multiaddrs: provider.multiaddrs
           })
 
-          this.#log('found relay peer %p in content routing', peerId)
+          this.log('found relay peer %p in content routing', peerId)
           this.safeDispatchEvent('relay:discover', { detail: peerId })
         }
       }
 
-      this.#log('found %d relay peers in content routing', found)
+      this.log('found %d relay peers in content routing', found)
     } catch (err: any) {
-      this.#log.error('failed when finding relays on the network', err)
+      this.log.error('failed when finding relays on the network', err)
     }
   }
 }

--- a/packages/transport-circuit-relay-v2/src/transport/index.ts
+++ b/packages/transport-circuit-relay-v2/src/transport/index.ts
@@ -279,7 +279,8 @@ class CircuitRelayTransport implements Transport {
       const maConn = streamToMaConnection({
         stream: pbstr.unwrap(),
         remoteAddr: ma,
-        localAddr: relayAddr.encapsulate(`/p2p-circuit/p2p/${this.peerId.toString()}`)
+        localAddr: relayAddr.encapsulate(`/p2p-circuit/p2p/${this.peerId.toString()}`),
+        logger: this.logger
       })
 
       this.#log('new outbound transient connection %a', maConn.remoteAddr)
@@ -379,7 +380,8 @@ class CircuitRelayTransport implements Transport {
     const maConn = streamToMaConnection({
       stream: pbstr.unwrap().unwrap(),
       remoteAddr,
-      localAddr
+      localAddr,
+      logger: this.logger
     })
 
     this.#log('new inbound transient connection %a', maConn.remoteAddr)

--- a/packages/transport-circuit-relay-v2/src/transport/index.ts
+++ b/packages/transport-circuit-relay-v2/src/transport/index.ts
@@ -117,10 +117,10 @@ class CircuitRelayTransport implements Transport {
   private readonly maxOutboundStopStreams?: number
   private readonly stopTimeout: number
   private started: boolean
-  readonly #log: Logger
+  private readonly log: Logger
 
   constructor (components: CircuitRelayTransportComponents, init: CircuitRelayTransportInit) {
-    this.#log = components.logger.forComponent('libp2p:circuit-relay:transport')
+    this.log = components.logger.forComponent('libp2p:circuit-relay:transport')
     this.registrar = components.registrar
     this.peerStore = components.peerStore
     this.connectionManager = components.connectionManager
@@ -138,7 +138,7 @@ class CircuitRelayTransport implements Transport {
       this.discovery.addEventListener('relay:discover', (evt) => {
         this.reservationStore.addRelay(evt.detail, 'discovered')
           .catch(err => {
-            this.#log.error('could not add discovered relay %p', evt.detail, err)
+            this.log.error('could not add discovered relay %p', evt.detail, err)
           })
       })
     }
@@ -147,7 +147,7 @@ class CircuitRelayTransport implements Transport {
     this.reservationStore.addEventListener('relay:not-enough-relays', () => {
       this.discovery?.discover()
         .catch(err => {
-          this.#log.error('could not discover relays', err)
+          this.log.error('could not discover relays', err)
         })
     })
 
@@ -164,7 +164,7 @@ class CircuitRelayTransport implements Transport {
 
     await this.registrar.handle(RELAY_V2_STOP_CODEC, (data) => {
       void this.onStop(data).catch(err => {
-        this.#log.error('error while handling STOP protocol', err)
+        this.log.error('error while handling STOP protocol', err)
         data.stream.abort(err)
       })
     }, {
@@ -194,7 +194,7 @@ class CircuitRelayTransport implements Transport {
   async dial (ma: Multiaddr, options: AbortOptions = {}): Promise<Connection> {
     if (ma.protoCodes().filter(code => code === CIRCUIT_PROTO_CODE).length !== 1) {
       const errMsg = 'Invalid circuit relay address'
-      this.#log.error(errMsg, ma)
+      this.log.error(errMsg, ma)
       throw new CodeError(errMsg, ERR_RELAYED_DIAL)
     }
 
@@ -207,7 +207,7 @@ class CircuitRelayTransport implements Transport {
 
     if (relayId == null || destinationId == null) {
       const errMsg = `Circuit relay dial to ${ma.toString()} failed as address did not have peer ids`
-      this.#log.error(errMsg)
+      this.log.error(errMsg)
       throw new CodeError(errMsg, ERR_RELAYED_DIAL)
     }
 
@@ -241,7 +241,7 @@ class CircuitRelayTransport implements Transport {
         disconnectOnFailure
       })
     } catch (err: any) {
-      this.#log.error('circuit relay dial to destination %p via relay %p failed', destinationPeer, relayPeer, err)
+      this.log.error('circuit relay dial to destination %p via relay %p failed', destinationPeer, relayPeer, err)
 
       if (stream != null) {
         stream.abort(err)
@@ -283,12 +283,12 @@ class CircuitRelayTransport implements Transport {
         logger: this.logger
       })
 
-      this.#log('new outbound transient connection %a', maConn.remoteAddr)
+      this.log('new outbound transient connection %a', maConn.remoteAddr)
       return await this.upgrader.upgradeOutbound(maConn, {
         transient: true
       })
     } catch (err) {
-      this.#log.error(`Circuit relay dial to destination ${destinationPeer.toString()} via relay ${connection.remotePeer.toString()} failed`, err)
+      this.log.error(`Circuit relay dial to destination ${destinationPeer.toString()} via relay ${connection.remotePeer.toString()} failed`, err)
       disconnectOnFailure && await connection.close()
       throw err
     }
@@ -329,10 +329,10 @@ class CircuitRelayTransport implements Transport {
       signal
     })
 
-    this.#log('new circuit relay v2 stop stream from %p with type %s', connection.remotePeer, request.type)
+    this.log('new circuit relay v2 stop stream from %p with type %s', connection.remotePeer, request.type)
 
     if (request?.type === undefined) {
-      this.#log.error('type was missing from circuit v2 stop protocol request from %s', connection.remotePeer)
+      this.log.error('type was missing from circuit v2 stop protocol request from %s', connection.remotePeer)
       await pbstr.write({ type: StopMessage.Type.STATUS, status: Status.MALFORMED_MESSAGE }, {
         signal
       })
@@ -342,7 +342,7 @@ class CircuitRelayTransport implements Transport {
 
     // Validate the STOP request has the required input
     if (request.type !== StopMessage.Type.CONNECT) {
-      this.#log.error('invalid stop connect request via peer %p', connection.remotePeer)
+      this.log.error('invalid stop connect request via peer %p', connection.remotePeer)
       await pbstr.write({ type: StopMessage.Type.STATUS, status: Status.UNEXPECTED_MESSAGE }, {
         signal
       })
@@ -351,7 +351,7 @@ class CircuitRelayTransport implements Transport {
     }
 
     if (!isValidStop(request)) {
-      this.#log.error('invalid stop connect request via peer %p', connection.remotePeer)
+      this.log.error('invalid stop connect request via peer %p', connection.remotePeer)
       await pbstr.write({ type: StopMessage.Type.STATUS, status: Status.MALFORMED_MESSAGE }, {
         signal
       })
@@ -362,7 +362,7 @@ class CircuitRelayTransport implements Transport {
     const remotePeerId = peerIdFromBytes(request.peer.id)
 
     if ((await this.connectionGater.denyInboundRelayedConnection?.(connection.remotePeer, remotePeerId)) === true) {
-      this.#log.error('connection gater denied inbound relayed connection from %p', connection.remotePeer)
+      this.log.error('connection gater denied inbound relayed connection from %p', connection.remotePeer)
       await pbstr.write({ type: StopMessage.Type.STATUS, status: Status.PERMISSION_DENIED }, {
         signal
       })
@@ -370,7 +370,7 @@ class CircuitRelayTransport implements Transport {
       return
     }
 
-    this.#log.trace('sending success response to %p', connection.remotePeer)
+    this.log.trace('sending success response to %p', connection.remotePeer)
     await pbstr.write({ type: StopMessage.Type.STATUS, status: Status.OK }, {
       signal
     })
@@ -384,11 +384,11 @@ class CircuitRelayTransport implements Transport {
       logger: this.logger
     })
 
-    this.#log('new inbound transient connection %a', maConn.remoteAddr)
+    this.log('new inbound transient connection %a', maConn.remoteAddr)
     await this.upgrader.upgradeInbound(maConn, {
       transient: true
     })
-    this.#log('%s connection %a upgraded', 'inbound', maConn.remoteAddr)
+    this.log('%s connection %a upgraded', 'inbound', maConn.remoteAddr)
   }
 }
 

--- a/packages/transport-circuit-relay-v2/src/transport/listener.ts
+++ b/packages/transport-circuit-relay-v2/src/transport/listener.ts
@@ -19,12 +19,12 @@ class CircuitRelayTransportListener extends TypedEventEmitter<ListenerEvents> im
   private readonly connectionManager: ConnectionManager
   private readonly relayStore: ReservationStore
   private readonly listeningAddrs: PeerMap<Multiaddr[]>
-  readonly #log: Logger
+  private readonly log: Logger
 
   constructor (components: CircuitRelayTransportListenerComponents) {
     super()
 
-    this.#log = components.logger.forComponent('libp2p:circuit-relay:transport:listener')
+    this.log = components.logger.forComponent('libp2p:circuit-relay:transport:listener')
     this.connectionManager = components.connectionManager
     this.relayStore = components.relayStore
     this.listeningAddrs = new PeerMap()
@@ -38,7 +38,7 @@ class CircuitRelayTransportListener extends TypedEventEmitter<ListenerEvents> im
   }
 
   async listen (addr: Multiaddr): Promise<void> {
-    this.#log('listen on %a', addr)
+    this.log('listen on %a', addr)
 
     // remove the circuit part to get the peer id of the relay
     const relayAddr = addr.decapsulate('/p2p-circuit')
@@ -57,7 +57,7 @@ class CircuitRelayTransportListener extends TypedEventEmitter<ListenerEvents> im
     }
 
     if (this.listeningAddrs.has(relayConn.remotePeer)) {
-      this.#log('already listening on relay %p', relayConn.remotePeer)
+      this.log('already listening on relay %p', relayConn.remotePeer)
       return
     }
 
@@ -80,12 +80,12 @@ class CircuitRelayTransportListener extends TypedEventEmitter<ListenerEvents> im
   #removeRelayPeer (peerId: PeerId): void {
     const had = this.listeningAddrs.has(peerId)
 
-    this.#log('relay peer removed %p - had reservation', peerId, had)
+    this.log('relay peer removed %p - had reservation', peerId, had)
 
     this.listeningAddrs.delete(peerId)
 
     if (had) {
-      this.#log.trace('removing relay event listener for peer %p', peerId)
+      this.log.trace('removing relay event listener for peer %p', peerId)
       this.relayStore.removeEventListener('relay:removed', this._onRemoveRelayPeer)
       // Announce listen addresses change
       this.safeDispatchEvent('close', {})

--- a/packages/transport-circuit-relay-v2/src/transport/reservation-store.ts
+++ b/packages/transport-circuit-relay-v2/src/transport/reservation-store.ts
@@ -86,12 +86,12 @@ export class ReservationStore extends TypedEventEmitter<ReservationStoreEvents> 
   private readonly maxReservationQueueLength: number
   private readonly reservationCompletionTimeout: number
   private started: boolean
-  readonly #log: Logger
+  private readonly log: Logger
 
   constructor (components: RelayStoreComponents, init?: RelayStoreInit) {
     super()
 
-    this.#log = components.logger.forComponent('libp2p:circuit-relay:transport:reservation-store')
+    this.log = components.logger.forComponent('libp2p:circuit-relay:transport:reservation-store')
     this.peerId = components.peerId
     this.connectionManager = components.connectionManager
     this.transportManager = components.transportManager
@@ -141,21 +141,21 @@ export class ReservationStore extends TypedEventEmitter<ReservationStoreEvents> 
    */
   async addRelay (peerId: PeerId, type: RelayType): Promise<void> {
     if (this.peerId.equals(peerId)) {
-      this.#log('not trying to use self as relay')
+      this.log('not trying to use self as relay')
       return
     }
 
     if (this.reserveQueue.size > this.maxReservationQueueLength) {
-      this.#log('not adding relay as the queue is full')
+      this.log('not adding relay as the queue is full')
       return
     }
 
     if (this.reserveQueue.hasJob(peerId)) {
-      this.#log('relay peer is already in the reservation queue')
+      this.log('relay peer is already in the reservation queue')
       return
     }
 
-    this.#log('add relay %p', peerId)
+    this.log('add relay %p', peerId)
 
     await this.reserveQueue.add(async () => {
       try {
@@ -164,7 +164,7 @@ export class ReservationStore extends TypedEventEmitter<ReservationStoreEvents> 
 
         if (existingReservation != null) {
           if (getExpirationMilliseconds(existingReservation.reservation.expire) > REFRESH_WINDOW) {
-            this.#log('already have reservation on relay peer %p and it expires in more than 10 minutes', peerId)
+            this.log('already have reservation on relay peer %p and it expires in more than 10 minutes', peerId)
             return
           }
 
@@ -179,7 +179,7 @@ export class ReservationStore extends TypedEventEmitter<ReservationStoreEvents> 
 
           return acc
         }, 0) >= this.maxDiscoveredRelays) {
-          this.#log('already have enough discovered relays')
+          this.log('already have enough discovered relays')
           return
         }
 
@@ -190,7 +190,7 @@ export class ReservationStore extends TypedEventEmitter<ReservationStoreEvents> 
         })
 
         if (connection.remoteAddr.protoNames().includes('p2p-circuit')) {
-          this.#log('not creating reservation over relayed connection')
+          this.log('not creating reservation over relayed connection')
           return
         }
 
@@ -198,7 +198,7 @@ export class ReservationStore extends TypedEventEmitter<ReservationStoreEvents> 
           signal
         })
 
-        this.#log('created reservation on relay peer %p', peerId)
+        this.log('created reservation on relay peer %p', peerId)
 
         const expiration = getExpirationMilliseconds(reservation.expire)
 
@@ -208,7 +208,7 @@ export class ReservationStore extends TypedEventEmitter<ReservationStoreEvents> 
 
         const timeout = setTimeout(() => {
           this.addRelay(peerId, type).catch(err => {
-            this.#log.error('could not refresh reservation to relay %p', peerId, err)
+            this.log.error('could not refresh reservation to relay %p', peerId, err)
           })
         }, timeoutDuration)
 
@@ -232,7 +232,7 @@ export class ReservationStore extends TypedEventEmitter<ReservationStoreEvents> 
         // listen on multiaddr that only the circuit transport is listening for
         await this.transportManager.listen([multiaddr(`/p2p/${peerId.toString()}/p2p-circuit`)])
       } catch (err) {
-        this.#log.error('could not reserve slot on %p', peerId, err)
+        this.log.error('could not reserve slot on %p', peerId, err)
 
         // cancel the renewal timeout if it's been set
         const reservation = this.reservations.get(peerId)
@@ -260,7 +260,7 @@ export class ReservationStore extends TypedEventEmitter<ReservationStoreEvents> 
   async #createReservation (connection: Connection, options: AbortOptions): Promise<Reservation> {
     options.signal?.throwIfAborted()
 
-    this.#log('requesting reservation from %p', connection.remotePeer)
+    this.log('requesting reservation from %p', connection.remotePeer)
     const stream = await connection.newStream(RELAY_V2_HOP_CODEC, options)
     const pbstr = pbStream(stream)
     const hopstr = pbstr.pb(HopMessage)
@@ -271,7 +271,7 @@ export class ReservationStore extends TypedEventEmitter<ReservationStoreEvents> 
     try {
       response = await hopstr.read(options)
     } catch (err: any) {
-      this.#log.error('error parsing reserve message response from %p because', connection.remotePeer, err)
+      this.log.error('error parsing reserve message response from %p because', connection.remotePeer, err)
       throw err
     } finally {
       await stream.close()
@@ -282,7 +282,7 @@ export class ReservationStore extends TypedEventEmitter<ReservationStoreEvents> 
     }
 
     const errMsg = `reservation failed with status ${response.status ?? 'undefined'}`
-    this.#log.error(errMsg)
+    this.log.error(errMsg)
 
     throw new Error(errMsg)
   }
@@ -297,7 +297,7 @@ export class ReservationStore extends TypedEventEmitter<ReservationStoreEvents> 
       return
     }
 
-    this.#log('connection to relay %p closed, removing reservation from local store', peerId)
+    this.log('connection to relay %p closed, removing reservation from local store', peerId)
 
     clearTimeout(existingReservation.timeout)
     this.reservations.delete(peerId)
@@ -305,7 +305,7 @@ export class ReservationStore extends TypedEventEmitter<ReservationStoreEvents> 
     this.safeDispatchEvent('relay:removed', { detail: peerId })
 
     if (this.reservations.size < this.maxDiscoveredRelays) {
-      this.#log('not enough relays %d/%d', this.reservations.size, this.maxDiscoveredRelays)
+      this.log('not enough relays %d/%d', this.reservations.size, this.maxDiscoveredRelays)
       this.safeDispatchEvent('relay:not-enough-relays', {})
     }
   }

--- a/packages/transport-circuit-relay-v2/src/utils.ts
+++ b/packages/transport-circuit-relay-v2/src/utils.ts
@@ -1,5 +1,4 @@
 import { CodeError } from '@libp2p/interface/errors'
-import { logger } from '@libp2p/logger'
 import { anySignal } from 'any-signal'
 import { CID } from 'multiformats/cid'
 import { sha256 } from 'multiformats/hashes/sha2'
@@ -9,8 +8,6 @@ import type { LoggerOptions } from '@libp2p/interface'
 import type { Stream } from '@libp2p/interface/connection'
 import type { Source } from 'it-stream-types'
 import type { Uint8ArrayList } from 'uint8arraylist'
-
-const log = logger('libp2p:circuit-relay:utils')
 
 async function * countStreamBytes (source: Source<Uint8Array | Uint8ArrayList>, limit: { remaining: bigint }, options: LoggerOptions): AsyncGenerator<Uint8Array | Uint8ArrayList, void, unknown> {
   const limitBytes = limit.remaining
@@ -77,7 +74,7 @@ export function createLimitedRelay (src: Stream, dst: Stream, abortSignal: Abort
 
     void dst.sink(dataLimit == null ? src.source : countStreamBytes(src.source, dataLimit, options))
       .catch(err => {
-        log.error('error while relaying streams src -> dst', err)
+        options.log.error('error while relaying streams src -> dst', err)
         abortStreams(err)
       })
       .finally(() => {
@@ -100,7 +97,7 @@ export function createLimitedRelay (src: Stream, dst: Stream, abortSignal: Abort
 
     void src.sink(dataLimit == null ? dst.source : countStreamBytes(dst.source, dataLimit, options))
       .catch(err => {
-        log.error('error while relaying streams dst -> src', err)
+        options.log.error('error while relaying streams dst -> src', err)
         abortStreams(err)
       })
       .finally(() => {

--- a/packages/transport-circuit-relay-v2/test/hop.spec.ts
+++ b/packages/transport-circuit-relay-v2/test/hop.spec.ts
@@ -15,7 +15,7 @@ import { DEFAULT_MAX_RESERVATION_STORE_SIZE, RELAY_SOURCE_TAG, RELAY_V2_HOP_CODE
 import { circuitRelayServer, type CircuitRelayService, circuitRelayTransport } from '../src/index.js'
 import { HopMessage, Status } from '../src/pb/index.js'
 import type { CircuitRelayServerInit } from '../src/server/index.js'
-import type { Libp2pEvents } from '@libp2p/interface'
+import type { ComponentLogger, Libp2pEvents } from '@libp2p/interface'
 import type { Connection, Stream } from '@libp2p/interface/connection'
 import type { ConnectionGater } from '@libp2p/interface/connection-gater'
 import type { ContentRouting } from '@libp2p/interface/content-routing'
@@ -42,6 +42,7 @@ interface Node {
   circuitRelayTransport: Transport
   connectionGater: ConnectionGater
   events: TypedEventTarget<Libp2pEvents>
+  logger: ComponentLogger
 }
 
 let peerIndex = 0
@@ -135,7 +136,8 @@ describe('circuit-relay hop protocol', function () {
       connectionManager,
       circuitRelayTransport: transport,
       connectionGater,
-      events
+      events,
+      logger: defaultLogger()
     }
 
     mockNetwork.addNode(node)

--- a/packages/transport-tcp/package.json
+++ b/packages/transport-tcp/package.json
@@ -52,7 +52,6 @@
   },
   "dependencies": {
     "@libp2p/interface": "^0.1.6",
-    "@libp2p/logger": "^3.1.0",
     "@libp2p/utils": "^4.0.7",
     "@multiformats/mafmt": "^12.1.6",
     "@multiformats/multiaddr": "^12.1.10",
@@ -61,6 +60,7 @@
   },
   "devDependencies": {
     "@libp2p/interface-compliance-tests": "^4.1.5",
+    "@libp2p/logger": "^3.1.0",
     "aegir": "^41.0.2",
     "it-all": "^3.0.3",
     "it-pipe": "^3.0.1",

--- a/packages/transport-tcp/src/listener.ts
+++ b/packages/transport-tcp/src/listener.ts
@@ -1,7 +1,6 @@
 import net from 'net'
 import { CodeError } from '@libp2p/interface/errors'
 import { TypedEventEmitter, CustomEvent } from '@libp2p/interface/events'
-import { logger } from '@libp2p/logger'
 import { CODE_P2P } from './constants.js'
 import { toMultiaddrConnection } from './socket-to-conn.js'
 import {
@@ -10,21 +9,20 @@ import {
   type NetConfig
 } from './utils.js'
 import type { TCPCreateListenerOptions } from './index.js'
+import type { ComponentLogger, Logger, LoggerOptions } from '@libp2p/interface'
 import type { MultiaddrConnection, Connection } from '@libp2p/interface/connection'
 import type { CounterGroup, MetricGroup, Metrics } from '@libp2p/interface/metrics'
 import type { Listener, ListenerEvents, Upgrader } from '@libp2p/interface/transport'
 import type { Multiaddr } from '@multiformats/multiaddr'
 
-const log = logger('libp2p:tcp:listener')
-
 /**
  * Attempts to close the given maConn. If a failure occurs, it will be logged
  */
-async function attemptClose (maConn: MultiaddrConnection): Promise<void> {
+async function attemptClose (maConn: MultiaddrConnection, options: LoggerOptions): Promise<void> {
   try {
     await maConn.close()
   } catch (err) {
-    log.error('an error occurred closing the connection', err)
+    options.log.error('an error occurred closing the connection', err)
   }
 }
 
@@ -45,6 +43,7 @@ interface Context extends TCPCreateListenerOptions {
   backlog?: number
   metrics?: Metrics
   closeServerOnMaxConnections?: CloseServerOnMaxConnectionsOpts
+  logger: ComponentLogger
 }
 
 export interface TCPListenerMetrics {
@@ -78,12 +77,14 @@ export class TCPListener extends TypedEventEmitter<ListenerEvents> implements Li
   private status: Status = { code: TCPListenerStatusCode.INACTIVE }
   private metrics?: TCPListenerMetrics
   private addr: string
+  readonly #log: Logger
 
   constructor (private readonly context: Context) {
     super()
 
     context.keepAlive = context.keepAlive ?? true
 
+    this.#log = context.logger.forComponent('libp2p:tcp:listener')
     this.addr = 'unknown'
     this.server = net.createServer(context, this.onSocket.bind(this))
 
@@ -172,7 +173,7 @@ export class TCPListener extends TypedEventEmitter<ListenerEvents> implements Li
     }
     // Avoid uncaught errors caused by unstable connections
     socket.on('error', err => {
-      log('socket error', err)
+      this.#log('socket error', err)
       this.metrics?.events.increment({ [`${this.addr} error`]: true })
     })
 
@@ -183,19 +184,20 @@ export class TCPListener extends TypedEventEmitter<ListenerEvents> implements Li
         socketInactivityTimeout: this.context.socketInactivityTimeout,
         socketCloseTimeout: this.context.socketCloseTimeout,
         metrics: this.metrics?.events,
-        metricPrefix: `${this.addr} `
+        metricPrefix: `${this.addr} `,
+        logger: this.context.logger
       })
     } catch (err) {
-      log.error('inbound connection failed', err)
+      this.#log.error('inbound connection failed', err)
       this.metrics?.errors.increment({ [`${this.addr} inbound_to_connection`]: true })
       return
     }
 
-    log('new inbound connection %s', maConn.remoteAddr)
+    this.#log('new inbound connection %s', maConn.remoteAddr)
     try {
       this.context.upgrader.upgradeInbound(maConn)
         .then((conn) => {
-          log('inbound connection upgraded %s', maConn.remoteAddr)
+          this.#log('inbound connection upgraded %s', maConn.remoteAddr)
           this.connections.add(maConn)
 
           socket.once('close', () => {
@@ -210,7 +212,7 @@ export class TCPListener extends TypedEventEmitter<ListenerEvents> implements Li
               // we can do. resume() will be called again every time a connection is dropped, which
               // acts as an eventual retry mechanism. onListenError allows the consumer act on this.
               this.resume().catch(e => {
-                log.error('error attempting to listen server once connection count under limit', e)
+                this.#log.error('error attempting to listen server once connection count under limit', e)
                 this.context.closeServerOnMaxConnections?.onListenError?.(e as Error)
               })
             }
@@ -225,27 +227,31 @@ export class TCPListener extends TypedEventEmitter<ListenerEvents> implements Li
             this.connections.size >= this.context.closeServerOnMaxConnections.closeAbove
           ) {
             this.pause(false).catch(e => {
-              log.error('error attempting to close server once connection count over limit', e)
+              this.#log.error('error attempting to close server once connection count over limit', e)
             })
           }
 
           this.dispatchEvent(new CustomEvent<Connection>('connection', { detail: conn }))
         })
         .catch(async err => {
-          log.error('inbound connection failed', err)
+          this.#log.error('inbound connection failed', err)
           this.metrics?.errors.increment({ [`${this.addr} inbound_upgrade`]: true })
 
-          await attemptClose(maConn)
+          await attemptClose(maConn, {
+            log: this.#log
+          })
         })
         .catch(err => {
-          log.error('closing inbound connection failed', err)
+          this.#log.error('closing inbound connection failed', err)
         })
     } catch (err) {
-      log.error('inbound connection failed', err)
+      this.#log.error('inbound connection failed', err)
 
-      attemptClose(maConn)
+      attemptClose(maConn, {
+        log: this.#log
+      })
         .catch(err => {
-          log.error('closing inbound connection failed', err)
+          this.#log.error('closing inbound connection failed', err)
           this.metrics?.errors.increment({ [`${this.addr} inbound_closing_failed`]: true })
         })
     }
@@ -276,7 +282,7 @@ export class TCPListener extends TypedEventEmitter<ListenerEvents> implements Li
           addrs = addrs.concat(getMultiaddrs('ip6', address.address, address.port))
         }
       } catch (err) {
-        log.error('could not turn %s:%s into multiaddr', address.address, address.port, err)
+        this.#log.error('could not turn %s:%s into multiaddr', address.address, address.port, err)
       }
     }
 
@@ -310,9 +316,11 @@ export class TCPListener extends TypedEventEmitter<ListenerEvents> implements Li
   async close (): Promise<void> {
     // Close connections and server the same time to avoid any race condition
     await Promise.all([
-      Promise.all(Array.from(this.connections.values()).map(async maConn => attemptClose(maConn))),
+      Promise.all(Array.from(this.connections.values()).map(async maConn => attemptClose(maConn, {
+        log: this.#log
+      }))),
       this.pause(true).catch(e => {
-        log.error('error attempting to close server once connection count over limit', e)
+        this.#log.error('error attempting to close server once connection count over limit', e)
       })
     ])
   }
@@ -334,7 +342,7 @@ export class TCPListener extends TypedEventEmitter<ListenerEvents> implements Li
     })
 
     this.status = { ...this.status, code: TCPListenerStatusCode.ACTIVE }
-    log('Listening on %s', this.server.address())
+    this.#log('Listening on %s', this.server.address())
   }
 
   private async pause (permanent: boolean): Promise<void> {
@@ -347,7 +355,7 @@ export class TCPListener extends TypedEventEmitter<ListenerEvents> implements Li
       return
     }
 
-    log('Closing server on %s', this.server.address())
+    this.#log('Closing server on %s', this.server.address())
 
     // NodeJS implementation tracks listening status with `this._handle` property.
     // - Server.close() sets this._handle to null immediately. If this._handle is null, ERR_SERVER_NOT_RUNNING is thrown

--- a/packages/transport-tcp/src/socket-to-conn.ts
+++ b/packages/transport-tcp/src/socket-to-conn.ts
@@ -1,16 +1,14 @@
 import { CodeError } from '@libp2p/interface/errors'
-import { logger } from '@libp2p/logger'
 import { ipPortToMultiaddr as toMultiaddr } from '@libp2p/utils/ip-port-to-multiaddr'
 // @ts-expect-error no types
 import toIterable from 'stream-to-it'
 import { CLOSE_TIMEOUT, SOCKET_TIMEOUT } from './constants.js'
 import { multiaddrToNetConfig } from './utils.js'
+import type { ComponentLogger } from '@libp2p/interface'
 import type { MultiaddrConnection } from '@libp2p/interface/connection'
 import type { CounterGroup } from '@libp2p/interface/metrics'
 import type { AbortOptions, Multiaddr } from '@multiformats/multiaddr'
 import type { Socket } from 'net'
-
-const log = logger('libp2p:tcp:socket')
 
 interface ToConnectionOptions {
   listeningAddr?: Multiaddr
@@ -20,6 +18,7 @@ interface ToConnectionOptions {
   socketCloseTimeout?: number
   metrics?: CounterGroup
   metricPrefix?: string
+  logger: ComponentLogger
 }
 
 /**
@@ -27,6 +26,7 @@ interface ToConnectionOptions {
  * https://github.com/libp2p/interface-transport#multiaddrconnection
  */
 export const toMultiaddrConnection = (socket: Socket, options: ToConnectionOptions): MultiaddrConnection => {
+  const log = options.logger.forComponent('libp2p:tcp:socket')
   const metrics = options.metrics
   const metricPrefix = options.metricPrefix ?? ''
   const inactivityTimeout = options.socketInactivityTimeout ?? SOCKET_TIMEOUT

--- a/packages/transport-tcp/test/compliance.spec.ts
+++ b/packages/transport-tcp/test/compliance.spec.ts
@@ -1,5 +1,6 @@
 import net from 'net'
 import tests from '@libp2p/interface-compliance-tests/transport'
+import { defaultLogger } from '@libp2p/logger'
 import { multiaddr } from '@multiformats/multiaddr'
 import sinon from 'sinon'
 import { tcp } from '../src/index.js'
@@ -7,7 +8,9 @@ import { tcp } from '../src/index.js'
 describe('interface-transport compliance', () => {
   tests({
     async setup () {
-      const transport = tcp()()
+      const transport = tcp()({
+        logger: defaultLogger()
+      })
       const addrs = [
         multiaddr('/ip4/127.0.0.1/tcp/9091'),
         multiaddr('/ip4/127.0.0.1/tcp/9092'),

--- a/packages/transport-tcp/test/connection-limits.spec.ts
+++ b/packages/transport-tcp/test/connection-limits.spec.ts
@@ -2,6 +2,7 @@ import net from 'node:net'
 import { promisify } from 'util'
 import { TypedEventEmitter } from '@libp2p/interface/events'
 import { mockUpgrader } from '@libp2p/interface-compliance-tests/mocks'
+import { defaultLogger } from '@libp2p/logger'
 import { multiaddr } from '@multiformats/multiaddr'
 import { expect } from 'aegir/chai'
 import { tcp } from '../src/index.js'
@@ -85,7 +86,9 @@ describe('closeAbove/listenBelow', () => {
     const closeAbove = 3
     const port = 9900
 
-    const trasnport = tcp({ closeServerOnMaxConnections: { listenBelow, closeAbove } })()
+    const trasnport = tcp({ closeServerOnMaxConnections: { listenBelow, closeAbove } })({
+      logger: defaultLogger()
+    })
 
     const upgrader = mockUpgrader({
       events: new TypedEventEmitter()
@@ -112,7 +115,9 @@ describe('closeAbove/listenBelow', () => {
     const closeAbove = 3
     const port = 9900
 
-    const trasnport = tcp({ closeServerOnMaxConnections: { listenBelow, closeAbove } })()
+    const trasnport = tcp({ closeServerOnMaxConnections: { listenBelow, closeAbove } })({
+      logger: defaultLogger()
+    })
 
     const upgrader = mockUpgrader({
       events: new TypedEventEmitter()
@@ -147,7 +152,9 @@ describe('closeAbove/listenBelow', () => {
     const closeAbove = 3
     const port = 9900
 
-    const trasnport = tcp({ closeServerOnMaxConnections: { listenBelow, closeAbove } })()
+    const trasnport = tcp({ closeServerOnMaxConnections: { listenBelow, closeAbove } })({
+      logger: defaultLogger()
+    })
 
     const upgrader = mockUpgrader({
       events: new TypedEventEmitter()
@@ -178,7 +185,9 @@ describe('closeAbove/listenBelow', () => {
     const closeAbove = 3
     const port = 9900
 
-    const trasnport = tcp({ closeServerOnMaxConnections: { listenBelow, closeAbove } })()
+    const trasnport = tcp({ closeServerOnMaxConnections: { listenBelow, closeAbove } })({
+      logger: defaultLogger()
+    })
 
     const upgrader = mockUpgrader({
       events: new TypedEventEmitter()

--- a/packages/transport-tcp/test/connection.spec.ts
+++ b/packages/transport-tcp/test/connection.spec.ts
@@ -1,5 +1,6 @@
 import { TypedEventEmitter } from '@libp2p/interface/events'
 import { mockUpgrader } from '@libp2p/interface-compliance-tests/mocks'
+import { defaultLogger } from '@libp2p/logger'
 import { multiaddr } from '@multiformats/multiaddr'
 import { expect } from 'aegir/chai'
 import { tcp } from '../src/index.js'
@@ -11,7 +12,9 @@ describe('valid localAddr and remoteAddr', () => {
   let upgrader: Upgrader
 
   beforeEach(() => {
-    transport = tcp()()
+    transport = tcp()({
+      logger: defaultLogger()
+    })
     upgrader = mockUpgrader({
       events: new TypedEventEmitter()
     })

--- a/packages/transport-tcp/test/filter.spec.ts
+++ b/packages/transport-tcp/test/filter.spec.ts
@@ -1,3 +1,4 @@
+import { defaultLogger } from '@libp2p/logger'
 import { multiaddr } from '@multiformats/multiaddr'
 import { expect } from 'aegir/chai'
 import { tcp } from '../src/index.js'
@@ -11,7 +12,9 @@ describe('filter addrs', () => {
   let transport: Transport
 
   before(() => {
-    transport = tcp()()
+    transport = tcp()({
+      logger: defaultLogger()
+    })
   })
 
   it('filter valid addrs for this transport', () => {

--- a/packages/transport-tcp/test/listen-dial.spec.ts
+++ b/packages/transport-tcp/test/listen-dial.spec.ts
@@ -2,6 +2,7 @@ import os from 'os'
 import path from 'path'
 import { TypedEventEmitter } from '@libp2p/interface/events'
 import { mockRegistrar, mockUpgrader } from '@libp2p/interface-compliance-tests/mocks'
+import { defaultLogger } from '@libp2p/logger'
 import { multiaddr } from '@multiformats/multiaddr'
 import { expect } from 'aegir/chai'
 import all from 'it-all'
@@ -20,7 +21,9 @@ describe('listen', () => {
   let upgrader: Upgrader
 
   beforeEach(() => {
-    transport = tcp()()
+    transport = tcp()({
+      logger: defaultLogger()
+    })
     upgrader = mockUpgrader({
       events: new TypedEventEmitter()
     })
@@ -178,7 +181,9 @@ describe('dial', () => {
       events: new TypedEventEmitter()
     })
 
-    transport = tcp()()
+    transport = tcp()({
+      logger: defaultLogger()
+    })
   })
 
   it('dial on IPv4', async () => {

--- a/packages/transport-tcp/test/max-connections.spec.ts
+++ b/packages/transport-tcp/test/max-connections.spec.ts
@@ -2,6 +2,7 @@ import net from 'node:net'
 import { promisify } from 'node:util'
 import { TypedEventEmitter } from '@libp2p/interface/events'
 import { mockUpgrader } from '@libp2p/interface-compliance-tests/mocks'
+import { defaultLogger } from '@libp2p/logger'
 import { multiaddr } from '@multiformats/multiaddr'
 import { expect } from 'aegir/chai'
 import { tcp } from '../src/index.js'
@@ -19,7 +20,9 @@ describe('maxConnections', () => {
     const port = 9900
 
     const seenRemoteConnections = new Set<string>()
-    const transport = tcp({ maxConnections })()
+    const transport = tcp({ maxConnections })({
+      logger: defaultLogger()
+    })
 
     const upgrader = mockUpgrader({
       events: new TypedEventEmitter()

--- a/packages/transport-tcp/test/socket-to-conn.spec.ts
+++ b/packages/transport-tcp/test/socket-to-conn.spec.ts
@@ -1,5 +1,6 @@
 import { createServer, Socket, type Server, type ServerOpts, type SocketConstructorOpts } from 'net'
 import os from 'os'
+import { defaultLogger } from '@libp2p/logger'
 import { expect } from 'aegir/chai'
 import defer from 'p-defer'
 import { toMultiaddrConnection } from '../src/socket-to-conn.js'
@@ -75,7 +76,8 @@ describe('socket-to-conn', () => {
     const serverErrored = defer<Error>()
 
     const inboundMaConn = toMultiaddrConnection(serverSocket, {
-      socketInactivityTimeout: 100
+      socketInactivityTimeout: 100,
+      logger: defaultLogger()
     })
     expect(inboundMaConn.timeline.open).to.be.ok()
     expect(inboundMaConn.timeline.close).to.not.be.ok()
@@ -121,7 +123,8 @@ describe('socket-to-conn', () => {
     const serverErrored = defer<Error>()
 
     const inboundMaConn = toMultiaddrConnection(serverSocket, {
-      socketInactivityTimeout: 100
+      socketInactivityTimeout: 100,
+      logger: defaultLogger()
     })
     expect(inboundMaConn.timeline.open).to.be.ok()
     expect(inboundMaConn.timeline.close).to.not.be.ok()
@@ -171,7 +174,8 @@ describe('socket-to-conn', () => {
     const serverErrored = defer<Error>()
 
     const inboundMaConn = toMultiaddrConnection(serverSocket, {
-      socketInactivityTimeout: 100
+      socketInactivityTimeout: 100,
+      logger: defaultLogger()
     })
     expect(inboundMaConn.timeline.open).to.be.ok()
     expect(inboundMaConn.timeline.close).to.not.be.ok()
@@ -213,7 +217,8 @@ describe('socket-to-conn', () => {
     const serverErrored = defer<Error>()
 
     const inboundMaConn = toMultiaddrConnection(serverSocket, {
-      socketInactivityTimeout: 100
+      socketInactivityTimeout: 100,
+      logger: defaultLogger()
     })
     expect(inboundMaConn.timeline.open).to.be.ok()
     expect(inboundMaConn.timeline.close).to.not.be.ok()
@@ -254,7 +259,8 @@ describe('socket-to-conn', () => {
 
     const inboundMaConn = toMultiaddrConnection(serverSocket, {
       socketInactivityTimeout: 100,
-      socketCloseTimeout: 10
+      socketCloseTimeout: 10,
+      logger: defaultLogger()
     })
     expect(inboundMaConn.timeline.open).to.be.ok()
     expect(inboundMaConn.timeline.close).to.not.be.ok()
@@ -293,7 +299,8 @@ describe('socket-to-conn', () => {
 
     const inboundMaConn = toMultiaddrConnection(serverSocket, {
       socketInactivityTimeout: 100,
-      socketCloseTimeout: 10
+      socketCloseTimeout: 10,
+      logger: defaultLogger()
     })
     expect(inboundMaConn.timeline.open).to.be.ok()
     expect(inboundMaConn.timeline.close).to.not.be.ok()
@@ -332,7 +339,8 @@ describe('socket-to-conn', () => {
 
     const inboundMaConn = toMultiaddrConnection(serverSocket, {
       socketInactivityTimeout: 500,
-      socketCloseTimeout: 100
+      socketCloseTimeout: 100,
+      logger: defaultLogger()
     })
     expect(inboundMaConn.timeline.open).to.be.ok()
     expect(inboundMaConn.timeline.close).to.not.be.ok()
@@ -374,7 +382,8 @@ describe('socket-to-conn', () => {
 
     const inboundMaConn = toMultiaddrConnection(serverSocket, {
       socketInactivityTimeout: 100,
-      socketCloseTimeout: 100
+      socketCloseTimeout: 100,
+      logger: defaultLogger()
     })
     expect(inboundMaConn.timeline.open).to.be.ok()
     expect(inboundMaConn.timeline.close).to.not.be.ok()

--- a/packages/transport-webrtc/src/maconn.ts
+++ b/packages/transport-webrtc/src/maconn.ts
@@ -1,11 +1,9 @@
-import { logger } from '@libp2p/logger'
 import { nopSink, nopSource } from './util.js'
+import type { ComponentLogger, Logger } from '@libp2p/interface'
 import type { MultiaddrConnection, MultiaddrConnectionTimeline } from '@libp2p/interface/connection'
 import type { CounterGroup } from '@libp2p/interface/metrics'
 import type { AbortOptions, Multiaddr } from '@multiformats/multiaddr'
 import type { Source, Sink } from 'it-stream-types'
-
-const log = logger('libp2p:webrtc:maconn')
 
 interface WebRTCMultiaddrConnectionInit {
   /**
@@ -29,7 +27,12 @@ interface WebRTCMultiaddrConnectionInit {
   metrics?: CounterGroup
 }
 
+export interface WebRTCMultiaddrConnectionComponents {
+  logger: ComponentLogger
+}
+
 export class WebRTCMultiaddrConnection implements MultiaddrConnection {
+  readonly #log: Logger
   /**
    * WebRTC Peer Connection
    */
@@ -60,7 +63,8 @@ export class WebRTCMultiaddrConnection implements MultiaddrConnection {
    */
   sink: Sink<Source<Uint8Array>, Promise<void>> = nopSink
 
-  constructor (init: WebRTCMultiaddrConnectionInit) {
+  constructor (components: WebRTCMultiaddrConnectionComponents, init: WebRTCMultiaddrConnectionInit) {
+    this.#log = components.logger.forComponent('libp2p:webrtc:maconn')
     this.remoteAddr = init.remoteAddr
     this.timeline = init.timeline
     this.peerConnection = init.peerConnection
@@ -68,7 +72,7 @@ export class WebRTCMultiaddrConnection implements MultiaddrConnection {
     const initialState = this.peerConnection.connectionState
 
     this.peerConnection.onconnectionstatechange = () => {
-      log.trace('peer connection state change', this.peerConnection.connectionState, 'initial state', initialState)
+      this.#log.trace('peer connection state change', this.peerConnection.connectionState, 'initial state', initialState)
 
       if (this.peerConnection.connectionState === 'disconnected' || this.peerConnection.connectionState === 'failed' || this.peerConnection.connectionState === 'closed') {
         // nothing else to do but close the connection
@@ -78,7 +82,7 @@ export class WebRTCMultiaddrConnection implements MultiaddrConnection {
   }
 
   async close (options?: AbortOptions): Promise<void> {
-    log.trace('closing connection')
+    this.#log.trace('closing connection')
 
     this.peerConnection.close()
     this.timeline.close = Date.now()
@@ -86,7 +90,7 @@ export class WebRTCMultiaddrConnection implements MultiaddrConnection {
   }
 
   abort (err: Error): void {
-    log.error('closing connection due to error', err)
+    this.#log.error('closing connection due to error', err)
 
     this.peerConnection.close()
     this.timeline.close = Date.now()

--- a/packages/transport-webrtc/src/maconn.ts
+++ b/packages/transport-webrtc/src/maconn.ts
@@ -32,7 +32,7 @@ export interface WebRTCMultiaddrConnectionComponents {
 }
 
 export class WebRTCMultiaddrConnection implements MultiaddrConnection {
-  readonly #log: Logger
+  private readonly log: Logger
   /**
    * WebRTC Peer Connection
    */
@@ -64,7 +64,7 @@ export class WebRTCMultiaddrConnection implements MultiaddrConnection {
   sink: Sink<Source<Uint8Array>, Promise<void>> = nopSink
 
   constructor (components: WebRTCMultiaddrConnectionComponents, init: WebRTCMultiaddrConnectionInit) {
-    this.#log = components.logger.forComponent('libp2p:webrtc:maconn')
+    this.log = components.logger.forComponent('libp2p:webrtc:maconn')
     this.remoteAddr = init.remoteAddr
     this.timeline = init.timeline
     this.peerConnection = init.peerConnection
@@ -72,7 +72,7 @@ export class WebRTCMultiaddrConnection implements MultiaddrConnection {
     const initialState = this.peerConnection.connectionState
 
     this.peerConnection.onconnectionstatechange = () => {
-      this.#log.trace('peer connection state change', this.peerConnection.connectionState, 'initial state', initialState)
+      this.log.trace('peer connection state change', this.peerConnection.connectionState, 'initial state', initialState)
 
       if (this.peerConnection.connectionState === 'disconnected' || this.peerConnection.connectionState === 'failed' || this.peerConnection.connectionState === 'closed') {
         // nothing else to do but close the connection
@@ -82,7 +82,7 @@ export class WebRTCMultiaddrConnection implements MultiaddrConnection {
   }
 
   async close (options?: AbortOptions): Promise<void> {
-    this.#log.trace('closing connection')
+    this.log.trace('closing connection')
 
     this.peerConnection.close()
     this.timeline.close = Date.now()
@@ -90,7 +90,7 @@ export class WebRTCMultiaddrConnection implements MultiaddrConnection {
   }
 
   abort (err: Error): void {
-    this.#log.error('closing connection due to error', err)
+    this.log.error('closing connection due to error', err)
 
     this.peerConnection.close()
     this.timeline.close = Date.now()

--- a/packages/transport-webrtc/src/muxer.ts
+++ b/packages/transport-webrtc/src/muxer.ts
@@ -114,14 +114,14 @@ export class DataChannelMuxer implements StreamMuxer {
   public streams: Stream[]
   public protocol: string
 
-  readonly #log: Logger
+  private readonly log: Logger
   private readonly peerConnection: RTCPeerConnection
   private readonly dataChannelOptions: DataChannelOptions
   private readonly metrics?: CounterGroup
   private readonly logger: ComponentLogger
 
   constructor (components: DataChannelMuxerComponents, readonly init: DataChannelMuxerInit) {
-    this.#log = components.logger.forComponent('libp2p:webrtc:muxer')
+    this.log = components.logger.forComponent('libp2p:webrtc:muxer')
     this.logger = components.logger
     this.streams = init.streams.map(s => s.stream)
     this.peerConnection = init.peerConnection
@@ -172,12 +172,12 @@ export class DataChannelMuxer implements StreamMuxer {
   }
 
   #onStreamEnd (stream: Stream, channel: RTCDataChannel): void {
-    this.#log.trace('stream %s %s %s onEnd', stream.direction, stream.id, stream.protocol)
+    this.log.trace('stream %s %s %s onEnd', stream.direction, stream.id, stream.protocol)
     drainAndClose(
       channel,
       `${stream.direction} ${stream.id} ${stream.protocol}`,
       this.dataChannelOptions.drainTimeout, {
-        log: this.#log
+        log: this.log
       }
     )
     this.streams = this.streams.filter(s => s.id !== stream.id)

--- a/packages/transport-webrtc/src/muxer.ts
+++ b/packages/transport-webrtc/src/muxer.ts
@@ -1,15 +1,13 @@
-import { logger } from '@libp2p/logger'
 import { createStream } from './stream.js'
 import { drainAndClose, nopSink, nopSource } from './util.js'
 import type { DataChannelOptions } from './index.js'
+import type { ComponentLogger, Logger } from '@libp2p/interface'
 import type { Stream } from '@libp2p/interface/connection'
 import type { CounterGroup } from '@libp2p/interface/metrics'
 import type { StreamMuxer, StreamMuxerFactory, StreamMuxerInit } from '@libp2p/interface/stream-muxer'
 import type { AbortOptions } from '@multiformats/multiaddr'
 import type { Source, Sink } from 'it-stream-types'
 import type { Uint8ArrayList } from 'uint8arraylist'
-
-const log = logger('libp2p:webrtc:muxer')
 
 const PROTOCOL = '/webrtc'
 
@@ -32,6 +30,10 @@ export interface DataChannelMuxerFactoryInit {
   dataChannelOptions?: DataChannelOptions
 }
 
+export interface DataChannelMuxerFactoryComponents {
+  logger: ComponentLogger
+}
+
 interface BufferedStream {
   stream: Stream
   channel: RTCDataChannel
@@ -48,8 +50,10 @@ export class DataChannelMuxerFactory implements StreamMuxerFactory {
   private bufferedStreams: BufferedStream[] = []
   private readonly metrics?: CounterGroup
   private readonly dataChannelOptions?: DataChannelOptions
+  private readonly components: DataChannelMuxerFactoryComponents
 
-  constructor (init: DataChannelMuxerFactoryInit) {
+  constructor (components: DataChannelMuxerFactoryComponents, init: DataChannelMuxerFactoryInit) {
+    this.components = components
     this.peerConnection = init.peerConnection
     this.metrics = init.metrics
     this.protocol = init.protocol ?? PROTOCOL
@@ -66,6 +70,7 @@ export class DataChannelMuxerFactory implements StreamMuxerFactory {
         onEnd: (err) => {
           bufferedStream.onEnd(err)
         },
+        logger: components.logger,
         ...this.dataChannelOptions
       })
 
@@ -80,7 +85,7 @@ export class DataChannelMuxerFactory implements StreamMuxerFactory {
   }
 
   createStreamMuxer (init?: StreamMuxerInit): StreamMuxer {
-    return new DataChannelMuxer({
+    return new DataChannelMuxer(this.components, {
       ...init,
       peerConnection: this.peerConnection,
       dataChannelOptions: this.dataChannelOptions,
@@ -95,6 +100,10 @@ export interface DataChannelMuxerInit extends DataChannelMuxerFactoryInit, Strea
   streams: BufferedStream[]
 }
 
+export interface DataChannelMuxerComponents {
+  logger: ComponentLogger
+}
+
 /**
  * A libp2p data channel stream muxer
  */
@@ -105,11 +114,15 @@ export class DataChannelMuxer implements StreamMuxer {
   public streams: Stream[]
   public protocol: string
 
+  readonly #log: Logger
   private readonly peerConnection: RTCPeerConnection
   private readonly dataChannelOptions: DataChannelOptions
   private readonly metrics?: CounterGroup
+  private readonly logger: ComponentLogger
 
-  constructor (readonly init: DataChannelMuxerInit) {
+  constructor (components: DataChannelMuxerComponents, readonly init: DataChannelMuxerInit) {
+    this.#log = components.logger.forComponent('libp2p:webrtc:muxer')
+    this.logger = components.logger
     this.streams = init.streams.map(s => s.stream)
     this.peerConnection = init.peerConnection
     this.protocol = init.protocol ?? PROTOCOL
@@ -129,6 +142,7 @@ export class DataChannelMuxer implements StreamMuxer {
         onEnd: () => {
           this.#onStreamEnd(stream, channel)
         },
+        logger: this.logger,
         ...this.dataChannelOptions
       })
 
@@ -158,8 +172,14 @@ export class DataChannelMuxer implements StreamMuxer {
   }
 
   #onStreamEnd (stream: Stream, channel: RTCDataChannel): void {
-    log.trace('stream %s %s %s onEnd', stream.direction, stream.id, stream.protocol)
-    drainAndClose(channel, `${stream.direction} ${stream.id} ${stream.protocol}`, this.dataChannelOptions.drainTimeout)
+    this.#log.trace('stream %s %s %s onEnd', stream.direction, stream.id, stream.protocol)
+    drainAndClose(
+      channel,
+      `${stream.direction} ${stream.id} ${stream.protocol}`,
+      this.dataChannelOptions.drainTimeout, {
+        log: this.#log
+      }
+    )
     this.streams = this.streams.filter(s => s.id !== stream.id)
     this.metrics?.increment({ stream_end: true })
     this.init?.onStreamEnd?.(stream)
@@ -206,6 +226,7 @@ export class DataChannelMuxer implements StreamMuxer {
       onEnd: () => {
         this.#onStreamEnd(stream, channel)
       },
+      logger: this.logger,
       ...this.dataChannelOptions
     })
     this.streams.push(stream)

--- a/packages/transport-webrtc/src/private-to-private/transport.ts
+++ b/packages/transport-webrtc/src/private-to-private/transport.ts
@@ -1,6 +1,5 @@
 import { CodeError } from '@libp2p/interface/errors'
 import { type CreateListenerOptions, type DialOptions, symbol, type Transport, type Listener, type Upgrader } from '@libp2p/interface/transport'
-import { logger } from '@libp2p/logger'
 import { peerIdFromString } from '@libp2p/peer-id'
 import { multiaddr, type Multiaddr } from '@multiformats/multiaddr'
 import { WebRTC } from '@multiformats/multiaddr-matcher'
@@ -12,6 +11,7 @@ import { initiateConnection } from './initiate-connection.js'
 import { WebRTCPeerListener } from './listener.js'
 import { handleIncomingStream } from './signaling-stream-handler.js'
 import type { DataChannelOptions } from '../index.js'
+import type { ComponentLogger, Logger } from '@libp2p/interface'
 import type { Connection } from '@libp2p/interface/connection'
 import type { PeerId } from '@libp2p/interface/peer-id'
 import type { CounterGroup, Metrics } from '@libp2p/interface/src/metrics/index.js'
@@ -19,8 +19,6 @@ import type { Startable } from '@libp2p/interface/startable'
 import type { IncomingStreamData, Registrar } from '@libp2p/interface-internal/registrar'
 import type { ConnectionManager } from '@libp2p/interface-internal/src/connection-manager/index.js'
 import type { TransportManager } from '@libp2p/interface-internal/transport-manager'
-
-const log = logger('libp2p:webrtc:peer')
 
 const WEBRTC_TRANSPORT = '/webrtc'
 const CIRCUIT_RELAY_TRANSPORT = '/p2p-circuit'
@@ -45,6 +43,7 @@ export interface WebRTCTransportComponents {
   transportManager: TransportManager
   connectionManager: ConnectionManager
   metrics?: Metrics
+  logger: ComponentLogger
 }
 
 export interface WebRTCTransportMetrics {
@@ -53,6 +52,7 @@ export interface WebRTCTransportMetrics {
 }
 
 export class WebRTCTransport implements Transport, Startable {
+  readonly #log: Logger
   private _started = false
   private readonly metrics?: WebRTCTransportMetrics
   private readonly shutdownController: AbortController
@@ -61,6 +61,7 @@ export class WebRTCTransport implements Transport, Startable {
     private readonly components: WebRTCTransportComponents,
     private readonly init: WebRTCTransportInit = {}
   ) {
+    this.#log = components.logger.forComponent('libp2p:webrtc')
     this.shutdownController = new AbortController()
 
     if (components.metrics != null) {
@@ -83,7 +84,7 @@ export class WebRTCTransport implements Transport, Startable {
 
   async start (): Promise<void> {
     await this.components.registrar.handle(SIGNALING_PROTO_ID, (data: IncomingStreamData) => {
-      this._onProtocol(data).catch(err => { log.error('failed to handle incoming connect from %p', data.connection.remotePeer, err) })
+      this._onProtocol(data).catch(err => { this.#log.error('failed to handle incoming connect from %p', data.connection.remotePeer, err) })
     }, {
       runOnTransientConnection: true
     })
@@ -118,10 +119,10 @@ export class WebRTCTransport implements Transport, Startable {
    * <relay address>/p2p/<relay-peer>/p2p-circuit/webrtc/p2p/<destination-peer>
   */
   async dial (ma: Multiaddr, options: DialOptions): Promise<Connection> {
-    log.trace('dialing address: %a', ma)
+    this.#log.trace('dialing address: %a', ma)
 
     const peerConnection = new RTCPeerConnection(this.init.rtcConfiguration)
-    const muxerFactory = new DataChannelMuxerFactory({
+    const muxerFactory = new DataChannelMuxerFactory(this.components, {
       peerConnection,
       dataChannelOptions: this.init.dataChannel
     })
@@ -132,10 +133,11 @@ export class WebRTCTransport implements Transport, Startable {
       dataChannelOptions: this.init.dataChannel,
       signal: options.signal,
       connectionManager: this.components.connectionManager,
-      transportManager: this.components.transportManager
+      transportManager: this.components.transportManager,
+      log: this.#log
     })
 
-    const webRTCConn = new WebRTCMultiaddrConnection({
+    const webRTCConn = new WebRTCMultiaddrConnection(this.components, {
       peerConnection,
       timeline: { open: Date.now() },
       remoteAddr: remoteAddress,
@@ -157,7 +159,7 @@ export class WebRTCTransport implements Transport, Startable {
   async _onProtocol ({ connection, stream }: IncomingStreamData): Promise<void> {
     const signal = AbortSignal.timeout(this.init.inboundConnectionTimeout ?? INBOUND_CONNECTION_TIMEOUT)
     const peerConnection = new RTCPeerConnection(this.init.rtcConfiguration)
-    const muxerFactory = new DataChannelMuxerFactory({
+    const muxerFactory = new DataChannelMuxerFactory(this.components, {
       peerConnection,
       dataChannelOptions: this.init.dataChannel
     })
@@ -167,10 +169,11 @@ export class WebRTCTransport implements Transport, Startable {
         peerConnection,
         connection,
         stream,
-        signal
+        signal,
+        log: this.#log
       })
 
-      const webRTCConn = new WebRTCMultiaddrConnection({
+      const webRTCConn = new WebRTCMultiaddrConnection(this.components, {
         peerConnection,
         timeline: { open: (new Date()).getTime() },
         remoteAddr: remoteAddress,
@@ -201,7 +204,7 @@ export class WebRTCTransport implements Transport, Startable {
     const shutDownListener = (): void => {
       webRTCConn.close()
         .catch(err => {
-          log.error('could not close WebRTCMultiaddrConnection', err)
+          this.#log.error('could not close WebRTCMultiaddrConnection', err)
         })
     }
 

--- a/packages/transport-webrtc/src/private-to-private/transport.ts
+++ b/packages/transport-webrtc/src/private-to-private/transport.ts
@@ -52,7 +52,7 @@ export interface WebRTCTransportMetrics {
 }
 
 export class WebRTCTransport implements Transport, Startable {
-  readonly #log: Logger
+  private readonly log: Logger
   private _started = false
   private readonly metrics?: WebRTCTransportMetrics
   private readonly shutdownController: AbortController
@@ -61,7 +61,7 @@ export class WebRTCTransport implements Transport, Startable {
     private readonly components: WebRTCTransportComponents,
     private readonly init: WebRTCTransportInit = {}
   ) {
-    this.#log = components.logger.forComponent('libp2p:webrtc')
+    this.log = components.logger.forComponent('libp2p:webrtc')
     this.shutdownController = new AbortController()
 
     if (components.metrics != null) {
@@ -84,7 +84,7 @@ export class WebRTCTransport implements Transport, Startable {
 
   async start (): Promise<void> {
     await this.components.registrar.handle(SIGNALING_PROTO_ID, (data: IncomingStreamData) => {
-      this._onProtocol(data).catch(err => { this.#log.error('failed to handle incoming connect from %p', data.connection.remotePeer, err) })
+      this._onProtocol(data).catch(err => { this.log.error('failed to handle incoming connect from %p', data.connection.remotePeer, err) })
     }, {
       runOnTransientConnection: true
     })
@@ -119,7 +119,7 @@ export class WebRTCTransport implements Transport, Startable {
    * <relay address>/p2p/<relay-peer>/p2p-circuit/webrtc/p2p/<destination-peer>
   */
   async dial (ma: Multiaddr, options: DialOptions): Promise<Connection> {
-    this.#log.trace('dialing address: %a', ma)
+    this.log.trace('dialing address: %a', ma)
 
     const peerConnection = new RTCPeerConnection(this.init.rtcConfiguration)
     const muxerFactory = new DataChannelMuxerFactory(this.components, {
@@ -134,7 +134,7 @@ export class WebRTCTransport implements Transport, Startable {
       signal: options.signal,
       connectionManager: this.components.connectionManager,
       transportManager: this.components.transportManager,
-      log: this.#log
+      log: this.log
     })
 
     const webRTCConn = new WebRTCMultiaddrConnection(this.components, {
@@ -170,7 +170,7 @@ export class WebRTCTransport implements Transport, Startable {
         connection,
         stream,
         signal,
-        log: this.#log
+        log: this.log
       })
 
       const webRTCConn = new WebRTCMultiaddrConnection(this.components, {
@@ -204,7 +204,7 @@ export class WebRTCTransport implements Transport, Startable {
     const shutDownListener = (): void => {
       webRTCConn.close()
         .catch(err => {
-          this.#log.error('could not close WebRTCMultiaddrConnection', err)
+          this.log.error('could not close WebRTCMultiaddrConnection', err)
         })
     }
 

--- a/packages/transport-webrtc/src/private-to-public/sdp.ts
+++ b/packages/transport-webrtc/src/private-to-public/sdp.ts
@@ -1,12 +1,10 @@
-import { logger } from '@libp2p/logger'
 import { bases } from 'multiformats/basics'
 import * as multihashes from 'multihashes'
 import { inappropriateMultiaddr, invalidArgument, invalidFingerprint, unsupportedHashAlgorithm } from '../error.js'
 import { CERTHASH_CODE } from './transport.js'
+import type { LoggerOptions } from '@libp2p/interface'
 import type { Multiaddr } from '@multiformats/multiaddr'
 import type { HashCode, HashName } from 'multihashes'
-
-const log = logger('libp2p:webrtc:sdp')
 
 /**
  * Get base2 | identity decoders
@@ -14,11 +12,11 @@ const log = logger('libp2p:webrtc:sdp')
 // @ts-expect-error - Not easy to combine these types.
 export const mbdecoder: any = Object.values(bases).map(b => b.decoder).reduce((d, b) => d.or(b))
 
-export function getLocalFingerprint (pc: RTCPeerConnection): string | undefined {
+export function getLocalFingerprint (pc: RTCPeerConnection, options: LoggerOptions): string | undefined {
   // try to fetch fingerprint from local certificate
   const localCert = pc.getConfiguration().certificates?.at(0)
   if (localCert == null || localCert.getFingerprints == null) {
-    log.trace('fetching fingerprint from local SDP')
+    options.log.trace('fetching fingerprint from local SDP')
     const localDescription = pc.localDescription
     if (localDescription == null) {
       return undefined
@@ -26,7 +24,7 @@ export function getLocalFingerprint (pc: RTCPeerConnection): string | undefined 
     return getFingerprintFromSdp(localDescription.sdp)
   }
 
-  log.trace('fetching fingerprint from local certificate')
+  options.log.trace('fetching fingerprint from local certificate')
 
   if (localCert.getFingerprints().length === 0) {
     return undefined
@@ -54,8 +52,6 @@ function ipv (ma: Multiaddr): string {
       return proto.toUpperCase()
     }
   }
-
-  log('Warning: multiaddr does not appear to contain IP4 or IP6, defaulting to IP6', ma)
 
   return 'IP6'
 }

--- a/packages/transport-webrtc/src/private-to-public/transport.ts
+++ b/packages/transport-webrtc/src/private-to-public/transport.ts
@@ -59,12 +59,12 @@ export interface WebRTCTransportDirectInit {
 }
 
 export class WebRTCDirectTransport implements Transport {
-  readonly #log: Logger
+  private readonly log: Logger
   private readonly metrics?: WebRTCMetrics
   private readonly components: WebRTCDirectTransportComponents
   private readonly init: WebRTCTransportDirectInit
   constructor (components: WebRTCDirectTransportComponents, init: WebRTCTransportDirectInit = {}) {
-    this.#log = components.logger.forComponent('libp2p:webrtc-direct')
+    this.log = components.logger.forComponent('libp2p:webrtc-direct')
     this.components = components
     this.init = init
     if (components.metrics != null) {
@@ -82,7 +82,7 @@ export class WebRTCDirectTransport implements Transport {
    */
   async dial (ma: Multiaddr, options: WebRTCDialOptions): Promise<Connection> {
     const rawConn = await this._connect(ma, options)
-    this.#log('dialing address: %a', ma)
+    this.log('dialing address: %a', ma)
     return rawConn
   }
 
@@ -145,7 +145,7 @@ export class WebRTCDirectTransport implements Transport {
         const handshakeDataChannel = peerConnection.createDataChannel('', { negotiated: true, id: 0 })
         const handshakeTimeout = setTimeout(() => {
           const error = `Data channel was never opened: state: ${handshakeDataChannel.readyState}`
-          this.#log.error(error)
+          this.log.error(error)
           this.metrics?.dialerEvents.increment({ open_error: true })
           reject(dataChannelError('data', error))
         }, HANDSHAKE_TIMEOUT_MS)
@@ -160,7 +160,7 @@ export class WebRTCDirectTransport implements Transport {
           clearTimeout(handshakeTimeout)
           const errorTarget = event.target?.toString() ?? 'not specified'
           const error = `Error opening a data channel for handshaking: ${errorTarget}`
-          this.#log.error(error)
+          this.log.error(error)
           // NOTE: We use unknown error here but this could potentially be considered a reset by some standards.
           this.metrics?.dialerEvents.increment({ unknown_error: true })
           reject(dataChannelError('data', error))
@@ -232,7 +232,7 @@ export class WebRTCDirectTransport implements Transport {
           case 'disconnected':
           case 'closed':
             maConn.close().catch((err) => {
-              this.#log.error('error closing connection', err)
+              this.log.error('error closing connection', err)
             }).finally(() => {
               // Remove the event listener once the connection is closed
               controller.abort()
@@ -273,7 +273,7 @@ export class WebRTCDirectTransport implements Transport {
     }
 
     const localFingerprint = sdp.getLocalFingerprint(pc, {
-      log: this.#log
+      log: this.log
     })
     if (localFingerprint == null) {
       throw invalidArgument('no local fingerprint found')

--- a/packages/transport-webrtc/src/private-to-public/transport.ts
+++ b/packages/transport-webrtc/src/private-to-public/transport.ts
@@ -1,6 +1,5 @@
 import { noise as Noise } from '@chainsafe/libp2p-noise'
 import { type CreateListenerOptions, symbol, type Transport, type Listener } from '@libp2p/interface/transport'
-import { logger } from '@libp2p/logger'
 import * as p from '@libp2p/peer-id'
 import { protocols } from '@multiformats/multiaddr'
 import { WebRTCDirect } from '@multiformats/multiaddr-matcher'
@@ -17,12 +16,11 @@ import * as sdp from './sdp.js'
 import { genUfrag } from './util.js'
 import type { WebRTCDialOptions } from './options.js'
 import type { DataChannelOptions } from '../index.js'
+import type { ComponentLogger, Logger } from '@libp2p/interface'
 import type { Connection } from '@libp2p/interface/connection'
 import type { CounterGroup, Metrics } from '@libp2p/interface/metrics'
 import type { PeerId } from '@libp2p/interface/peer-id'
 import type { Multiaddr } from '@multiformats/multiaddr'
-
-const log = logger('libp2p:webrtc:transport')
 
 /**
  * The time to wait, in milliseconds, for the data channel handshake to complete
@@ -49,6 +47,7 @@ export const CERTHASH_CODE: number = protocols('certhash').code
 export interface WebRTCDirectTransportComponents {
   peerId: PeerId
   metrics?: Metrics
+  logger: ComponentLogger
 }
 
 export interface WebRTCMetrics {
@@ -60,10 +59,12 @@ export interface WebRTCTransportDirectInit {
 }
 
 export class WebRTCDirectTransport implements Transport {
+  readonly #log: Logger
   private readonly metrics?: WebRTCMetrics
   private readonly components: WebRTCDirectTransportComponents
   private readonly init: WebRTCTransportDirectInit
   constructor (components: WebRTCDirectTransportComponents, init: WebRTCTransportDirectInit = {}) {
+    this.#log = components.logger.forComponent('libp2p:webrtc-direct')
     this.components = components
     this.init = init
     if (components.metrics != null) {
@@ -81,7 +82,7 @@ export class WebRTCDirectTransport implements Transport {
    */
   async dial (ma: Multiaddr, options: WebRTCDialOptions): Promise<Connection> {
     const rawConn = await this._connect(ma, options)
-    log('dialing address: %a', ma)
+    this.#log('dialing address: %a', ma)
     return rawConn
   }
 
@@ -144,7 +145,7 @@ export class WebRTCDirectTransport implements Transport {
         const handshakeDataChannel = peerConnection.createDataChannel('', { negotiated: true, id: 0 })
         const handshakeTimeout = setTimeout(() => {
           const error = `Data channel was never opened: state: ${handshakeDataChannel.readyState}`
-          log.error(error)
+          this.#log.error(error)
           this.metrics?.dialerEvents.increment({ open_error: true })
           reject(dataChannelError('data', error))
         }, HANDSHAKE_TIMEOUT_MS)
@@ -159,7 +160,7 @@ export class WebRTCDirectTransport implements Transport {
           clearTimeout(handshakeTimeout)
           const errorTarget = event.target?.toString() ?? 'not specified'
           const error = `Error opening a data channel for handshaking: ${errorTarget}`
-          log.error(error)
+          this.#log.error(error)
           // NOTE: We use unknown error here but this could potentially be considered a reset by some standards.
           this.metrics?.dialerEvents.increment({ unknown_error: true })
           reject(dataChannelError('data', error))
@@ -194,7 +195,12 @@ export class WebRTCDirectTransport implements Transport {
       // we pass in undefined for these parameters.
       const noise = Noise({ prologueBytes: fingerprintsPrologue })()
 
-      const wrappedChannel = createStream({ channel: handshakeDataChannel, direction: 'inbound', ...(this.init.dataChannel ?? {}) })
+      const wrappedChannel = createStream({
+        channel: handshakeDataChannel,
+        direction: 'inbound',
+        logger: this.components.logger,
+        ...(this.init.dataChannel ?? {})
+      })
       const wrappedDuplex = {
         ...wrappedChannel,
         sink: wrappedChannel.sink.bind(wrappedChannel),
@@ -209,7 +215,7 @@ export class WebRTCDirectTransport implements Transport {
 
       // Creating the connection before completion of the noise
       // handshake ensures that the stream opening callback is set up
-      const maConn = new WebRTCMultiaddrConnection({
+      const maConn = new WebRTCMultiaddrConnection(this.components, {
         peerConnection,
         remoteAddr: ma,
         timeline: {
@@ -226,7 +232,7 @@ export class WebRTCDirectTransport implements Transport {
           case 'disconnected':
           case 'closed':
             maConn.close().catch((err) => {
-              log.error('error closing connection', err)
+              this.#log.error('error closing connection', err)
             }).finally(() => {
               // Remove the event listener once the connection is closed
               controller.abort()
@@ -240,7 +246,11 @@ export class WebRTCDirectTransport implements Transport {
       // Track opened peer connection
       this.metrics?.dialerEvents.increment({ peer_connection: true })
 
-      const muxerFactory = new DataChannelMuxerFactory({ peerConnection, metrics: this.metrics?.dialerEvents, dataChannelOptions: this.init.dataChannel })
+      const muxerFactory = new DataChannelMuxerFactory(this.components, {
+        peerConnection,
+        metrics: this.metrics?.dialerEvents,
+        dataChannelOptions: this.init.dataChannel
+      })
 
       // For outbound connections, the remote is expected to start the noise handshake.
       // Therefore, we need to secure an inbound noise connection from the remote.
@@ -262,7 +272,9 @@ export class WebRTCDirectTransport implements Transport {
       throw invalidArgument('no local certificate')
     }
 
-    const localFingerprint = sdp.getLocalFingerprint(pc)
+    const localFingerprint = sdp.getLocalFingerprint(pc, {
+      log: this.#log
+    })
     if (localFingerprint == null) {
       throw invalidArgument('no local fingerprint found')
     }

--- a/packages/transport-webrtc/src/stream.ts
+++ b/packages/transport-webrtc/src/stream.ts
@@ -1,6 +1,5 @@
 import { CodeError } from '@libp2p/interface/errors'
 import { AbstractStream, type AbstractStreamInit } from '@libp2p/interface/stream-muxer/stream'
-import { logger } from '@libp2p/logger'
 import * as lengthPrefixed from 'it-length-prefixed'
 import { type Pushable, pushable } from 'it-pushable'
 import pDefer from 'p-defer'
@@ -10,7 +9,7 @@ import { raceSignal } from 'race-signal'
 import { Uint8ArrayList } from 'uint8arraylist'
 import { Message } from './pb/message.js'
 import type { DataChannelOptions } from './index.js'
-import type { AbortOptions } from '@libp2p/interface'
+import type { AbortOptions, ComponentLogger } from '@libp2p/interface'
 import type { Direction } from '@libp2p/interface/connection'
 import type { DeferredPromise } from 'p-defer'
 
@@ -22,6 +21,8 @@ export interface WebRTCStreamInit extends AbstractStreamInit, DataChannelOptions
    * {@link https://developer.mozilla.org/en-US/docs/Web/API/RTCDataChannel}
    */
   channel: RTCDataChannel
+
+  logger: ComponentLogger
 }
 
 /**
@@ -379,6 +380,8 @@ export interface WebRTCStreamOptions extends DataChannelOptions {
    * A callback invoked when the channel ends
    */
   onEnd?(err?: Error | undefined): void
+
+  logger: ComponentLogger
 }
 
 export function createStream (options: WebRTCStreamOptions): WebRTCStream {
@@ -386,7 +389,7 @@ export function createStream (options: WebRTCStreamOptions): WebRTCStream {
 
   return new WebRTCStream({
     id: direction === 'inbound' ? (`i${channel.id}`) : `r${channel.id}`,
-    log: logger(`libp2p:webrtc:stream:${direction}:${channel.id}`),
+    log: options.logger.forComponent(`libp2p:webrtc:stream:${direction}:${channel.id}`),
     ...options
   })
 }

--- a/packages/transport-webrtc/src/util.ts
+++ b/packages/transport-webrtc/src/util.ts
@@ -1,9 +1,7 @@
-import { logger } from '@libp2p/logger'
 import { detect } from 'detect-browser'
 import pDefer from 'p-defer'
 import pTimeout from 'p-timeout'
-
-const log = logger('libp2p:webrtc:utils')
+import type { LoggerOptions } from '@libp2p/interface'
 
 const browser = detect()
 export const isFirefox = ((browser != null) && browser.name === 'firefox')
@@ -14,7 +12,7 @@ export const nopSink = async (_: any): Promise<void> => {}
 
 export const DATA_CHANNEL_DRAIN_TIMEOUT = 30 * 1000
 
-export function drainAndClose (channel: RTCDataChannel, direction: string, drainTimeout: number = DATA_CHANNEL_DRAIN_TIMEOUT): void {
+export function drainAndClose (channel: RTCDataChannel, direction: string, drainTimeout: number = DATA_CHANNEL_DRAIN_TIMEOUT, options: LoggerOptions): void {
   if (channel.readyState !== 'open') {
     return
   }
@@ -23,7 +21,7 @@ export function drainAndClose (channel: RTCDataChannel, direction: string, drain
     .then(async () => {
       // wait for bufferedAmount to become zero
       if (channel.bufferedAmount > 0) {
-        log('%s drain channel with %d buffered bytes', direction, channel.bufferedAmount)
+        options.log('%s drain channel with %d buffered bytes', direction, channel.bufferedAmount)
         const deferred = pDefer()
         let drained = false
 
@@ -31,7 +29,7 @@ export function drainAndClose (channel: RTCDataChannel, direction: string, drain
 
         const closeListener = (): void => {
           if (!drained) {
-            log('%s drain channel closed before drain', direction)
+            options.log('%s drain channel closed before drain', direction)
             deferred.resolve()
           }
         }
@@ -58,7 +56,7 @@ export function drainAndClose (channel: RTCDataChannel, direction: string, drain
       }
     })
     .catch(err => {
-      log.error('error closing outbound stream', err)
+      options.log.error('error closing outbound stream', err)
     })
 }
 

--- a/packages/transport-webrtc/test/maconn.browser.spec.ts
+++ b/packages/transport-webrtc/test/maconn.browser.spec.ts
@@ -1,5 +1,6 @@
 /* eslint-disable @typescript-eslint/no-unused-expressions */
 
+import { defaultLogger } from '@libp2p/logger'
 import { multiaddr } from '@multiformats/multiaddr'
 import { expect } from 'aegir/chai'
 import { stubObject } from 'sinon-ts'
@@ -17,6 +18,8 @@ describe('Multiaddr Connection', () => {
       reset: () => {}
     })
     const maConn = new WebRTCMultiaddrConnection({
+      logger: defaultLogger()
+    }, {
       peerConnection,
       remoteAddr,
       timeline: {

--- a/packages/transport-webrtc/test/muxer.spec.ts
+++ b/packages/transport-webrtc/test/muxer.spec.ts
@@ -1,5 +1,6 @@
 /* eslint-disable @typescript-eslint/no-unused-expressions */
 
+import { defaultLogger } from '@libp2p/logger'
 import { expect } from 'aegir/chai'
 import pRetry from 'p-retry'
 import { stubInterface } from 'sinon-ts'
@@ -13,6 +14,8 @@ describe('muxer', () => {
     const peerConnection: RTCPeerConnection = {}
 
     const muxerFactory = new DataChannelMuxerFactory({
+      logger: defaultLogger()
+    }, {
       peerConnection
     })
 

--- a/packages/transport-webrtc/test/stream.browser.spec.ts
+++ b/packages/transport-webrtc/test/stream.browser.spec.ts
@@ -1,3 +1,4 @@
+import { defaultLogger } from '@libp2p/logger'
 import { expect } from 'aegir/chai'
 import delay from 'delay'
 import * as lengthPrefixed from 'it-length-prefixed'
@@ -12,7 +13,7 @@ const TEST_MESSAGE = 'test_message'
 function setup (): { peerConnection: RTCPeerConnection, dataChannel: RTCDataChannel, stream: WebRTCStream } {
   const peerConnection = new RTCPeerConnection()
   const dataChannel = peerConnection.createDataChannel('whatever', { negotiated: true, id: 91 })
-  const stream = createStream({ channel: dataChannel, direction: 'outbound', closeTimeout: 1 })
+  const stream = createStream({ channel: dataChannel, direction: 'outbound', closeTimeout: 1, logger: defaultLogger() })
 
   return { peerConnection, dataChannel, stream }
 }

--- a/packages/transport-webrtc/test/stream.spec.ts
+++ b/packages/transport-webrtc/test/stream.spec.ts
@@ -1,5 +1,6 @@
 /* eslint-disable @typescript-eslint/consistent-type-assertions */
 
+import { defaultLogger } from '@libp2p/logger'
 import { expect } from 'aegir/chai'
 import length from 'it-length'
 import * as lengthPrefixed from 'it-length-prefixed'
@@ -27,7 +28,8 @@ describe('Max message size', () => {
     const webrtcStream = createStream({
       channel,
       direction: 'outbound',
-      closeTimeout: 1
+      closeTimeout: 1,
+      logger: defaultLogger()
     })
 
     p.push(data)
@@ -58,7 +60,8 @@ describe('Max message size', () => {
 
     const webrtcStream = createStream({
       channel,
-      direction: 'outbound'
+      direction: 'outbound',
+      logger: defaultLogger()
     })
 
     p.push(data)
@@ -89,7 +92,8 @@ describe('Max message size', () => {
       direction: 'outbound',
       onEnd: () => {
         closed.resolve()
-      }
+      },
+      logger: defaultLogger()
     })
 
     const t0 = Date.now()

--- a/packages/transport-webrtc/test/transport.browser.spec.ts
+++ b/packages/transport-webrtc/test/transport.browser.spec.ts
@@ -2,6 +2,7 @@
 
 import { type CreateListenerOptions, symbol } from '@libp2p/interface/transport'
 import { mockMetrics, mockUpgrader } from '@libp2p/interface-compliance-tests/mocks'
+import { defaultLogger } from '@libp2p/logger'
 import { createEd25519PeerId } from '@libp2p/peer-id-factory'
 import { multiaddr } from '@multiformats/multiaddr'
 import { expect } from 'aegir/chai'
@@ -23,7 +24,8 @@ describe('WebRTCDirect Transport', () => {
     metrics = mockMetrics()()
     components = {
       peerId: await createEd25519PeerId(),
-      metrics
+      metrics,
+      logger: defaultLogger()
     }
   })
 

--- a/packages/transport-websockets/.aegir.js
+++ b/packages/transport-websockets/.aegir.js
@@ -8,6 +8,7 @@ export default {
       const { mockRegistrar, mockUpgrader } = await import('@libp2p/interface-compliance-tests/mocks')
       const { TypedEventEmitter } = await import('@libp2p/interface/events')
       const { webSockets } = await import('./dist/src/index.js')
+      const { defaultLogger } = await import('@libp2p/logger')
 
       const protocol = '/echo/1.0.0'
       const registrar = mockRegistrar()
@@ -22,7 +23,9 @@ export default {
         events: new TypedEventEmitter()
       })
 
-      const ws = webSockets()()
+      const ws = webSockets()({
+        logger: defaultLogger()
+      })
       const ma = multiaddr('/ip4/127.0.0.1/tcp/9095/ws')
       const listener = ws.createListener({
         upgrader

--- a/packages/transport-websockets/package.json
+++ b/packages/transport-websockets/package.json
@@ -70,7 +70,6 @@
   },
   "dependencies": {
     "@libp2p/interface": "^0.1.6",
-    "@libp2p/logger": "^3.1.0",
     "@libp2p/utils": "^4.0.7",
     "@multiformats/mafmt": "^12.1.6",
     "@multiformats/multiaddr": "^12.1.10",
@@ -84,6 +83,7 @@
   },
   "devDependencies": {
     "@libp2p/interface-compliance-tests": "^4.1.5",
+    "@libp2p/logger": "^3.1.0",
     "aegir": "^41.0.2",
     "is-loopback-addr": "^2.0.1",
     "it-all": "^3.0.3",

--- a/packages/transport-websockets/src/index.ts
+++ b/packages/transport-websockets/src/index.ts
@@ -65,7 +65,6 @@
 
 import { AbortError, CodeError } from '@libp2p/interface/errors'
 import { type Transport, type MultiaddrFilter, symbol, type CreateListenerOptions, type DialOptions, type Listener } from '@libp2p/interface/transport'
-import { logger } from '@libp2p/logger'
 import { multiaddrToUri as toUri } from '@multiformats/multiaddr-to-uri'
 import { connect, type WebSocketOptions } from 'it-ws/client'
 import pDefer from 'p-defer'
@@ -73,14 +72,12 @@ import { isBrowser, isWebWorker } from 'wherearewe'
 import * as filters from './filters.js'
 import { createListener } from './listener.js'
 import { socketToMaConn } from './socket-to-conn.js'
-import type { AbortOptions } from '@libp2p/interface'
+import type { AbortOptions, ComponentLogger, Logger } from '@libp2p/interface'
 import type { Connection } from '@libp2p/interface/connection'
 import type { Multiaddr } from '@multiformats/multiaddr'
 import type { Server } from 'http'
 import type { DuplexWebSocket } from 'it-ws/duplex'
 import type { ClientOptions } from 'ws'
-
-const log = logger('libp2p:websockets')
 
 export interface WebSocketsInit extends AbortOptions, WebSocketOptions {
   filter?: MultiaddrFilter
@@ -88,10 +85,18 @@ export interface WebSocketsInit extends AbortOptions, WebSocketOptions {
   server?: Server
 }
 
-class WebSockets implements Transport {
-  private readonly init?: WebSocketsInit
+export interface WebSocketsComponents {
+  logger: ComponentLogger
+}
 
-  constructor (init?: WebSocketsInit) {
+class WebSockets implements Transport {
+  readonly #log: Logger
+  private readonly init?: WebSocketsInit
+  private readonly logger: ComponentLogger
+
+  constructor (components: WebSocketsComponents, init?: WebSocketsInit) {
+    this.#log = components.logger.forComponent('libp2p:websockets')
+    this.logger = components.logger
     this.init = init
   }
 
@@ -100,15 +105,17 @@ class WebSockets implements Transport {
   readonly [symbol] = true
 
   async dial (ma: Multiaddr, options: DialOptions): Promise<Connection> {
-    log('dialing %s', ma)
+    this.#log('dialing %s', ma)
     options = options ?? {}
 
     const socket = await this._connect(ma, options)
-    const maConn = socketToMaConn(socket, ma)
-    log('new outbound connection %s', maConn.remoteAddr)
+    const maConn = socketToMaConn(socket, ma, {
+      logger: this.logger
+    })
+    this.#log('new outbound connection %s', maConn.remoteAddr)
 
     const conn = await options.upgrader.upgradeOutbound(maConn)
-    log('outbound connection %s upgraded', maConn.remoteAddr)
+    this.#log('outbound connection %s upgraded', maConn.remoteAddr)
     return conn
   }
 
@@ -117,7 +124,7 @@ class WebSockets implements Transport {
       throw new AbortError()
     }
     const cOpts = ma.toOptions()
-    log('dialing %s:%s', cOpts.host, cOpts.port)
+    this.#log('dialing %s:%s', cOpts.host, cOpts.port)
 
     const errorPromise = pDefer()
     const rawSocket = connect(toUri(ma), this.init)
@@ -126,14 +133,14 @@ class WebSockets implements Transport {
       // information about what happened
       // https://developer.mozilla.org/en-US/docs/Web/API/WebSocket/error_event
       const err = new CodeError(`Could not connect to ${ma.toString()}`, 'ERR_CONNECTION_FAILED')
-      log.error('connection error:', err)
+      this.#log.error('connection error:', err)
       errorPromise.reject(err)
     })
 
     if (options.signal == null) {
       await Promise.race([rawSocket.connected(), errorPromise.promise])
 
-      log('connected %s', ma)
+      this.#log('connected %s', ma)
       return rawSocket
     }
 
@@ -143,7 +150,7 @@ class WebSockets implements Transport {
       onAbort = () => {
         reject(new AbortError())
         rawSocket.close().catch(err => {
-          log.error('error closing raw socket', err)
+          this.#log.error('error closing raw socket', err)
         })
       }
 
@@ -163,7 +170,7 @@ class WebSockets implements Transport {
       }
     }
 
-    log('connected %s', ma)
+    this.#log('connected %s', ma)
     return rawSocket
   }
 
@@ -173,7 +180,12 @@ class WebSockets implements Transport {
    * `upgrader.upgradeInbound`
    */
   createListener (options: CreateListenerOptions): Listener {
-    return createListener({ ...this.init, ...options })
+    return createListener({
+      logger: this.logger
+    }, {
+      ...this.init,
+      ...options
+    })
   }
 
   /**
@@ -197,8 +209,8 @@ class WebSockets implements Transport {
   }
 }
 
-export function webSockets (init: WebSocketsInit = {}): (components?: any) => Transport {
-  return () => {
-    return new WebSockets(init)
+export function webSockets (init: WebSocketsInit = {}): (components: WebSocketsComponents) => Transport {
+  return (components) => {
+    return new WebSockets(components, init)
   }
 }

--- a/packages/transport-websockets/src/index.ts
+++ b/packages/transport-websockets/src/index.ts
@@ -90,12 +90,12 @@ export interface WebSocketsComponents {
 }
 
 class WebSockets implements Transport {
-  readonly #log: Logger
+  private readonly log: Logger
   private readonly init?: WebSocketsInit
   private readonly logger: ComponentLogger
 
   constructor (components: WebSocketsComponents, init?: WebSocketsInit) {
-    this.#log = components.logger.forComponent('libp2p:websockets')
+    this.log = components.logger.forComponent('libp2p:websockets')
     this.logger = components.logger
     this.init = init
   }
@@ -105,17 +105,17 @@ class WebSockets implements Transport {
   readonly [symbol] = true
 
   async dial (ma: Multiaddr, options: DialOptions): Promise<Connection> {
-    this.#log('dialing %s', ma)
+    this.log('dialing %s', ma)
     options = options ?? {}
 
     const socket = await this._connect(ma, options)
     const maConn = socketToMaConn(socket, ma, {
       logger: this.logger
     })
-    this.#log('new outbound connection %s', maConn.remoteAddr)
+    this.log('new outbound connection %s', maConn.remoteAddr)
 
     const conn = await options.upgrader.upgradeOutbound(maConn)
-    this.#log('outbound connection %s upgraded', maConn.remoteAddr)
+    this.log('outbound connection %s upgraded', maConn.remoteAddr)
     return conn
   }
 
@@ -124,7 +124,7 @@ class WebSockets implements Transport {
       throw new AbortError()
     }
     const cOpts = ma.toOptions()
-    this.#log('dialing %s:%s', cOpts.host, cOpts.port)
+    this.log('dialing %s:%s', cOpts.host, cOpts.port)
 
     const errorPromise = pDefer()
     const rawSocket = connect(toUri(ma), this.init)
@@ -133,14 +133,14 @@ class WebSockets implements Transport {
       // information about what happened
       // https://developer.mozilla.org/en-US/docs/Web/API/WebSocket/error_event
       const err = new CodeError(`Could not connect to ${ma.toString()}`, 'ERR_CONNECTION_FAILED')
-      this.#log.error('connection error:', err)
+      this.log.error('connection error:', err)
       errorPromise.reject(err)
     })
 
     if (options.signal == null) {
       await Promise.race([rawSocket.connected(), errorPromise.promise])
 
-      this.#log('connected %s', ma)
+      this.log('connected %s', ma)
       return rawSocket
     }
 
@@ -150,7 +150,7 @@ class WebSockets implements Transport {
       onAbort = () => {
         reject(new AbortError())
         rawSocket.close().catch(err => {
-          this.#log.error('error closing raw socket', err)
+          this.log.error('error closing raw socket', err)
         })
       }
 
@@ -170,7 +170,7 @@ class WebSockets implements Transport {
       }
     }
 
-    this.#log('connected %s', ma)
+    this.log('connected %s', ma)
     return rawSocket
   }
 

--- a/packages/transport-websockets/src/listener.ts
+++ b/packages/transport-websockets/src/listener.ts
@@ -1,10 +1,10 @@
 import os from 'os'
 import { TypedEventEmitter, CustomEvent } from '@libp2p/interface/events'
-import { logger } from '@libp2p/logger'
 import { ipPortToMultiaddr as toMultiaddr } from '@libp2p/utils/ip-port-to-multiaddr'
 import { multiaddr, protocols } from '@multiformats/multiaddr'
 import { createServer } from 'it-ws/server'
 import { socketToMaConn } from './socket-to-conn.js'
+import type { ComponentLogger, Logger } from '@libp2p/interface'
 import type { Connection } from '@libp2p/interface/connection'
 import type { Listener, ListenerEvents, CreateListenerOptions } from '@libp2p/interface/transport'
 import type { Multiaddr } from '@multiformats/multiaddr'
@@ -12,16 +12,24 @@ import type { Server } from 'http'
 import type { DuplexWebSocket } from 'it-ws/duplex'
 import type { WebSocketServer } from 'it-ws/server'
 
-const log = logger('libp2p:websockets:listener')
+export interface WebSocketListenerComponents {
+  logger: ComponentLogger
+}
+
+export interface WebSocketListenerInit extends CreateListenerOptions {
+  server?: Server
+}
 
 class WebSocketListener extends TypedEventEmitter<ListenerEvents> implements Listener {
   private readonly connections: Set<DuplexWebSocket>
   private listeningMultiaddr?: Multiaddr
   private readonly server: WebSocketServer
+  readonly #log: Logger
 
-  constructor (init: WebSocketListenerInit) {
+  constructor (components: WebSocketListenerComponents, init: WebSocketListenerInit) {
     super()
 
+    this.#log = components.logger.forComponent('libp2p:websockets:listener')
     // Keep track of open connections to destroy when the listener is closed
     this.connections = new Set<DuplexWebSocket>()
 
@@ -30,8 +38,10 @@ class WebSocketListener extends TypedEventEmitter<ListenerEvents> implements Lis
     this.server = createServer({
       ...init,
       onConnection: (stream: DuplexWebSocket) => {
-        const maConn = socketToMaConn(stream, toMultiaddr(stream.remoteAddress ?? '', stream.remotePort ?? 0))
-        log('new inbound connection %s', maConn.remoteAddr)
+        const maConn = socketToMaConn(stream, toMultiaddr(stream.remoteAddress ?? '', stream.remotePort ?? 0), {
+          logger: components.logger
+        })
+        this.#log('new inbound connection %s', maConn.remoteAddr)
 
         this.connections.add(stream)
 
@@ -42,7 +52,7 @@ class WebSocketListener extends TypedEventEmitter<ListenerEvents> implements Lis
         try {
           void init.upgrader.upgradeInbound(maConn)
             .then((conn) => {
-              log('inbound connection %s upgraded', maConn.remoteAddr)
+              this.#log('inbound connection %s upgraded', maConn.remoteAddr)
 
               if (init?.handler != null) {
                 init?.handler(conn)
@@ -53,16 +63,16 @@ class WebSocketListener extends TypedEventEmitter<ListenerEvents> implements Lis
               }))
             })
             .catch(async err => {
-              log.error('inbound connection failed to upgrade', err)
+              this.#log.error('inbound connection failed to upgrade', err)
 
               await maConn.close().catch(err => {
-                log.error('inbound connection failed to close after upgrade failed', err)
+                this.#log.error('inbound connection failed to close after upgrade failed', err)
               })
             })
         } catch (err) {
-          log.error('inbound connection failed to upgrade', err)
+          this.#log.error('inbound connection failed to upgrade', err)
           maConn.close().catch(err => {
-            log.error('inbound connection failed to close after upgrade failed', err)
+            this.#log.error('inbound connection failed to close after upgrade failed', err)
           })
         }
       }
@@ -151,10 +161,6 @@ class WebSocketListener extends TypedEventEmitter<ListenerEvents> implements Lis
   }
 }
 
-export interface WebSocketListenerInit extends CreateListenerOptions {
-  server?: Server
-}
-
-export function createListener (init: WebSocketListenerInit): Listener {
-  return new WebSocketListener(init)
+export function createListener (components: WebSocketListenerComponents, init: WebSocketListenerInit): Listener {
+  return new WebSocketListener(components, init)
 }

--- a/packages/transport-websockets/src/listener.ts
+++ b/packages/transport-websockets/src/listener.ts
@@ -24,12 +24,12 @@ class WebSocketListener extends TypedEventEmitter<ListenerEvents> implements Lis
   private readonly connections: Set<DuplexWebSocket>
   private listeningMultiaddr?: Multiaddr
   private readonly server: WebSocketServer
-  readonly #log: Logger
+  private readonly log: Logger
 
   constructor (components: WebSocketListenerComponents, init: WebSocketListenerInit) {
     super()
 
-    this.#log = components.logger.forComponent('libp2p:websockets:listener')
+    this.log = components.logger.forComponent('libp2p:websockets:listener')
     // Keep track of open connections to destroy when the listener is closed
     this.connections = new Set<DuplexWebSocket>()
 
@@ -41,7 +41,7 @@ class WebSocketListener extends TypedEventEmitter<ListenerEvents> implements Lis
         const maConn = socketToMaConn(stream, toMultiaddr(stream.remoteAddress ?? '', stream.remotePort ?? 0), {
           logger: components.logger
         })
-        this.#log('new inbound connection %s', maConn.remoteAddr)
+        this.log('new inbound connection %s', maConn.remoteAddr)
 
         this.connections.add(stream)
 
@@ -52,7 +52,7 @@ class WebSocketListener extends TypedEventEmitter<ListenerEvents> implements Lis
         try {
           void init.upgrader.upgradeInbound(maConn)
             .then((conn) => {
-              this.#log('inbound connection %s upgraded', maConn.remoteAddr)
+              this.log('inbound connection %s upgraded', maConn.remoteAddr)
 
               if (init?.handler != null) {
                 init?.handler(conn)
@@ -63,16 +63,16 @@ class WebSocketListener extends TypedEventEmitter<ListenerEvents> implements Lis
               }))
             })
             .catch(async err => {
-              this.#log.error('inbound connection failed to upgrade', err)
+              this.log.error('inbound connection failed to upgrade', err)
 
               await maConn.close().catch(err => {
-                this.#log.error('inbound connection failed to close after upgrade failed', err)
+                this.log.error('inbound connection failed to close after upgrade failed', err)
               })
             })
         } catch (err) {
-          this.#log.error('inbound connection failed to upgrade', err)
+          this.log.error('inbound connection failed to upgrade', err)
           maConn.close().catch(err => {
-            this.#log.error('inbound connection failed to close after upgrade failed', err)
+            this.log.error('inbound connection failed to close after upgrade failed', err)
           })
         }
       }

--- a/packages/transport-websockets/src/socket-to-conn.ts
+++ b/packages/transport-websockets/src/socket-to-conn.ts
@@ -1,22 +1,20 @@
 import { CodeError } from '@libp2p/interface/errors'
-import { logger } from '@libp2p/logger'
 import { abortableSource } from 'abortable-iterator'
 import { CLOSE_TIMEOUT } from './constants.js'
-import type { AbortOptions } from '@libp2p/interface'
+import type { AbortOptions, ComponentLogger } from '@libp2p/interface'
 import type { MultiaddrConnection } from '@libp2p/interface/connection'
 import type { Multiaddr } from '@multiformats/multiaddr'
 import type { DuplexWebSocket } from 'it-ws/duplex'
 
-const log = logger('libp2p:websockets:socket')
-
 export interface SocketToConnOptions extends AbortOptions {
   localAddr?: Multiaddr
+  logger: ComponentLogger
 }
 
 // Convert a stream into a MultiaddrConnection
 // https://github.com/libp2p/interface-transport#multiaddrconnection
-export function socketToMaConn (stream: DuplexWebSocket, remoteAddr: Multiaddr, options?: SocketToConnOptions): MultiaddrConnection {
-  options = options ?? {}
+export function socketToMaConn (stream: DuplexWebSocket, remoteAddr: Multiaddr, options: SocketToConnOptions): MultiaddrConnection {
+  const log = options.logger.forComponent('libp2p:websockets:socket')
 
   const maConn: MultiaddrConnection = {
     async sink (source) {

--- a/packages/transport-websockets/test/browser.ts
+++ b/packages/transport-websockets/test/browser.ts
@@ -2,6 +2,7 @@
 
 import { TypedEventEmitter } from '@libp2p/interface/events'
 import { mockUpgrader } from '@libp2p/interface-compliance-tests/mocks'
+import { defaultLogger } from '@libp2p/logger'
 import { multiaddr } from '@multiformats/multiaddr'
 import { expect } from 'aegir/chai'
 import all from 'it-all'
@@ -20,7 +21,9 @@ describe('libp2p-websockets', () => {
   let conn: Connection
 
   beforeEach(async () => {
-    ws = webSockets()()
+    ws = webSockets()({
+      logger: defaultLogger()
+    })
     conn = await ws.dial(ma, {
       upgrader: mockUpgrader({
         events: new TypedEventEmitter()
@@ -93,6 +96,8 @@ describe('libp2p-websockets', () => {
   })
 
   it('.createServer throws in browser', () => {
-    expect(webSockets()().createListener).to.throw()
+    expect(webSockets()({
+      logger: defaultLogger()
+    }).createListener).to.throw()
   })
 })

--- a/packages/transport-websockets/test/compliance.node.ts
+++ b/packages/transport-websockets/test/compliance.node.ts
@@ -2,6 +2,7 @@
 
 import http from 'http'
 import tests from '@libp2p/interface-compliance-tests/transport'
+import { defaultLogger } from '@libp2p/logger'
 import { multiaddr } from '@multiformats/multiaddr'
 import * as filters from '../src/filters.js'
 import { webSockets } from '../src/index.js'
@@ -11,7 +12,9 @@ import type { Listener } from '@libp2p/interface/transport'
 describe('interface-transport compliance', () => {
   tests({
     async setup () {
-      const ws = webSockets({ filter: filters.all })()
+      const ws = webSockets({ filter: filters.all })({
+        logger: defaultLogger()
+      })
       const addrs = [
         multiaddr('/ip4/127.0.0.1/tcp/9091/ws'),
         multiaddr('/ip4/127.0.0.1/tcp/9092/ws'),

--- a/packages/transport-websockets/test/node.ts
+++ b/packages/transport-websockets/test/node.ts
@@ -6,6 +6,7 @@ import http from 'http'
 import https from 'https'
 import { TypedEventEmitter } from '@libp2p/interface/events'
 import { mockRegistrar, mockUpgrader } from '@libp2p/interface-compliance-tests/mocks'
+import { defaultLogger } from '@libp2p/logger'
 import { multiaddr } from '@multiformats/multiaddr'
 import { expect } from 'aegir/chai'
 import { isLoopbackAddr } from 'is-loopback-addr'
@@ -46,7 +47,9 @@ const upgrader = mockUpgrader({
 
 describe('instantiate the transport', () => {
   it('create', () => {
-    const ws = webSockets()()
+    const ws = webSockets()({
+      logger: defaultLogger()
+    })
     expect(ws).to.exist()
   })
 })
@@ -55,7 +58,9 @@ describe('listen', () => {
   it('should close connections when stopping the listener', async () => {
     const ma = multiaddr('/ip4/127.0.0.1/tcp/47382/ws')
 
-    const ws = webSockets()()
+    const ws = webSockets()({
+      logger: defaultLogger()
+    })
     const listener = ws.createListener({
       handler: (conn) => {
         void conn.newStream([protocol]).then(async (stream) => {
@@ -83,7 +88,9 @@ describe('listen', () => {
     let listener: Listener
 
     beforeEach(() => {
-      ws = webSockets()()
+      ws = webSockets()({
+        logger: defaultLogger()
+      })
     })
 
     afterEach(async () => {
@@ -199,7 +206,9 @@ describe('listen', () => {
     const ma = multiaddr('/ip6/::1/tcp/9091/ws')
 
     beforeEach(() => {
-      ws = webSockets()()
+      ws = webSockets()({
+        logger: defaultLogger()
+      })
     })
 
     it('listen, check for promise', async () => {
@@ -245,7 +254,9 @@ describe('dial', () => {
     const ma = multiaddr('/ip4/127.0.0.1/tcp/9091/ws')
 
     beforeEach(async () => {
-      ws = webSockets()()
+      ws = webSockets()({
+        logger: defaultLogger()
+      })
       listener = ws.createListener({ upgrader })
       await listener.listen(ma)
     })
@@ -281,7 +292,9 @@ describe('dial', () => {
 
     it('should resolve port 0', async () => {
       const ma = multiaddr('/ip4/127.0.0.1/tcp/0/ws')
-      const ws = webSockets()()
+      const ws = webSockets()({
+        logger: defaultLogger()
+      })
 
       // Create a Promise that resolves when a connection is handled
       const deferred = defer()
@@ -311,7 +324,9 @@ describe('dial', () => {
     const ma = multiaddr('/ip4/0.0.0.0/tcp/0/ws')
 
     beforeEach(async () => {
-      ws = webSockets()()
+      ws = webSockets()({
+        logger: defaultLogger()
+      })
       listener = ws.createListener({
         handler: (conn) => {
           void conn.newStream([protocol]).then(async (stream) => {
@@ -361,7 +376,9 @@ describe('dial', () => {
         cert: fs.readFileSync('./test/fixtures/certificate.pem'),
         key: fs.readFileSync('./test/fixtures/key.pem')
       })
-      ws = webSockets({ websocket: { rejectUnauthorized: false }, server })()
+      ws = webSockets({ websocket: { rejectUnauthorized: false }, server })({
+        logger: defaultLogger()
+      })
       listener = ws.createListener({
         handler: (conn) => {
           void conn.newStream([protocol]).then(async (stream) => {
@@ -403,7 +420,9 @@ describe('dial', () => {
     const ma = multiaddr('/ip6/::1/tcp/9091/ws')
 
     beforeEach(async () => {
-      ws = webSockets()()
+      ws = webSockets()({
+        logger: defaultLogger()
+      })
       listener = ws.createListener({
         handler: (conn) => {
           void conn.newStream([protocol]).then(async (stream) => {
@@ -445,7 +464,9 @@ describe('filter addrs', () => {
 
   describe('default filter addrs with only dns', () => {
     before(() => {
-      ws = webSockets()()
+      ws = webSockets()({
+        logger: defaultLogger()
+      })
     })
 
     it('should filter out invalid WS addresses', function () {
@@ -513,7 +534,9 @@ describe('filter addrs', () => {
 
   describe('custom filter addrs', () => {
     before(() => {
-      ws = webSockets()({ filter: filters.all })
+      ws = webSockets({ filter: filters.all })({
+        logger: defaultLogger()
+      })
     })
 
     it('should fail invalid WS addresses', function () {

--- a/packages/transport-webtransport/package.json
+++ b/packages/transport-webtransport/package.json
@@ -47,7 +47,6 @@
   "dependencies": {
     "@chainsafe/libp2p-noise": "^13.0.0",
     "@libp2p/interface": "^0.1.6",
-    "@libp2p/logger": "^3.1.0",
     "@libp2p/peer-id": "^3.0.6",
     "@multiformats/multiaddr": "^12.1.10",
     "@multiformats/multiaddr-matcher": "^1.1.0",
@@ -57,6 +56,7 @@
     "uint8arrays": "^4.0.6"
   },
   "devDependencies": {
+    "@libp2p/logger": "^3.1.0",
     "@libp2p/peer-id-factory": "^3.0.8",
     "aegir": "^41.0.2",
     "libp2p": "^0.46.21",

--- a/packages/transport-webtransport/src/stream.ts
+++ b/packages/transport-webtransport/src/stream.ts
@@ -1,12 +1,10 @@
-import { logger } from '@libp2p/logger'
 import { Uint8ArrayList } from 'uint8arraylist'
-import type { AbortOptions } from '@libp2p/interface'
+import type { AbortOptions, ComponentLogger } from '@libp2p/interface'
 import type { Direction, Stream } from '@libp2p/interface/connection'
 import type { Source } from 'it-stream-types'
 
-const log = logger('libp2p:webtransport:stream')
-
-export async function webtransportBiDiStreamToStream (bidiStream: WebTransportBidirectionalStream, streamId: string, direction: Direction, activeStreams: Stream[], onStreamEnd: undefined | ((s: Stream) => void)): Promise<Stream> {
+export async function webtransportBiDiStreamToStream (bidiStream: WebTransportBidirectionalStream, streamId: string, direction: Direction, activeStreams: Stream[], onStreamEnd: undefined | ((s: Stream) => void), logger: ComponentLogger): Promise<Stream> {
+  const log = logger.forComponent('libp2p:webtransport:stream')
   const writer = bidiStream.writable.getWriter()
   const reader = bidiStream.readable.getReader()
   await writer.ready

--- a/packages/transport-webtransport/test/transport.spec.ts
+++ b/packages/transport-webtransport/test/transport.spec.ts
@@ -1,6 +1,7 @@
 /* eslint-disable no-console */
 /* eslint-env mocha */
 
+import { defaultLogger } from '@libp2p/logger'
 import { createEd25519PeerId } from '@libp2p/peer-id-factory'
 import { multiaddr } from '@multiformats/multiaddr'
 import { expect } from 'aegir/chai'
@@ -11,7 +12,8 @@ describe('WebTransport Transport', () => {
 
   beforeEach(async () => {
     components = {
-      peerId: await createEd25519PeerId()
+      peerId: await createEd25519PeerId(),
+      logger: defaultLogger()
     }
   })
 

--- a/packages/upnp-nat/src/upnp-nat.ts
+++ b/packages/upnp-nat/src/upnp-nat.ts
@@ -24,12 +24,12 @@ export class UPnPNAT implements Startable {
   private readonly gateway?: string
   private started: boolean
   private client?: NatAPI
-  readonly #log: Logger
+  private readonly log: Logger
 
   constructor (components: UPnPNATComponents, init: UPnPNATInit) {
     this.components = components
 
-    this.#log = components.logger.forComponent('libp2p:upnp-nat')
+    this.log = components.logger.forComponent('libp2p:upnp-nat')
     this.started = false
     this.externalAddress = init.externalAddress
     this.localAddress = init.localAddress
@@ -66,7 +66,7 @@ export class UPnPNAT implements Startable {
     // done async to not slow down startup
     void this.mapIpAddresses().catch((err) => {
       // hole punching errors are non-fatal
-      this.#log.error(err)
+      this.log.error(err)
     })
   }
 
@@ -108,7 +108,7 @@ export class UPnPNAT implements Startable {
 
       const publicPort = highPort()
 
-      this.#log(`opening uPnP connection from ${publicIp}:${publicPort} to ${host}:${port}`)
+      this.log(`opening uPnP connection from ${publicIp}:${publicPort} to ${host}:${port}`)
 
       await client.map({
         publicPort,
@@ -152,7 +152,7 @@ export class UPnPNAT implements Startable {
       await this.client.close()
       this.client = undefined
     } catch (err: any) {
-      this.#log.error(err)
+      this.log.error(err)
     }
   }
 }

--- a/packages/utils/package.json
+++ b/packages/utils/package.json
@@ -92,7 +92,6 @@
   "dependencies": {
     "@chainsafe/is-ip": "^2.0.2",
     "@libp2p/interface": "^0.1.6",
-    "@libp2p/logger": "^3.1.0",
     "@multiformats/multiaddr": "^12.1.10",
     "@multiformats/multiaddr-matcher": "^1.1.0",
     "is-loopback-addr": "^2.0.1",
@@ -102,6 +101,7 @@
     "uint8arraylist": "^2.4.3"
   },
   "devDependencies": {
+    "@libp2p/logger": "^3.1.0",
     "@libp2p/peer-id-factory": "^3.0.8",
     "aegir": "^41.0.2",
     "it-all": "^3.0.3",

--- a/packages/utils/src/ip-port-to-multiaddr.ts
+++ b/packages/utils/src/ip-port-to-multiaddr.ts
@@ -1,9 +1,6 @@
 import { isIPv4, isIPv6 } from '@chainsafe/is-ip'
 import { CodeError } from '@libp2p/interface/errors'
-import { logger } from '@libp2p/logger'
 import { type Multiaddr, multiaddr } from '@multiformats/multiaddr'
-
-const log = logger('libp2p:ip-port-to-multiaddr')
 
 export const Errors = {
   ERR_INVALID_IP_PARAMETER: 'ERR_INVALID_IP_PARAMETER',
@@ -35,7 +32,5 @@ export function ipPortToMultiaddr (ip: string, port: number | string): Multiaddr
     return multiaddr(`/ip6/${ip}/tcp/${port}`)
   }
 
-  const errMsg = `invalid ip:port for creating a multiaddr: ${ip}:${port}`
-  log.error(errMsg)
-  throw new CodeError(errMsg, Errors.ERR_INVALID_IP)
+  throw new CodeError(`invalid ip:port for creating a multiaddr: ${ip}:${port}`, Errors.ERR_INVALID_IP)
 }

--- a/packages/utils/src/stream-to-ma-conn.ts
+++ b/packages/utils/src/stream-to-ma-conn.ts
@@ -1,14 +1,12 @@
-import { logger } from '@libp2p/logger'
-import type { AbortOptions } from '@libp2p/interface'
+import type { AbortOptions, ComponentLogger } from '@libp2p/interface'
 import type { MultiaddrConnection, Stream } from '@libp2p/interface/connection'
 import type { Multiaddr } from '@multiformats/multiaddr'
-
-const log = logger('libp2p:stream:converter')
 
 export interface StreamProperties {
   stream: Stream
   remoteAddr: Multiaddr
   localAddr: Multiaddr
+  logger: ComponentLogger
 }
 
 /**
@@ -16,8 +14,9 @@ export interface StreamProperties {
  * https://github.com/libp2p/interface-transport#multiaddrconnection
  */
 export function streamToMaConnection (props: StreamProperties): MultiaddrConnection {
-  const { stream, remoteAddr } = props
+  const { stream, remoteAddr, logger } = props
   const { sink, source } = stream
+  const log = logger.forComponent('libp2p:stream:converter')
 
   const mapSource = (async function * () {
     for await (const list of source) {

--- a/packages/utils/test/stream-to-ma-conn.spec.ts
+++ b/packages/utils/test/stream-to-ma-conn.spec.ts
@@ -1,5 +1,6 @@
 /* eslint-env mocha */
 
+import { defaultLogger } from '@libp2p/logger'
 import { multiaddr } from '@multiformats/multiaddr'
 import { expect } from 'aegir/chai'
 import all from 'it-all'
@@ -42,7 +43,8 @@ describe('Convert stream into a multiaddr connection', () => {
     const maConn = streamToMaConnection({
       stream: toMuxedStream(stream),
       localAddr,
-      remoteAddr
+      remoteAddr,
+      logger: defaultLogger()
     })
 
     expect(maConn).to.exist()
@@ -62,7 +64,8 @@ describe('Convert stream into a multiaddr connection', () => {
     const maConn = streamToMaConnection({
       stream: toMuxedStream(stream),
       localAddr,
-      remoteAddr
+      remoteAddr,
+      logger: defaultLogger()
     })
 
     const data = uint8ArrayFromString('hey')


### PR DESCRIPTION
Refactors all components to accept a `ComponentLogger` that lets us prefix log lines with peer ids/arbitrary strings, etc.

Closes #2207
Closes #2105

## Change checklist

- [x] I have performed a self-review of my own code
- [ ] I have made corresponding changes to the documentation if necessary (this includes comments as well)
- [x] I have added tests that prove my fix is effective or that my feature works