### PR TITLE
fix: perform find peer during dial if peer has no multiaddrs

### DIFF
--- a/packages/libp2p/src/peer-routing.ts
+++ b/packages/libp2p/src/peer-routing.ts
@@ -22,7 +22,7 @@ export class DefaultPeerRouting implements PeerRouting {
   private readonly peerStore: PeerStore
   private readonly routers: PeerRouting[]
 
-  constructor (components: DefaultPeerRoutingComponents, init: PeerRoutingInit) {
+  constructor (components: DefaultPeerRoutingComponents, init: PeerRoutingInit = {}) {
     this.log = components.logger.forComponent('libp2p:peer-routing')
     this.peerId = components.peerId
     this.peerStore = components.peerStore
@@ -57,10 +57,12 @@ export class DefaultPeerRouting implements PeerRouting {
         continue
       }
 
-      // ensure we have the addresses for a given peer
-      await this.peerStore.merge(peer.id, {
-        multiaddrs: peer.multiaddrs
-      })
+      // store the addresses for the peer if found
+      if (peer.multiaddrs.length > 0) {
+        await this.peerStore.merge(peer.id, {
+          multiaddrs: peer.multiaddrs
+        })
+      }
 
       return peer
     }
@@ -105,21 +107,16 @@ export class DefaultPeerRouting implements PeerRouting {
         }
       }()
     )) {
-      // the peer was yielded by a content router without multiaddrs and we
-      // failed to load them
       if (peer == null) {
         continue
       }
 
-      // skip peers without addresses
-      if (peer.multiaddrs.length === 0) {
-        continue
+      // store the addresses for the peer if found
+      if (peer.multiaddrs.length > 0) {
+        await this.peerStore.merge(peer.id, {
+          multiaddrs: peer.multiaddrs
+        })
       }
-
-      // ensure we have the addresses for a given peer
-      await this.peerStore.merge(peer.id, {
-        multiaddrs: peer.multiaddrs
-      })
 
       // deduplicate peers
       if (seen.has(peer.id)) {

--- a/packages/libp2p/test/connection-manager/auto-dial.spec.ts
+++ b/packages/libp2p/test/connection-manager/auto-dial.spec.ts
@@ -16,7 +16,7 @@ import { fromString as uint8ArrayFromString } from 'uint8arrays/from-string'
 import { defaultComponents } from '../../src/components.js'
 import { AutoDial } from '../../src/connection-manager/auto-dial.js'
 import { LAST_DIAL_FAILURE_KEY } from '../../src/connection-manager/constants.js'
-import { matchPeerId } from '../fixtures/match-peer-id.js'
+import { matchPeerId } from '../fixtures/matchers.js'
 import type { ConnectionManager } from '@libp2p/interface-internal'
 
 describe('auto-dial', () => {

--- a/packages/libp2p/test/connection-manager/direct.node.ts
+++ b/packages/libp2p/test/connection-manager/direct.node.ts
@@ -31,6 +31,7 @@ import { DialQueue } from '../../src/connection-manager/dial-queue.js'
 import { DefaultConnectionManager } from '../../src/connection-manager/index.js'
 import { codes as ErrorCodes } from '../../src/errors.js'
 import { createLibp2pNode, type Libp2pNode } from '../../src/libp2p.js'
+import { DefaultPeerRouting } from '../../src/peer-routing.js'
 import { DefaultTransportManager } from '../../src/transport-manager.js'
 import { ECHO_PROTOCOL, echo } from '../fixtures/echo-service.js'
 import type { TransportManager } from '@libp2p/interface-internal'
@@ -75,6 +76,7 @@ describe('dialing (direct, TCP)', () => {
     remoteTM.add(tcp()({
       logger: defaultLogger()
     }))
+    remoteComponents.peerRouting = new DefaultPeerRouting(remoteComponents)
 
     const localEvents = new TypedEventEmitter()
     localComponents = defaultComponents({
@@ -92,6 +94,7 @@ describe('dialing (direct, TCP)', () => {
       inboundUpgradeTimeout: 1000
     })
     localComponents.addressManager = new DefaultAddressManager(localComponents)
+    localComponents.peerRouting = new DefaultPeerRouting(localComponents)
     localTM = localComponents.transportManager = new DefaultTransportManager(localComponents)
     localTM.add(tcp()({
       logger: defaultLogger()

--- a/packages/libp2p/test/connection-manager/index.spec.ts
+++ b/packages/libp2p/test/connection-manager/index.spec.ts
@@ -14,7 +14,7 @@ import { DefaultConnectionManager, type DefaultConnectionManagerComponents } fro
 import { createBaseOptions } from '../fixtures/base-options.browser.js'
 import { createNode } from '../fixtures/creators/peer.js'
 import type { Libp2pNode } from '../../src/libp2p.js'
-import type { AbortOptions, Connection, ConnectionGater, PeerId, PeerStore } from '@libp2p/interface'
+import type { AbortOptions, Connection, ConnectionGater, PeerId, PeerRouting, PeerStore } from '@libp2p/interface'
 import type { TransportManager } from '@libp2p/interface-internal'
 
 const defaultOptions = {
@@ -28,6 +28,7 @@ function defaultComponents (peerId: PeerId): DefaultConnectionManagerComponents 
   return {
     peerId,
     peerStore: stubInterface<PeerStore>(),
+    peerRouting: stubInterface<PeerRouting>(),
     transportManager: stubInterface<TransportManager>(),
     connectionGater: stubInterface<ConnectionGater>(),
     events: new TypedEventEmitter(),

--- a/packages/libp2p/test/fixtures/matchers.ts
+++ b/packages/libp2p/test/fixtures/matchers.ts
@@ -1,6 +1,11 @@
 import Sinon from 'sinon'
 import type { PeerId } from '@libp2p/interface'
+import type { Multiaddr } from '@multiformats/multiaddr'
 
 export function matchPeerId (peerId: PeerId): Sinon.SinonMatcher {
   return Sinon.match(p => p.toString() === peerId.toString())
+}
+
+export function matchMultiaddr (ma: Multiaddr): Sinon.SinonMatcher {
+  return Sinon.match(m => m.toString() === ma.toString())
 }

--- a/packages/libp2p/test/registrar/registrar.spec.ts
+++ b/packages/libp2p/test/registrar/registrar.spec.ts
@@ -17,7 +17,7 @@ import { type Components, defaultComponents } from '../../src/components.js'
 import { DefaultConnectionManager } from '../../src/connection-manager/index.js'
 import { createLibp2pNode, type Libp2pNode } from '../../src/libp2p.js'
 import { DefaultRegistrar } from '../../src/registrar.js'
-import { matchPeerId } from '../fixtures/match-peer-id.js'
+import { matchPeerId } from '../fixtures/matchers.js'
 import type { ConnectionManager, Registrar, TransportManager } from '@libp2p/interface-internal'
 
 const protocol = '/test/1.0.0'


### PR DESCRIPTION
A recent change to go-libp2p started yielding peers with no multiaddrs during DHT queries.

These peer ids have addresses that can be found during a find peer query but performing this query for every peer is expensive, so do the lookup only when dialing the peer.

## Change checklist

- [x] I have performed a self-review of my own code
- [ ] I have made corresponding changes to the documentation if necessary (this includes comments as well)
- [x] I have added tests that prove my fix is effective or that my feature works