### PR TITLE
fix: tcp server close race condition

### DIFF
--- a/packages/transport-tcp/src/listener.ts
+++ b/packages/transport-tcp/src/listener.ts
@@ -329,7 +329,7 @@ export class TCPListener extends TypedEventEmitter<ListenerEvents> implements Li
   async close (): Promise<void> {
     const err = new CodeError('Listener is closing', 'ERR_LISTENER_CLOSING')
 
-    // forcibly close each connection
+    // synchronously close each connection
     this.connections.forEach(conn => {
       conn.abort(err)
     })

--- a/packages/transport-tcp/src/listener.ts
+++ b/packages/transport-tcp/src/listener.ts
@@ -17,8 +17,9 @@ import type { Multiaddr } from '@multiformats/multiaddr'
 async function attemptClose (maConn: MultiaddrConnection, options: LoggerOptions): Promise<void> {
   try {
     await maConn.close()
-  } catch (err) {
+  } catch (err: any) {
     options.log.error('an error occurred closing the connection', err)
+    maConn.abort(err)
   }
 }
 

--- a/packages/transport-tcp/src/listener.ts
+++ b/packages/transport-tcp/src/listener.ts
@@ -1,5 +1,5 @@
 import net from 'net'
-import { CodeError, TypedEventEmitter, CustomEvent } from '@libp2p/interface'
+import { CodeError, TypedEventEmitter } from '@libp2p/interface'
 import { CODE_P2P } from './constants.js'
 import { toMultiaddrConnection } from './socket-to-conn.js'
 import {
@@ -23,10 +23,19 @@ async function attemptClose (maConn: MultiaddrConnection, options: LoggerOptions
 }
 
 export interface CloseServerOnMaxConnectionsOpts {
-  /** Server listens once connection count is less than `listenBelow` */
+  /**
+   * Server listens once connection count is less than `listenBelow`
+   */
   listenBelow: number
-  /** Close server once connection count is greater than or equal to `closeAbove` */
+
+  /**
+   * Close server once connection count is greater than or equal to `closeAbove`
+   */
   closeAbove: number
+
+  /**
+   * Invoked when there was an error listening on a socket
+   */
   onListenError?(err: Error): void
 }
 
@@ -50,8 +59,9 @@ export interface TCPListenerMetrics {
 
 enum TCPListenerStatusCode {
   /**
-   * When server object is initialized but we don't know the listening address yet or
-   * the server object is stopped manually, can be resumed only by calling listen()
+   * When server object is initialized but we don't know the listening address
+   * yet or the server object is stopped manually, can be resumed only by
+   * calling listen()
    **/
   INACTIVE = 0,
   ACTIVE = 1,
@@ -87,7 +97,8 @@ export class TCPListener extends TypedEventEmitter<ListenerEvents> implements Li
 
     // https://nodejs.org/api/net.html#servermaxconnections
     // If set reject connections when the server's connection count gets high
-    // Useful to prevent too resource exhaustion via many open connections on high bursts of activity
+    // Useful to prevent too resource exhaustion via many open connections on
+    // high bursts of activity
     if (context.maxConnections !== undefined) {
       this.server.maxConnections = context.maxConnections
     }
@@ -95,7 +106,7 @@ export class TCPListener extends TypedEventEmitter<ListenerEvents> implements Li
     if (context.closeServerOnMaxConnections != null) {
       // Sanity check options
       if (context.closeServerOnMaxConnections.closeAbove < context.closeServerOnMaxConnections.listenBelow) {
-        throw new CodeError('closeAbove must be >= listenBelow', 'ERROR_CONNECTION_LIMITS')
+        throw new CodeError('closeAbove must be >= listenBelow', 'ERR_CONNECTION_LIMITS')
       }
     }
 
@@ -144,22 +155,23 @@ export class TCPListener extends TypedEventEmitter<ListenerEvents> implements Li
           })
         }
 
-        this.dispatchEvent(new CustomEvent('listening'))
+        this.safeDispatchEvent('listening')
       })
       .on('error', err => {
         this.metrics?.errors.increment({ [`${this.addr} listen_error`]: true })
-        this.dispatchEvent(new CustomEvent<Error>('error', { detail: err }))
+        this.safeDispatchEvent('error', { detail: err })
       })
       .on('close', () => {
         this.metrics?.status.update({
           [this.addr]: this.status.code
         })
 
-        // If this event is emitted, the transport manager will remove the listener from it's cache
-        // in the meanwhile if the connections are dropped then listener will start listening again
-        // and the transport manager will not be able to close the server
+        // If this event is emitted, the transport manager will remove the
+        // listener from it's cache in the meanwhile if the connections are
+        // dropped then listener will start listening again and the transport
+        // manager will not be able to close the server
         if (this.status.code !== TCPListenerStatusCode.PAUSED) {
-          this.dispatchEvent(new CustomEvent('close'))
+          this.safeDispatchEvent('close')
         }
       })
   }
