### PR TITLE
docs: add links to finished RFCs to docs for peer-record

### DIFF
--- a/packages/peer-record/src/index.ts
+++ b/packages/peer-record/src/index.ts
@@ -9,7 +9,7 @@
  *
  * This envelope stores a marshaled record implementing the [interface-record](https://github.com/libp2p/js-libp2p/blob/main/packages/interface/src/record/index.ts). These Records are designed to be serialized to bytes and placed inside of the envelopes before being shared with other peers.
  *
- * You can read further about the envelope in [libp2p/specs#217](https://github.com/libp2p/specs/pull/217).
+ * You can read further about the envelope in [RFC 0002 - Signed Envelopes](https://github.com/libp2p/specs/blob/master/RFC/0002-signed-envelopes.md). For the original discussion about it you can look at the PR that was used to create it: [libp2p/specs#217](https://github.com/libp2p/specs/pull/217).
  *
  * @example Creating a peer record
  *
@@ -68,7 +68,7 @@
  *
  * A peer record contains the peers' publicly reachable listen addresses, and may be extended in the future to contain additional metadata relevant to routing. It also contains a `seqNumber` field, a timestamp per the spec, so that we can verify the most recent record.
  *
- * You can read further about the Peer Record in [libp2p/specs#217](https://github.com/libp2p/specs/pull/217).
+ * You can read further about the Peer Record in [RFC 0003 - Peer Routing Records](https://github.com/libp2p/specs/blob/master/RFC/0003-routing-records.md). For the original discussion about it you can view the PR that created the RFC: [libp2p/specs#217](https://github.com/libp2p/specs/pull/217).
  *
  * @example
  *


### PR DESCRIPTION
## Title
**docs: add links to finished RFCs to docs for peer-record**

## Description
Update docs to link to actual RFCs and not just to PRs. 
Fixes https://github.com/libp2p/js-libp2p/issues/2404

## Change checklist

- [x] I have performed a self-review of my own code
- [x] I have made corresponding changes to the documentation if necessary (this includes comments as well)
