### PR TITLE
chore: remove empty object from test

### DIFF
--- a/packages/libp2p/test/core/core.spec.ts
+++ b/packages/libp2p/test/core/core.spec.ts
@@ -12,7 +12,7 @@ describe('core', () => {
   })
 
   it('should start a minimal node', async () => {
-    libp2p = await createLibp2p({})
+    libp2p = await createLibp2p()
 
     expect(libp2p).to.have.property('status', 'started')
   })


### PR DESCRIPTION
No need to pass an empty init object

## Change checklist

- [x] I have performed a self-review of my own code
- [ ] I have made corresponding changes to the documentation if necessary (this includes comments as well)
- [ ] I have added tests that prove my fix is effective or that my feature works