### PR TITLE
fix: typescript enums need to be value-compatible

### DIFF
--- a/packages/kad-dht/src/index.ts
+++ b/packages/kad-dht/src/index.ts
@@ -81,6 +81,7 @@
  */
 
 import { KadDHT as KadDHTClass } from './kad-dht.js'
+import { MessageType } from './message/dht.js'
 import { removePrivateAddressesMapper, removePublicAddressesMapper, passthroughMapper } from './utils.js'
 import type { ProvidersInit } from './providers.js'
 import type { Libp2pEvents, ComponentLogger, TypedEventTarget, Metrics, PeerId, PeerInfo, PeerStore, RoutingOptions } from '@libp2p/interface'
@@ -109,14 +110,7 @@ export enum EventTypes {
 /**
  * The types of messages sent to peers during DHT queries
  */
-export enum MessageType {
-  PUT_VALUE = 0,
-  GET_VALUE,
-  ADD_PROVIDER,
-  GET_PROVIDERS,
-  FIND_NODE,
-  PING
-}
+export { MessageType }
 
 export type MessageName = keyof typeof MessageType
 

--- a/packages/kad-dht/src/query/events.ts
+++ b/packages/kad-dht/src/query/events.ts
@@ -1,13 +1,12 @@
 import { CustomEvent } from '@libp2p/interface'
-import type { SendQueryEvent, PeerResponseEvent, DialPeerEvent, AddPeerEvent, ValueEvent, ProviderEvent, QueryErrorEvent, FinalPeerEvent } from '../index.js'
-import type { MessageType as PbMessageType } from '../message/dht.js'
+import type { MessageType, SendQueryEvent, PeerResponseEvent, DialPeerEvent, AddPeerEvent, ValueEvent, ProviderEvent, QueryErrorEvent, FinalPeerEvent } from '../index.js'
 import type { Libp2pRecord } from '../record/index.js'
 import type { PeerId, PeerInfo } from '@libp2p/interface'
 import type { ProgressOptions } from 'progress-events'
 
 export interface QueryEventFields {
   to: PeerId
-  type: PbMessageType
+  type: MessageType
 }
 
 export function sendQueryEvent (fields: QueryEventFields, options: ProgressOptions = {}): SendQueryEvent {
@@ -26,7 +25,7 @@ export function sendQueryEvent (fields: QueryEventFields, options: ProgressOptio
 
 export interface PeerResponseEventFields {
   from: PeerId
-  messageType: PbMessageType
+  messageType: MessageType
   closer?: PeerInfo[]
   providers?: PeerInfo[]
   record?: Libp2pRecord

--- a/packages/kad-dht/src/query/events.ts
+++ b/packages/kad-dht/src/query/events.ts
@@ -1,13 +1,13 @@
 import { CustomEvent } from '@libp2p/interface'
-import { MessageType } from '../message/dht.js'
 import type { SendQueryEvent, PeerResponseEvent, DialPeerEvent, AddPeerEvent, ValueEvent, ProviderEvent, QueryErrorEvent, FinalPeerEvent } from '../index.js'
+import type { MessageType as PbMessageType } from '../message/dht.js'
 import type { Libp2pRecord } from '../record/index.js'
 import type { PeerId, PeerInfo } from '@libp2p/interface'
 import type { ProgressOptions } from 'progress-events'
 
 export interface QueryEventFields {
   to: PeerId
-  type: MessageType
+  type: PbMessageType
 }
 
 export function sendQueryEvent (fields: QueryEventFields, options: ProgressOptions = {}): SendQueryEvent {
@@ -16,7 +16,7 @@ export function sendQueryEvent (fields: QueryEventFields, options: ProgressOptio
     name: 'SEND_QUERY',
     type: 0,
     messageName: fields.type,
-    messageType: MessageType[fields.type]
+    messageType: fields.type
   }
 
   options.onProgress?.(new CustomEvent('kad-dht:query:send-query', { detail: event }))
@@ -24,15 +24,15 @@ export function sendQueryEvent (fields: QueryEventFields, options: ProgressOptio
   return event
 }
 
-export interface PeerResponseEventField {
+export interface PeerResponseEventFields {
   from: PeerId
-  messageType: MessageType
+  messageType: PbMessageType
   closer?: PeerInfo[]
   providers?: PeerInfo[]
   record?: Libp2pRecord
 }
 
-export function peerResponseEvent (fields: PeerResponseEventField, options: ProgressOptions = {}): PeerResponseEvent {
+export function peerResponseEvent (fields: PeerResponseEventFields, options: ProgressOptions = {}): PeerResponseEvent {
   const event: PeerResponseEvent = {
     ...fields,
     name: 'PEER_RESPONSE',

--- a/packages/kad-dht/test/kad-dht.spec.ts
+++ b/packages/kad-dht/test/kad-dht.spec.ts
@@ -15,7 +15,7 @@ import sinon from 'sinon'
 import { equals as uint8ArrayEquals } from 'uint8arrays/equals'
 import { fromString as uint8ArrayFromString } from 'uint8arrays/from-string'
 import * as c from '../src/constants.js'
-import { EventTypes, type FinalPeerEvent, MessageType, type QueryEvent, type ValueEvent } from '../src/index.js'
+import { EventTypes, type FinalPeerEvent, type QueryEvent, type ValueEvent } from '../src/index.js'
 import { MessageType as PBMessageType } from '../src/message/dht.js'
 import { peerResponseEvent } from '../src/query/events.js'
 import { Libp2pRecord } from '../src/record/index.js'
@@ -431,7 +431,7 @@ describe('KadDHT', () => {
       // Simulate going out to the network and returning the record
       sinon.stub(dht.peerRouting, 'getValueOrPeers').callsFake(async function * (peer) {
         yield peerResponseEvent({
-          messageType: MessageType.GET_VALUE,
+          messageType: PBMessageType.GET_VALUE,
           from: peer,
           record: rec
         })

--- a/packages/kad-dht/test/kad-dht.spec.ts
+++ b/packages/kad-dht/test/kad-dht.spec.ts
@@ -15,8 +15,7 @@ import sinon from 'sinon'
 import { equals as uint8ArrayEquals } from 'uint8arrays/equals'
 import { fromString as uint8ArrayFromString } from 'uint8arrays/from-string'
 import * as c from '../src/constants.js'
-import { EventTypes, type FinalPeerEvent, type QueryEvent, type ValueEvent } from '../src/index.js'
-import { MessageType as PBMessageType } from '../src/message/dht.js'
+import { EventTypes, MessageType } from '../src/index.js'
 import { peerResponseEvent } from '../src/query/events.js'
 import { Libp2pRecord } from '../src/record/index.js'
 import * as kadUtils from '../src/utils.js'
@@ -25,6 +24,7 @@ import { createValues } from './utils/create-values.js'
 import { countDiffPeers } from './utils/index.js'
 import { sortClosestPeers } from './utils/sort-closest-peers.js'
 import { TestDHT } from './utils/test-dht.js'
+import type { FinalPeerEvent, QueryEvent, ValueEvent } from '../src/index.js'
 import type { KadDHT } from '../src/kad-dht.js'
 import type { PeerId } from '@libp2p/interface'
 import type { CID } from 'multiformats/cid'
@@ -431,7 +431,7 @@ describe('KadDHT', () => {
       // Simulate going out to the network and returning the record
       sinon.stub(dht.peerRouting, 'getValueOrPeers').callsFake(async function * (peer) {
         yield peerResponseEvent({
-          messageType: PBMessageType.GET_VALUE,
+          messageType: MessageType.GET_VALUE,
           from: peer,
           record: rec
         })
@@ -475,7 +475,7 @@ describe('KadDHT', () => {
 
       for (const [peerId, msg] of calls) {
         expect(idsB58).includes(peerId.toString())
-        expect(msg.type).equals(PBMessageType.ADD_PROVIDER)
+        expect(msg.type).equals(MessageType.ADD_PROVIDER)
         expect(valuesBuffs).includes(msg.key)
         expect(msg.providers.length).equals(1)
         expect(peerIdFromBytes(msg.providers[0].id).toString()).equals(idsB58[3])


### PR DESCRIPTION
As of TypeScript 5.4.x enums need to have the same values to be compatible so re-use the exported enum from the message definition.

Refs: https://devblogs.microsoft.com/typescript/announcing-typescript-5-4/#new-enum-assignability-restrictions

## Change checklist

- [x] I have performed a self-review of my own code
- [ ] I have made corresponding changes to the documentation if necessary (this includes comments as well)
- [ ] I have added tests that prove my fix is effective or that my feature works