### PR TITLE
fix: mark all packages side-effect free

### DIFF
--- a/packages/connection-encrypter-plaintext/package.json
+++ b/packages/connection-encrypter-plaintext/package.json
@@ -66,5 +66,6 @@
     "aegir": "^42.0.0",
     "protons": "^7.3.0",
     "sinon": "^17.0.1"
-  }
+  },
+  "sideEffects": false
 }

--- a/packages/crypto/package.json
+++ b/packages/crypto/package.json
@@ -106,5 +106,6 @@
     "./dist/src/keys/rsa.js": "./dist/src/keys/rsa-browser.js",
     "./dist/src/keys/secp256k1.js": "./dist/src/keys/secp256k1-browser.js",
     "./dist/src/webcrypto.js": "./dist/src/webcrypto-browser.js"
-  }
+  },
+  "sideEffects": false
 }

--- a/packages/interface-internal/package.json
+++ b/packages/interface-internal/package.json
@@ -54,5 +54,6 @@
   },
   "devDependencies": {
     "aegir": "^42.0.0"
-  }
+  },
+  "sideEffects": false
 }

--- a/packages/interface/package.json
+++ b/packages/interface/package.json
@@ -62,5 +62,6 @@
   },
   "react-native": {
     "./dist/src/events.js": "./dist/src/events.browser.js"
-  }
+  },
+  "sideEffects": false
 }

--- a/packages/kad-dht/package.json
+++ b/packages/kad-dht/package.json
@@ -119,5 +119,6 @@
   },
   "browser": {
     "./dist/src/routing-table/generated-prefix-list.js": "./dist/src/routing-table/generated-prefix-list-browser.js"
-  }
+  },
+  "sideEffects": false
 }

--- a/packages/keychain/package.json
+++ b/packages/keychain/package.json
@@ -72,5 +72,6 @@
     "@libp2p/peer-id-factory": "^4.0.4",
     "aegir": "^42.0.0",
     "datastore-core": "^9.1.1"
-  }
+  },
+  "sideEffects": false
 }

--- a/packages/libp2p/package.json
+++ b/packages/libp2p/package.json
@@ -138,5 +138,6 @@
   "react-native": {
     "./dist/src/connection-manager/constants.js": "./dist/src/connection-manager/constants.browser.js",
     "./dist/src/config/connection-gater.js": "./dist/src/config/connection-gater.browser.js"
-  }
+  },
+  "sideEffects": false
 }

--- a/packages/logger/package.json
+++ b/packages/logger/package.json
@@ -65,5 +65,6 @@
     "aegir": "^42.0.0",
     "sinon": "^17.0.1",
     "uint8arrays": "^5.0.0"
-  }
+  },
+  "sideEffects": false
 }

--- a/packages/metrics-prometheus/package.json
+++ b/packages/metrics-prometheus/package.json
@@ -62,5 +62,6 @@
     "it-drain": "^3.0.5",
     "it-pipe": "^3.0.1",
     "p-defer": "^4.0.0"
-  }
+  },
+  "sideEffects": false
 }

--- a/packages/multistream-select/package.json
+++ b/packages/multistream-select/package.json
@@ -76,5 +76,6 @@
     "it-pair": "^2.0.6",
     "it-pipe": "^3.0.1",
     "p-timeout": "^6.0.0"
-  }
+  },
+  "sideEffects": false
 }

--- a/packages/peer-collections/package.json
+++ b/packages/peer-collections/package.json
@@ -62,5 +62,6 @@
     "aegir": "^42.0.0",
     "sinon": "^17.0.1",
     "sinon-ts": "^2.0.0"
-  }
+  },
+  "sideEffects": false
 }

--- a/packages/peer-discovery-bootstrap/package.json
+++ b/packages/peer-discovery-bootstrap/package.json
@@ -63,5 +63,6 @@
     "@libp2p/logger": "^4.0.4",
     "aegir": "^42.0.0",
     "sinon-ts": "^2.0.0"
-  }
+  },
+  "sideEffects": false
 }

--- a/packages/peer-discovery-mdns/package.json
+++ b/packages/peer-discovery-mdns/package.json
@@ -65,5 +65,6 @@
     "aegir": "^42.0.0",
     "p-wait-for": "^5.0.2",
     "sinon-ts": "^2.0.0"
-  }
+  },
+  "sideEffects": false
 }

--- a/packages/peer-id-factory/package.json
+++ b/packages/peer-id-factory/package.json
@@ -68,5 +68,6 @@
     "aegir": "^42.0.0",
     "multiformats": "^13.0.0",
     "protons": "^7.3.0"
-  }
+  },
+  "sideEffects": false
 }

--- a/packages/peer-id/package.json
+++ b/packages/peer-id/package.json
@@ -59,5 +59,6 @@
   },
   "devDependencies": {
     "aegir": "^42.0.0"
-  }
+  },
+  "sideEffects": false
 }

--- a/packages/peer-record/package.json
+++ b/packages/peer-record/package.json
@@ -74,5 +74,6 @@
     "@libp2p/peer-id-factory": "^4.0.4",
     "aegir": "^42.0.0",
     "protons": "^7.3.0"
-  }
+  },
+  "sideEffects": false
 }

--- a/packages/peer-store/package.json
+++ b/packages/peer-store/package.json
@@ -82,5 +82,6 @@
     "p-event": "^6.0.0",
     "protons": "^7.3.0",
     "sinon": "^17.0.1"
-  }
+  },
+  "sideEffects": false
 }

--- a/packages/pnet/package.json
+++ b/packages/pnet/package.json
@@ -68,5 +68,6 @@
     "@types/xsalsa20": "^1.1.0",
     "aegir": "^42.0.0",
     "it-all": "^3.0.3"
