### PR TITLE
docs: update dht readme

### DIFF
--- a/packages/kad-dht/README.md
+++ b/packages/kad-dht/README.md
@@ -45,7 +45,7 @@ const node = await createLibp2p({
   services: {
     aminoDHT: kadDHT({
       protocol: '/ipfs/kad/1.0.0',
-      addressFilter: removePrivateAddressesMapper
+      peerInfoMapper: removePrivateAddressesMapper
     })
   }
 })
@@ -71,7 +71,7 @@ const node = await createLibp2p({
   services: {
     lanDHT: kadDHT({
       protocol: '/ipfs/lan/kad/1.0.0',
-      addressFilter: removePublicAddressesMapper,
+      peerInfoMapper: removePublicAddressesMapper,
       clientMode: false
     })
   }

--- a/packages/kad-dht/src/index.ts
+++ b/packages/kad-dht/src/index.ts
@@ -39,7 +39,7 @@
  *   services: {
  *     aminoDHT: kadDHT({
  *       protocol: '/ipfs/kad/1.0.0',
- *       addressFilter: removePrivateAddressesMapper
+ *       peerInfoMapper: removePrivateAddressesMapper
  *     })
  *   }
  * })
@@ -65,7 +65,7 @@
  *   services: {
  *     lanDHT: kadDHT({
  *       protocol: '/ipfs/lan/kad/1.0.0',
- *       addressFilter: removePublicAddressesMapper,
+ *       peerInfoMapper: removePublicAddressesMapper,
  *       clientMode: false
  *     })
  *   }

--- a/packages/transport-tcp/README.md
+++ b/packages/transport-tcp/README.md
@@ -11,7 +11,7 @@ A [libp2p transport](https://docs.libp2p.io/concepts/transports/overview/) based
 
 ## Example
 
-```js
+```TypeScript
 import { tcp } from '@libp2p/tcp'
 import { multiaddr } from '@multiformats/multiaddr'
 import { pipe } from 'it-pipe'


### PR DESCRIPTION
The `addressFilter` init option should be `peerInfoMapper`

## Change checklist

- [ ] I have performed a self-review of my own code
- [x] I have made corresponding changes to the documentation if necessary (this includes comments as well)
- [ ] I have added tests that prove my fix is effective or that my feature works