### PR TITLE
fix!: release majors of modules that had patches during v1.0

### DIFF
--- a/packages/multistream-select/src/handle.ts
+++ b/packages/multistream-select/src/handle.ts
@@ -55,7 +55,7 @@ import type { Duplex } from 'it-stream-types'
  */
 export async function handle <Stream extends Duplex<any, any, any>> (stream: Stream, protocols: string | string[], options: MultistreamSelectInit): Promise<ProtocolStream<Stream>> {
   protocols = Array.isArray(protocols) ? protocols : [protocols]
-  options?.log?.trace('handle: available protocols %s', protocols)
+  options.log.trace('handle: available protocols %s', protocols)
 
   const lp = lpStream(stream, {
     ...options,
@@ -64,21 +64,21 @@ export async function handle <Stream extends Duplex<any, any, any>> (stream: Str
   })
 
   while (true) {
-    options?.log?.trace('handle: reading incoming string')
+    options.log.trace('handle: reading incoming string')
     const protocol = await multistream.readString(lp, options)
-    options?.log?.trace('handle: read "%s"', protocol)
+    options.log.trace('handle: read "%s"', protocol)
 
     if (protocol === PROTOCOL_ID) {
-      options?.log?.trace('handle: respond with "%s" for "%s"', PROTOCOL_ID, protocol)
+      options.log.trace('handle: respond with "%s" for "%s"', PROTOCOL_ID, protocol)
       await multistream.write(lp, uint8ArrayFromString(`${PROTOCOL_ID}\n`), options)
-      options?.log?.trace('handle: responded with "%s" for "%s"', PROTOCOL_ID, protocol)
+      options.log.trace('handle: responded with "%s" for "%s"', PROTOCOL_ID, protocol)
       continue
     }
 
     if (protocols.includes(protocol)) {
-      options?.log?.trace('handle: respond with "%s" for "%s"', protocol, protocol)
+      options.log.trace('handle: respond with "%s" for "%s"', protocol, protocol)
       await multistream.write(lp, uint8ArrayFromString(`${protocol}\n`), options)
-      options?.log?.trace('handle: responded with "%s" for "%s"', protocol, protocol)
+      options.log.trace('handle: responded with "%s" for "%s"', protocol, protocol)
 
       return { stream: lp.unwrap(), protocol }
     }
@@ -90,14 +90,14 @@ export async function handle <Stream extends Duplex<any, any, any>> (stream: Str
         uint8ArrayFromString('\n')
       )
 
-      options?.log?.trace('handle: respond with "%s" for %s', protocols, protocol)
+      options.log.trace('handle: respond with "%s" for %s', protocols, protocol)
       await multistream.write(lp, protos, options)
-      options?.log?.trace('handle: responded with "%s" for %s', protocols, protocol)
+      options.log.trace('handle: responded with "%s" for %s', protocols, protocol)
       continue
     }
 
-    options?.log?.('handle: respond with "na" for "%s"', protocol)
+    options.log('handle: respond with "na" for "%s"', protocol)
     await multistream.write(lp, uint8ArrayFromString('na\n'), options)
-    options?.log?.('handle: responded with "na" for "%s"', protocol)
+    options.log('handle: responded with "na" for "%s"', protocol)
   }
 }

--- a/packages/multistream-select/src/multistream.ts
+++ b/packages/multistream-select/src/multistream.ts
@@ -2,7 +2,6 @@ import { CodeError } from '@libp2p/interface'
 import { type Uint8ArrayList } from 'uint8arraylist'
 import { fromString as uint8ArrayFromString } from 'uint8arrays/from-string'
 import { toString as uint8ArrayToString } from 'uint8arrays/to-string'
-import type { MultistreamSelectInit } from '.'
 import type { AbortOptions, LoggerOptions } from '@libp2p/interface'
 import type { LengthPrefixedStream } from 'it-length-prefixed-stream'
 import type { Duplex, Source } from 'it-stream-types'
@@ -12,25 +11,25 @@ const NewLine = uint8ArrayFromString('\n')
 /**
  * `write` encodes and writes a single buffer
  */
