### PR TITLE
docs: migration guide -> missing import

### DIFF
--- a/doc/migrations/v0.46-v1.0.0.md
+++ b/doc/migrations/v0.46-v1.0.0.md
@@ -376,6 +376,7 @@ As of `libp2p@1.0.0` the keychain is no longer part of the default bundle so to 
 import { keychain, type KeychainInit } from '@libp2p/keychain'
 import { defaultLogger } from '@libp2p/logger'
 import { LevelDatastore } from 'datastore-level'
+import { Key } from 'interface-datastore/key'
 import { createLibp2p } from 'libp2p'
 
 // the datastore should come from your config
@@ -402,7 +403,7 @@ if (await datastore.has(selfKey)) {
 }
 
 const node = await createLibp2p({
-  peerId,
+  peerId
   // ... other options
 })
 


### PR DESCRIPTION
migration guide (specifically https://github.com/libp2p/js-libp2p/blob/c9ed1c7d62e9af974789eb753d6f8e3c6410df94/doc/migrations/v0.46-v1.0.0.md#keeping-the-same-peerid-after-a-restart) was missing an import for `Key`. This may not be the correct import, but appears to be what libp2p/keychain and others are using.

related: https://github.com/libp2p/js-libp2p/issues/2317 once the correct import is added.