### PR TITLE
chore: lock go version to 1.20

### DIFF
--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -62,6 +62,10 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@v3
+      # needed for webtransport tests, remove after https://github.com/libp2p/js-libp2p/pull/2422
+      - uses: actions/setup-go@0c52d547c9bc32b1aa3301fd7a9cb496313a4491 # v5.0.0
+        with:
+          go-version: 1.20
       - uses: actions/setup-node@v3
         with:
           node-version: lts/*
@@ -78,6 +82,10 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@v3
+      # needed for webtransport tests, remove after https://github.com/libp2p/js-libp2p/pull/2422
+      - uses: actions/setup-go@0c52d547c9bc32b1aa3301fd7a9cb496313a4491 # v5.0.0
+        with:
+          go-version: 1.20
       - uses: actions/setup-node@v3
         with:
           node-version: lts/*

--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -65,7 +65,7 @@ jobs:
       # needed for webtransport tests, remove after https://github.com/libp2p/js-libp2p/pull/2422
       - uses: actions/setup-go@0c52d547c9bc32b1aa3301fd7a9cb496313a4491 # v5.0.0
         with:
-          go-version: 1.20
+          go-version: '1.20'
       - uses: actions/setup-node@v3
         with:
           node-version: lts/*
@@ -85,7 +85,7 @@ jobs:
       # needed for webtransport tests, remove after https://github.com/libp2p/js-libp2p/pull/2422
       - uses: actions/setup-go@0c52d547c9bc32b1aa3301fd7a9cb496313a4491 # v5.0.0
         with:
-          go-version: 1.20
+          go-version: '1.20'
       - uses: actions/setup-node@v3
         with:
           node-version: lts/*


### PR DESCRIPTION
Install a specific version of go because sometimes quic-go isn't buildable on the latest release.

## Change checklist

- [x] I have performed a self-review of my own code
- [ ] I have made corresponding changes to the documentation if necessary (this includes comments as well)
- [ ] I have added tests that prove my fix is effective or that my feature works