### PR TITLE
fix: query routing for RSA public key

### DIFF
--- a/packages/libp2p/src/libp2p.ts
+++ b/packages/libp2p/src/libp2p.ts
@@ -311,10 +311,16 @@ export class Libp2pNode<T extends ServiceMap = Record<string, unknown>> extends 
       return peer.publicKey
     }
 
-    const peerInfo = await this.peerStore.get(peer)
+    try {
+      const peerInfo = await this.peerStore.get(peer)
 
-    if (peerInfo.id.publicKey != null) {
-      return peerInfo.id.publicKey
+      if (peerInfo.id.publicKey != null) {
+        return peerInfo.id.publicKey
+      }
+    } catch (err: any) {
+      if (err.code !== codes.ERR_NOT_FOUND) {
+        throw err
+      }
     }
 
     const peerKey = uint8ArrayConcat([
@@ -324,6 +330,7 @@ export class Libp2pNode<T extends ServiceMap = Record<string, unknown>> extends 
 
     // search any available content routing methods
     const bytes = await this.contentRouting.get(peerKey, options)
+
     // ensure the returned key is valid
     unmarshalPublicKey(bytes)
 


### PR DESCRIPTION
Updates the test to assert that the routing is, in fact, queried for a missing RSA public key.

## Change checklist

- [x] I have performed a self-review of my own code
- [ ] I have made corresponding changes to the documentation if necessary (this includes comments as well)
- [x] I have added tests that prove my fix is effective or that my feature works