### PR TITLE
chore: fix mplex tests

### DIFF
--- a/packages/stream-multiplexer-mplex/test/fixtures/utils.ts
+++ b/packages/stream-multiplexer-mplex/test/fixtures/utils.ts
@@ -16,3 +16,55 @@ export function messageWithBytes (msg: Message): Message | MessageWithBytes {
 
   return msg
 }
+
+export function arrayToGenerator <T> (data: T[]): AsyncGenerator<T, void, unknown> {
+  let done: Error | boolean = false
+  let index = -1
+
+  const generator: AsyncGenerator<T, void, unknown> = {
+    [Symbol.asyncIterator]: () => {
+      return generator
+    },
+    async next () {
+      if (done instanceof Error) {
+        throw done
+      }
+
+      index++
+
+      if (index === data.length) {
+        done = true
+      }
+
+      if (done) {
+        return {
+          done: true,
+          value: undefined
+        }
+      }
+
+      return {
+        done: false,
+        value: data[index]
+      }
+    },
+    async return (): Promise<IteratorReturnResult<void>> {
+      done = true
+
+      return {
+        done: true,
+        value: undefined
+      }
+    },
+    async throw (err: Error): Promise<IteratorReturnResult<void>> {
+      done = err
+
+      return {
+        done: true,
+        value: undefined
+      }
+    }
+  }
+
+  return generator
+}

--- a/packages/stream-multiplexer-mplex/test/stream.spec.ts
+++ b/packages/stream-multiplexer-mplex/test/stream.spec.ts
@@ -13,7 +13,7 @@ import { Uint8ArrayList } from 'uint8arraylist'
 import { fromString as uint8ArrayFromString } from 'uint8arrays'
 import { MessageTypes, MessageTypeNames } from '../src/message-types.js'
 import { createStream } from '../src/stream.js'
-import { messageWithBytes } from './fixtures/utils.js'
+import { arrayToGenerator, messageWithBytes } from './fixtures/utils.js'
 import type { Message } from '../src/message-types.js'
 import type { MplexStream } from '../src/stream.js'
 
@@ -95,7 +95,7 @@ async function streamPair (n: number, onInitiatorMessage?: onMessage, onReceiver
 
   try {
     await pipe(
-      input,
+      arrayToGenerator(input),
       initiator,
       (source) => map(source, buf => {
         const msg: Message = bufferToMessage(buf)
@@ -392,7 +392,6 @@ describe('stream', () => {
       MessageTypes.MESSAGE_INITIATOR,
       MessageTypes.MESSAGE_INITIATOR,
       MessageTypes.MESSAGE_INITIATOR,
-      MessageTypes.MESSAGE_INITIATOR,
       MessageTypes.MESSAGE_INITIATOR
     ])
 
@@ -453,7 +452,6 @@ describe('stream', () => {
     // All messages sent to recipient
     expect(initiatorSentMessages.map(m => m.type)).to.deep.equal([
       MessageTypes.NEW_STREAM,
-      MessageTypes.MESSAGE_INITIATOR,
       MessageTypes.MESSAGE_INITIATOR,
       MessageTypes.MESSAGE_INITIATOR,
       MessageTypes.MESSAGE_INITIATOR,


### PR DESCRIPTION
The timing has changed on these tests has changed to do a release of `it-foreach` which now does not introduce artificial async when calling the each method.

## Change checklist

- [x] I have performed a self-review of my own code
- [ ] I have made corresponding changes to the documentation if necessary (this includes comments as well)
- [x] I have added tests that prove my fix is effective or that my feature works