### PR TITLE
fix: allow no transports in config

### DIFF
--- a/packages/libp2p/src/config.ts
+++ b/packages/libp2p/src/config.ts
@@ -28,10 +28,6 @@ const DefaultConfig: Partial<Libp2pInit> = {
 export function validateConfig <T extends ServiceMap = Record<string, unknown>> (opts: RecursivePartial<Libp2pInit<T>>): Libp2pInit<T> {
   const resultingOptions: Libp2pInit<T> = mergeOptions(DefaultConfig, opts)
 
-  if (resultingOptions.transports == null || resultingOptions.transports.length < 1) {
-    throw new CodeError(messages.ERR_TRANSPORTS_REQUIRED, codes.ERR_TRANSPORTS_REQUIRED)
-  }
-
   if (resultingOptions.connectionProtector === null && globalThis.process?.env?.LIBP2P_FORCE_PNET != null) { // eslint-disable-line no-undef
     throw new CodeError(messages.ERR_PROTECTOR_REQUIRED, codes.ERR_PROTECTOR_REQUIRED)
   }

--- a/packages/libp2p/src/content-routing/index.ts
+++ b/packages/libp2p/src/content-routing/index.ts
@@ -76,7 +76,7 @@ export class CompoundContentRouting implements ContentRouting, Startable {
    */
   async put (key: Uint8Array, value: Uint8Array, options?: AbortOptions): Promise<void> {
     if (!this.isStarted()) {
-      throw new CodeError(messages.NOT_STARTED_YET, codes.DHT_NOT_STARTED)
+      throw new CodeError(messages.NOT_STARTED_YET, codes.ERR_NODE_NOT_STARTED)
     }
 
     await Promise.all(this.routers.map(async (router) => {
@@ -90,7 +90,7 @@ export class CompoundContentRouting implements ContentRouting, Startable {
    */
   async get (key: Uint8Array, options?: AbortOptions): Promise<Uint8Array> {
     if (!this.isStarted()) {
-      throw new CodeError(messages.NOT_STARTED_YET, codes.DHT_NOT_STARTED)
+      throw new CodeError(messages.NOT_STARTED_YET, codes.ERR_NODE_NOT_STARTED)
     }
 
     return Promise.any(this.routers.map(async (router) => {

--- a/packages/libp2p/src/errors.ts
+++ b/packages/libp2p/src/errors.ts
@@ -1,20 +1,10 @@
 export enum messages {
   NOT_STARTED_YET = 'The libp2p node is not started yet',
-  DHT_DISABLED = 'DHT is not available',
-  PUBSUB_DISABLED = 'PubSub is not available',
-  CONN_ENCRYPTION_REQUIRED = 'At least one connection encryption module is required',
-  ERR_TRANSPORTS_REQUIRED = 'At least one transport module is required',
   ERR_PROTECTOR_REQUIRED = 'Private network is enforced, but no protector was provided',
   NOT_FOUND = 'Not found'
 }
 
 export enum codes {
-  DHT_DISABLED = 'ERR_DHT_DISABLED',
-  ERR_PUBSUB_DISABLED = 'ERR_PUBSUB_DISABLED',
-  PUBSUB_NOT_STARTED = 'ERR_PUBSUB_NOT_STARTED',
-  DHT_NOT_STARTED = 'ERR_DHT_NOT_STARTED',
-  CONN_ENCRYPTION_REQUIRED = 'ERR_CONN_ENCRYPTION_REQUIRED',
-  ERR_TRANSPORTS_REQUIRED = 'ERR_TRANSPORTS_REQUIRED',
   ERR_PROTECTOR_REQUIRED = 'ERR_PROTECTOR_REQUIRED',
   ERR_PEER_DIAL_INTERCEPTED = 'ERR_PEER_DIAL_INTERCEPTED',
   ERR_CONNECTION_INTERCEPTED = 'ERR_CONNECTION_INTERCEPTED',


### PR DESCRIPTION
There are times where a node could be configured with no transports, for example if it is going to do all of it's work via delegates.

Removes the check for at least one transport module being configured.

## Change checklist

- [x] I have performed a self-review of my own code
- [ ] I have made corresponding changes to the documentation if necessary (this includes comments as well)
- [ ] I have added tests that prove my fix is effective or that my feature works