### PR TITLE
chore: enable publishing with npm provenance

### DIFF
--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -218,6 +218,9 @@ jobs:
       transport-interop
     ]
     if: github.event_name == 'push' && github.ref == 'refs/heads/main'
+    # https://docs.npmjs.com/generating-provenance-statements
+    permissions:
+      id-token: write
     steps:
       - uses: GoogleCloudPlatform/release-please-action@v2
         id: release

--- a/package.json
+++ b/package.json
@@ -29,7 +29,7 @@
     "lint": "aegir run lint",
     "dep-check": "aegir run dep-check",
     "release": "run-s build docs:no-publish npm:release docs",
-    "npm:release": "aegir exec --bail false npm -- publish",
+    "npm:release": "aegir exec --bail false npm -- publish --provenance",
     "release:rc": "aegir release-rc",
     "docs": "aegir docs",
     "docs:no-publish": "aegir docs --publish false -- --exclude interop --exclude doc"


### PR DESCRIPTION
Adds config to publish npm packages with links back to the build that generated the artefacts.

https://github.blog/2023-04-19-introducing-npm-package-provenance/

## Change checklist

- [x] I have performed a self-review of my own code
- [ ] I have made corresponding changes to the documentation if necessary (this includes comments as well)
- [ ] I have added tests that prove my fix is effective or that my feature works