### PR TITLE
docs: add links to finished RFCs to docs for peer-record

### DIFF
--- a/packages/peer-record/README.md
+++ b/packages/peer-record/README.md
@@ -15,7 +15,7 @@ Libp2p provides an all-purpose data container called **envelope**. It was create
 
 This envelope stores a marshaled record implementing the [interface-record](https://github.com/libp2p/js-libp2p-interfaces/tree/master/src/record). These Records are designed to be serialized to bytes and placed inside of the envelopes before being shared with other peers.
 
-You can read further about the envelope in [libp2p/specs#217](https://github.com/libp2p/specs/pull/217).
+You can read further about the envelope in [RFC 0002 - Signed Envelopes](https://github.com/libp2p/specs/blob/master/RFC/0002-signed-envelopes.md). For the original discussion about it you can look at the PR that was used to create it: [libp2p/specs#217](https://github.com/libp2p/specs/pull/217).
 
 ## Example
 
@@ -74,7 +74,7 @@ Libp2p peer records were created to enable the distribution of verifiable addres
 
 A peer record contains the peers' publicly reachable listen addresses, and may be extended in the future to contain additional metadata relevant to routing. It also contains a `seqNumber` field, a timestamp per the spec, so that we can verify the most recent record.
 
-You can read further about the Peer Record in [libp2p/specs#217](https://github.com/libp2p/specs/pull/217).
+You can read further about the Peer Record in [RFC 0003 - Peer Routing Records](https://github.com/libp2p/specs/blob/master/RFC/0003-routing-records.md). For the original discussion about it you can view the PR that created the RFC: [libp2p/specs#217](https://github.com/libp2p/specs/pull/217).
 
 ## Example
 


### PR DESCRIPTION
## Title
<!---
The title of the PR will be the commit message of the merge commit, so please make sure it is descriptive enough.
We utilize the Conventional Commits specification for our commit messages. See <https://www.conventionalcommits.org/en/v1.0.0/#specification> for more information.
The commit tag types can be of one of the following: feat, fix, deps, refactor, chore, docs. See <https://github.com/libp2p/js-libp2p/blob/master/.github/workflows/main.yml#L235-L242>
The title must also be fewer than 72 characters long or it will fail the Semantic PR check. See <https://github.com/libp2p/js-libp2p/blob/master/.github/workflows/semantic-pull-request.yml>
--->
docs: add links to finished RFCs to docs for peer-record

## Description
<!--
Please write a summary of your changes and why you made them.
Please include any relevant issues in here, for example:
Related https://github.com/libp2p/js-libp2p/issues/ABCD.
Fixes https://github.com/libp2p/js-libp2p/issues/XYZ.
-->
Update docs to link to actual RFCs and not just to PRs.
Fixes https://github.com/libp2p/js-libp2p/issues/2404

## Notes & open questions
As a newcomer, finding the docs was often confusing because many links are outdated, I am attempting to contribute a bit here by updating some outdated links as I find them.


## Change checklist

- [x] I have performed a self-review of my own code
- [x] I have made corresponding changes to the documentation if necessary (this includes comments as well)