### PR TITLE
fix: query for circuit relays after start

### DIFF
--- a/packages/transport-circuit-relay-v2/src/transport/discovery.ts
+++ b/packages/transport-circuit-relay-v2/src/transport/discovery.ts
@@ -59,12 +59,14 @@ export class RelayDiscovery extends TypedEventEmitter<RelayDiscoveryEvents> impl
       }
     })
 
+    this.started = true
+  }
+
+  afterStart (): void {
     void this.discover()
       .catch(err => {
         this.log.error('error listening on relays', err)
       })
-
-    this.started = true
   }
 
   stop (): void {

--- a/packages/transport-circuit-relay-v2/src/transport/discovery.ts
+++ b/packages/transport-circuit-relay-v2/src/transport/discovery.ts
@@ -65,7 +65,7 @@ export class RelayDiscovery extends TypedEventEmitter<RelayDiscoveryEvents> impl
   afterStart (): void {
     void this.discover()
       .catch(err => {
-        this.log.error('error listening on relays', err)
+        this.log.error('error discovering relays', err)
       })
   }
 

--- a/packages/transport-circuit-relay-v2/src/transport/reservation-store.ts
+++ b/packages/transport-circuit-relay-v2/src/transport/reservation-store.ts
@@ -115,11 +115,11 @@ export class ReservationStore extends TypedEventEmitter<ReservationStoreEvents> 
     return this.started
   }
 
-  async start (): Promise<void> {
+  start (): void {
     this.started = true
   }
 
-  async stop (): Promise<void> {
+  stop (): void {
     this.reserveQueue.clear()
     this.reservations.forEach(({ timeout }) => {
       clearTimeout(timeout)

--- a/packages/transport-circuit-relay-v2/src/transport/transport.ts
+++ b/packages/transport-circuit-relay-v2/src/transport/transport.ts
@@ -116,6 +116,8 @@ export class CircuitRelayTransport implements Transport {
       runOnTransientConnection: true
     })
 
+    await this.discovery?.start()
+
     this.started = true
   }
 

--- a/packages/transport-circuit-relay-v2/src/transport/transport.ts
+++ b/packages/transport-circuit-relay-v2/src/transport/transport.ts
@@ -103,8 +103,7 @@ export class CircuitRelayTransport implements Transport {
   }
 
   async start (): Promise<void> {
-    await this.reservationStore.start()
-    await this.discovery?.start()
+    this.reservationStore.start()
 
     await this.registrar.handle(RELAY_V2_STOP_CODEC, (data) => {
       void this.onStop(data).catch(err => {
@@ -120,9 +119,13 @@ export class CircuitRelayTransport implements Transport {
     this.started = true
   }
 
+  afterStart (): void {
+    this.discovery?.afterStart()
+  }
+
   async stop (): Promise<void> {
     this.discovery?.stop()
-    await this.reservationStore.stop()
+    this.reservationStore.stop()
     await this.registrar.unhandle(RELAY_V2_STOP_CODEC)
 
     this.started = false


### PR DESCRIPTION
This should be done in the `afterStart` method otherwise the DHT query manager may not have been started yet.

## Change checklist

- [x] I have performed a self-review of my own code
- [ ] I have made corresponding changes to the documentation if necessary (this includes comments as well)
- [ ] I have added tests that prove my fix is effective or that my feature works