### PR TITLE
fix: make peerid optional in peerid.equals

### DIFF
--- a/packages/interface/src/peer-id/index.ts
+++ b/packages/interface/src/peer-id/index.ts
@@ -12,7 +12,7 @@ interface BasePeerId {
   toString(): string
   toCID(): CID
   toBytes(): Uint8Array
-  equals(other: PeerId | Uint8Array | string): boolean
+  equals(other?: PeerId | Uint8Array | string): boolean
 }
 
 export interface RSAPeerId extends BasePeerId {

--- a/packages/peer-id/src/index.ts
+++ b/packages/peer-id/src/index.ts
@@ -115,7 +115,11 @@ class PeerIdImpl {
   /**
    * Checks the equality of `this` peer against a given PeerId
    */
-  equals (id: PeerId | Uint8Array | string): boolean {
+  equals (id?: PeerId | Uint8Array | string): boolean {
+    if (id == null) {
+      return false
+    }
+
     if (id instanceof Uint8Array) {
       return uint8ArrayEquals(this.multihash.bytes, id)
     } else if (typeof id === 'string') {

--- a/packages/peer-id/test/index.spec.ts
+++ b/packages/peer-id/test/index.spec.ts
@@ -47,6 +47,18 @@ describe('PeerId', () => {
     expect(id.equals(peerIdFromBytes(buf))).to.be.true()
   })
 
+  it('equals nothing', async () => {
+    const buf = uint8ArrayFromString('12D3KooWbtp1AcgweFSArD7dbKWYpAr8MZR1tofwNwLFLjeNGLWa', 'base58btc')
+    const id = peerIdFromBytes(buf)
+    expect(id.equals()).to.be.false()
+  })
+
+  it('equals undefined', async () => {
+    const buf = uint8ArrayFromString('12D3KooWbtp1AcgweFSArD7dbKWYpAr8MZR1tofwNwLFLjeNGLWa', 'base58btc')
+    const id = peerIdFromBytes(buf)
+    expect(id.equals(undefined)).to.be.false()
+  })
+
   it('parses a PeerId as Ed25519', async () => {
     const id = peerIdFromString('12D3KooWbtp1AcgweFSArD7dbKWYpAr8MZR1tofwNwLFLjeNGLWa')
     expect(id).to.have.property('type', 'Ed25519')


### PR DESCRIPTION
This makes the code a bit more flexible, for example when taking action based on an optional peerid having been passed to a function when an existing peer id is known.

## Change checklist

- [x] I have performed a self-review of my own code
- [ ] I have made corresponding changes to the documentation if necessary (this includes comments as well)
- [x] I have added tests that prove my fix is effective or that my feature works