### PR TITLE
fix: disable Nagle's algorithm by default

### DIFF
--- a/packages/transport-tcp/src/index.ts
+++ b/packages/transport-tcp/src/index.ts
@@ -157,6 +157,7 @@ class TCP implements Transport {
 
   async dial (ma: Multiaddr, options: TCPDialOptions): Promise<Connection> {
     options.keepAlive = options.keepAlive ?? true
+    options.noDelay = options.noDelay ?? true
 
     // options.signal destroys the socket before 'connect' event
     const socket = await this._connect(ma, options)

--- a/packages/transport-tcp/src/listener.ts
+++ b/packages/transport-tcp/src/listener.ts
@@ -83,6 +83,7 @@ export class TCPListener extends TypedEventEmitter<ListenerEvents> implements Li
     super()
 
     context.keepAlive = context.keepAlive ?? true
+    context.noDelay = context.noDelay ?? true
 
     this.log = context.logger.forComponent('libp2p:tcp:listener')
     this.addr = 'unknown'


### PR DESCRIPTION
By default Node.js enables Nagle's algorithm. This adds a small delay when sending tiny buffers to batch-send them later.

Unfortunately this makes protocol negotiation slower as the protocol strings are small enough to be batch sent.

The change here is to turn it off by default, this reduces the perf test connection establisment from 1.2s to 0.8s.

See the latency measurements in the "Connection Establishment" test [on this run](https://observablehq.com/@libp2p-workspace/performance-dashboard?branch=cac8364ac83a4d8856851687a605e50b1e3855fb) for an example.

#2241 will let users turn this back on if they need it.

## Change checklist

- [x] I have performed a self-review of my own code
- [ ] I have made corresponding changes to the documentation if necessary (this includes comments as well)
- [x] I have added tests that prove my fix is effective or that my feature works