### PR TITLE
docs: add note about webtransport only supporting dial

### DIFF
--- a/packages/transport-webtransport/README.md
+++ b/packages/transport-webtransport/README.md
@@ -9,6 +9,18 @@
 
 A [libp2p transport](https://docs.libp2p.io/concepts/transports/overview/) based on [WebTransport](https://www.w3.org/TR/webtransport/).
 
+>
+> ⚠️ **Note**
+>
+> This WebTransport implementation currently only allows dialing to other
+> nodes. It does not yet allow listening for incoming dials. This feature
+> requires QUIC support to land in Node JS first.
+>
+> QUIC support in Node JS is actively being worked on.
+> You can keep an eye on the progress by watching the
+> [related issues on the Node JS issue tracker](https://github.com/nodejs/node/labels/quic)
+>
+
 ## Example
 
 ```js


### PR DESCRIPTION
## Title
docs: add note about webtransport only supporting dial

## Description
This adds a note at the top of the WebTransport `README.md` to remind people of the fact that currently, the WebTransport implementation in js-libp2p only supports dialing out to other nodes and does not actually support listening for incoming dials because js-libp2p depends on Node JS and QUIC support has not landed in Node JS yet.

Related https://github.com/libp2p/js-libp2p/issues/2371

## Notes & open questions
-

## Change checklist

- [x] I have performed a self-review of my own code
- [x] I have made corresponding changes to the documentation if necessary (this includes comments as well)