@@ -191,6 +203,7 @@ export class TCPListener extends TypedEventEmitter<ListenerEvents> implements Li
     }
 
     this.log('new inbound connection %s', maConn.remoteAddr)
+
     try {
       this.context.upgrader.upgradeInbound(maConn)
         .then((conn) => {
@@ -204,10 +217,12 @@ export class TCPListener extends TypedEventEmitter<ListenerEvents> implements Li
               this.context.closeServerOnMaxConnections != null &&
               this.connections.size < this.context.closeServerOnMaxConnections.listenBelow
             ) {
-              // The most likely case of error is if the port taken by this application is binded by
-              // another process during the time the server if closed. In that case there's not much
-              // we can do. resume() will be called again every time a connection is dropped, which
-              // acts as an eventual retry mechanism. onListenError allows the consumer act on this.
+              // The most likely case of error is if the port taken by this
+              // application is bound by another process during the time the
+              // server if closed. In that case there's not much we can do.
+              // resume() will be called again every time a connection is
+              // dropped, which acts as an eventual retry mechanism.
+              // onListenError allows the consumer act on this.
               this.resume().catch(e => {
                 this.log.error('error attempting to listen server once connection count under limit', e)
                 this.context.closeServerOnMaxConnections?.onListenError?.(e as Error)
@@ -228,7 +243,7 @@ export class TCPListener extends TypedEventEmitter<ListenerEvents> implements Li
             })
           }
 
-          this.dispatchEvent(new CustomEvent<Connection>('connection', { detail: conn }))
+          this.safeDispatchEvent('connection', { detail: conn })
         })
         .catch(async err => {
           this.log.error('inbound connection failed', err)
@@ -311,14 +326,17 @@ export class TCPListener extends TypedEventEmitter<ListenerEvents> implements Li
   }
 
   async close (): Promise<void> {
-    // Close connections and server the same time to avoid any race condition
     await Promise.all([
-      Promise.all(Array.from(this.connections.values()).map(async maConn => attemptClose(maConn, {
-        log: this.log
-      }))),
-      this.pause(true).catch(e => {
-        this.log.error('error attempting to close server once connection count over limit', e)
-      })
+      // close the server - n.b. the non-async portion of this happens before
+      // we try to close connections so `this.status` is updated and the 'close'
+      // event can be emitted for each listener
+      this.pause(true),
+
+      // close connections
+      ...Array.from(this.connections.values())
+        .map(async maConn => attemptClose(maConn, {
+          log: this.log
+        }))
     ])
   }
 
@@ -333,13 +351,14 @@ export class TCPListener extends TypedEventEmitter<ListenerEvents> implements Li
     const netConfig = this.status.netConfig
 
     await new Promise<void>((resolve, reject) => {
-      // NOTE: 'listening' event is only fired on success. Any error such as port already binded, is emitted via 'error'
+      // NOTE: 'listening' event is only fired on success. Any error such as
+      // port already bound, is emitted via 'error'
       this.server.once('error', reject)
       this.server.listen(netConfig, resolve)
     })
 
     this.status = { ...this.status, code: TCPListenerStatusCode.ACTIVE }
-    this.log('Listening on %s', this.server.address())
+    this.log('listening on %s', this.server.address())
   }
 
   private async pause (permanent: boolean): Promise<void> {
@@ -352,7 +371,7 @@ export class TCPListener extends TypedEventEmitter<ListenerEvents> implements Li
       return
     }
 
-    this.log('Closing server on %s', this.server.address())
+    this.log('closing server on %s', this.server.address())
 
     // NodeJS implementation tracks listening status with `this._handle` property.
     // - Server.close() sets this._handle to null immediately. If this._handle is null, ERR_SERVER_NOT_RUNNING is thrown
@@ -370,8 +389,16 @@ export class TCPListener extends TypedEventEmitter<ListenerEvents> implements Li
     // We need to set this status before closing server, so other procedures are aware
     // during the time the server is closing
     this.status = permanent ? { code: TCPListenerStatusCode.INACTIVE } : { ...this.status, code: TCPListenerStatusCode.PAUSED }
+
     await new Promise<void>((resolve, reject) => {
-      this.server.close(err => { (err != null) ? reject(err) : resolve() })
+      this.server.close(err => {
+        if (err != null) {
+          reject(err)
+          return
+        }
+
+        resolve()
+      })
     })
   }
 }

