### PR TITLE
fix: give send data a chance to complete before closing stream

### DIFF
--- a/packages/utils/src/abstract-stream.ts
+++ b/packages/utils/src/abstract-stream.ts
@@ -342,17 +342,10 @@ export abstract class AbstractStream implements Stream {
         await raceSignal(this.sendingData.promise, options.signal)
       }
 
-      // stop reading from the source passed to `.sink` in the microtask queue
-      // - this lets any data queued by the user in the current tick get read
-      // before we exit
-      await new Promise((resolve, reject) => {
-        queueMicrotask(() => {
-          this.log.trace('aborting source passed to .sink')
-          this.sinkController.abort()
-          raceSignal(this.sinkEnd.promise, options.signal)
-            .then(resolve, reject)
-        })
-      })
+      // stop reading from the source passed to `.sink`
+      this.log.trace('aborting source passed to .sink')
+      this.sinkController.abort()
+      await raceSignal(this.sinkEnd.promise, options.signal)
     }
 
     this.writeStatus = 'closed'

--- a/packages/utils/src/abstract-stream.ts
+++ b/packages/utils/src/abstract-stream.ts
@@ -182,7 +182,7 @@ export abstract class AbstractStream implements Stream {
 
           const res = this.sendData(data, options)
 
-          if (isPromise(res)) { // eslint-disable-line max-depth
+          if (isPromise(res)) {
             this.sendingData = pDefer()
             await res
             this.sendingData.resolve()


### PR DESCRIPTION
When gracefully closing a stream, allow the stream to send it's final data payload before aborting it.

## Change checklist

- [x] I have performed a self-review of my own code
- [ ] I have made corresponding changes to the documentation if necessary (this includes comments as well)
- [x] I have added tests that prove my fix is effective or that my feature works