### PR TITLE
feat!: allow stream muxers and connection encrypters to yield lists

### DIFF
--- a/packages/connection-encrypter-plaintext/package.json
+++ b/packages/connection-encrypter-plaintext/package.json
@@ -50,9 +50,7 @@
     "@libp2p/interface": "^0.1.2",
     "@libp2p/peer-id": "^3.0.6",
     "@multiformats/multiaddr": "^12.1.10",
-    "it-handshake": "^4.1.3",
-    "it-length-prefixed": "^9.0.3",
-    "it-map": "^3.0.4",
+    "it-protobuf-stream": "^1.1.1",
     "it-stream-types": "^2.0.1",
     "protons-runtime": "^5.0.0",
     "uint8arraylist": "^2.4.3"

--- a/packages/connection-encrypter-plaintext/src/index.ts
+++ b/packages/connection-encrypter-plaintext/src/index.ts
@@ -22,49 +22,53 @@
 
 import { UnexpectedPeerError, InvalidCryptoExchangeError } from '@libp2p/interface/errors'
 import { peerIdFromBytes, peerIdFromKeys } from '@libp2p/peer-id'
-import { handshake } from 'it-handshake'
-import * as lp from 'it-length-prefixed'
-import map from 'it-map'
+import { pbStream } from 'it-protobuf-stream'
 import { Exchange, KeyType } from './pb/proto.js'
 import type { ComponentLogger, Logger } from '@libp2p/interface'
+import type { MultiaddrConnection } from '@libp2p/interface/connection'
 import type { ConnectionEncrypter, SecuredConnection } from '@libp2p/interface/connection-encrypter'
 import type { PeerId } from '@libp2p/interface/peer-id'
-import type { Duplex, Source } from 'it-stream-types'
+import type { Duplex } from 'it-stream-types'
 import type { Uint8ArrayList } from 'uint8arraylist'
 
 const PROTOCOL = '/plaintext/2.0.0'
-
-function lpEncodeExchange (exchange: Exchange): Uint8ArrayList {
-  const pb = Exchange.encode(exchange)
-
-  return lp.encode.single(pb)
-}
 
 export interface PlaintextComponents {
   logger: ComponentLogger
 }
 
