### PR TITLE
fix: silence max listeners warning

### DIFF
--- a/packages/interface/src/event-target.ts
+++ b/packages/interface/src/event-target.ts
@@ -1,3 +1,5 @@
+import { setMaxListeners } from './events.js'
+
 export interface EventCallback<EventType> { (evt: EventType): void }
 export interface EventObject<EventType> { handleEvent: EventCallback<EventType> }
 export type EventHandler<EventType> = EventCallback<EventType> | EventObject<EventType>
@@ -33,6 +35,14 @@ export interface TypedEventTarget <EventMap extends Record<string, any>> extends
  */
 export class TypedEventEmitter<EventMap extends Record<string, any>> extends EventTarget implements TypedEventTarget<EventMap> {
   #listeners = new Map<any, Listener[]>()
+
+  constructor () {
+    super()
+
+    // silence MaxListenersExceededWarning warning on Node.js, this is a red
+    // herring almost all of the time
+    setMaxListeners(Infinity, this)
+  }
 
   listenerCount (type: string): number {
     const listeners = this.#listeners.get(type)

--- a/packages/libp2p/src/connection-manager/dial-queue.ts
+++ b/packages/libp2p/src/connection-manager/dial-queue.ts
@@ -79,10 +79,9 @@ export class DialQueue {
     this.dialTimeout = init.dialTimeout ?? defaultOptions.dialTimeout
     this.connections = init.connections ?? new PeerMap()
     this.log = components.logger.forComponent('libp2p:connection-manager:dial-queue')
-
     this.components = components
-    this.shutDownController = new AbortController()
 
+    this.shutDownController = new AbortController()
     setMaxListeners(Infinity, this.shutDownController.signal)
 
     for (const [key, value] of Object.entries(init.resolvers ?? {})) {
@@ -103,6 +102,7 @@ export class DialQueue {
 
   start (): void {
     this.shutDownController = new AbortController()
+    setMaxListeners(Infinity, this.shutDownController.signal)
   }
 
   /**

--- a/packages/libp2p/src/upgrader.ts
+++ b/packages/libp2p/src/upgrader.ts
@@ -671,7 +671,7 @@ export class DefaultUpgrader implements Upgrader {
         throw new Error(`no crypto module found for ${protocol}`)
       }
 
-      connection.log('encrypting outbound connection to %p using %p', remotePeerId)
+      connection.log('encrypting outbound connection to %p using %s', remotePeerId, encrypter)
 
       return {
         ...await encrypter.secureOutbound(this.components.peerId, stream, remotePeerId),

--- a/packages/transport-websockets/test/compliance.node.ts
+++ b/packages/transport-websockets/test/compliance.node.ts
@@ -16,10 +16,10 @@ describe('interface-transport compliance', () => {
         logger: defaultLogger()
       })
       const addrs = [
-        multiaddr('/ip4/127.0.0.1/tcp/9091/ws'),
-        multiaddr('/ip4/127.0.0.1/tcp/9092/ws'),
-        multiaddr('/dns4/ipfs.io/tcp/9092/ws'),
-        multiaddr('/dns4/ipfs.io/tcp/9092/wss')
+        multiaddr('/ip4/127.0.0.1/tcp/9096/ws'),
+        multiaddr('/ip4/127.0.0.1/tcp/9097/ws'),
+        multiaddr('/dns4/ipfs.io/tcp/9098/ws'),
+        multiaddr('/dns4/ipfs.io/tcp/9099/wss')
       ]
 
       let delayMs = 0


### PR DESCRIPTION
When recreating the dial queue shutdown controller, we must also increase the number of listeners it can have, otherwise warnings are printed when there are more than 10 peers in the dial queue.

## Change checklist

- [x] I have performed a self-review of my own code
- [ ] I have made corresponding changes to the documentation if necessary (this includes comments as well)
- [ ] I have added tests that prove my fix is effective or that my feature works