### PR TITLE
fix: make transports optional

### DIFF
--- a/packages/libp2p/src/index.ts
+++ b/packages/libp2p/src/index.ts
@@ -76,7 +76,7 @@ export interface Libp2pInit<T extends ServiceMap = { x: Record<string, unknown> 
   /**
    * An array that must include at least 1 compliant transport
    */
-  transports: Array<(components: Components) => Transport>
+  transports?: Array<(components: Components) => Transport>
   streamMuxers?: Array<(components: Components) => StreamMuxerFactory>
   connectionEncryption?: Array<(components: Components) => ConnectionEncrypter>
   peerDiscovery?: Array<(components: Components) => PeerDiscovery>
@@ -150,7 +150,7 @@ export type Libp2pOptions<T extends ServiceMap = Record<string, unknown>> = Recu
  * const libp2p = await createLibp2p(options)
  * ```
  */
-export async function createLibp2p <T extends ServiceMap = { x: Record<string, unknown> }> (options: Libp2pOptions<T>): Promise<Libp2p<T>> {
+export async function createLibp2p <T extends ServiceMap = { x: Record<string, unknown> }> (options: Libp2pOptions<T> = {}): Promise<Libp2p<T>> {
   const node = await createLibp2pNode(options)
 
   if (options.start !== false) {

--- a/packages/libp2p/src/libp2p.ts
+++ b/packages/libp2p/src/libp2p.ts
@@ -145,7 +145,7 @@ export class Libp2pNode<T extends ServiceMap = Record<string, unknown>> extends 
     })
 
     // Transport modules
-    init.transports.forEach((fn, index) => {
+    init.transports?.forEach((fn, index) => {
       this.components.transportManager.add(this.configureComponent(`transport-${index}`, fn(this.components)))
     })
 
@@ -385,7 +385,7 @@ export class Libp2pNode<T extends ServiceMap = Record<string, unknown>> extends 
  * Returns a new Libp2pNode instance - this exposes more of the internals than the
  * libp2p interface and is useful for testing and debugging.
  */
-export async function createLibp2pNode <T extends ServiceMap = Record<string, unknown>> (options: Libp2pOptions<T>): Promise<Libp2pNode<T>> {
+export async function createLibp2pNode <T extends ServiceMap = Record<string, unknown>> (options: Libp2pOptions<T> = {}): Promise<Libp2pNode<T>> {
   options.peerId ??= await createEd25519PeerId()
 
   return new Libp2pNode(validateConfig(options))

--- a/packages/libp2p/test/core/core.spec.ts
+++ b/packages/libp2p/test/core/core.spec.ts
@@ -1,0 +1,19 @@
+/* eslint-env mocha */
+
+import { expect } from 'aegir/chai'
+import { createLibp2p } from '../../src/index.js'
+import type { Libp2p } from '@libp2p/interface'
+
+describe('core', () => {
+  let libp2p: Libp2p
+
+  after(async () => {
+    await libp2p.stop()
+  })
+
+  it('should start a minimal node', async () => {
+    libp2p = await createLibp2p({})
+
+    expect(libp2p).to.have.property('status', 'started')
+  })
+})


### PR DESCRIPTION
Follow up to #2293 that makes the transports array optional.

## Change checklist

- [x] I have performed a self-review of my own code
- [ ] I have made corresponding changes to the documentation if necessary (this includes comments as well)
- [x] I have added tests that prove my fix is effective or that my feature works