### PR TITLE
fix: reset dial queue shut down controller on node restart

### DIFF
--- a/packages/integration-tests/test/lifecycle.spec.ts
+++ b/packages/integration-tests/test/lifecycle.spec.ts
@@ -1,0 +1,27 @@
+import { multiaddr } from '@multiformats/multiaddr'
+import { createLibp2p } from 'libp2p'
+import { createBaseOptions } from './fixtures/base-options.js'
+import type { Libp2p } from '@libp2p/interface'
+
+describe('lifecycle', () => {
+  let peer: Libp2p
+
+  afterEach(async () => {
+    await peer?.stop()
+  })
+
+  it('can dial a node after restarting', async () => {
+    const ma = multiaddr(process.env.RELAY_MULTIADDR)
+
+    peer = await createLibp2p(createBaseOptions())
+
+    await peer.dial(ma)
+
+    // stop and restart peer
+    await peer.stop()
+    await peer.start()
+
+    // once started, attempt to dial again
+    await peer.dial(ma)
+  })
+})

--- a/packages/libp2p/src/connection-manager/dial-queue.ts
+++ b/packages/libp2p/src/connection-manager/dial-queue.ts
@@ -73,7 +73,7 @@ export class DialQueue {
   private readonly dialTimeout: number
   private readonly inProgressDialCount?: Metric
   private readonly pendingDialCount?: Metric
-  private readonly shutDownController: AbortController
+  private shutDownController: AbortController
   private readonly connections: PeerMap<Connection[]>
   private readonly log: Logger
 
@@ -138,11 +138,16 @@ export class DialQueue {
     })
   }
 
+  start (): void {
+    this.shutDownController = new AbortController()
+  }
+
   /**
    * Clears any pending dials
    */
   stop (): void {
     this.shutDownController.abort()
+    this.queue.clear()
   }
 
   /**

--- a/packages/libp2p/src/connection-manager/index.ts
+++ b/packages/libp2p/src/connection-manager/index.ts
@@ -338,6 +338,7 @@ export class DefaultConnectionManager implements ConnectionManager, Startable {
       }
     })
 
+    this.dialQueue.start()
     this.autoDial.start()
 
     this.started = true


### PR DESCRIPTION
When a node is stopped and started we need to reset the dial queue shutdown controller otherwise every dial attempt after a restart will be rejected as the shutdown controller signal is still aborted.

Fixes #2188

## Change checklist

- [x] I have performed a self-review of my own code
- [ ] I have made corresponding changes to the documentation if necessary (this includes comments as well)
- [x] I have added tests that prove my fix is effective or that my feature works