### PR TITLE
feat: support streaming hashes for key sign/verify

### DIFF
--- a/packages/crypto/package.json
+++ b/packages/crypto/package.json
@@ -107,6 +107,7 @@
     "./dist/src/hmac/index.js": "./dist/src/hmac/index-browser.js",
     "./dist/src/keys/ecdh.js": "./dist/src/keys/ecdh-browser.js",
     "./dist/src/keys/ed25519.js": "./dist/src/keys/ed25519-browser.js",
-    "./dist/src/keys/rsa.js": "./dist/src/keys/rsa-browser.js"
+    "./dist/src/keys/rsa.js": "./dist/src/keys/rsa-browser.js",
+    "./dist/src/keys/secp256k1.js": "./dist/src/keys/secp256k1-browser.js"
   }
 }

--- a/packages/crypto/src/keys/ed25519-browser.ts
+++ b/packages/crypto/src/keys/ed25519-browser.ts
@@ -1,5 +1,6 @@
 import { ed25519 as ed } from '@noble/curves/ed25519'
 import type { Uint8ArrayKeyPair } from './interface'
+import type { Uint8ArrayList } from 'uint8arraylist'
 
 const PUBLIC_KEY_BYTE_LENGTH = 32
 const PRIVATE_KEY_BYTE_LENGTH = 64 // private key is actually 32 bytes but for historical reasons we concat private and public keys
@@ -44,14 +45,14 @@ export async function generateKeyFromSeed (seed: Uint8Array): Promise<Uint8Array
   }
 }
 
