### PR TITLE
fix: set libp2p status to started before stopping

### DIFF
--- a/packages/libp2p/src/libp2p.ts
+++ b/packages/libp2p/src/libp2p.ts
@@ -215,6 +215,8 @@ export class Libp2pNode<T extends ServiceMap = Record<string, unknown>> extends 
       this.log('libp2p has started')
     } catch (err: any) {
       this.log.error('An error occurred starting libp2p', err)
+      // set status to 'started' so this.stop() will stop any running components
+      this.status = 'started'
       await this.stop()
       throw err
     }


### PR DESCRIPTION
In order to stop components that have been started during a failed startup, set the current status to started after catching the error - `this.stop` will immediately set it to `stopping`.

## Change checklist

- [x] I have performed a self-review of my own code
- [ ] I have made corresponding changes to the documentation if necessary (this includes comments as well)
- [ ] I have added tests that prove my fix is effective or that my feature works