+export interface PlaintextInit {
+  /**
+   * The peer id exchange must complete within this many milliseconds
+   * (default: 1000)
+   */
+  timeout?: number
+}
+
 class Plaintext implements ConnectionEncrypter {
   public protocol: string = PROTOCOL
   private readonly log: Logger
+  private readonly timeout: number
 
-  constructor (components: PlaintextComponents) {
+  constructor (components: PlaintextComponents, init: PlaintextInit = {}) {
     this.log = components.logger.forComponent('libp2p:plaintext')
+    this.timeout = init.timeout ?? 1000
   }
 
-  async secureInbound (localId: PeerId, conn: Duplex<AsyncGenerator<Uint8Array>, Source<Uint8Array>, Promise<void>>, remoteId?: PeerId): Promise<SecuredConnection> {
+  async secureInbound <Stream extends Duplex<AsyncGenerator<Uint8Array | Uint8ArrayList>> = MultiaddrConnection> (localId: PeerId, conn: Stream, remoteId?: PeerId): Promise<SecuredConnection<Stream>> {
     return this._encrypt(localId, conn, remoteId)
   }
 
-  async secureOutbound (localId: PeerId, conn: Duplex<AsyncGenerator<Uint8Array>, Source<Uint8Array>, Promise<void>>, remoteId?: PeerId): Promise<SecuredConnection> {
+  async secureOutbound <Stream extends Duplex<AsyncGenerator<Uint8Array | Uint8ArrayList>> = MultiaddrConnection> (localId: PeerId, conn: Stream, remoteId?: PeerId): Promise<SecuredConnection<Stream>> {
     return this._encrypt(localId, conn, remoteId)
   }
 
   /**
    * Encrypt connection
    */
-  async _encrypt (localId: PeerId, conn: Duplex<AsyncGenerator<Uint8Array>, Source<Uint8Array>, Promise<void>>, remoteId?: PeerId): Promise<SecuredConnection> {
-    const shake = handshake(conn)
+  async _encrypt <Stream extends Duplex<AsyncGenerator<Uint8Array | Uint8ArrayList>> = MultiaddrConnection> (localId: PeerId, conn: Stream, remoteId?: PeerId): Promise<SecuredConnection<Stream>> {
+    const signal = AbortSignal.timeout(this.timeout)
+    const pb = pbStream(conn).pb(Exchange)
 
     let type = KeyType.RSA
 
@@ -75,45 +79,40 @@ class Plaintext implements ConnectionEncrypter {
     }
 
     // Encode the public key and write it to the remote peer
-    shake.write(
-      lpEncodeExchange({
-        id: localId.toBytes(),
-        pubkey: {
-          Type: type,
-          Data: localId.publicKey ?? new Uint8Array(0)
-        }
-      }).subarray()
-    )
+    await pb.write({
+      id: localId.toBytes(),
+      pubkey: {
+        Type: type,
+        Data: localId.publicKey ?? new Uint8Array(0)
+      }
+    }, {
+      signal
+    })
 
     this.log('write pubkey exchange to peer %p', remoteId)
 
     // Get the Exchange message
-    const response = (await lp.decode.fromReader(shake.reader).next()).value
-
-    if (response == null) {
-      throw new Error('Did not read response')
-    }
-
-    const id = Exchange.decode(response)
-    this.log('read pubkey exchange from peer %p', remoteId)
+    const response = await pb.read({
+      signal
+    })
 
     let peerId
     try {
-      if (id.pubkey == null) {
+      if (response.pubkey == null) {
         throw new Error('Public key missing')
       }
 
-      if (id.pubkey.Data.length === 0) {
+      if (response.pubkey.Data.length === 0) {
         throw new Error('Public key data too short')
       }
 
-      if (id.id == null) {
+      if (response.id == null) {
         throw new Error('Remote id missing')
       }
 
-      peerId = await peerIdFromKeys(id.pubkey.Data)
+      peerId = await peerIdFromKeys(response.pubkey.Data)
 
-      if (!peerId.equals(peerIdFromBytes(id.id))) {
+      if (!peerId.equals(peerIdFromBytes(response.id))) {
         throw new Error('Public key did not match id')
       }
     } catch (err: any) {
@@ -127,18 +126,13 @@ class Plaintext implements ConnectionEncrypter {
 
     this.log('plaintext key exchange completed successfully with peer %p', peerId)
 
-    shake.rest()
-
     return {
-      conn: {
-        sink: shake.stream.sink,
-        source: map(shake.stream.source, (buf) => buf.subarray())
-      },
+      conn: pb.unwrap().unwrap(),
       remotePeer: peerId
     }
   }
 }
 
-export function plaintext (): (components: PlaintextComponents) => ConnectionEncrypter {
-  return (components) => new Plaintext(components)
+export function plaintext (init?: PlaintextInit): (components: PlaintextComponents) => ConnectionEncrypter {
+  return (components) => new Plaintext(components, init)
 }

--- a/packages/interface-compliance-tests/src/connection-encryption/index.ts
+++ b/packages/interface-compliance-tests/src/connection-encryption/index.ts
@@ -57,7 +57,9 @@ export default (common: TestSetup<ConnectionEncrypter>): void => {
       // Send some data and collect the result
       const input = uint8ArrayFromString('data to encrypt')
       const result = await pipe(
-        [input],
+        async function * () {
+          yield input
+        },
         outboundResult.conn,
         async (source) => all(source)
       )

--- a/packages/interface-compliance-tests/src/connection-encryption/utils/index.ts
+++ b/packages/interface-compliance-tests/src/connection-encryption/utils/index.ts
@@ -3,11 +3,12 @@ import { multiaddr } from '@multiformats/multiaddr'
 import { duplexPair } from 'it-pair/duplex'
 import type { MultiaddrConnection } from '@libp2p/interface/connection'
 import type { Duplex, Source } from 'it-stream-types'
+import type { Uint8ArrayList } from 'uint8arraylist'
 
 export function createMaConnPair (): [MultiaddrConnection, MultiaddrConnection] {
-  const [local, remote] = duplexPair<Uint8Array>()
+  const [local, remote] = duplexPair<Uint8Array | Uint8ArrayList>()
 
-  function duplexToMaConn (duplex: Duplex<AsyncGenerator<Uint8Array>, Source<Uint8Array>, Promise<void>>): MultiaddrConnection {
+  function duplexToMaConn (duplex: Duplex<AsyncGenerator<Uint8Array | Uint8ArrayList>, Source<Uint8Array | Uint8ArrayList>, Promise<void>>): MultiaddrConnection {
     const output: MultiaddrConnection = {
       ...duplex,
       close: async () => {},

--- a/packages/interface-compliance-tests/src/mocks/connection.ts
+++ b/packages/interface-compliance-tests/src/mocks/connection.ts
@@ -287,7 +287,7 @@ export interface Peer {
 }
 
 export function multiaddrConnectionPair (a: { peerId: PeerId, registrar: Registrar }, b: { peerId: PeerId, registrar: Registrar }): [ MultiaddrConnection, MultiaddrConnection ] {
-  const [peerBtoPeerA, peerAtoPeerB] = duplexPair<Uint8Array>()
+  const [peerBtoPeerA, peerAtoPeerB] = duplexPair<Uint8Array | Uint8ArrayList>()
 
   return [
     mockMultiaddrConnection(peerAtoPeerB, b.peerId),

--- a/packages/interface-compliance-tests/src/mocks/duplex.ts
+++ b/packages/interface-compliance-tests/src/mocks/duplex.ts
@@ -1,6 +1,7 @@
 import type { Duplex, Source } from 'it-stream-types'
+import type { Uint8ArrayList } from 'uint8arraylist'
 
-export function mockDuplex (): Duplex<AsyncGenerator<Uint8Array>, Source<Uint8Array>, Promise<void>> {
+export function mockDuplex (): Duplex<AsyncGenerator<Uint8Array | Uint8ArrayList>, Source<Uint8Array | Uint8ArrayList>, Promise<void>> {
   return {
     source: (async function * () {
       yield * []

--- a/packages/interface-compliance-tests/src/mocks/multiaddr-connection.ts
+++ b/packages/interface-compliance-tests/src/mocks/multiaddr-connection.ts
@@ -6,8 +6,9 @@ import type { MultiaddrConnection } from '@libp2p/interface/connection'
 import type { PeerId } from '@libp2p/interface/peer-id'
 import type { Multiaddr } from '@multiformats/multiaddr'
 import type { Duplex } from 'it-stream-types'
+import type { Uint8ArrayList } from 'uint8arraylist'
 
-export function mockMultiaddrConnection (source: Duplex<AsyncGenerator<Uint8Array>> & Partial<MultiaddrConnection>, peerId: PeerId): MultiaddrConnection {
+export function mockMultiaddrConnection (source: Duplex<AsyncGenerator<Uint8Array | Uint8ArrayList>> & Partial<MultiaddrConnection>, peerId: PeerId): MultiaddrConnection {
   const maConn: MultiaddrConnection = {
     async close () {
 
@@ -36,7 +37,7 @@ export function mockMultiaddrConnPair (opts: MockMultiaddrConnPairOptions): { in
   const { addrs, remotePeer } = opts
   const controller = new AbortController()
   const [localAddr, remoteAddr] = addrs
-  const [inboundStream, outboundStream] = duplexPair<Uint8Array>()
+  const [inboundStream, outboundStream] = duplexPair<Uint8Array | Uint8ArrayList>()
 
   const outbound: MultiaddrConnection = {
     ...outboundStream,

--- a/packages/interface-compliance-tests/src/stream-muxer/base-test.ts
+++ b/packages/interface-compliance-tests/src/stream-muxer/base-test.ts
@@ -22,7 +22,7 @@ async function drainAndClose (stream: Duplex<any>): Promise<void> {
 export default (common: TestSetup<StreamMuxerFactory>): void => {
   describe('base', () => {
     it('Open a stream from the dialer', async () => {
-      const p = duplexPair<Uint8Array>()
+      const p = duplexPair<Uint8Array | Uint8ArrayList>()
       const dialerFactory = await common.setup()
       const dialer = dialerFactory.createStreamMuxer({ direction: 'outbound' })
       const onStreamPromise: DeferredPromise<Stream> = defer()
@@ -75,7 +75,7 @@ export default (common: TestSetup<StreamMuxerFactory>): void => {
     })
 
     it('Open a stream from the listener', async () => {
-      const p = duplexPair<Uint8Array>()
+      const p = duplexPair<Uint8Array | Uint8ArrayList>()
       const onStreamPromise: DeferredPromise<Stream> = defer()
       const dialerFactory = await common.setup()
       const dialer = dialerFactory.createStreamMuxer({
@@ -106,7 +106,7 @@ export default (common: TestSetup<StreamMuxerFactory>): void => {
     })
 
     it('Open a stream on both sides', async () => {
-      const p = duplexPair<Uint8Array>()
+      const p = duplexPair<Uint8Array | Uint8ArrayList>()
       const onDialerStreamPromise: DeferredPromise<Stream> = defer()
       const onListenerStreamPromise: DeferredPromise<Stream> = defer()
       const dialerFactory = await common.setup()
@@ -146,7 +146,7 @@ export default (common: TestSetup<StreamMuxerFactory>): void => {
 
     it('Open a stream on one side, write, open a stream on the other side', async () => {
       const toString = (source: Source<Uint8ArrayList>): AsyncGenerator<string> => map(source, (u) => uint8ArrayToString(u.subarray()))
-      const p = duplexPair<Uint8Array>()
+      const p = duplexPair<Uint8Array | Uint8ArrayList>()
       const onDialerStreamPromise: DeferredPromise<Stream> = defer()
       const onListenerStreamPromise: DeferredPromise<Stream> = defer()
       const dialerFactory = await common.setup()

--- a/packages/interface-compliance-tests/src/stream-muxer/close-test.ts
+++ b/packages/interface-compliance-tests/src/stream-muxer/close-test.ts
@@ -84,7 +84,7 @@ export default (common: TestSetup<StreamMuxerFactory>): void => {
         }
       })
 
-      const p = duplexPair<Uint8Array>()
+      const p = duplexPair<Uint8Array | Uint8ArrayList>()
       void pipe(p[0], dialer, p[0])
       void pipe(p[1], listener, p[1])
 
@@ -104,7 +104,7 @@ export default (common: TestSetup<StreamMuxerFactory>): void => {
 
       // Pause, and then close the dialer
       await delay(50)
-      await pipe([], dialer, drain)
+      await pipe(async function * () {}, dialer, drain)
 
       expect(openedStreams).to.have.equal(expectedStreams)
       expect(dialer.streams).to.have.lengthOf(0)
@@ -126,7 +126,7 @@ export default (common: TestSetup<StreamMuxerFactory>): void => {
         }
       })
 
-      const p = duplexPair<Uint8Array>()
+      const p = duplexPair<Uint8Array | Uint8ArrayList>()
       void pipe(p[0], dialer, p[0])
       void pipe(p[1], listener, p[1])
 
@@ -169,7 +169,7 @@ export default (common: TestSetup<StreamMuxerFactory>): void => {
         }
       })
 
-      const p = duplexPair<Uint8Array>()
+      const p = duplexPair<Uint8Array | Uint8ArrayList>()
       void pipe(p[0], dialer, p[0])
       void pipe(p[1], listener, p[1])
 
@@ -225,7 +225,7 @@ export default (common: TestSetup<StreamMuxerFactory>): void => {
     })
 
     it('closing one of the muxed streams doesn\'t close others', async () => {
-      const p = duplexPair<Uint8Array>()
+      const p = duplexPair<Uint8Array | Uint8ArrayList>()
       const dialerFactory = await common.setup()
       const dialer = dialerFactory.createStreamMuxer({ direction: 'outbound' })
 
@@ -276,7 +276,7 @@ export default (common: TestSetup<StreamMuxerFactory>): void => {
     it('can close a stream for writing', async () => {
       const deferred = pDefer<Error>()
 
-      const p = duplexPair<Uint8Array>()
+      const p = duplexPair<Uint8Array | Uint8ArrayList>()
       const dialerFactory = await common.setup()
       const dialer = dialerFactory.createStreamMuxer({ direction: 'outbound' })
       const data = [randomBuffer(), randomBuffer()]
@@ -321,7 +321,7 @@ export default (common: TestSetup<StreamMuxerFactory>): void => {
 
     it('can close a stream for reading', async () => {
       const deferred = pDefer<Uint8ArrayList[]>()
-      const p = duplexPair<Uint8Array>()
+      const p = duplexPair<Uint8Array | Uint8ArrayList>()
       const dialerFactory = await common.setup()
       const dialer = dialerFactory.createStreamMuxer({ direction: 'outbound' })
       const data = [randomBuffer(), randomBuffer()].map(d => new Uint8ArrayList(d))
@@ -387,7 +387,7 @@ export default (common: TestSetup<StreamMuxerFactory>): void => {
     it('should wait for all data to be sent when closing streams', async () => {
       const deferred = pDefer<Message>()
 
-      const p = duplexPair<Uint8Array>()
+      const p = duplexPair<Uint8Array | Uint8ArrayList>()
       const dialerFactory = await common.setup()
       const dialer = dialerFactory.createStreamMuxer({ direction: 'outbound' })
 
@@ -429,7 +429,7 @@ export default (common: TestSetup<StreamMuxerFactory>): void => {
     it('should abort closing a stream with outstanding data to read', async () => {
       const deferred = pDefer<Message>()
 
-      const p = duplexPair<Uint8Array>()
+      const p = duplexPair<Uint8Array | Uint8ArrayList>()
       const dialerFactory = await common.setup()
       const dialer = dialerFactory.createStreamMuxer({ direction: 'outbound' })
 

--- a/packages/interface-compliance-tests/src/stream-muxer/spawner.ts
+++ b/packages/interface-compliance-tests/src/stream-muxer/spawner.ts
@@ -9,7 +9,7 @@ import { fromString as uint8ArrayFromString } from 'uint8arrays/from-string'
 import type { StreamMuxer, StreamMuxerInit } from '@libp2p/interface/stream-muxer'
 
 export default async (createMuxer: (init?: StreamMuxerInit) => Promise<StreamMuxer>, nStreams: number, nMsg: number, limit?: number): Promise<void> => {
-  const [dialerSocket, listenerSocket] = duplexPair<Uint8Array>()
+  const [dialerSocket, listenerSocket] = duplexPair<Uint8Array | Uint8ArrayList>()
 
   const msg = new Uint8ArrayList(uint8ArrayFromString('simple msg'))
 

--- a/packages/interface/src/connection-encrypter/index.ts
+++ b/packages/interface/src/connection-encrypter/index.ts
@@ -1,5 +1,7 @@
+import type { MultiaddrConnection } from '../connection/index.js'
 import type { PeerId } from '../peer-id/index.js'
-import type { Duplex, Source } from 'it-stream-types'
+import type { Duplex } from 'it-stream-types'
+import type { Uint8ArrayList } from 'uint8arraylist'
 
 /**
  * A libp2p connection encrypter module must be compliant to this interface
@@ -13,18 +15,18 @@ export interface ConnectionEncrypter<Extension = unknown> {
    * pass it for extra verification, otherwise it will be determined during
    * the handshake.
    */
-  secureOutbound(localPeer: PeerId, connection: Duplex<AsyncGenerator<Uint8Array>, Source<Uint8Array>, Promise<void>>, remotePeer?: PeerId): Promise<SecuredConnection<Extension>>
+  secureOutbound <Stream extends Duplex<AsyncGenerator<Uint8Array | Uint8ArrayList>> = MultiaddrConnection> (localPeer: PeerId, connection: Stream, remotePeer?: PeerId): Promise<SecuredConnection<Stream, Extension>>
 
   /**
    * Decrypt incoming data. If the remote PeerId is known,
    * pass it for extra verification, otherwise it will be determined during
    * the handshake
    */
-  secureInbound(localPeer: PeerId, connection: Duplex<AsyncGenerator<Uint8Array>, Source<Uint8Array>, Promise<void>>, remotePeer?: PeerId): Promise<SecuredConnection<Extension>>
+  secureInbound <Stream extends Duplex<AsyncGenerator<Uint8Array | Uint8ArrayList>> = MultiaddrConnection> (localPeer: PeerId, connection: Stream, remotePeer?: PeerId): Promise<SecuredConnection<Stream, Extension>>
 }
 
-export interface SecuredConnection<Extension = unknown> {
-  conn: Duplex<AsyncGenerator<Uint8Array>, Source<Uint8Array>, Promise<void>>
+export interface SecuredConnection<Stream = any, Extension = unknown> {
+  conn: Stream
   remoteExtensions?: Extension
   remotePeer: PeerId
 }

--- a/packages/interface/src/connection/index.ts
+++ b/packages/interface/src/connection/index.ts
@@ -318,7 +318,7 @@ export interface MultiaddrConnectionTimeline {
  * a peer. It is a low-level primitive and is the raw connection
  * without encryption or stream multiplexing.
  */
-export interface MultiaddrConnection extends Duplex<AsyncGenerator<Uint8Array>, Source<Uint8Array>, Promise<void>> {
+export interface MultiaddrConnection extends Duplex<AsyncGenerator<Uint8Array | Uint8ArrayList>> {
   /**
    * Gracefully close the connection. All queued data will be written to the
    * underlying transport.

--- a/packages/interface/src/stream-muxer/index.ts
+++ b/packages/interface/src/stream-muxer/index.ts
@@ -1,6 +1,6 @@
 import type { Direction, Stream } from '../connection/index.js'
 import type { AbortOptions } from '../index.js'
-import type { Duplex, Source } from 'it-stream-types'
+import type { Duplex } from 'it-stream-types'
 import type { Uint8ArrayList } from 'uint8arraylist'
 
 export interface StreamMuxerFactory {
@@ -18,7 +18,7 @@ export interface StreamMuxerFactory {
 /**
  * A libp2p stream muxer
  */
-export interface StreamMuxer extends Duplex<AsyncGenerator<Uint8Array>, Source<Uint8ArrayList | Uint8Array>, Promise<void>> {
+export interface StreamMuxer extends Duplex<AsyncGenerator<Uint8Array | Uint8ArrayList>> {
   /**
    * The protocol used to select this muxer during connection opening
    */

--- a/packages/metrics-prometheus/package.json
+++ b/packages/metrics-prometheus/package.json
@@ -46,7 +46,8 @@
     "@libp2p/interface": "^0.1.6",
     "it-foreach": "^2.0.3",
     "it-stream-types": "^2.0.1",
-    "prom-client": "^15.0.0"
+    "prom-client": "^15.0.0",
+    "uint8arraylist": "^2.4.3"
   },
   "devDependencies": {
     "@libp2p/interface-compliance-tests": "^4.1.5",

--- a/packages/metrics-prometheus/src/index.ts
+++ b/packages/metrics-prometheus/src/index.ts
@@ -164,7 +164,8 @@ import { PrometheusMetric } from './metric.js'
 import type { ComponentLogger, Logger } from '@libp2p/interface'
 import type { MultiaddrConnection, Stream, Connection } from '@libp2p/interface/connection'
 import type { CalculatedMetricOptions, Counter, CounterGroup, Metric, MetricGroup, MetricOptions, Metrics } from '@libp2p/interface/metrics'
-import type { Duplex, Source } from 'it-stream-types'
+import type { Duplex } from 'it-stream-types'
+import type { Uint8ArrayList } from 'uint8arraylist'
 
 // prom-client metrics are global
 const metrics = new Map<string, any>()
@@ -268,7 +269,7 @@ class PrometheusMetrics implements Metrics {
    * Override the sink/source of the stream to count the bytes
    * in and out
    */
-  _track (stream: Duplex<Source<any>>, name: string): void {
+  _track (stream: Duplex<AsyncGenerator<Uint8Array | Uint8ArrayList>>, name: string): void {
     const self = this
 
     const sink = stream.sink

--- a/packages/metrics-prometheus/test/streams.spec.ts
+++ b/packages/metrics-prometheus/test/streams.spec.ts
@@ -50,9 +50,9 @@ describe('streams', () => {
 
     // send data to the remote over the tracked stream
     const data = Uint8Array.from([0, 1, 2, 3, 4])
-    await outbound.sink([
-      data
-    ])
+    await outbound.sink(async function * () {
+      yield data
+    }())
 
     // wait for all bytes to be received
     await deferred.promise
@@ -82,9 +82,9 @@ describe('streams', () => {
 
     // send data to the remote over the tracked stream
     const data = Uint8Array.from([0, 1, 2, 3, 4])
-    await outbound.sink([
-      data
-    ])
+    await outbound.sink(async function * () {
+      yield data
+    }())
 
     // process all the bytes
     void pipe(inbound, drain).then(() => {

--- a/packages/pnet/package.json
+++ b/packages/pnet/package.json
@@ -47,11 +47,12 @@
   "dependencies": {
     "@libp2p/crypto": "^2.0.5",
     "@libp2p/interface": "^0.1.3",
-    "it-handshake": "^4.1.3",
+    "it-byte-stream": "^1.0.5",
     "it-map": "^3.0.4",
     "it-pair": "^2.0.6",
     "it-pipe": "^3.0.1",
     "it-stream-types": "^2.0.1",
+    "uint8arraylist": "^2.4.7",
     "uint8arrays": "^4.0.6",
     "xsalsa20": "^1.1.0"
   },

--- a/packages/pnet/src/index.ts
+++ b/packages/pnet/src/index.ts
@@ -58,7 +58,7 @@
 
 import { randomBytes } from '@libp2p/crypto'
 import { CodeError } from '@libp2p/interface/errors'
-import { handshake } from 'it-handshake'
+import { byteStream } from 'it-byte-stream'
 import map from 'it-map'
 import { duplexPair } from 'it-pair/duplex'
 import { pipe } from 'it-pipe'
@@ -71,12 +71,21 @@ import * as Errors from './errors.js'
 import { NONCE_LENGTH } from './key-generator.js'
 import type { ComponentLogger, Logger } from '@libp2p/interface'
 import type { ConnectionProtector, MultiaddrConnection } from '@libp2p/interface/connection'
+import type { Uint8ArrayList } from 'uint8arraylist'
 
 export { generateKey } from './key-generator.js'
 
 export interface ProtectorInit {
-  enabled?: boolean
+  /**
+   * A pre-shared key. This must be the same byte value for all peers in the
+   * swarm in order for them to communicate.
+   */
   psk: Uint8Array
+  /**
+   * The initial nonce exchange must complete within this many milliseconds
+   * (default: 1000)
+   */
+  timeout?: number
 }
 
 export interface ProtectorComponents {
@@ -87,7 +96,7 @@ class PreSharedKeyConnectionProtector implements ConnectionProtector {
   public tag: string
   private readonly log: Logger
   private readonly psk: Uint8Array
-  private readonly enabled: boolean
+  private readonly timeout: number
 
   /**
    * Takes a Private Shared Key (psk) and provides a `protect` method
@@ -95,16 +104,11 @@ class PreSharedKeyConnectionProtector implements ConnectionProtector {
    */
   constructor (components: ProtectorComponents, init: ProtectorInit) {
     this.log = components.logger.forComponent('libp2p:pnet')
-    this.enabled = init.enabled !== false
+    this.timeout = init.timeout ?? 1000
 
-    if (this.enabled) {
-      const decodedPSK = decodeV1PSK(init.psk)
-      this.psk = decodedPSK.psk
-      this.tag = decodedPSK.tag ?? ''
-    } else {
-      this.psk = new Uint8Array()
-      this.tag = ''
-    }
+    const decodedPSK = decodeV1PSK(init.psk)
+    this.psk = decodedPSK.psk
+    this.tag = decodedPSK.tag ?? ''
   }
 
   /**
@@ -113,10 +117,6 @@ class PreSharedKeyConnectionProtector implements ConnectionProtector {
    * created with.
    */
   async protect (connection: MultiaddrConnection): Promise<MultiaddrConnection> {
-    if (!this.enabled) {
-      return connection
-    }
-
     if (connection == null) {
       throw new CodeError(Errors.NO_HANDSHAKE_CONNECTION, Errors.ERR_INVALID_PARAMETERS)
     }
@@ -125,26 +125,27 @@ class PreSharedKeyConnectionProtector implements ConnectionProtector {
     this.log('protecting the connection')
     const localNonce = randomBytes(NONCE_LENGTH)
 
-    const shake = handshake(connection)
-    shake.write(localNonce)
+    const signal = AbortSignal.timeout(this.timeout)
 
-    const result = await shake.reader.next(NONCE_LENGTH)
+    const bytes = byteStream(connection)
+    await bytes.write(localNonce, {
+      signal
+    })
 
-    if (result.value == null) {
-      throw new CodeError(Errors.STREAM_ENDED, Errors.ERR_INVALID_PARAMETERS)
-    }
+    const result = await bytes.read(NONCE_LENGTH, {
+      signal
+    })
 
-    const remoteNonce = result.value.slice()
-    shake.rest()
+    const remoteNonce = result.subarray()
 
     // Create the boxing/unboxing pipe
     this.log('exchanged nonces')
-    const [internal, external] = duplexPair<Uint8Array>()
+    const [internal, external] = duplexPair<Uint8Array | Uint8ArrayList>()
     pipe(
       external,
       // Encrypt all outbound traffic
       createBoxStream(localNonce, this.psk),
-      shake.stream,
+      bytes.unwrap(),
       (source) => map(source, (buf) => buf.subarray()),
       // Decrypt all inbound traffic
       createUnboxStream(remoteNonce, this.psk),

--- a/packages/pnet/test/index.spec.ts
+++ b/packages/pnet/test/index.spec.ts
@@ -48,7 +48,10 @@ describe('private network', () => {
     ])
 
     void pipe(
-      [uint8ArrayFromString('hello world'), uint8ArrayFromString('doo dah')],
+      async function * () {
+        yield uint8ArrayFromString('hello world')
+        yield uint8ArrayFromString('doo dah')
+      },
       aToB
     )
 
@@ -79,7 +82,6 @@ describe('private network', () => {
       logger: defaultLogger()
     })
     const protectorB = preSharedKey({
-      enabled: true,
       psk: wrongSwarmKeyBuffer
     })({
       logger: defaultLogger()
@@ -91,7 +93,10 @@ describe('private network', () => {
     ])
 
     void pipe(
-      [uint8ArrayFromString('hello world'), uint8ArrayFromString('doo dah')],
+      async function * () {
+        yield uint8ArrayFromString('hello world')
+        yield uint8ArrayFromString('doo dah')
+      },
       aToB
     )
 

--- a/packages/stream-multiplexer-mplex/package.json
+++ b/packages/stream-multiplexer-mplex/package.json
@@ -60,7 +60,6 @@
     "@libp2p/interface": "^0.1.6",
     "@libp2p/utils": "^4.0.7",
     "benchmark": "^2.1.4",
-    "it-batched-bytes": "^2.0.2",
     "it-pushable": "^3.2.1",
     "it-stream-types": "^2.0.1",
     "rate-limiter-flexible": "^3.0.0",
@@ -81,7 +80,6 @@
     "it-map": "^3.0.3",
     "it-pair": "^2.0.6",
     "it-pipe": "^3.0.1",
-    "it-to-buffer": "^4.0.3",
     "p-defer": "^4.0.0",
     "random-int": "^3.0.0"
   },

--- a/packages/stream-multiplexer-mplex/src/index.ts
+++ b/packages/stream-multiplexer-mplex/src/index.ts
@@ -53,18 +53,6 @@ export interface MplexInit {
   maxUnprocessedMessageQueueSize?: number
 
   /**
-   * Each byte array written into a multiplexed stream is converted to one or
-   * more messages which are sent as byte arrays to the remote node. Sending
-   * lots of small messages can be expensive - use this setting to batch up
-   * the serialized bytes of all messages sent during the current tick up to
-   * this limit to send in one go similar to Nagle's algorithm. N.b. you
-   * should benchmark your application carefully when using this setting as it
-   * may cause the opposite of the desired effect. Omit this setting to send
-   * all messages as they become available. (default: undefined)
-   */
-  minSendBytes?: number
-
-  /**
    * The maximum number of multiplexed streams that can be open at any
    * one time. A request to open more than this will have a stream
    * reset message sent immediately as a response for the newly opened

--- a/packages/stream-multiplexer-mplex/src/mplex.ts
+++ b/packages/stream-multiplexer-mplex/src/mplex.ts
@@ -1,7 +1,7 @@
 import { CodeError } from '@libp2p/interface/errors'
 import { closeSource } from '@libp2p/utils/close-source'
 import { pipe } from 'it-pipe'
-import { type PushableV, pushableV } from 'it-pushable'
+import { type Pushable, pushable } from 'it-pushable'
 import { RateLimiterMemory } from 'rate-limiter-flexible'
 import { toString as uint8ArrayToString } from 'uint8arrays'
 import { Decoder } from './decode.js'
@@ -53,13 +53,13 @@ export class MplexStreamMuxer implements StreamMuxer {
   public protocol = '/mplex/6.7.0'
 
   public sink: Sink<Source<Uint8ArrayList | Uint8Array>, Promise<void>>
-  public source: AsyncGenerator<Uint8Array>
+  public source: AsyncGenerator<Uint8ArrayList | Uint8Array>
 
   private readonly log: Logger
   private _streamId: number
   private readonly _streams: { initiators: Map<number, MplexStream>, receivers: Map<number, MplexStream> }
   private readonly _init: MplexStreamMuxerInit
-  private readonly _source: PushableV<Message>
+  private readonly _source: Pushable<Message>
   private readonly closeController: AbortController
   private readonly rateLimiter: RateLimiterMemory
   private readonly closeTimeout: number
@@ -92,7 +92,7 @@ export class MplexStreamMuxer implements StreamMuxer {
     /**
      * An iterable source
      */
-    this._source = pushableV<Message>({
+    this._source = pushable<Message>({
       objectMode: true,
       onEnd: (): void => {
         // the source has ended, we can't write any more messages to gracefully
@@ -108,7 +108,7 @@ export class MplexStreamMuxer implements StreamMuxer {
     })
     this.source = pipe(
       this._source,
-      source => encode(source, this._init.minSendBytes)
+      source => encode(source)
     )
 
     /**

--- a/packages/stream-multiplexer-mplex/test/coder.spec.ts
+++ b/packages/stream-multiplexer-mplex/test/coder.spec.ts
@@ -13,9 +13,9 @@ import type { Message, NewStreamMessage } from '../src/message-types.js'
 
 describe('coder', () => {
   it('should encode header', async () => {
-    const source: Message[][] = [[{ id: 17, type: 0, data: new Uint8ArrayList(uint8ArrayFromString('17')) }]]
+    const source: Message[] = [{ id: 17, type: 0, data: new Uint8ArrayList(uint8ArrayFromString('17')) }]
 
-    const data = uint8ArrayConcat(await all(encode(source)))
+    const data = new Uint8ArrayList(...await all(encode(source))).subarray()
 
     const expectedHeader = uint8ArrayFromString('880102', 'base16')
     expect(data.slice(0, expectedHeader.length)).to.equalBytes(expectedHeader)
@@ -29,34 +29,34 @@ describe('coder', () => {
   })
 
   it('should encode several msgs into buffer', async () => {
-    const source: Message[][] = [[
+    const source: Message[] = [
       { id: 17, type: 0, data: new Uint8ArrayList(uint8ArrayFromString('17')) },
       { id: 19, type: 0, data: new Uint8ArrayList(uint8ArrayFromString('19')) },
       { id: 21, type: 0, data: new Uint8ArrayList(uint8ArrayFromString('21')) }
-    ]]
+    ]
 
-    const data = uint8ArrayConcat(await all(encode(source)))
+    const data = new Uint8ArrayList(...await all(encode(source))).subarray()
 
     expect(data).to.equalBytes(uint8ArrayFromString('88010231379801023139a801023231', 'base16'))
   })
 
   it('should encode from Uint8ArrayList', async () => {
-    const source: NewStreamMessage[][] = [[{
+    const source: NewStreamMessage[] = [{
       id: 17,
       type: 0,
       data: new Uint8ArrayList(
         uint8ArrayFromString(Math.random().toString()),
         uint8ArrayFromString(Math.random().toString())
       )
-    }]]
+    }]
 
-    const data = uint8ArrayConcat(await all(encode(source)))
+    const data = new Uint8ArrayList(...await all(encode(source))).subarray()
 
     expect(data).to.equalBytes(
       uint8ArrayConcat([
         uint8ArrayFromString('8801', 'base16'),
-        Uint8Array.from([source[0][0].data.length]),
-        source[0][0].data instanceof Uint8Array ? source[0][0].data : source[0][0].data.slice()
+        Uint8Array.from([source[0].data.length]),
+        source[0].data instanceof Uint8Array ? source[0].data : source[0].data.slice()
       ])
     )
   })
@@ -77,9 +77,9 @@ describe('coder', () => {
   })
 
   it('should encode zero length body msg', async () => {
-    const source: Message[][] = [[{ id: 17, type: 0, data: new Uint8ArrayList() }]]
+    const source: Message[] = [{ id: 17, type: 0, data: new Uint8ArrayList() }]
 
-    const data = uint8ArrayConcat(await all(encode(source)))
+    const data = new Uint8ArrayList(...await all(encode(source))).subarray()
 
     expect(data).to.equalBytes(uint8ArrayFromString('880100', 'base16'))
   })

--- a/packages/stream-multiplexer-mplex/test/fixtures/decode.ts
+++ b/packages/stream-multiplexer-mplex/test/fixtures/decode.ts
@@ -3,9 +3,10 @@
 import { Decoder, MAX_MSG_QUEUE_SIZE, MAX_MSG_SIZE } from '../../src/decode.js'
 import type { Message } from '../../src/message-types.js'
 import type { Source } from 'it-stream-types'
+import type { Uint8ArrayList } from 'uint8arraylist'
 
 export function decode (maxMessageSize: number = MAX_MSG_SIZE, maxUnprocessedMessageQueueSize: number = MAX_MSG_QUEUE_SIZE) {
-  return async function * decodeMessages (source: Source<Uint8Array>): Source<Message> {
+  return async function * decodeMessages (source: Source<Uint8Array | Uint8ArrayList>): Source<Message> {
     const decoder = new Decoder(maxMessageSize, maxUnprocessedMessageQueueSize)
 
     for await (const chunk of source) {

--- a/packages/stream-multiplexer-mplex/test/mplex.spec.ts
+++ b/packages/stream-multiplexer-mplex/test/mplex.spec.ts
@@ -8,7 +8,6 @@ import all from 'it-all'
 import { pushable } from 'it-pushable'
 import pDefer from 'p-defer'
 import { Uint8ArrayList } from 'uint8arraylist'
-import { concat as uint8ArrayConcat } from 'uint8arrays/concat'
 import { fromString as uint8ArrayFromString } from 'uint8arrays/from-string'
 import { encode } from '../src/encode.js'
 import { mplex } from '../src/index.js'
@@ -47,34 +46,34 @@ describe('mplex', () => {
       logger: defaultLogger()
     })
     const muxer = factory.createStreamMuxer()
-    const stream = pushable()
+    const stream = pushable<Uint8ArrayList | Uint8Array>()
 
     // max out the streams for this connection
     for (let i = 0; i < maxInboundStreams; i++) {
-      const source: NewStreamMessage[][] = [[{
+      const source: NewStreamMessage[] = [{
         id: i,
         type: 0,
         data: new Uint8ArrayList(uint8ArrayFromString('17'))
-      }]]
+      }]
 
-      const data = uint8ArrayConcat(await all(encode(source)))
+      const data = new Uint8ArrayList(...(await all(encode(source))))
 
       stream.push(data)
     }
 
     // simulate a new incoming stream
-    const source: NewStreamMessage[][] = [[{
+    const source: NewStreamMessage[] = [{
       id: 11,
       type: 0,
       data: new Uint8ArrayList(uint8ArrayFromString('17'))
-    }]]
+    }]
 
-    const data = uint8ArrayConcat(await all(encode(source)))
+    const data = new Uint8ArrayList(...(await all(encode(source))))
 
     stream.push(data)
     stream.end()
 
-    const bufs: Uint8Array[] = []
+    const bufs: Array<Uint8Array | Uint8ArrayList> = []
     const sinkDone = pDefer()
 
     void Promise.resolve().then(async () => {
@@ -100,13 +99,13 @@ describe('mplex', () => {
     const id = 17
 
     // simulate a new incoming stream that sends lots of data
-    const input: Source<Message[]> = (async function * send () {
+    const input: Source<Message> = (async function * send () {
       const newStreamMessage: NewStreamMessage = {
         id,
         type: MessageTypes.NEW_STREAM,
         data: new Uint8ArrayList(new Uint8Array(1024))
       }
-      yield [newStreamMessage]
+      yield newStreamMessage
 
       await delay(10)
 
@@ -116,7 +115,7 @@ describe('mplex', () => {
           type: MessageTypes.MESSAGE_INITIATOR,
           data: new Uint8ArrayList(new Uint8Array(1024 * 1000))
         }
-        yield [dataMessage]
+        yield dataMessage
 
         sent++
 
@@ -129,7 +128,7 @@ describe('mplex', () => {
         id,
         type: MessageTypes.CLOSE_INITIATOR
       }
-      yield [closeMessage]
+      yield closeMessage
     })()
 
     // create the muxer
@@ -179,63 +178,5 @@ describe('mplex', () => {
     await muxerFinished.promise
     expect(messages).to.have.nested.property('[0].id', id)
     expect(messages).to.have.nested.property('[0].type', MessageTypes.RESET_RECEIVER)
-  })
-
-  it('should batch bytes to send', async () => {
-    const minSendBytes = 10
-
-    // input bytes, smaller than batch size
-    const input: Uint8Array[] = [
-      Uint8Array.from([0, 1, 2, 3, 4]),
-      Uint8Array.from([0, 1, 2, 3, 4]),
-      Uint8Array.from([0, 1, 2, 3, 4])
-    ]
-
-    // create the muxer
-    const factory = mplex({
-      minSendBytes
-    })({
-      logger: defaultLogger()
-    })
-    const muxer = factory.createStreamMuxer({})
-
-    // collect outgoing mplex messages
-    const muxerFinished = pDefer()
-    let output: Uint8Array[] = []
-    void Promise.resolve().then(async () => {
-      output = await all(muxer.source)
-      muxerFinished.resolve()
-    })
-
-    // create a stream
-    const stream = await muxer.newStream()
-    const streamFinished = pDefer()
-    // send messages over the stream
-    void Promise.resolve().then(async () => {
-      await stream.sink(async function * () {
-        yield * input
-      }())
-      await stream.close()
-      streamFinished.resolve()
-    })
-
-    // wait for all data to be sent over the stream
-    await streamFinished.promise
-
-    // close the muxer
-    await muxer.sink([])
-
-    // wait for all output to be collected
-    await muxerFinished.promise
-
-    // last message is unbatched
-    const closeMessage = output.pop()
-    expect(closeMessage).to.have.lengthOf(2)
-
-    // all other messages should be above or equal to the batch size
-    expect(output).to.have.lengthOf(2)
-    for (const buf of output) {
-      expect(buf).to.have.length.that.is.at.least(minSendBytes)
-    }
   })
 })

--- a/packages/transport-tcp/src/socket-to-conn.ts
+++ b/packages/transport-tcp/src/socket-to-conn.ts
@@ -98,7 +98,15 @@ export const toMultiaddrConnection = (socket: Socket, options: ToConnectionOptio
   const maConn: MultiaddrConnection = {
     async sink (source) {
       try {
-        await sink(source)
+        await sink((async function * () {
+          for await (const buf of source) {
+            if (buf instanceof Uint8Array) {
+              yield buf
+            } else {
+              yield buf.subarray()
+            }
+          }
+        })())
       } catch (err: any) {
         // If aborted we can safely ignore
         if (err.type !== 'aborted') {

--- a/packages/transport-tcp/test/socket-to-conn.spec.ts
+++ b/packages/transport-tcp/test/socket-to-conn.spec.ts
@@ -231,9 +231,9 @@ describe('socket-to-conn', () => {
     })
 
     // send some data between the client and server
-    await inboundMaConn.sink([
-      Uint8Array.from([0, 1, 2, 3])
-    ])
+    await inboundMaConn.sink(async function * () {
+      yield Uint8Array.from([0, 1, 2, 3])
+    }())
 
     // server socket should no longer be writable
     expect(serverSocket.writable).to.be.false()

--- a/packages/transport-webrtc/src/maconn.ts
+++ b/packages/transport-webrtc/src/maconn.ts
@@ -4,6 +4,7 @@ import type { MultiaddrConnection, MultiaddrConnectionTimeline } from '@libp2p/i
 import type { CounterGroup } from '@libp2p/interface/metrics'
 import type { AbortOptions, Multiaddr } from '@multiformats/multiaddr'
 import type { Source, Sink } from 'it-stream-types'
+import type { Uint8ArrayList } from 'uint8arraylist'
 
 interface WebRTCMultiaddrConnectionInit {
   /**
@@ -62,7 +63,7 @@ export class WebRTCMultiaddrConnection implements MultiaddrConnection {
   /**
    * The stream destination, a no-op as the transport natively supports multiplexing
    */
-  sink: Sink<Source<Uint8Array>, Promise<void>> = nopSink
+  sink: Sink<Source<Uint8Array | Uint8ArrayList>, Promise<void>> = nopSink
 
   constructor (components: WebRTCMultiaddrConnectionComponents, init: WebRTCMultiaddrConnectionInit) {
     this.log = components.logger.forComponent('libp2p:webrtc:maconn')

--- a/packages/transport-websockets/src/socket-to-conn.ts
+++ b/packages/transport-websockets/src/socket-to-conn.ts
@@ -20,7 +20,15 @@ export function socketToMaConn (stream: DuplexWebSocket, remoteAddr: Multiaddr, 
 
     async sink (source) {
       try {
-        await stream.sink(source)
+        await stream.sink((async function * () {
+          for await (const buf of source) {
+            if (buf instanceof Uint8Array) {
+              yield buf
+            } else {
+              yield buf.subarray()
+            }
+          }
+        })())
       } catch (err: any) {
         if (err.type !== 'aborted') {
           log.error(err)

--- a/packages/transport-webtransport/src/index.ts
+++ b/packages/transport-webtransport/src/index.ts
@@ -36,6 +36,7 @@ import type { PeerId } from '@libp2p/interface/peer-id'
 import type { StreamMuxerFactory, StreamMuxerInit, StreamMuxer } from '@libp2p/interface/stream-muxer'
 import type { Source } from 'it-stream-types'
 import type { MultihashDigest } from 'multiformats/hashes/interface'
+import type { Uint8ArrayList } from 'uint8arraylist'
 
 interface WebTransportSessionCleanup {
   (metric: string): void
@@ -237,9 +238,13 @@ class WebTransportTransport implements Transport {
           }
         }
       })(),
-      sink: async function (source: Source<Uint8Array>) {
+      sink: async function (source: Source<Uint8Array | Uint8ArrayList>) {
         for await (const chunk of source) {
-          await writer.write(chunk)
+          if (chunk instanceof Uint8Array) {
+            await writer.write(chunk)
+          } else {
+            await writer.write(chunk.subarray())
+          }
         }
       }
     }

--- a/packages/utils/test/stream-to-ma-conn.spec.ts
+++ b/packages/utils/test/stream-to-ma-conn.spec.ts
@@ -71,7 +71,9 @@ describe('Convert stream into a multiaddr connection', () => {
 
     const data = uint8ArrayFromString('hey')
     const streamData = await pipe(
-      [data],
+      async function * () {
+        yield data
+      },
       maConn,
       async (source) => all(source)
     )


### PR DESCRIPTION
Updates the stream type for `MultiaddrConnection` to `Uint8Array | Uint8ArrayList` - this lets us yield `Uint8ArrayList`s from stream muxers and connection encrypters instead of having to copy the list contents into a new `Uint8Array` every time.

This lowers the connection latency slightly and increases stream throughput according to the [perf test results](https://observablehq.com/@libp2p-workspace/performance-dashboard?branch=fa6fd4179febbd14ed92d4a7e83d52f729a3af07).

BREAKING CHANGE: the `minSendBytes` option has been removed from Mplex since the transport can now decide how to optimise sending data

## Change checklist

- [x] I have performed a self-review of my own code
- [ ] I have made corresponding changes to the documentation if necessary (this includes comments as well)
- [x] I have added tests that prove my fix is effective or that my feature works