### PR TITLE
fix: WebRTC transport unhandled promise rejection during connect

### DIFF
--- a/packages/transport-webrtc/package.json
+++ b/packages/transport-webrtc/package.json
@@ -58,7 +58,6 @@
     "@multiformats/mafmt": "^12.1.6",
     "@multiformats/multiaddr": "^12.1.10",
     "@multiformats/multiaddr-matcher": "^1.1.0",
-    "any-signal": "^4.1.1",
     "detect-browser": "^5.3.0",
     "it-length-prefixed": "^9.0.3",
     "it-pipe": "^3.0.1",

--- a/packages/transport-webrtc/src/private-to-private/initiate-connection.ts
+++ b/packages/transport-webrtc/src/private-to-private/initiate-connection.ts
@@ -1,11 +1,10 @@
 import { CodeError } from '@libp2p/interface'
 import { peerIdFromString } from '@libp2p/peer-id'
 import { pbStream } from 'it-protobuf-stream'
-import pDefer, { type DeferredPromise } from 'p-defer'
 import { type RTCPeerConnection, RTCSessionDescription } from '../webrtc/index.js'
 import { Message } from './pb/message.js'
 import { SIGNALING_PROTO_ID, splitAddr, type WebRTCTransportMetrics } from './transport.js'
-import { readCandidatesUntilConnected, resolveOnConnected } from './util.js'
+import { readCandidatesUntilConnected } from './util.js'
 import type { DataChannelOptions } from '../index.js'
 import type { LoggerOptions, Connection } from '@libp2p/interface'
 import type { ConnectionManager, IncomingStreamData, TransportManager } from '@libp2p/interface-internal'
@@ -65,17 +64,8 @@ export async function initiateConnection ({ peerConnection, signal, metrics, mul
     })
 
     const messageStream = pbStream(stream).pb(Message)
-    const connectedPromise: DeferredPromise<void> = pDefer()
-    const sdpAbortedListener = (): void => {
-      connectedPromise.reject(new CodeError('SDP handshake aborted', 'ERR_SDP_HANDSHAKE_ABORTED'))
-    }
 
     try {
-      resolveOnConnected(peerConnection, connectedPromise)
-
-      // reject the connectedPromise if the signal aborts
-      signal?.addEventListener('abort', sdpAbortedListener)
-
       // we create the channel so that the RTCPeerConnection has a component for
       // which to collect candidates. The label is not relevant to connection
       // initiation but can be useful for debugging
@@ -102,7 +92,7 @@ export async function initiateConnection ({ peerConnection, signal, metrics, mul
           })
       }
       peerConnection.onicecandidateerror = (event) => {
-        log('initiator ICE candidate error', event)
+        log.error('initiator ICE candidate error', event)
       }
 
       // create an offer
