### PR TITLE
feat: support default options for tcp sockets/servers

### DIFF
--- a/packages/transport-tcp/src/index.ts
+++ b/packages/transport-tcp/src/index.ts
@@ -101,15 +101,40 @@ export interface TCPOptions {
    * Open server (start listening for new connections) if connections fall below a limit.
    */
   closeServerOnMaxConnections?: CloseServerOnMaxConnectionsOpts
+
+  /**
+   * Options passed to `net.connect` for every opened TCP socket
+   */
+  socket?: TCPSocketOptions
+
+  /**
+   * Options passed to every `net.createServer` for every TCP server
+   */
+  server?: TCPSocketOptions
 }
 
 /**
  * Expose a subset of net.connect options
  */
 export interface TCPSocketOptions extends AbortOptions {
+  /**
+   * @see https://nodejs.org/dist/latest-v18.x/docs/api/net.html#serverlisten
+   */
   noDelay?: boolean
+
+  /**
+   * @see https://nodejs.org/dist/latest-v18.x/docs/api/net.html#serverlisten
+   */
   keepAlive?: boolean
+
+  /**
+   * @see https://nodejs.org/dist/latest-v18.x/docs/api/net.html#serverlisten
+   */
   keepAliveInitialDelay?: number
+
+  /**
+   * @see https://nodejs.org/dist/latest-v18.x/docs/api/net.html#new-netsocketoptions
+   */
   allowHalfOpen?: boolean
 }
 