-export async function hashAndSign (privateKey: Uint8Array, msg: Uint8Array): Promise<Uint8Array> {
+export async function hashAndSign (privateKey: Uint8Array, msg: Uint8Array | Uint8ArrayList): Promise<Uint8Array> {
   const privateKeyRaw = privateKey.subarray(0, KEYS_BYTE_LENGTH)
 
-  return ed.sign(msg, privateKeyRaw)
+  return ed.sign(msg instanceof Uint8Array ? msg : msg.subarray(), privateKeyRaw)
 }
 
-export async function hashAndVerify (publicKey: Uint8Array, sig: Uint8Array, msg: Uint8Array): Promise<boolean> {
-  return ed.verify(sig, msg, publicKey)
+export async function hashAndVerify (publicKey: Uint8Array, sig: Uint8Array, msg: Uint8Array | Uint8ArrayList): Promise<boolean> {
+  return ed.verify(sig, msg instanceof Uint8Array ? msg : msg.subarray(), publicKey)
 }
 
 function concatKeys (privateKeyRaw: Uint8Array, publicKey: Uint8Array): Uint8Array {

--- a/packages/crypto/src/keys/ed25519-class.ts
+++ b/packages/crypto/src/keys/ed25519-class.ts
@@ -7,6 +7,7 @@ import * as crypto from './ed25519.js'
 import { exporter } from './exporter.js'
 import * as pbm from './keys.js'
 import type { Multibase } from 'multiformats'
+import type { Uint8ArrayList } from 'uint8arraylist'
 
 export class Ed25519PublicKey {
   private readonly _key: Uint8Array
@@ -15,7 +16,7 @@ export class Ed25519PublicKey {
     this._key = ensureKey(key, crypto.publicKeyLength)
   }
 
-  async verify (data: Uint8Array, sig: Uint8Array): Promise<boolean> {
+  async verify (data: Uint8Array | Uint8ArrayList, sig: Uint8Array): Promise<boolean> {
     return crypto.hashAndVerify(this._key, sig, data)
   }
 
@@ -52,7 +53,7 @@ export class Ed25519PrivateKey {
     this._publicKey = ensureKey(publicKey, crypto.publicKeyLength)
   }
 
-  async sign (message: Uint8Array): Promise<Uint8Array> {
+  async sign (message: Uint8Array | Uint8ArrayList): Promise<Uint8Array> {
     return crypto.hashAndSign(this._key, message)
   }
 

--- a/packages/crypto/src/keys/ed25519.ts
+++ b/packages/crypto/src/keys/ed25519.ts
@@ -1,5 +1,6 @@
 import crypto from 'crypto'
 import { promisify } from 'util'
+import { concat as uint8arrayConcat } from 'uint8arrays/concat'
 import { fromString as uint8arrayFromString } from 'uint8arrays/from-string'
 import { toString as uint8arrayToString } from 'uint8arrays/to-string'
 import type { Uint8ArrayKeyPair } from './interface.js'
@@ -48,7 +49,7 @@ export async function generateKey (): Promise<Uint8ArrayKeyPair> {
   const publicKeyRaw = uint8arrayFromString(key.privateKey.x, 'base64url')
 
   return {
-    privateKey: concatKeys(privateKeyRaw, publicKeyRaw),
+    privateKey: uint8arrayConcat([privateKeyRaw, publicKeyRaw], privateKeyRaw.byteLength + publicKeyRaw.byteLength),
     publicKey: publicKeyRaw
   }
 }
@@ -67,7 +68,7 @@ export async function generateKeyFromSeed (seed: Uint8Array): Promise<Uint8Array
   const publicKeyRaw = derivePublicKey(seed)
 
   return {
-    privateKey: concatKeys(seed, publicKeyRaw),
+    privateKey: uint8arrayConcat([seed, publicKeyRaw], seed.byteLength + publicKeyRaw.byteLength),
     publicKey: publicKeyRaw
   }
 }
@@ -126,13 +127,4 @@ export async function hashAndVerify (key: Uint8Array, sig: Uint8Array, msg: Uint
   })
 
   return crypto.verify(null, msg instanceof Uint8Array ? msg : msg.subarray(), obj, sig)
-}
-
-function concatKeys (privateKeyRaw: Uint8Array, publicKey: Uint8Array): Uint8Array {
-  const privateKey = new Uint8Array(PRIVATE_KEY_BYTE_LENGTH)
-  for (let i = 0; i < KEYS_BYTE_LENGTH; i++) {
-    privateKey[i] = privateKeyRaw[i]
-    privateKey[KEYS_BYTE_LENGTH + i] = publicKey[i]
-  }
-  return privateKey
 }

--- a/packages/crypto/src/keys/ed25519.ts
+++ b/packages/crypto/src/keys/ed25519.ts
@@ -3,6 +3,7 @@ import { promisify } from 'util'
 import { fromString as uint8arrayFromString } from 'uint8arrays/from-string'
 import { toString as uint8arrayToString } from 'uint8arrays/to-string'
 import type { Uint8ArrayKeyPair } from './interface.js'
+import type { Uint8ArrayList } from 'uint8arraylist'
 
 const keypair = promisify(crypto.generateKeyPair)
 
@@ -71,7 +72,7 @@ export async function generateKeyFromSeed (seed: Uint8Array): Promise<Uint8Array
   }
 }
 
-export async function hashAndSign (key: Uint8Array, msg: Uint8Array): Promise<Buffer> {
+export async function hashAndSign (key: Uint8Array, msg: Uint8Array | Uint8ArrayList): Promise<Buffer> {
   if (!(key instanceof Uint8Array)) {
     throw new TypeError('"key" must be a node.js Buffer, or Uint8Array.')
   }
@@ -99,10 +100,10 @@ export async function hashAndSign (key: Uint8Array, msg: Uint8Array): Promise<Bu
     }
   })
 
-  return crypto.sign(null, msg, obj)
+  return crypto.sign(null, msg instanceof Uint8Array ? msg : msg.subarray(), obj)
 }
 