@@ -140,7 +130,7 @@ export async function initiateConnection ({ peerConnection, signal, metrics, mul
 
       log.trace('initiator read candidates until connected')
 
-      await readCandidatesUntilConnected(connectedPromise, peerConnection, messageStream, {
+      await readCandidatesUntilConnected(peerConnection, messageStream, {
         direction: 'initiator',
         signal,
         log
@@ -164,8 +154,6 @@ export async function initiateConnection ({ peerConnection, signal, metrics, mul
       stream.abort(err)
       throw err
     } finally {
-      // remove event listeners
-      signal?.removeEventListener('abort', sdpAbortedListener)
       peerConnection.onicecandidate = null
       peerConnection.onicecandidateerror = null
     }

--- a/packages/transport-webrtc/src/private-to-private/listener.ts
+++ b/packages/transport-webrtc/src/private-to-private/listener.ts
@@ -25,7 +25,6 @@ export class WebRTCPeerListener extends TypedEventEmitter<ListenerEvents> implem
     this.transportManager = components.transportManager
 
     this.shutdownController = init.shutdownController
-    setMaxListeners(Infinity, this.shutdownController.signal)
   }
 
   async listen (): Promise<void> {

--- a/packages/transport-webrtc/src/private-to-private/listener.ts
+++ b/packages/transport-webrtc/src/private-to-private/listener.ts
@@ -1,4 +1,4 @@
-import { TypedEventEmitter, setMaxListeners } from '@libp2p/interface'
+import { TypedEventEmitter } from '@libp2p/interface'
 import { Circuit } from '@multiformats/mafmt'
 import type { PeerId, ListenerEvents, Listener } from '@libp2p/interface'
 import type { TransportManager } from '@libp2p/interface-internal'

--- a/packages/transport-webrtc/src/private-to-private/listener.ts
+++ b/packages/transport-webrtc/src/private-to-private/listener.ts
@@ -1,4 +1,4 @@
-import { TypedEventEmitter } from '@libp2p/interface'
+import { TypedEventEmitter, setMaxListeners } from '@libp2p/interface'
 import { Circuit } from '@multiformats/mafmt'
 import type { PeerId, ListenerEvents, Listener } from '@libp2p/interface'
 import type { TransportManager } from '@libp2p/interface-internal'
@@ -25,6 +25,7 @@ export class WebRTCPeerListener extends TypedEventEmitter<ListenerEvents> implem
     this.transportManager = components.transportManager
 
     this.shutdownController = init.shutdownController
+    setMaxListeners(Infinity, this.shutdownController.signal)
   }
 
   async listen (): Promise<void> {

--- a/packages/transport-webrtc/src/private-to-private/transport.ts
+++ b/packages/transport-webrtc/src/private-to-private/transport.ts
@@ -1,4 +1,4 @@
-import { CodeError } from '@libp2p/interface'
+import { CodeError, setMaxListeners } from '@libp2p/interface'
 import { type CreateListenerOptions, type DialOptions, transportSymbol, type Transport, type Listener, type Upgrader, type ComponentLogger, type Logger, type Connection, type PeerId, type CounterGroup, type Metrics, type Startable } from '@libp2p/interface'
 import { peerIdFromString } from '@libp2p/peer-id'
 import { multiaddr, type Multiaddr } from '@multiformats/multiaddr'
@@ -56,6 +56,7 @@ export class WebRTCTransport implements Transport, Startable {
   ) {
     this.log = components.logger.forComponent('libp2p:webrtc')
     this.shutdownController = new AbortController()
+    setMaxListeners(Infinity, this.shutdownController.signal)
 
     if (components.metrics != null) {
       this.metrics = {

--- a/packages/transport-webrtc/src/private-to-private/util.ts
+++ b/packages/transport-webrtc/src/private-to-private/util.ts
@@ -1,6 +1,5 @@
 import { CodeError } from '@libp2p/interface'
-import { closeSource } from '@libp2p/utils/close-source'
-import { anySignal } from 'any-signal'
+import pDefer from 'p-defer'
 import { isFirefox } from '../util.js'
 import { RTCIceCandidate } from '../webrtc/index.js'
 import { Message } from './pb/message.js'
@@ -12,32 +11,19 @@ export interface ReadCandidatesOptions extends AbortOptions, LoggerOptions {
   direction: string
 }
 
-export const readCandidatesUntilConnected = async (connectedPromise: DeferredPromise<void>, pc: RTCPeerConnection, stream: MessageStream<Message, Stream>, options: ReadCandidatesOptions): Promise<void> => {
-  // if we connect, stop trying to read from the stream
-  const controller = new AbortController()
-  connectedPromise.promise.then(() => {
-    controller.abort()
-  }, () => {
-    controller.abort()
-  })
-
-  const signal = anySignal([
-    controller.signal,
-    options.signal
-  ])
-
-  const abortListener = (): void => {
-    closeSource(stream.unwrap().unwrap().source, options.log)
-  }
-
-  signal.addEventListener('abort', abortListener)
-
+export const readCandidatesUntilConnected = async (pc: RTCPeerConnection, stream: MessageStream<Message, Stream>, options: ReadCandidatesOptions): Promise<void> => {
   try {
+    const connectedPromise: DeferredPromise<void> = pDefer()
+    resolveOnConnected(pc, connectedPromise)
+
     // read candidates until we are connected or we reach the end of the stream
     while (true) {
+      // if we connect, stop trying to read from the stream
       const message = await Promise.race([
         connectedPromise.promise,
-        stream.read()
+        stream.read({
+          signal: options.signal
+        })
       ])
 
       // stream ended or we became connected
@@ -72,15 +58,20 @@ export const readCandidatesUntilConnected = async (connectedPromise: DeferredPro
     }
   } catch (err) {
     options.log.error('%s error parsing ICE candidate', options.direction, err)
-  } finally {
-    signal.removeEventListener('abort', abortListener)
-    signal.clear()
+
+    if (options.signal?.aborted === true) {
+      throw err
+    }
   }
 }
 
-export function resolveOnConnected (pc: RTCPeerConnection, promise: DeferredPromise<void>): void {
+function getConnectionState (pc: RTCPeerConnection): string {
+  return isFirefox ? pc.iceConnectionState : pc.connectionState
+}
+
+function resolveOnConnected (pc: RTCPeerConnection, promise: DeferredPromise<void>): void {
   pc[isFirefox ? 'oniceconnectionstatechange' : 'onconnectionstatechange'] = (_) => {
-    switch (isFirefox ? pc.iceConnectionState : pc.connectionState) {
+    switch (getConnectionState(pc)) {
       case 'connected':
         promise.resolve()
         break


### PR DESCRIPTION
Simplifies the connection logic to just use the abort signal to abort the dial instead of the abort signal and multiple deferred promises.

Fixes a crash in node where the abort signal passed into a WebRTC private to private dial can cause an unhandled promise rejection due to a race condition between the abort firing and awaiting the `connectedPromise` promise:

```
file:///Users/alex/Documents/Workspaces/ipfs/helia-http-gateway/node_modules/@libp2p/webrtc/dist/src/private-to-private/initiate-connection.js:42
            connectedPromise.reject(new CodeError('SDP handshake aborted', 'ERR_SDP_HANDSHAKE_ABORTED'));
                                    ^

CodeError: SDP handshake aborted
    at EventTarget.sdpAbortedListener (file:///Users/alex/Documents/Workspaces/ipfs/helia-http-gateway/node_modules/@libp2p/webrtc/dist/src/private-to-private/initiate-connection.js:42:37)
    at [nodejs.internal.kHybridDispatch] (node:internal/event_target:807:20)
    at EventTarget.dispatchEvent (node:internal/event_target:742:26)
    at abortSignal (node:internal/abort_controller:369:10)
    at AbortController.abort (node:internal/abort_controller:391:5)
    at EventTarget.onAbort (file:///Users/alex/Documents/Workspaces/ipfs/helia-http-gateway/node_modules/any-signal/dist/src/index.js:8:20)
    at [nodejs.internal.kHybridDispatch] (node:internal/event_target:807:20)
    at EventTarget.dispatchEvent (node:internal/event_target:742:26)
    at abortSignal (node:internal/abort_controller:369:10)
    at AbortController.abort (node:internal/abort_controller:391:5) {
  code: 'ERR_SDP_HANDSHAKE_ABORTED',
  props: {}
}

Node.js v20.8.0
```

## Change checklist

- [x] I have performed a self-review of my own code
- [ ] I have made corresponding changes to the documentation if necessary (this includes comments as well)
- [ ] I have added tests that prove my fix is effective or that my feature works