### PR TITLE
fix: ensure dht query is aborted on early exit

### DIFF
--- a/packages/kad-dht/package.json
+++ b/packages/kad-dht/package.json
@@ -87,6 +87,7 @@
     "private-ip": "^3.0.1",
     "progress-events": "^1.0.0",
     "protons-runtime": "^5.0.0",
+    "race-signal": "^1.0.2",
     "uint8-varint": "^2.0.0",
     "uint8arraylist": "^2.4.3",
     "uint8arrays": "^5.0.0"

--- a/packages/kad-dht/test/query.spec.ts
+++ b/packages/kad-dht/test/query.spec.ts
@@ -93,8 +93,6 @@ describe('QueryManager', () => {
 
   function createQueryFunction (topology: Topology): QueryFunc {
     const queryFunc: QueryFunc = async function * (context) {
-      context.signal.throwIfAborted()
-
       const { peer } = context
 
       const res = topology[peer.toString()]


### PR DESCRIPTION
If query results are consumed from a `for await..of`-style loop, and that loop is exited from before the results are complete, ensure we abort any running sub-queries.

## Change checklist

- [x] I have performed a self-review of my own code
- [ ] I have made corresponding changes to the documentation if necessary (this includes comments as well)
- [x] I have added tests that prove my fix is effective or that my feature works