### PR TITLE
feat: use peer logger by default

### DIFF
--- a/packages/libp2p/src/libp2p.ts
+++ b/packages/libp2p/src/libp2p.ts
@@ -4,7 +4,7 @@ import { CodeError } from '@libp2p/interface/errors'
 import { TypedEventEmitter, CustomEvent, setMaxListeners } from '@libp2p/interface/events'
 import { peerDiscovery } from '@libp2p/interface/peer-discovery'
 import { type PeerRouting, peerRouting } from '@libp2p/interface/peer-routing'
-import { defaultLogger } from '@libp2p/logger'
+import { peerLogger } from '@libp2p/logger'
 import { PeerSet } from '@libp2p/peer-collections'
 import { peerIdFromString } from '@libp2p/peer-id'
 import { createEd25519PeerId } from '@libp2p/peer-id-factory'
@@ -70,7 +70,7 @@ export class Libp2pNode<T extends ServiceMap = Record<string, unknown>> extends 
 
     this.#started = false
     this.peerId = init.peerId
-    this.logger = init.logger ?? defaultLogger()
+    this.logger = init.logger ?? peerLogger(this.peerId)
     this.log = this.logger.forComponent('libp2p')
     // @ts-expect-error {} may not be of type T
     this.services = {}


### PR DESCRIPTION
Switches the default logger to one that prefixes log lines with a truncated version of the node's peer id.

This can be overridden at configuration time, eg:

```js
const node = await createLibp2p()

// e.g.
// 12…tsSg:libp2p:component hello world
```

```js
import { defaultLogger } from '@libp2p/logger'

const node = await createLibp2p({
  logger: defaultLogger()
})

// e.g.
// libp2p:component hello world
```

```js
import { prefixLogger } from '@libp2p/logger'

const node = await createLibp2p({
  logger: prefixLogger('custom-prefix')
})

// e.g.
// custom-prefix:libp2p:component hello world
```

Refs: #2105
Refs: #2198
Refs: #378

## Change checklist

- [x] I have performed a self-review of my own code
- [ ] I have made corresponding changes to the documentation if necessary (this includes comments as well)
- [ ] I have added tests that prove my fix is effective or that my feature works