### PR TITLE
fix: allow mss lazy select on read

### DIFF
--- a/packages/libp2p/src/upgrader.ts
+++ b/packages/libp2p/src/upgrader.ts
@@ -389,7 +389,8 @@ export class DefaultUpgrader implements Upgrader {
             .then(async () => {
               const protocols = this.components.registrar.getProtocols()
               const { stream, protocol } = await mss.handle(muxedStream, protocols, {
-                log: muxedStream.log
+                log: muxedStream.log,
+                yieldBytes: false
               })
 
               if (connection == null) {
@@ -458,7 +459,8 @@ export class DefaultUpgrader implements Upgrader {
 
           const { stream, protocol } = await mss.select(muxedStream, protocols, {
             ...options,
-            log: muxedStream.log
+            log: muxedStream.log,
+            yieldBytes: false
           })
 
           connection.log('negotiated protocol stream %s with id %s', protocol, muxedStream.id)

--- a/packages/multistream-select/package.json
+++ b/packages/multistream-select/package.json
@@ -58,6 +58,7 @@
     "it-length-prefixed-stream": "^1.1.1",
     "it-pipe": "^3.0.1",
     "it-stream-types": "^2.0.1",
+    "uint8-varint": "^2.0.2",
     "uint8arraylist": "^2.4.3",
     "uint8arrays": "^4.0.6"
   },

--- a/packages/multistream-select/src/handle.ts
+++ b/packages/multistream-select/src/handle.ts
@@ -58,6 +58,7 @@ export async function handle <Stream extends Duplex<any, any, any>> (stream: Str
   options.log.trace('handle: available protocols %s', protocols)
 
   const lp = lpStream(stream, {
+    ...options,
     maxDataLength: MAX_PROTOCOL_LENGTH,
     maxLengthLength: 2 // 2 bytes is enough to length-prefix MAX_PROTOCOL_LENGTH
   })

--- a/packages/multistream-select/src/handle.ts
+++ b/packages/multistream-select/src/handle.ts
@@ -55,24 +55,29 @@ import type { Duplex } from 'it-stream-types'
  */
 export async function handle <Stream extends Duplex<any, any, any>> (stream: Stream, protocols: string | string[], options: MultistreamSelectInit): Promise<ProtocolStream<Stream>> {
   protocols = Array.isArray(protocols) ? protocols : [protocols]
+  options.log.trace('available protocols %s', protocols)
+
   const lp = lpStream(stream, {
-    maxDataLength: MAX_PROTOCOL_LENGTH
+    maxDataLength: MAX_PROTOCOL_LENGTH,
+    maxLengthLength: 2 // 2 bytes is enough to length-prefix MAX_PROTOCOL_LENGTH
   })
 
   while (true) {
-    options.log.trace('handle - available protocols %s', protocols)
+    options?.log.trace('reading incoming string')
     const protocol = await multistream.readString(lp, options)
     options.log.trace('read "%s"', protocol)
 
     if (protocol === PROTOCOL_ID) {
       options.log.trace('respond with "%s" for "%s"', PROTOCOL_ID, protocol)
       await multistream.write(lp, uint8ArrayFromString(`${PROTOCOL_ID}\n`), options)
+      options.log.trace('responded with "%s" for "%s"', PROTOCOL_ID, protocol)
       continue
     }
 
     if (protocols.includes(protocol)) {
       options.log.trace('respond with "%s" for "%s"', protocol, protocol)
       await multistream.write(lp, uint8ArrayFromString(`${protocol}\n`), options)
+      options.log.trace('responded with "%s" for "%s"', protocol, protocol)
 
       return { stream: lp.unwrap(), protocol }
     }
@@ -84,8 +89,9 @@ export async function handle <Stream extends Duplex<any, any, any>> (stream: Str
         uint8ArrayFromString('\n')
       )
 
-      await multistream.write(lp, protos, options)
       options.log.trace('respond with "%s" for %s', protocols, protocol)
+      await multistream.write(lp, protos, options)
+      options.log.trace('responded with "%s" for %s', protocols, protocol)
       continue
     }
 

--- a/packages/multistream-select/src/handle.ts
+++ b/packages/multistream-select/src/handle.ts
@@ -55,7 +55,7 @@ import type { Duplex } from 'it-stream-types'
  */
 export async function handle <Stream extends Duplex<any, any, any>> (stream: Stream, protocols: string | string[], options: MultistreamSelectInit): Promise<ProtocolStream<Stream>> {
   protocols = Array.isArray(protocols) ? protocols : [protocols]
-  options.log.trace('available protocols %s', protocols)
+  options.log.trace('handle: available protocols %s', protocols)
 
   const lp = lpStream(stream, {
     maxDataLength: MAX_PROTOCOL_LENGTH,
@@ -63,21 +63,21 @@ export async function handle <Stream extends Duplex<any, any, any>> (stream: Str
   })
 
   while (true) {
-    options?.log.trace('reading incoming string')
+    options?.log.trace('handle: reading incoming string')
     const protocol = await multistream.readString(lp, options)
-    options.log.trace('read "%s"', protocol)
+    options.log.trace('handle: read "%s"', protocol)
 
     if (protocol === PROTOCOL_ID) {
-      options.log.trace('respond with "%s" for "%s"', PROTOCOL_ID, protocol)
+      options.log.trace('handle: respond with "%s" for "%s"', PROTOCOL_ID, protocol)
       await multistream.write(lp, uint8ArrayFromString(`${PROTOCOL_ID}\n`), options)
-      options.log.trace('responded with "%s" for "%s"', PROTOCOL_ID, protocol)
+      options.log.trace('handle: responded with "%s" for "%s"', PROTOCOL_ID, protocol)
       continue
     }
 
     if (protocols.includes(protocol)) {
-      options.log.trace('respond with "%s" for "%s"', protocol, protocol)
+      options.log.trace('handle: respond with "%s" for "%s"', protocol, protocol)
       await multistream.write(lp, uint8ArrayFromString(`${protocol}\n`), options)
-      options.log.trace('responded with "%s" for "%s"', protocol, protocol)
+      options.log.trace('handle: responded with "%s" for "%s"', protocol, protocol)
 
       return { stream: lp.unwrap(), protocol }
     }
@@ -89,13 +89,14 @@ export async function handle <Stream extends Duplex<any, any, any>> (stream: Str
         uint8ArrayFromString('\n')
       )
 
-      options.log.trace('respond with "%s" for %s', protocols, protocol)
+      options.log.trace('handle: respond with "%s" for %s', protocols, protocol)
       await multistream.write(lp, protos, options)
-      options.log.trace('responded with "%s" for %s', protocols, protocol)
+      options.log.trace('handle: responded with "%s" for %s', protocols, protocol)
       continue
     }
 
-    options.log('respond with "na" for "%s"', protocol)
+    options.log('handle: respond with "na" for "%s"', protocol)
     await multistream.write(lp, uint8ArrayFromString('na\n'), options)
+    options.log('handle: responded with "na" for "%s"', protocol)
   }
 }

--- a/packages/multistream-select/src/index.ts
+++ b/packages/multistream-select/src/index.ts
@@ -22,6 +22,7 @@
 
 import { PROTOCOL_ID } from './constants.js'
 import type { AbortOptions, LoggerOptions } from '@libp2p/interface'
+import type { LengthPrefixedStreamOpts } from 'it-length-prefixed-stream'
 
 export { PROTOCOL_ID }
 
@@ -30,7 +31,7 @@ export interface ProtocolStream<Stream> {
   protocol: string
 }
 
-export interface MultistreamSelectInit extends AbortOptions, LoggerOptions {
+export interface MultistreamSelectInit extends AbortOptions, LoggerOptions, Partial<LengthPrefixedStreamOpts> {
 
 }
 

--- a/packages/multistream-select/src/select.ts
+++ b/packages/multistream-select/src/select.ts
@@ -55,6 +55,7 @@ import type { Duplex } from 'it-stream-types'
 export async function select <Stream extends Duplex<any, any, any>> (stream: Stream, protocols: string | string[], options: MultistreamSelectInit): Promise<ProtocolStream<Stream>> {
   protocols = Array.isArray(protocols) ? [...protocols] : [protocols]
   const lp = lpStream(stream, {
+    ...options,
     maxDataLength: MAX_PROTOCOL_LENGTH
   })
   const protocol = protocols.shift()
@@ -117,6 +118,7 @@ export function lazySelect <Stream extends Duplex<any, any, any>> (stream: Strea
     sink: originalSink,
     source: originalSource
   }, {
+    ...options,
     maxDataLength: MAX_PROTOCOL_LENGTH
   })
 

--- a/packages/multistream-select/test/multistream.spec.ts
+++ b/packages/multistream-select/test/multistream.spec.ts
@@ -61,7 +61,7 @@ describe('Multistream', () => {
       const duplexes = duplexPair<Uint8Array>()
       const inputStream = lpStream(duplexes[0])
       const outputStream = lpStream(duplexes[1], {
-        maxDataLength: 100
+        maxDataLength: 9999
       })
 
       void inputStream.write(input)


### PR DESCRIPTION
Updates the multistream lazy select to support lazy select on streams that are only read from.

## Change checklist

- [x] I have performed a self-review of my own code
- [ ] I have made corresponding changes to the documentation if necessary (this includes comments as well)
- [x] I have added tests that prove my fix is effective or that my feature works