### PR TITLE
fix: WebRTC uncaught promise rejection on incoming connection

### DIFF
--- a/packages/transport-webrtc/src/private-to-private/initiate-connection.ts
+++ b/packages/transport-webrtc/src/private-to-private/initiate-connection.ts
@@ -96,7 +96,10 @@ export async function initiateConnection ({ peerConnection, signal, metrics, mul
       }
 
       // create an offer
-      const offerSdp = await peerConnection.createOffer()
+      const offerSdp = await peerConnection.createOffer().catch(err => {
+        log.error('could not execute createOffer', err)
+        throw new CodeError('Failed to set createOffer', 'ERR_SDP_HANDSHAKE_FAILED')
+      })
 
       log.trace('initiator send SDP offer %s', offerSdp.sdp)
 
@@ -117,7 +120,7 @@ export async function initiateConnection ({ peerConnection, signal, metrics, mul
       })
 
       if (answerMessage.type !== Message.Type.SDP_ANSWER) {
-        throw new CodeError('remote should send an SDP answer', 'ERR_SDP_HANDSHAKE_FAILED')
+        throw new CodeError('Remote should send an SDP answer', 'ERR_SDP_HANDSHAKE_FAILED')
       }
 
       log.trace('initiator receive SDP answer %s', answerMessage.data)

--- a/packages/transport-webrtc/test/peer.spec.ts
+++ b/packages/transport-webrtc/test/peer.spec.ts
@@ -214,7 +214,7 @@ describe('webrtc dialer', () => {
     const answer = await pc.createAnswer()
     await pc.setLocalDescription(answer)
 
-    await expect(initiatorPeerConnectionPromise).to.be.rejectedWith(/remote should send an SDP answer/)
+    await expect(initiatorPeerConnectionPromise).to.be.rejectedWith(/Remote should send an SDP answer/)
 
     pc.close()
   })


### PR DESCRIPTION
We catch WebRTC errors, log them and throw normalised errors to ensure they are the same across WebRTC stacks (FF, Chrome, node).

#2299 made one of these operations async which would cause an UHPR if thrown.


## Change checklist

- [x] I have performed a self-review of my own code
- [ ] I have made corresponding changes to the documentation if necessary (this includes comments as well)
- [ ] I have added tests that prove my fix is effective or that my feature works