-export async function hashAndVerify (key: Uint8Array, sig: Uint8Array, msg: Uint8Array): Promise<boolean> {
+export async function hashAndVerify (key: Uint8Array, sig: Uint8Array, msg: Uint8Array | Uint8ArrayList): Promise<boolean> {
   if (key.byteLength !== PUBLIC_KEY_BYTE_LENGTH) {
     throw new TypeError('"key" must be 32 bytes in length.')
   } else if (!(key instanceof Uint8Array)) {
@@ -124,7 +125,7 @@ export async function hashAndVerify (key: Uint8Array, sig: Uint8Array, msg: Uint
     }
   })
 
-  return crypto.verify(null, msg, obj, sig)
+  return crypto.verify(null, msg instanceof Uint8Array ? msg : msg.subarray(), obj, sig)
 }
 
 function concatKeys (privateKeyRaw: Uint8Array, publicKey: Uint8Array): Uint8Array {

--- a/packages/crypto/src/keys/rsa-class.ts
+++ b/packages/crypto/src/keys/rsa-class.ts
@@ -9,6 +9,7 @@ import { exporter } from './exporter.js'
 import * as pbm from './keys.js'
 import * as crypto from './rsa.js'
 import type { Multibase } from 'multiformats'
+import type { Uint8ArrayList } from 'uint8arraylist'
 
 export const MAX_KEY_SIZE = 8192
 
@@ -19,7 +20,7 @@ export class RsaPublicKey {
     this._key = key
   }
 
-  async verify (data: Uint8Array, sig: Uint8Array): Promise<boolean> {
+  async verify (data: Uint8Array | Uint8ArrayList, sig: Uint8Array): Promise<boolean> {
     return crypto.hashAndVerify(this._key, sig, data)
   }
 
@@ -34,7 +35,7 @@ export class RsaPublicKey {
     }).subarray()
   }
 
