### PR TITLE
docs: add note about persisting peer ids in the keychain

### DIFF
--- a/doc/migrations/v0.46-v1.0.0.md
+++ b/doc/migrations/v0.46-v1.0.0.md
@@ -20,6 +20,7 @@ A migration guide for refactoring your application code from libp2p `v0.46` to `
   - [Misc](#misc)
     - [KeyChain](#keychain)
   - [Pnet](#pnet)
+- [Keeping the same PeerId after a restart](#keeping-the-same-peerid-after-a-restart)
 - [Metrics](#metrics)
 - [Connection Manager](#connection-manager)
 
@@ -363,6 +364,52 @@ const node = await createLibp2p({
     psk: generateKey(new Uint8Array(95))
   })
 })
+```
+
+## Keeping the same PeerId after a restart
+
+The libp2p PeerId is a public/private keypair. libp2p uses the keychain to encrypt it at rest when the node is not running.
+
+As of `libp2p@1.0.0` the keychain is no longer part of the default bundle so to replicate this behaviour you need to use a temporary keychain instance to load the peer id from the datastore before starting your node.
+
+```TypeScript
+import { keychain, type KeychainInit } from '@libp2p/keychain'
+import { defaultLogger } from '@libp2p/logger'
+import { LevelDatastore } from 'datastore-level'
+import { createLibp2p } from 'libp2p'
+
+// the datastore should come from your config
+const datastore = new LevelDatastore('/path/to/db')
+// the keychain options should come from your config
+const keychainInit: KeychainInit = {
+  pass: 'very long, very secure password'
+}
+
+// if peerId is undefined, one will be generated
+let peerId: PeerId | undefined
+
+// try to load it from the keychain
+const chain = keychain(keychainInit)({
+  datastore,
+  logger: defaultLogger()
+})
+
+const selfKey = new Key('/pkcs8/self')
+
+if (await datastore.has(selfKey)) {
+  // load the peer id from the keychain
+  peerId = await chain.exportPeerId('self')
+}
+
+const node = await createLibp2p({
+  peerId,
+  // ... other options
+})
+
+if (peerId != null && !await datastore.has(selfKey)) {
+  // a new PeerId would have been generated so store it in the keychain for next time
+  await chain.importPeer('self', libp2p.peerId)
+}
 ```
 
 ## Metrics

--- a/doc/migrations/v0.46-v1.0.0.md
+++ b/doc/migrations/v0.46-v1.0.0.md
@@ -368,9 +368,9 @@ const node = await createLibp2p({
 
 ## Keeping the same PeerId after a restart
 
-The libp2p PeerId is a public/private keypair. libp2p uses the keychain to encrypt it at rest when the node is not running.
+The libp2p `PeerId` is a public/private keypair which is encrypted at rest by libp2p's `@libp2p/keychain` module.
 
-As of `libp2p@1.0.0` the keychain is no longer part of the default bundle so to replicate this behaviour you need to use a temporary keychain instance to load the peer id from the datastore before starting your node.
+As of `libp2p@1.0.0` the keychain is no longer part of the default bundle so to replicate this behaviour you need to use the `@libp2p/keychain` module to load a peer id from the datastore before starting your node.
 
 ```TypeScript
 import { keychain, type KeychainInit } from '@libp2p/keychain'


### PR DESCRIPTION
This was missed from the release notes.

## Change checklist

- [ ] I have performed a self-review of my own code
- [x] I have made corresponding changes to the documentation if necessary (this includes comments as well)
- [ ] I have added tests that prove my fix is effective or that my feature works