### PR TITLE
fix: export version from libp2p

### DIFF
--- a/packages/libp2p/package.json
+++ b/packages/libp2p/package.json
@@ -12,6 +12,7 @@
     "url": "https://github.com/libp2p/js-libp2p/issues"
   },
   "publishConfig": {
+    "access": "public",
     "provenance": true
   },
   "keywords": [
@@ -24,6 +25,22 @@
   ],
   "type": "module",
   "types": "./dist/src/index.d.ts",
+  "typesVersions": {
+    "*": {
+      "*": [
+        "*",
+        "dist/*",
+        "dist/src/*",
+        "dist/src/*/index"
+      ],
+      "src/*": [
+        "*",
+        "dist/*",
+        "dist/src/*",
+        "dist/src/*/index"
+      ]
+    }
+  },
   "files": [
     "src",
     "dist",
@@ -34,6 +51,10 @@
     ".": {
       "types": "./dist/src/index.d.ts",
       "import": "./dist/src/index.js"
+    },
+    "./version": {
+      "types": "./dist/src/version.d.ts",
+      "import": "./dist/src/version.js"
     }
   },
   "eslintConfig": {


### PR DESCRIPTION
To allow consumers to programatically report the version of libp2p that is running, export the version file.

## Change checklist

- [x] I have performed a self-review of my own code
- [ ] I have made corresponding changes to the documentation if necessary (this includes comments as well)
- [ ] I have added tests that prove my fix is effective or that my feature works