### PR TITLE
fix: update interface internal and release as v1

### DIFF
--- a/packages/interface-internal/src/registrar/index.ts
+++ b/packages/interface-internal/src/registrar/index.ts
@@ -1,7 +1,14 @@
 import type { Connection, Stream, Topology } from '@libp2p/interface'
 
 export interface IncomingStreamData {
+  /**
+   * The stream that has been opened
+   */
   stream: Stream
+
+  /**
+   * The connection that the stream was opened on
+   */
   connection: Connection
 }
 
@@ -29,7 +36,14 @@ export interface StreamHandlerOptions {
 }
 
 export interface StreamHandlerRecord {
+  /**
+   * The handler that was registered to handle streams opened on the protocol
+   */
   handler: StreamHandler
+
+  /**
+   * The options that were used to register the stream handler
+   */
   options: StreamHandlerOptions
 }
 

--- a/packages/interface-internal/src/transport-manager/index.ts
+++ b/packages/interface-internal/src/transport-manager/index.ts
@@ -2,13 +2,51 @@ import type { Connection, Listener, Transport } from '@libp2p/interface'
 import type { Multiaddr } from '@multiformats/multiaddr'
 
 export interface TransportManager {
+  /**
+   * Add a transport to the transport manager
+   */
   add(transport: Transport): void
+
+  /**
+   * Dial a multiaddr. Connections returned by this method will not be tracked
+   * by the connection manager so can cause memory leaks. If you need to dial
+   * a multiaddr, you may want to call openConnection on the connection manager
+   * instead.
+   */
   dial(ma: Multiaddr, options?: any): Promise<Connection>
+
+  /**
+   * Return all addresses currently being listened on
+   */
   getAddrs(): Multiaddr[]
+
+  /**
+   * Return all registered transports
+   */
   getTransports(): Transport[]
+
+  /**
+   * Return all listeners
+   */
   getListeners(): Listener[]
+
+  /**
+   * Get the transport for a given multiaddr, if one has been configured
+   */
   transportForMultiaddr(ma: Multiaddr): Transport | undefined
+
+  /**
+   * Listen on the passed multiaddrs
+   */
   listen(addrs: Multiaddr[]): Promise<void>
+
+  /**
+   * Remove a previously configured transport
+   */
   remove(key: string): Promise<void>
+
+  /**
+   * Remove all transports
+   */
   removeAll(): Promise<void>
 }


### PR DESCRIPTION
To allow following semver on `@libp2p/interface-internal`, release as v1.

Release-As: 1.0.0

## Change checklist

- [x] I have performed a self-review of my own code
- [ ] I have made corresponding changes to the documentation if necessary (this includes comments as well)
- [ ] I have added tests that prove my fix is effective or that my feature works