### PR TITLE
fix: use optimistic protocol negotation

### DIFF
--- a/packages/integration-tests/test/circuit-relay.node.ts
+++ b/packages/integration-tests/test/circuit-relay.node.ts
@@ -522,7 +522,7 @@ describe('circuit-relay', () => {
       expect(conns).to.have.lengthOf(1)
 
       // this should fail as the local peer has HOP disabled
-      await expect(conns[0].newStream(RELAY_V2_HOP_CODEC))
+      await expect(conns[0].newStream([RELAY_V2_HOP_CODEC, '/other/1.0.0']))
         .to.be.rejected()
 
       // we should still be connected to the relay

--- a/packages/integration-tests/test/ping.spec.ts
+++ b/packages/integration-tests/test/ping.spec.ts
@@ -9,7 +9,7 @@ import pDefer from 'p-defer'
 import { createBaseOptions } from './fixtures/base-options.js'
 import type { Libp2p } from '@libp2p/interface'
 
-describe('ping', () => {
+describe.only('ping', () => {
   let nodes: Array<Libp2p<{ ping: PingService }>>
 
   beforeEach(async () => {

--- a/packages/libp2p/src/connection-manager/dial-queue.ts
+++ b/packages/libp2p/src/connection-manager/dial-queue.ts
@@ -461,7 +461,7 @@ export class DialQueue {
       // internal peer dial queue - only one dial per peer at a time
       const peerDialQueue = new PQueue({ concurrency: 1 })
       peerDialQueue.on('error', (err) => {
-        this.log.error('error dialing [%s] %o', pendingDial.multiaddrs, err)
+        this.log.error('error dialing %s %o', pendingDial.multiaddrs, err)
       })
 
       const conn = await Promise.any(pendingDial.multiaddrs.map(async (addr, i) => {

--- a/packages/libp2p/test/connection-manager/direct.node.ts
+++ b/packages/libp2p/test/connection-manager/direct.node.ts
@@ -388,7 +388,7 @@ describe('libp2p.dialer (direct, TCP)', () => {
     const connection = await libp2p.dial(remoteLibp2p.getMultiaddrs())
 
     // Create local to remote streams
-    const stream = await connection.newStream('/echo/1.0.0')
+    const stream = await connection.newStream(['/echo/1.0.0', '/other/1.0.0'])
     await connection.newStream('/stream-count/3')
     await libp2p.dialProtocol(remoteLibp2p.peerId, '/stream-count/4')
 
@@ -398,8 +398,8 @@ describe('libp2p.dialer (direct, TCP)', () => {
     source.push(uint8ArrayFromString('hello'))
 
     // Create remote to local streams
-    await remoteLibp2p.dialProtocol(libp2p.peerId, '/stream-count/1')
-    await remoteLibp2p.dialProtocol(libp2p.peerId, '/stream-count/2')
+    await remoteLibp2p.dialProtocol(libp2p.peerId, ['/stream-count/1', '/other/1.0.0'])
+    await remoteLibp2p.dialProtocol(libp2p.peerId, ['/stream-count/2', '/other/1.0.0'])
 
     // Verify stream count
     const remoteConn = remoteLibp2p.getConnections(libp2p.peerId)

--- a/packages/libp2p/test/connection-manager/index.node.ts
+++ b/packages/libp2p/test/connection-manager/index.node.ts
@@ -5,6 +5,8 @@ import { start } from '@libp2p/interface/startable'
 import { mockConnection, mockDuplex, mockMultiaddrConnection } from '@libp2p/interface-compliance-tests/mocks'
 import { expect } from 'aegir/chai'
 import delay from 'delay'
+import all from 'it-all'
+import { pipe } from 'it-pipe'
 import pWaitFor from 'p-wait-for'
 import sinon from 'sinon'
 import { stubInterface } from 'sinon-ts'
@@ -13,6 +15,7 @@ import { DefaultConnectionManager } from '../../src/connection-manager/index.js'
 import { codes } from '../../src/errors.js'
 import { createBaseOptions } from '../fixtures/base-options.browser.js'
 import { createNode, createPeerId } from '../fixtures/creators/peer.js'
+import { ECHO_PROTOCOL, echo } from '../fixtures/echo-service.js'
 import type { Libp2p } from '../../src/index.js'
 import type { Libp2pNode } from '../../src/libp2p.js'
 import type { ConnectionGater } from '@libp2p/interface/connection-gater'
@@ -401,6 +404,9 @@ describe('libp2p.connections', () => {
           peerId: peerIds[1],
           addresses: {
             listen: ['/ip4/127.0.0.1/tcp/0/ws']
+          },
+          services: {
+            echo: echo()
           }
         })
       })
@@ -591,16 +597,23 @@ describe('libp2p.connections', () => {
           },
           connectionGater: {
             denyInboundUpgradedConnection
+          },
+          services: {
+            echo: echo()
           }
         })
       })
       await remoteLibp2p.peerStore.patch(libp2p.peerId, {
         multiaddrs: libp2p.getMultiaddrs()
       })
-      await remoteLibp2p.dial(libp2p.peerId)
+      const connection = await remoteLibp2p.dial(libp2p.peerId)
+      const stream = await connection.newStream(ECHO_PROTOCOL)
+      const input = [Uint8Array.from([0])]
+      const output = await pipe(input, stream, async (source) => all(source))
 
       expect(denyInboundUpgradedConnection.called).to.be.true()
       expect(denyInboundUpgradedConnection.getCall(0)).to.have.nested.property('args[0].multihash.digest').that.equalBytes(remoteLibp2p.peerId.multihash.digest)
+      expect(output.map(b => b.subarray())).to.deep.equal(input)
     })
 
     it('intercept outbound upgraded', async () => {
@@ -620,10 +633,14 @@ describe('libp2p.connections', () => {
       await libp2p.peerStore.patch(remoteLibp2p.peerId, {
         multiaddrs: remoteLibp2p.getMultiaddrs()
       })
-      await libp2p.dial(remoteLibp2p.peerId)
+      const connection = await libp2p.dial(remoteLibp2p.peerId)
+      const stream = await connection.newStream(ECHO_PROTOCOL)
+      const input = [Uint8Array.from([0])]
+      const output = await pipe(input, stream, async (source) => all(source))
 
       expect(denyOutboundUpgradedConnection.called).to.be.true()
       expect(denyOutboundUpgradedConnection.getCall(0)).to.have.nested.property('args[0].multihash.digest').that.equalBytes(remoteLibp2p.peerId.multihash.digest)
+      expect(output.map(b => b.subarray())).to.deep.equal(input)
     })
   })
 })

--- a/packages/libp2p/test/content-routing/dht/utils.ts
+++ b/packages/libp2p/test/content-routing/dht/utils.ts
@@ -1,3 +1,4 @@
 export const subsystemMulticodecs = [
-  '/ipfs/lan/kad/1.0.0'
+  '/ipfs/lan/kad/1.0.0',
+  '/other/1.0.0'
 ]

--- a/packages/libp2p/test/fixtures/echo-service.ts
+++ b/packages/libp2p/test/fixtures/echo-service.ts
@@ -1,0 +1,39 @@
+import { pipe } from 'it-pipe'
+import type { Startable } from '@libp2p/interface/startable'
+import type { Registrar } from '@libp2p/interface-internal/registrar'
+
+export const ECHO_PROTOCOL = '/echo/1.0.0'
+
+export interface EchoInit {
+  protocol?: string
+}
+
+export interface EchoComponents {
+  registrar: Registrar
+}
+
+class EchoService implements Startable {
+  private readonly protocol: string
+  private readonly registrar: Registrar
+
+  constructor (components: EchoComponents, init: EchoInit = {}) {
+    this.protocol = init.protocol ?? ECHO_PROTOCOL
+    this.registrar = components.registrar
+  }
+
+  async start (): Promise<void> {
+    await this.registrar.handle(this.protocol, ({ stream }) => {
+      void pipe(stream, stream)
+    })
+  }
+
+  async stop (): Promise<void> {
+    await this.registrar.unhandle(this.protocol)
+  }
+}
+
+export function echo (init: EchoInit = {}): (components: EchoComponents) => unknown {
+  return (components) => {
+    return new EchoService(components, init)
+  }
+}

--- a/packages/multistream-select/src/select.ts
+++ b/packages/multistream-select/src/select.ts
@@ -130,7 +130,7 @@ export function lazySelect <Stream extends Duplex<any, any, any>> (stream: Strea
         // if writing before selecting, send selection with first data chunk
         if (!selected) {
           selected = true
-          options?.log.trace('lazy: write ["%s", "%s", data] in sink', PROTOCOL_ID, protocol)
+          options?.log.trace('lazy: write ["%s", "%s", data(%d)] in sink', PROTOCOL_ID, protocol, buf.byteLength)
 
           const protocolString = `${protocol}\n`
 
@@ -143,7 +143,7 @@ export function lazySelect <Stream extends Duplex<any, any, any>> (stream: Strea
             buf
           ).subarray()
 
-          options?.log.trace('lazy: wrote ["%s", "%s", data] in sink', PROTOCOL_ID, protocol)
+          options?.log.trace('lazy: wrote ["%s", "%s", data(%d)] in sink', PROTOCOL_ID, protocol, buf.byteLength)
         } else {
           yield buf
         }


### PR DESCRIPTION
When negotiating connection encrypters, multiplexers or stream protocols, if we only have one protocol to negotiate there's no point sending it, then waiting for a response, then sending some data, we can just send it, and the data, then assuming the remote doesn't immediately close the negotiation channel, read the response at our leisure.

This saves a round trip for the first chunk of stream data and reduces our connection latency in the [libp2p perf tests](https://observablehq.com/@libp2p-workspace/performance-dashboard?branch=5cc924abf20105dbc984128aeca625984ae2da20) from 0.45 to 0.3ms.

## Change checklist

- [x] I have performed a self-review of my own code
- [ ] I have made corresponding changes to the documentation if necessary (this includes comments as well)
- [x] I have added tests that prove my fix is effective or that my feature works