### PR TITLE
fix: remove results map on job queue clear

### DIFF
--- a/packages/utils/src/peer-job-queue.ts
+++ b/packages/utils/src/peer-job-queue.ts
@@ -179,4 +179,9 @@ export class PeerJobQueue extends PQueue<PeerPriorityQueue, PeerPriorityQueueOpt
       }
     }, opts) as Promise<T>
   }
+
+  clear (): void {
+    this.results.clear()
+    super.clear()
+  }
 }


### PR DESCRIPTION
After clearing jobs, the results map should be empty.

## Change checklist

- [x] I have performed a self-review of my own code
- [ ] I have made corresponding changes to the documentation if necessary (this includes comments as well)
- [x] I have added tests that prove my fix is effective or that my feature works