-export async function write (writer: LengthPrefixedStream<Duplex<AsyncGenerator<Uint8Array | Uint8ArrayList>, Source<Uint8Array>>>, buffer: Uint8Array | Uint8ArrayList, options?: MultistreamSelectInit): Promise<void> {
+export async function write (writer: LengthPrefixedStream<Duplex<AsyncGenerator<Uint8Array | Uint8ArrayList>, Source<Uint8Array>>>, buffer: Uint8Array | Uint8ArrayList, options?: AbortOptions): Promise<void> {
   await writer.write(buffer, options)
 }
 
 /**
  * `writeAll` behaves like `write`, except it encodes an array of items as a single write
  */
-export async function writeAll (writer: LengthPrefixedStream<Duplex<AsyncGenerator<Uint8Array | Uint8ArrayList>, Source<Uint8Array>>>, buffers: Uint8Array[], options?: MultistreamSelectInit): Promise<void> {
+export async function writeAll (writer: LengthPrefixedStream<Duplex<AsyncGenerator<Uint8Array | Uint8ArrayList>, Source<Uint8Array>>>, buffers: Uint8Array[], options?: AbortOptions): Promise<void> {
   await writer.writeV(buffers, options)
 }
 
 /**
  * Read a length-prefixed buffer from the passed stream, stripping the final newline character
  */
-export async function read (reader: LengthPrefixedStream<Duplex<AsyncGenerator<Uint8Array | Uint8ArrayList>, Source<Uint8Array>>>, options?: AbortOptions & LoggerOptions): Promise<Uint8ArrayList> {
+export async function read (reader: LengthPrefixedStream<Duplex<AsyncGenerator<Uint8Array | Uint8ArrayList>, Source<Uint8Array>>>, options: AbortOptions & LoggerOptions): Promise<Uint8ArrayList> {
   const buf = await reader.read(options)
 
   if (buf.byteLength === 0 || buf.get(buf.byteLength - 1) !== NewLine[0]) {
-    options?.log?.error('Invalid mss message - missing newline', buf)
+    options.log.error('Invalid mss message - missing newline', buf)
     throw new CodeError('missing newline', 'ERR_INVALID_MULTISTREAM_SELECT_MESSAGE')
   }
 
@@ -40,7 +39,7 @@ export async function read (reader: LengthPrefixedStream<Duplex<AsyncGenerator<U
 /**
  * Read a length-prefixed string from the passed stream, stripping the final newline character
  */
-export async function readString (reader: LengthPrefixedStream<Duplex<AsyncGenerator<Uint8Array | Uint8ArrayList>, Source<Uint8Array>>>, options?: AbortOptions & LoggerOptions): Promise<string> {
+export async function readString (reader: LengthPrefixedStream<Duplex<AsyncGenerator<Uint8Array | Uint8ArrayList>, Source<Uint8Array>>>, options: AbortOptions & LoggerOptions): Promise<string> {
   const buf = await read(reader, options)
 
   return uint8ArrayToString(buf.subarray())

--- a/packages/multistream-select/test/multistream.spec.ts
+++ b/packages/multistream-select/test/multistream.spec.ts
@@ -16,9 +16,7 @@ describe('Multistream', () => {
       const inputStream = lpStream(duplexes[0])
       const outputStream = lpStream(duplexes[1])
 
-      void Multistream.write(inputStream, input, {
-        log: logger('mss:test')
-      })
+      void Multistream.write(inputStream, input)
 
       const output = await outputStream.read()
       expect(output.subarray()).to.equalBytes(input)
@@ -36,7 +34,9 @@ describe('Multistream', () => {
 
       void inputStream.write(uint8ArrayFromString(`${input}\n`))
 
-      const output = await Multistream.read(outputStream)
+      const output = await Multistream.read(outputStream, {
+        log: logger('mss:test')
+      })
       expect(output.subarray()).to.equalBytes(inputBuf)
     })
 
@@ -50,7 +50,9 @@ describe('Multistream', () => {
 
       void inputStream.write(inputBuf)
 
-      await expect(Multistream.read(outputStream)).to.eventually.be.rejected()
+      await expect(Multistream.read(outputStream, {
+        log: logger('mss:test')
+      })).to.eventually.be.rejected()
         .with.property('code', 'ERR_INVALID_MULTISTREAM_SELECT_MESSAGE')
     })
 
@@ -66,7 +68,9 @@ describe('Multistream', () => {
 
       void inputStream.write(input)
 
-      await expect(Multistream.read(outputStream)).to.eventually.be.rejected()
+      await expect(Multistream.read(outputStream, {
+        log: logger('mss:test')
+      })).to.eventually.be.rejected()
         .with.property('code', 'ERR_MSG_DATA_TOO_LONG')
     })
 
@@ -79,7 +83,9 @@ describe('Multistream', () => {
 
       void inputStream.write(input)
 
-      await expect(Multistream.read(outputStream)).to.eventually.be.rejected()
+      await expect(Multistream.read(outputStream, {
+        log: logger('mss:test')
+      })).to.eventually.be.rejected()
         .with.property('code', 'ERR_INVALID_MULTISTREAM_SELECT_MESSAGE')
     })
 

--- a/packages/peer-collections/src/index.ts
+++ b/packages/peer-collections/src/index.ts
@@ -4,6 +4,33 @@
  * We can't use PeerIds as collection keys because collection keys are compared using same-value-zero equality, so this is just a group of collections that stringifies PeerIds before storing them.
  *
  * PeerIds cache stringified versions of themselves so this should be a cheap operation.
+ *
+ * @example Peer lists
+ *
+ * ```JavaScript
+ * import { peerList } from '@libp2p/peer-collections'
+ *
+ * const list = peerList()
+ * list.push(peerId)
+ * ```
+ *
+ * @example Peer maps
+ *
+ * ```JavaScript
+ * import { peerMap } from '@libp2p/peer-collections'
+ *
+ * const map = peerMap<string>()
+ * map.set(peerId, 'value')
+ * ```
+ *
+ * @example Peer sets
+ *
+ * ```JavaScript
+ * import { peerSet } from '@libp2p/peer-collections'
+ *
+ * const set = peerSet()
+ * set.add(peerId)
+ * ```
  */
 
 export { PeerMap } from './map.js'

--- a/packages/peer-id-factory/src/index.ts
+++ b/packages/peer-id-factory/src/index.ts
@@ -1,7 +1,7 @@
 /**
  * @packageDocumentation
  *
- * Generate, import, and export PeerIDs, for use with [IPFS](https://github.com/ipfs/ipfs).
+ * Generate, import, and export PeerIDs.
  *
  * A Peer ID is the SHA-256 [multihash](https://github.com/multiformats/multihash) of a public key.
  *

--- a/packages/peer-record/src/index.ts
+++ b/packages/peer-record/src/index.ts
@@ -11,7 +11,7 @@
  *
  * You can read further about the envelope in [libp2p/specs#217](https://github.com/libp2p/specs/pull/217).
  *
- * @example
+ * @example Creating a peer record
  *
  * Create an envelope with an instance of an [interface-record](https://github.com/libp2p/js-libp2p/blob/main/packages/interface/src/record/index.ts) implementation and prepare it for being exchanged:
  *
@@ -42,7 +42,7 @@
  * const wireData = e.marshal()
  * ```
  *
- * @example
+ * @example Consuming a peer record
  *
  * Consume a received envelope (`wireData`) and transform it back to a record:
  *

--- a/packages/peer-store/src/index.ts
+++ b/packages/peer-store/src/index.ts
@@ -1,3 +1,9 @@
+/**
+ * @packageDocumentation
+ *
+ * The peer store is where libp2p stores data about the peers it has encountered on the network.
+ */
+
 import { RecordEnvelope, PeerRecord } from '@libp2p/peer-record'
 import all from 'it-all'
 import { PersistentStore, type PeerUpdate } from './store.js'

--- a/packages/pubsub-floodsub/src/index.ts
+++ b/packages/pubsub-floodsub/src/index.ts
@@ -9,7 +9,7 @@
  *
  * Instead please use [gossipsub](https://www.npmjs.com/package/@chainsafe/libp2p-gossipsub) - a more complete implementation which is also compatible with floodsub.
  *
- * @example
+ * @example Configuring libp2p to use floodsub
  *
  * ```JavaScript
  * import { createLibp2pNode } from 'libp2p'

--- a/packages/pubsub/src/index.ts
+++ b/packages/pubsub/src/index.ts
@@ -4,6 +4,7 @@
  * A set of components to be extended in order to create a pubsub implementation.
  *
  * @example
+ *
  * ```javascript
  * import { PubSubBaseProtocol } from '@libp2p/pubsub'
  *


### PR DESCRIPTION
Pre-v1.0 versions of libp2p are still depending on post-1.0 modules which means they have a mixed set of versions.

The change here is to cause those modules to have major releases.

BREAKING CHANGE: requires libp2p v1

## Change checklist

- [x] I have performed a self-review of my own code
- [ ] I have made corresponding changes to the documentation if necessary (this includes comments as well)
- [ ] I have added tests that prove my fix is effective or that my feature works