--- a/packages/transport-tcp/src/socket-to-conn.ts
+++ b/packages/transport-tcp/src/socket-to-conn.ts
@@ -153,6 +153,7 @@ export const toMultiaddrConnection = (socket: Socket, options: ToConnectionOptio
           socket.once('close', () => {
             // socket completely closed
             log('%s socket closed', lOptsStr)
+
             resolve()
           })
           socket.once('error', (err: Error) => {
@@ -196,6 +197,10 @@ export const toMultiaddrConnection = (socket: Socket, options: ToConnectionOptio
       log('%s socket abort due to error', lOptsStr, err)
 
       socket.destroy(err)
+
+      if (maConn.timeline.close == null) {
+        maConn.timeline.close = Date.now()
+      }
     },
 
     log

--- a/packages/transport-tcp/src/socket-to-conn.ts
+++ b/packages/transport-tcp/src/socket-to-conn.ts
@@ -141,6 +141,12 @@ export const toMultiaddrConnection = (socket: Socket, options: ToConnectionOptio
         }
       }
 
+      const abortSignalListener = (): void => {
+        socket.destroy(new CodeError('Destroying socket after timeout', 'ERR_CLOSE_TIMEOUT'))
+      }
+
+      options.signal?.addEventListener('abort', abortSignalListener)
+
       try {
         log('%s closing socket', lOptsStr)
         await new Promise<void>((resolve, reject) => {
@@ -181,6 +187,8 @@ export const toMultiaddrConnection = (socket: Socket, options: ToConnectionOptio
         })
       } catch (err: any) {
         this.abort(err)
+      } finally {
+        options.signal?.removeEventListener('abort', abortSignalListener)
       }
     },
 

--- a/packages/transport-tcp/test/socket-to-conn.spec.ts
+++ b/packages/transport-tcp/test/socket-to-conn.spec.ts
@@ -418,7 +418,7 @@ describe('socket-to-conn', () => {
     await expect(serverClosed.promise).to.eventually.be.true()
 
     // remote didn't read our data
-    await expect(serverErrored.promise).to.eventually.have.property('code', 'ERR_SOCKET_READ_TIMEOUT')
+    await expect(serverErrored.promise).to.eventually.have.property('code', 'ERR_CLOSE_TIMEOUT')
 
     // the connection closing was recorded
     expect(inboundMaConn.timeline.close).to.be.a('number')

--- a/packages/transport-websockets/test/compliance.node.ts
+++ b/packages/transport-websockets/test/compliance.node.ts
@@ -16,10 +16,10 @@ describe('interface-transport compliance', () => {
         logger: defaultLogger()
       })
       const addrs = [
-        multiaddr('/ip4/127.0.0.1/tcp/9096/ws'),
-        multiaddr('/ip4/127.0.0.1/tcp/9097/ws'),
-        multiaddr('/dns4/ipfs.io/tcp/9098/ws'),
-        multiaddr('/dns4/ipfs.io/tcp/9099/wss')
+        multiaddr('/ip4/127.0.0.1/tcp/9091/ws'),
+        multiaddr('/ip4/127.0.0.1/tcp/9092/ws'),
+        multiaddr('/dns4/ipfs.io/tcp/9092/ws'),
+        multiaddr('/dns4/ipfs.io/tcp/9092/wss')
       ]
 
       let delayMs = 0

--- a/packages/transport-websockets/test/compliance.node.ts
+++ b/packages/transport-websockets/test/compliance.node.ts
@@ -16,10 +16,10 @@ describe('interface-transport compliance', () => {
         logger: defaultLogger()
       })
       const addrs = [
-        multiaddr('/ip4/127.0.0.1/tcp/9091/ws'),
-        multiaddr('/ip4/127.0.0.1/tcp/9092/ws'),
-        multiaddr('/dns4/ipfs.io/tcp/9092/ws'),
-        multiaddr('/dns4/ipfs.io/tcp/9092/wss')
+        multiaddr('/ip4/127.0.0.1/tcp/9096/ws'),
+        multiaddr('/ip4/127.0.0.1/tcp/9097/ws'),
+        multiaddr('/dns4/ipfs.io/tcp/9097/ws'),
+        multiaddr('/dns4/ipfs.io/tcp/9097/wss')
       ]
 
       let delayMs = 0


### PR DESCRIPTION
Fixes a race condition introduced by https://github.com/libp2p/js-libp2p/pull/2058

By starting to closing connections before starting to close the server, on a slow machine or one under load it's possible for a connection to close before the server status is set to `INACTIVE`, then the listener will never emit it's `'close'` event and the node will not shut down.

Also has edits for style & consistency.

## Change checklist

- [x] I have performed a self-review of my own code
- [ ] I have made corresponding changes to the documentation if necessary (this includes comments as well)
- [ ] I have added tests that prove my fix is effective or that my feature works