-  }
+  },
+  "sideEffects": false
 }

--- a/packages/protocol-autonat/package.json
+++ b/packages/protocol-autonat/package.json
@@ -73,5 +73,6 @@
     "protons": "^7.3.0",
     "sinon": "^17.0.1",
     "sinon-ts": "^2.0.0"
-  }
+  },
+  "sideEffects": false
 }

--- a/packages/protocol-dcutr/package.json
+++ b/packages/protocol-dcutr/package.json
@@ -66,5 +66,6 @@
     "protons": "^7.3.0",
     "sinon": "^17.0.1",
     "sinon-ts": "^2.0.0"
-  }
+  },
+  "sideEffects": false
 }

--- a/packages/protocol-fetch/package.json
+++ b/packages/protocol-fetch/package.json
@@ -66,5 +66,6 @@
     "protons": "^7.3.0",
     "sinon": "^17.0.1",
     "sinon-ts": "^2.0.0"
-  }
+  },
+  "sideEffects": false
 }

--- a/packages/protocol-identify/package.json
+++ b/packages/protocol-identify/package.json
@@ -75,5 +75,6 @@
     "protons": "^7.3.0",
     "sinon": "^17.0.1",
     "sinon-ts": "^2.0.0"
-  }
+  },
+  "sideEffects": false
 }

--- a/packages/protocol-perf/package.json
+++ b/packages/protocol-perf/package.json
@@ -64,5 +64,6 @@
     "it-last": "^3.0.3",
     "it-pair": "^2.0.6",
     "sinon-ts": "^2.0.0"
-  }
+  },
+  "sideEffects": false
 }

--- a/packages/protocol-ping/package.json
+++ b/packages/protocol-ping/package.json
@@ -65,5 +65,6 @@
     "it-pair": "^2.0.6",
     "p-defer": "^4.0.0",
     "sinon-ts": "^2.0.0"
-  }
+  },
+  "sideEffects": false
 }

--- a/packages/pubsub-floodsub/package.json
+++ b/packages/pubsub-floodsub/package.json
@@ -77,5 +77,6 @@
     "p-wait-for": "^5.0.2",
     "protons": "^7.3.0",
     "sinon": "^17.0.1"
-  }
+  },
+  "sideEffects": false
 }

--- a/packages/pubsub/package.json
+++ b/packages/pubsub/package.json
@@ -109,5 +109,6 @@
     "protons": "^7.3.0",
     "protons-runtime": "^5.0.0",
     "sinon": "^17.0.1"
-  }
+  },
+  "sideEffects": false
 }

--- a/packages/stream-multiplexer-mplex/package.json
+++ b/packages/stream-multiplexer-mplex/package.json
@@ -85,5 +85,6 @@
     "it-pair": "^2.0.6",
     "p-defer": "^4.0.0",
     "random-int": "^3.0.0"
-  }
+  },
+  "sideEffects": false
 }

--- a/packages/transport-circuit-relay-v2/package.json
+++ b/packages/transport-circuit-relay-v2/package.json
@@ -84,5 +84,6 @@
     "race-signal": "^1.0.2",
     "sinon": "^17.0.1",
     "sinon-ts": "^2.0.0"
-  }
+  },
+  "sideEffects": false
 }

--- a/packages/transport-tcp/package.json
+++ b/packages/transport-tcp/package.json
@@ -71,5 +71,6 @@
     "p-defer": "^4.0.0",
     "sinon": "^17.0.1",
     "uint8arrays": "^5.0.0"
-  }
+  },
+  "sideEffects": false
 }

--- a/packages/transport-webrtc/package.json
+++ b/packages/transport-webrtc/package.json
@@ -101,5 +101,6 @@
   },
   "react-native": {
     "./dist/src/webrtc/index.js": "./dist/src/webrtc/index.react-native.js"
-  }
+  },
+  "sideEffects": false
 }

--- a/packages/transport-websockets/package.json
+++ b/packages/transport-websockets/package.json
@@ -100,5 +100,6 @@
   },
   "browser": {
     "./dist/src/listener.js": "./dist/src/listener.browser.js"
-  }
+  },
+  "sideEffects": false
 }

--- a/packages/transport-webtransport/package.json
+++ b/packages/transport-webtransport/package.json
@@ -71,5 +71,6 @@
   },
   "react-native": {
     "./dist/src/listener.js": "./dist/src/listener.browser.js"
-  }
+  },
+  "sideEffects": false
 }

--- a/packages/upnp-nat/package.json
+++ b/packages/upnp-nat/package.json
@@ -62,5 +62,6 @@
     "@libp2p/peer-id-factory": "^4.0.4",
     "aegir": "^42.0.0",
     "sinon-ts": "^2.0.0"
-  }
+  },
+  "sideEffects": false
 }

--- a/packages/utils/package.json
+++ b/packages/utils/package.json
@@ -149,5 +149,6 @@
     "sinon": "^17.0.1",
     "sinon-ts": "^2.0.0",
     "uint8arrays": "^5.0.0"
-  }
+  },
+  "sideEffects": false
 }


### PR DESCRIPTION
[Tree shaking](https://webpack.js.org/guides/tree-shaking/) results in smaller web bundles by deleting unused code.

Our modules are side-effect free so mark them as such to signal to bundlers that unused exports can be excluded from bundles.

## Change checklist

- [x] I have performed a self-review of my own code
- [ ] I have made corresponding changes to the documentation if necessary (this includes comments as well)
- [ ] I have added tests that prove my fix is effective or that my feature works