### PR TITLE
fix: add name property to exported interface errors

### DIFF
--- a/packages/interface/src/errors.ts
+++ b/packages/interface/src/errors.ts
@@ -9,6 +9,7 @@ export class AbortError extends Error {
 
   constructor (message: string = 'The operation was aborted') {
     super(message)
+    this.name = 'AbortError'
     this.code = AbortError.code
     this.type = AbortError.type
   }

--- a/packages/interface/src/errors.ts
+++ b/packages/interface/src/errors.ts
@@ -55,6 +55,7 @@ export class UnexpectedPeerError extends Error {
 
   constructor (message = 'Unexpected Peer') {
     super(message)
+    this.name = 'UnexpectedPeerError'
     this.code = UnexpectedPeerError.code
   }
 
@@ -66,6 +67,7 @@ export class InvalidCryptoExchangeError extends Error {
 
   constructor (message = 'Invalid crypto exchange') {
     super(message)
+    this.name = 'InvalidCryptoExchangeError'
     this.code = InvalidCryptoExchangeError.code
   }
 
@@ -77,6 +79,7 @@ export class InvalidCryptoTransmissionError extends Error {
 
   constructor (message = 'Invalid crypto transmission') {
     super(message)
+    this.name = 'InvalidCryptoTransmissionError'
     this.code = InvalidCryptoTransmissionError.code
   }
 


### PR DESCRIPTION
## Description

As discussed in https://github.com/ipfs/helia-verified-fetch/issues/25#issuecomment-2018003309, this PR adds the name property to the AbortError type. 

This has a couple of benefits:
- Sticks the common convention for Error types (all built in Error types have the name property set to the class name)
- Allows checking the error type at runtime in a TS codebase without importing the type

## Notes & open questions

- Should we also set the name property on UnexpectedPeerError, InvalidCryptoExchangeError and InvalidCryptoTransmissionError?

## Change checklist

- [x] I have performed a self-review of my own code
- [x] I have made corresponding changes to the documentation if necessary (this includes comments as well)
- [ ] I have added tests that prove my fix is effective or that my feature works