### PR TITLE
feat: add simple echo protocol

### DIFF
--- a/packages/protocol-echo/LICENSE
+++ b/packages/protocol-echo/LICENSE
@@ -1,0 +1,4 @@
+This project is dual licensed under MIT and Apache-2.0.
+
+MIT: https://www.opensource.org/licenses/mit
+Apache-2.0: https://www.apache.org/licenses/license-2.0

--- a/packages/protocol-echo/LICENSE-APACHE
+++ b/packages/protocol-echo/LICENSE-APACHE
@@ -1,0 +1,5 @@
+Licensed under the Apache License, Version 2.0 (the "License"); you may not use this file except in compliance with the License. You may obtain a copy of the License at
+
+http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software distributed under the License is distributed on an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the License for the specific language governing permissions and limitations under the License.

--- a/packages/protocol-echo/LICENSE-MIT
+++ b/packages/protocol-echo/LICENSE-MIT
@@ -1,0 +1,19 @@
+The MIT License (MIT)
+
+Permission is hereby granted, free of charge, to any person obtaining a copy
+of this software and associated documentation files (the "Software"), to deal
+in the Software without restriction, including without limitation the rights
+to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+copies of the Software, and to permit persons to whom the Software is
+furnished to do so, subject to the following conditions:
+
+The above copyright notice and this permission notice shall be included in
+all copies or substantial portions of the Software.
+
+THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN
+THE SOFTWARE.

