### PR TITLE
chore: temporarily disable interop tests

### DIFF
--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -172,37 +172,39 @@ jobs:
       - uses: ipfs/aegir/actions/cache-node-modules@master
       - run: npm run test:interop -- --bail
 
-  transport-interop:
-    needs: build
-    runs-on: ${{ fromJSON(github.repository == 'libp2p/js-libp2p' && '["self-hosted", "linux", "x64", "4xlarge"]' || '"ubuntu-latest"') }}
-    steps:
-      - uses: actions/checkout@v3
-      - uses: actions/setup-node@v3
-        with:
-          node-version: lts/*
-      - uses: ipfs/aegir/actions/cache-node-modules@master
-        with:
-          directories: |
-            ./interop/dist
-            ./interop/node_modules
-      - name: Build images
-        run: (cd interop && make -j 4)
-      - name: Save package-lock.json as artifact
-        uses: actions/upload-artifact@v2
-        with:
-          name: package locks
-          path: |
-            package-lock.json
-            interop/package-lock.json
-      - uses: libp2p/test-plans/.github/actions/run-interop-ping-test@master
-        with:
-          test-filter: js-libp2p-head
-          test-ignore: nim
-          extra-versions: ${{ github.workspace }}/interop/node-version.json ${{ github.workspace }}/interop/chromium-version.json ${{ github.workspace }}/interop/firefox-version.json
-          s3-cache-bucket: ${{ vars.S3_LIBP2P_BUILD_CACHE_BUCKET_NAME }}
-          s3-access-key-id: ${{ vars.S3_LIBP2P_BUILD_CACHE_AWS_ACCESS_KEY_ID }}
-          s3-secret-access-key: ${{ secrets.S3_LIBP2P_BUILD_CACHE_AWS_SECRET_ACCESS_KEY }}
-          worker-count: 16
+  # these are currently broken pending a rust upgrade
+  # https://github.com/libp2p/test-plans/issues/343
+  # transport-interop:
+  #   needs: build
+  #   runs-on: ${{ fromJSON(github.repository == 'libp2p/js-libp2p' && '["self-hosted", "linux", "x64", "4xlarge"]' || '"ubuntu-latest"') }}
+  #   steps:
+  #     - uses: actions/checkout@v3
+  #     - uses: actions/setup-node@v3
+  #       with:
+  #         node-version: lts/*
+  #     - uses: ipfs/aegir/actions/cache-node-modules@master
+  #       with:
+  #         directories: |
+  #           ./interop/dist
+  #           ./interop/node_modules
+  #     - name: Build images
+  #       run: (cd interop && make -j 4)
+  #     - name: Save package-lock.json as artifact
+  #       uses: actions/upload-artifact@v2
+  #       with:
+  #         name: package locks
+  #         path: |
+  #           package-lock.json
+  #           interop/package-lock.json
+  #     - uses: libp2p/test-plans/.github/actions/run-interop-ping-test@master
+  #       with:
+  #         test-filter: js-libp2p-head
+  #         test-ignore: nim
+  #         extra-versions: ${{ github.workspace }}/interop/node-version.json ${{ github.workspace }}/interop/chromium-version.json ${{ github.workspace }}/interop/firefox-version.json
+  #         s3-cache-bucket: ${{ vars.S3_LIBP2P_BUILD_CACHE_BUCKET_NAME }}
+  #         s3-access-key-id: ${{ vars.S3_LIBP2P_BUILD_CACHE_AWS_ACCESS_KEY_ID }}
+  #         s3-secret-access-key: ${{ secrets.S3_LIBP2P_BUILD_CACHE_AWS_SECRET_ACCESS_KEY }}
+  #         worker-count: 16
 
   release:
     runs-on: ubuntu-latest
@@ -214,8 +216,8 @@ jobs:
       test-firefox-webworker,
       test-electron-main,
       test-electron-renderer,
-      test-interop,
-      transport-interop
+      test-interop #,
+      #transport-interop
     ]
     if: github.event_name == 'push' && github.ref == 'refs/heads/main'
     permissions:


### PR DESCRIPTION
Disable tests until rust-libp2p builds again.

Refs: https://github.com/libp2p/test-plans/issues/343

## Change checklist

- [x] I have performed a self-review of my own code
- [ ] I have made corresponding changes to the documentation if necessary (this includes comments as well)
- [ ] I have added tests that prove my fix is effective or that my feature works