-  encrypt (bytes: Uint8Array): Uint8Array {
+  encrypt (bytes: Uint8Array | Uint8ArrayList): Uint8Array {
     return crypto.encrypt(this._key, bytes)
   }
 
@@ -62,7 +63,7 @@ export class RsaPrivateKey {
     return crypto.getRandomValues(16)
   }
 
-  async sign (message: Uint8Array): Promise<Uint8Array> {
+  async sign (message: Uint8Array | Uint8ArrayList): Promise<Uint8Array> {
     return crypto.hashAndSign(this._key, message)
   }
 
@@ -74,7 +75,7 @@ export class RsaPrivateKey {
     return new RsaPublicKey(this._publicKey)
   }
 
-  decrypt (bytes: Uint8Array): Uint8Array {
+  decrypt (bytes: Uint8Array | Uint8ArrayList): Uint8Array {
     return crypto.decrypt(this._key, bytes)
   }
 

--- a/packages/crypto/src/keys/rsa.ts
+++ b/packages/crypto/src/keys/rsa.ts
@@ -4,6 +4,7 @@ import { CodeError } from '@libp2p/interface/errors'
 import randomBytes from '../random-bytes.js'
 import * as utils from './rsa-utils.js'
 import type { JWKKeyPair } from './interface.js'
+import type { Uint8ArrayList } from 'uint8arraylist'
 
 const keypair = promisify(crypto.generateKeyPair)
 
@@ -42,30 +43,56 @@ export async function unmarshalPrivateKey (key: JsonWebKey): Promise<JWKKeyPair>
 
 export { randomBytes as getRandomValues }
 
-export async function hashAndSign (key: JsonWebKey, msg: Uint8Array): Promise<Uint8Array> {
-  return crypto.createSign('RSA-SHA256')
-    .update(msg)
-    // @ts-expect-error node types are missing jwk as a format
-    .sign({ format: 'jwk', key })
+export async function hashAndSign (key: JsonWebKey, msg: Uint8Array | Uint8ArrayList): Promise<Uint8Array> {
+  const hash = crypto.createSign('RSA-SHA256')
+
+  if (msg instanceof Uint8Array) {
+    hash.update(msg)
+  } else {
+    for (const buf of msg) {
+      hash.update(buf)
+    }
+  }
+
+  // @ts-expect-error node types are missing jwk as a format
+  return hash.sign({ format: 'jwk', key })
 }
 
-export async function hashAndVerify (key: JsonWebKey, sig: Uint8Array, msg: Uint8Array): Promise<boolean> {
-  return crypto.createVerify('RSA-SHA256')
-    .update(msg)
-    // @ts-expect-error node types are missing jwk as a format
-    .verify({ format: 'jwk', key }, sig)
+export async function hashAndVerify (key: JsonWebKey, sig: Uint8Array, msg: Uint8Array | Uint8ArrayList): Promise<boolean> {
+  const hash = crypto.createVerify('RSA-SHA256')
+
+  if (msg instanceof Uint8Array) {
+    hash.update(msg)
+  } else {
+    for (const buf of msg) {
+      hash.update(buf)
+    }
+  }
+
+  // @ts-expect-error node types are missing jwk as a format
+  return hash.verify({ format: 'jwk', key }, sig)
 }
 
 const padding = crypto.constants.RSA_PKCS1_PADDING
 
-export function encrypt (key: JsonWebKey, bytes: Uint8Array): Uint8Array {
-  // @ts-expect-error node types are missing jwk as a format
-  return crypto.publicEncrypt({ format: 'jwk', key, padding }, bytes)
+export function encrypt (key: JsonWebKey, bytes: Uint8Array | Uint8ArrayList): Uint8Array {
+  if (bytes instanceof Uint8Array) {
+    // @ts-expect-error node types are missing jwk as a format
+    return crypto.publicEncrypt({ format: 'jwk', key, padding }, bytes)
+  } else {
+    // @ts-expect-error node types are missing jwk as a format
+    return crypto.publicEncrypt({ format: 'jwk', key, padding }, bytes.subarray())
+  }
 }
 
-export function decrypt (key: JsonWebKey, bytes: Uint8Array): Uint8Array {
-  // @ts-expect-error node types are missing jwk as a format
-  return crypto.privateDecrypt({ format: 'jwk', key, padding }, bytes)
+export function decrypt (key: JsonWebKey, bytes: Uint8Array | Uint8ArrayList): Uint8Array {
+  if (bytes instanceof Uint8Array) {
+    // @ts-expect-error node types are missing jwk as a format
+    return crypto.privateDecrypt({ format: 'jwk', key, padding }, bytes)
+  } else {
+    // @ts-expect-error node types are missing jwk as a format
+    return crypto.privateDecrypt({ format: 'jwk', key, padding }, bytes.subarray())
+  }
 }
 
 export function keySize (jwk: JsonWebKey): number {

--- a/packages/crypto/src/keys/secp256k1-class.ts
+++ b/packages/crypto/src/keys/secp256k1-class.ts
@@ -6,6 +6,7 @@ import { exporter } from './exporter.js'
 import * as keysProtobuf from './keys.js'
 import * as crypto from './secp256k1.js'
 import type { Multibase } from 'multiformats'
+import type { Uint8ArrayList } from 'uint8arraylist'
 
 export class Secp256k1PublicKey {
   private readonly _key: Uint8Array
@@ -15,7 +16,7 @@ export class Secp256k1PublicKey {
     this._key = key
   }
 
-  async verify (data: Uint8Array, sig: Uint8Array): Promise<boolean> {
+  async verify (data: Uint8Array | Uint8ArrayList, sig: Uint8Array): Promise<boolean> {
     return crypto.hashAndVerify(this._key, sig, data)
   }
 
@@ -52,7 +53,7 @@ export class Secp256k1PrivateKey {
     crypto.validatePublicKey(this._publicKey)
   }
 
-  async sign (message: Uint8Array): Promise<Uint8Array> {
+  async sign (message: Uint8Array | Uint8ArrayList): Promise<Uint8Array> {
     return crypto.hashAndSign(this._key, message)
   }
 

--- a/packages/crypto/test/keys/ed25519.spec.ts
+++ b/packages/crypto/test/keys/ed25519.spec.ts
@@ -1,5 +1,6 @@
 /* eslint-env mocha */
 import { expect } from 'aegir/chai'
+import { Uint8ArrayList } from 'uint8arraylist'
 import { fromString as uint8ArrayFromString } from 'uint8arrays/from-string'
 import * as crypto from '../../src/index.js'
 import { Ed25519PrivateKey } from '../../src/keys/ed25519-class.js'
@@ -59,6 +60,22 @@ describe('ed25519', function () {
     const sig = await key.sign(text)
     const res = await key.public.verify(text, sig)
     expect(res).to.be.eql(true)
+  })
+
+  it('signs a list', async () => {
+    const text = new Uint8ArrayList(
+      crypto.randomBytes(512),
+      crypto.randomBytes(512)
+    )
+    const sig = await key.sign(text)
+
+    await expect(key.sign(text.subarray()))
+      .to.eventually.deep.equal(sig, 'list did not have same signature as a single buffer')
+
+    await expect(key.public.verify(text, sig))
+      .to.eventually.be.true('did not verify message as list')
+    await expect(key.public.verify(text.subarray(), sig))
+      .to.eventually.be.true('did not verify message as single buffer')
   })
 
   it('encoding', () => {

--- a/packages/crypto/test/keys/rsa.spec.ts
+++ b/packages/crypto/test/keys/rsa.spec.ts
@@ -1,6 +1,7 @@
 /* eslint max-nested-callbacks: ["error", 8] */
 /* eslint-env mocha */
 import { expect } from 'aegir/chai'
+import { Uint8ArrayList } from 'uint8arraylist'
 import { fromString as uint8ArrayFromString } from 'uint8arrays/from-string'
 import * as crypto from '../../src/index.js'
 import { MAX_KEY_SIZE, RsaPrivateKey, RsaPublicKey } from '../../src/keys/rsa-class.js'
@@ -45,6 +46,22 @@ describe('RSA', function () {
     const sig = await key.sign(text)
     const res = await key.public.verify(text, sig)
     expect(res).to.be.eql(true)
+  })
+
+  it('signs a list', async () => {
+    const text = new Uint8ArrayList(
+      crypto.randomBytes(512),
+      crypto.randomBytes(512)
+    )
+    const sig = await key.sign(text)
+
+    await expect(key.sign(text.subarray()))
+      .to.eventually.deep.equal(sig, 'list did not have same signature as a single buffer')
+
+    await expect(key.public.verify(text, sig))
+      .to.eventually.be.true('did not verify message as list')
+    await expect(key.public.verify(text.subarray(), sig))
+      .to.eventually.be.true('did not verify message as single buffer')
   })
 
   it('encoding', async () => {

--- a/packages/crypto/test/keys/secp256k1.spec.ts
+++ b/packages/crypto/test/keys/secp256k1.spec.ts
@@ -1,5 +1,6 @@
 /* eslint-env mocha */
 import { expect } from 'aegir/chai'
+import { Uint8ArrayList } from 'uint8arraylist'
 import { fromString as uint8ArrayFromString } from 'uint8arrays/from-string'
 import * as crypto from '../../src/index.js'
 import * as Secp256k1 from '../../src/keys/secp256k1-class.js'
@@ -38,6 +39,22 @@ describe('secp256k1 keys', () => {
     const sig = await key.sign(text)
     const res = await key.public.verify(text, sig)
     expect(res).to.equal(true)
+  })
+
+  it('signs a list', async () => {
+    const text = new Uint8ArrayList(
+      crypto.randomBytes(512),
+      crypto.randomBytes(512)
+    )
+    const sig = await key.sign(text)
+
+    await expect(key.sign(text.subarray()))
+      .to.eventually.deep.equal(sig, 'list did not have same signature as a single buffer')
+
+    await expect(key.public.verify(text, sig))
+      .to.eventually.be.true('did not verify message as list')
+    await expect(key.public.verify(text.subarray(), sig))
+      .to.eventually.be.true('did not verify message as single buffer')
   })
 
   it('encoding', () => {

--- a/packages/interface/src/keys/index.ts
+++ b/packages/interface/src/keys/index.ts
@@ -1,6 +1,8 @@
+import type { Uint8ArrayList } from 'uint8arraylist'
+
 export interface PublicKey {
   readonly bytes: Uint8Array
-  verify(data: Uint8Array, sig: Uint8Array): Promise<boolean>
+  verify(data: Uint8Array | Uint8ArrayList, sig: Uint8Array): Promise<boolean>
   marshal(): Uint8Array
   equals(key: PublicKey): boolean
   hash(): Promise<Uint8Array>
@@ -12,7 +14,7 @@ export interface PublicKey {
 export interface PrivateKey {
   readonly public: PublicKey
   readonly bytes: Uint8Array
-  sign(data: Uint8Array): Promise<Uint8Array>
+  sign(data: Uint8Array | Uint8ArrayList): Promise<Uint8Array>
   marshal(): Uint8Array
   equals(key: PrivateKey): boolean
   hash(): Promise<Uint8Array>


### PR DESCRIPTION
Accept `Uint8ArrayList`s as arguments to sign or verify and use streaming hashes internally when they are passed (if supported). This way we can skip having to copy the `Uint8ArrayList` contents into a `Uint8Array` first.

## Change checklist

- [x] I have performed a self-review of my own code
- [ ] I have made corresponding changes to the documentation if necessary (this includes comments as well)
- [x] I have added tests that prove my fix is effective or that my feature works