--- a/packages/protocol-echo/README.md
+++ b/packages/protocol-echo/README.md
@@ -1,0 +1,94 @@
+# @libp2p/echo
+
+[![libp2p.io](https://img.shields.io/badge/project-libp2p-yellow.svg?style=flat-square)](http://libp2p.io/)
+[![Discuss](https://img.shields.io/discourse/https/discuss.libp2p.io/posts.svg?style=flat-square)](https://discuss.libp2p.io)
+[![codecov](https://img.shields.io/codecov/c/github/libp2p/js-libp2p.svg?style=flat-square)](https://codecov.io/gh/libp2p/js-libp2p)
+[![CI](https://img.shields.io/github/actions/workflow/status/libp2p/js-libp2p/main.yml?branch=main\&style=flat-square)](https://github.com/libp2p/js-libp2p/actions/workflows/main.yml?query=branch%3Amain)
+
+> Implementation of an Echo protocol
+
+# About
+
+<!--
+
+!IMPORTANT!
+
+Everything in this README between "# About" and "# Install" is automatically
+generated and will be overwritten the next time the doc generator is run.
+
+To make changes to this section, please update the @packageDocumentation section
+of src/index.js or src/index.ts
+
+To experiment with formatting, please run "npm run docs" from the root of this
+repo and examine the changes made.
+
+-->
+
+An implementation of a simple Echo protocol.
+
+Any data received by the receiver will be sent back to the sender.
+
+## Example
+
+```TypeScript
+import { noise } from '@chainsafe/libp2p-noise'
+import { yamux } from '@chainsafe/libp2p-yamux'
+import { echo } from '@libp2p/echo'
+import { peerIdFromString } from '@libp2p/peer-id'
+import { createLibp2p } from 'libp2p'
+
+const receiver = await createLibp2p({
+  addresses: {
+    listen: ['/ip4/0.0.0.0/tcp/0']
+  },
+  connectionEncryption: [noise()],
+  streamMuxers: [yamux()],
+  services: {
+    echo: echo()
+  }
+})
+
+const sender = await createLibp2p({
+  addresses: {
+    listen: ['/ip4/0.0.0.0/tcp/0']
+  },
+  connectionEncryption: [noise()],
+  streamMuxers: [yamux()],
+  services: {
+    echo: echo()
+  }
+})
+
+const stream = await sender.dialProtocol(receiver.getMultiaddrs(), sender.services.echo.protocol)
+
+// write/read stream
+```
+
+# Install
+
+```console
+$ npm i @libp2p/echo
+```
+
+## Browser `<script>` tag
+
+Loading this module through a script tag will make it's exports available as `Libp2pEcho` in the global namespace.
+
+```html
+<script src="https://unpkg.com/@libp2p/echo/dist/index.min.js"></script>
+```
+
+# API Docs
+
+- <https://libp2p.github.io/js-libp2p/modules/_libp2p_echo.html>
+
+# License
+
+Licensed under either of
+
+- Apache 2.0, ([LICENSE-APACHE](LICENSE-APACHE) / <http://www.apache.org/licenses/LICENSE-2.0>)
+- MIT ([LICENSE-MIT](LICENSE-MIT) / <http://opensource.org/licenses/MIT>)
+
+# Contribution
+
+Unless you explicitly state otherwise, any contribution intentionally submitted for inclusion in the work by you, as defined in the Apache-2.0 license, shall be dual licensed as above, without any additional terms or conditions.

--- a/packages/protocol-echo/package.json
+++ b/packages/protocol-echo/package.json
@@ -1,0 +1,69 @@
+{
+  "name": "@libp2p/echo",
+  "version": "0.0.0",
+  "description": "Implementation of an Echo protocol",
+  "license": "Apache-2.0 OR MIT",
+  "homepage": "https://github.com/libp2p/js-libp2p/tree/main/packages/protocol-echo#readme",
+  "repository": {
+    "type": "git",
+    "url": "git+https://github.com/libp2p/js-libp2p.git"
+  },
+  "bugs": {
+    "url": "https://github.com/libp2p/js-libp2p/issues"
+  },
+  "publishConfig": {
+    "access": "public",
+    "provenance": true
+  },
+  "type": "module",
+  "types": "./dist/src/index.d.ts",
+  "files": [
+    "src",
+    "dist",
+    "!dist/test",
+    "!**/*.tsbuildinfo"
+  ],
+  "exports": {
+    ".": {
+      "types": "./dist/src/index.d.ts",
+      "import": "./dist/src/index.js"
+    }
+  },
+  "eslintConfig": {
+    "extends": "ipfs",
+    "parserOptions": {
+      "project": true,
+      "sourceType": "module"
+    }
+  },
+  "scripts": {
+    "start": "node dist/src/main.js",
+    "build": "aegir build",
+    "test": "aegir test",
+    "clean": "aegir clean",
+    "generate": "protons ./src/pb/index.proto",
+    "lint": "aegir lint",
+    "test:chrome": "aegir test -t browser --cov",
+    "test:chrome-webworker": "aegir test -t webworker",
+    "test:firefox": "aegir test -t browser -- --browser firefox",
+    "test:firefox-webworker": "aegir test -t webworker -- --browser firefox",
+    "test:node": "aegir test -t node --cov",
+    "dep-check": "aegir dep-check",
+    "doc-check": "aegir doc-check"
+  },
+  "dependencies": {
+    "@libp2p/interface": "^1.1.4",
+    "@libp2p/interface-internal": "^1.0.9",
+    "it-pipe": "^3.0.1"
+  },
+  "devDependencies": {
+    "@libp2p/logger": "^4.0.7",
+    "aegir": "^42.2.4",
+    "it-all": "^3.0.4",
+    "it-pair": "^2.0.6",
+    "sinon": "^17.0.1",
+    "sinon-ts": "^2.0.0",
+    "uint8arraylist": "^2.4.8"
+  },
+  "sideEffects": false
+}

--- a/packages/protocol-echo/src/constants.ts
+++ b/packages/protocol-echo/src/constants.ts
@@ -1,0 +1,2 @@
+export const PROTOCOL_VERSION = '1.0.0'
+export const PROTOCOL_NAME = 'echo'

--- a/packages/protocol-echo/src/echo.ts
+++ b/packages/protocol-echo/src/echo.ts
@@ -1,0 +1,45 @@
+import { pipe } from 'it-pipe'
+import { PROTOCOL_NAME, PROTOCOL_VERSION } from './constants.js'
+import type { Echo as EchoInterface, EchoComponents, EchoInit } from './index.js'
+import type { Logger, Startable } from '@libp2p/interface'
+
+/**
+ * A simple echo stream, any data received will be sent back to the sender
+ */
+export class Echo implements Startable, EchoInterface {
+  public readonly protocol: string
+  private readonly components: EchoComponents
+  private started: boolean
+  private readonly init: EchoInit
+  private readonly log: Logger
+
+  constructor (components: EchoComponents, init: EchoInit = {}) {
+    this.log = components.logger.forComponent('libp2p:echo')
+    this.started = false
+    this.components = components
+    this.protocol = `/${[init.protocolPrefix, PROTOCOL_NAME, PROTOCOL_VERSION].filter(Boolean).join('/')}`
+    this.init = init
+  }
+
+  async start (): Promise<void> {
+    await this.components.registrar.handle(this.protocol, ({ stream }) => {
+      void pipe(stream, stream)
+        .catch((err: any) => {
+          this.log.error('error piping stream', err)
+        })
+    }, {
+      maxInboundStreams: this.init.maxInboundStreams,
+      maxOutboundStreams: this.init.maxOutboundStreams
+    })
+    this.started = true
+  }
+
+  async stop (): Promise<void> {
+    await this.components.registrar.unhandle(this.protocol)
+    this.started = false
+  }
+
+  isStarted (): boolean {
+    return this.started
+  }
+}

--- a/packages/protocol-echo/src/index.ts
+++ b/packages/protocol-echo/src/index.ts
@@ -1,0 +1,67 @@
+/**
+ * @packageDocumentation
+ *
+ * An implementation of a simple Echo protocol.
+ *
+ * Any data received by the receiver will be sent back to the sender.
+ *
+ * @example
+ *
+ * ```TypeScript
+ * import { noise } from '@chainsafe/libp2p-noise'
+ * import { yamux } from '@chainsafe/libp2p-yamux'
+ * import { echo } from '@libp2p/echo'
+ * import { peerIdFromString } from '@libp2p/peer-id'
+ * import { createLibp2p } from 'libp2p'
+ *
+ * const receiver = await createLibp2p({
+ *   addresses: {
+ *     listen: ['/ip4/0.0.0.0/tcp/0']
+ *   },
+ *   connectionEncryption: [noise()],
+ *   streamMuxers: [yamux()],
+ *   services: {
+ *     echo: echo()
+ *   }
+ * })
+ *
+ * const sender = await createLibp2p({
+ *   addresses: {
+ *     listen: ['/ip4/0.0.0.0/tcp/0']
+ *   },
+ *   connectionEncryption: [noise()],
+ *   streamMuxers: [yamux()],
+ *   services: {
+ *     echo: echo()
+ *   }
+ * })
+ *
+ * const stream = await sender.dialProtocol(receiver.getMultiaddrs(), sender.services.echo.protocol)
+ *
+ * // write/read stream
+ * ```
+ */
+
+import { Echo as EchoClass } from './echo.js'
+import type { ComponentLogger } from '@libp2p/interface'
+import type { ConnectionManager, Registrar } from '@libp2p/interface-internal'
+
+export interface EchoInit {
+  protocolPrefix?: string
+  maxInboundStreams?: number
+  maxOutboundStreams?: number
+}
+
+export interface EchoComponents {
+  registrar: Registrar
+  connectionManager: ConnectionManager
+  logger: ComponentLogger
+}
+
+export interface Echo {
+  protocol: string
+}
+
+export function echo (init: EchoInit = {}): (components: EchoComponents) => Echo {
+  return (components) => new EchoClass(components, init)
+}

--- a/packages/protocol-echo/test/index.spec.ts
+++ b/packages/protocol-echo/test/index.spec.ts
@@ -1,0 +1,79 @@
+/* eslint-env mocha */
+
+import { start, stop } from '@libp2p/interface'
+import { defaultLogger } from '@libp2p/logger'
+import { expect } from 'aegir/chai'
+import all from 'it-all'
+import { duplexPair } from 'it-pair/duplex'
+import { pipe } from 'it-pipe'
+import sinon from 'sinon'
+import { stubInterface, type StubbedInstance } from 'sinon-ts'
+import { Uint8ArrayList } from 'uint8arraylist'
+import { Echo } from '../src/echo.js'
+import type { ComponentLogger, Connection, Stream } from '@libp2p/interface'
+import type { ConnectionManager, Registrar } from '@libp2p/interface-internal'
+
+interface StubbedFetchComponents {
+  registrar: StubbedInstance<Registrar>
+  connectionManager: StubbedInstance<ConnectionManager>
+  logger: ComponentLogger
+}
+
+async function createComponents (): Promise<StubbedFetchComponents> {
+  return {
+    registrar: stubInterface<Registrar>(),
+    connectionManager: stubInterface<ConnectionManager>(),
+    logger: defaultLogger()
+  }
+}
+
+describe('echo', () => {
+  let components: StubbedFetchComponents
+  let echo: Echo
+
+  beforeEach(async () => {
+    components = await createComponents()
+    echo = new Echo(components)
+  })
+
+  afterEach(async () => {
+    sinon.restore()
+
+    await stop(echo)
+  })
+
+  it('should have a protocol', async () => {
+    expect(echo.protocol).to.equal('/echo/1.0.0')
+  })
+
+  it('should echo data', async () => {
+    await start(echo)
+
+    const duplex = duplexPair<any>()
+    const outgoingStream = stubInterface<Stream>()
+    outgoingStream.source = duplex[0].source
+    outgoingStream.sink.callsFake(async source => duplex[0].sink(source))
+
+    const incomingStream = stubInterface<Stream>()
+    incomingStream.source = duplex[1].source
+    incomingStream.sink.callsFake(async source => duplex[1].sink(source))
+
+    const handler = components.registrar.handle.getCall(0).args[1]
+    handler({
+      stream: incomingStream,
+      connection: stubInterface<Connection>()
+    })
+
+    const input = Uint8Array.from([0, 1, 2, 3])
+
+    const output = await pipe(
+      [input],
+      outgoingStream,
+      async (source) => {
+        return new Uint8ArrayList(...(await all(source))).subarray()
+      }
+    )
+
+    expect(output).to.equalBytes(input)
+  })
+})

--- a/packages/protocol-echo/tsconfig.json
+++ b/packages/protocol-echo/tsconfig.json
@@ -1,0 +1,21 @@
+{
+  "extends": "aegir/src/config/tsconfig.aegir.json",
+  "compilerOptions": {
+    "outDir": "dist"
+  },
+  "include": [
+    "src",
+    "test"
+  ],
+  "references": [
+    {
+      "path": "../interface"
+    },
+    {
+      "path": "../interface-internal"
+    },
+    {
+      "path": "../logger"
+    }
+  ]
+}

--- a/packages/protocol-echo/typedoc.json
+++ b/packages/protocol-echo/typedoc.json
@@ -1,0 +1,5 @@
+{
+  "entryPoints": [
+    "./src/index.ts"
+  ]
+}


### PR DESCRIPTION
To save us having to re-implement an echo protocol over and over again in documentation and examples, just publish a simple reusable echo protocol module.

## Change checklist

- [x] I have performed a self-review of my own code
- [x] I have made corresponding changes to the documentation if necessary (this includes comments as well)
- [x] I have added tests that prove my fix is effective or that my feature works