@@ -205,10 +230,13 @@ class TCP implements Transport {
 
     return new Promise<Socket>((resolve, reject) => {
       const start = Date.now()
-      const cOpts = multiaddrToNetConfig(ma) as (IpcSocketConnectOpts & TcpSocketConnectOpts)
+      const cOpts = multiaddrToNetConfig(ma, {
+        ...(this.opts.socket ?? {}),
+        ...options
+      }) as (IpcSocketConnectOpts & TcpSocketConnectOpts)
       const cOptsStr = cOpts.path ?? `${cOpts.host ?? ''}:${cOpts.port}`
 
-      this.log('dialing %j', cOpts)
+      this.log('dialing %o', cOpts)
       const rawSocket = net.connect(cOpts)
 
       const onError = (err: Error): void => {
@@ -228,13 +256,13 @@ class TCP implements Transport {
       }
 
       const onConnect = (): void => {
-        this.log('connection opened %j', cOpts)
+        this.log('connection opened %o', cOpts)
         this.metrics?.dialerEvents.increment({ connect: true })
         done()
       }
 
       const onAbort = (): void => {
-        this.log('connection aborted %j', cOpts)
+        this.log('connection aborted %o', cOpts)
         this.metrics?.dialerEvents.increment({ abort: true })
         rawSocket.destroy()
         done(new AbortError())
@@ -273,6 +301,7 @@ class TCP implements Transport {
    */
   createListener (options: TCPCreateListenerOptions): Listener {
     return new TCPListener({
+      ...(this.opts.server ?? {}),
       ...options,
       maxConnections: this.opts.maxConnections,
       backlog: this.opts.backlog,

--- a/packages/transport-tcp/src/index.ts
+++ b/packages/transport-tcp/src/index.ts
@@ -234,13 +234,12 @@ class TCP implements Transport {
         ...(this.opts.socket ?? {}),
         ...options
       }) as (IpcSocketConnectOpts & TcpSocketConnectOpts)
-      const cOptsStr = cOpts.path ?? `${cOpts.host ?? ''}:${cOpts.port}`
 
       this.log('dialing %a', ma)
       const rawSocket = net.connect(cOpts)
 
       const onError = (err: Error): void => {
-        err.message = `connection error ${cOptsStr}: ${err.message}`
+        err.message = `connection error ${cOpts.path ?? `${cOpts.host ?? ''}:${cOpts.port}`}: ${err.message}`
         this.metrics?.dialerEvents.increment({ error: true })
 
         done(err)

--- a/packages/transport-tcp/src/index.ts
+++ b/packages/transport-tcp/src/index.ts
@@ -239,7 +239,8 @@ class TCP implements Transport {
       const rawSocket = net.connect(cOpts)
 
       const onError = (err: Error): void => {
-        err.message = `connection error ${cOpts.path ?? `${cOpts.host ?? ''}:${cOpts.port}`}: ${err.message}`
+        const cOptsStr = cOpts.path ?? `${cOpts.host ?? ''}:${cOpts.port}`
+        err.message = `connection error ${cOptsStr}: ${err.message}`
         this.metrics?.dialerEvents.increment({ error: true })
 
         done(err)

--- a/packages/transport-tcp/src/index.ts
+++ b/packages/transport-tcp/src/index.ts
@@ -105,12 +105,12 @@ export interface TCPOptions {
   /**
    * Options passed to `net.connect` for every opened TCP socket
    */
-  socket?: TCPSocketOptions
+  dialOpts?: TCPSocketOptions
 
   /**
    * Options passed to every `net.createServer` for every TCP server
    */
-  server?: TCPSocketOptions
+  listenOpts?: TCPSocketOptions
 }
 
 /**
@@ -231,7 +231,7 @@ class TCP implements Transport {
     return new Promise<Socket>((resolve, reject) => {
       const start = Date.now()
       const cOpts = multiaddrToNetConfig(ma, {
-        ...(this.opts.socket ?? {}),
+        ...(this.opts.dialOpts ?? {}),
         ...options
       }) as (IpcSocketConnectOpts & TcpSocketConnectOpts)
 
@@ -301,7 +301,7 @@ class TCP implements Transport {
    */
   createListener (options: TCPCreateListenerOptions): Listener {
     return new TCPListener({
-      ...(this.opts.server ?? {}),
+      ...(this.opts.listenOpts ?? {}),
       ...options,
       maxConnections: this.opts.maxConnections,
       backlog: this.opts.backlog,

--- a/packages/transport-tcp/src/index.ts
+++ b/packages/transport-tcp/src/index.ts
@@ -236,7 +236,7 @@ class TCP implements Transport {
       }) as (IpcSocketConnectOpts & TcpSocketConnectOpts)
       const cOptsStr = cOpts.path ?? `${cOpts.host ?? ''}:${cOpts.port}`
 
-      this.log('dialing %o', cOpts)
+      this.log('dialing %a', ma)
       const rawSocket = net.connect(cOpts)
 
       const onError = (err: Error): void => {
@@ -247,7 +247,7 @@ class TCP implements Transport {
       }
 
       const onTimeout = (): void => {
-        this.log('connection timeout %s', cOptsStr)
+        this.log('connection timeout %a', ma)
         this.metrics?.dialerEvents.increment({ timeout: true })
 
         const err = new CodeError(`connection timeout after ${Date.now() - start}ms`, 'ERR_CONNECT_TIMEOUT')
@@ -256,13 +256,13 @@ class TCP implements Transport {
       }
 
       const onConnect = (): void => {
-        this.log('connection opened %o', cOpts)
+        this.log('connection opened %a', ma)
         this.metrics?.dialerEvents.increment({ connect: true })
         done()
       }
 
       const onAbort = (): void => {
-        this.log('connection aborted %o', cOpts)
+        this.log('connection aborted %a', ma)
         this.metrics?.dialerEvents.increment({ abort: true })
         rawSocket.destroy()
         done(new AbortError())

--- a/packages/transport-tcp/src/utils.ts
+++ b/packages/transport-tcp/src/utils.ts
@@ -22,7 +22,7 @@ export function multiaddrToNetConfig (addr: Multiaddr, config: NetConfig = {}): 
   }
 
   // tcp listening
-  return { ...addr.toOptions(), ...config }
+  return { ...config, ...addr.toOptions() }
 }
 
 export function getMultiaddrs (proto: 'ip4' | 'ip6', ip: string, port: number): Multiaddr[] {


### PR DESCRIPTION
Allow specifying default socket options to `net.connect` and `net.createServer` - this allows users to turn keep alive, tcp delays, etc on/off as per their individual requirements.

```js
tcp({
  socket: {
    // net.connect options here
  },
  server: {
    // net.createServer options here
  }
})

```

## Change checklist

- [x] I have performed a self-review of my own code
- [ ] I have made corresponding changes to the documentation if necessary (this includes comments as well)
- [ ] I have added tests that prove my fix is effective or that my feature works