### PR TITLE
fix(libp2p): Export Components type for use in apps that use libp2p

### DIFF
--- a/packages/libp2p/src/index.ts
+++ b/packages/libp2p/src/index.ts
@@ -16,13 +16,14 @@
 
 import { createLibp2pNode } from './libp2p.js'
 import type { AddressManagerInit } from './address-manager/index.js'
-import type { Components } from './components.js'
 import type { ConnectionManagerInit } from './connection-manager/index.js'
 import type { TransportManagerInit } from './transport-manager.js'
 import type { Libp2p, ServiceMap, RecursivePartial, ComponentLogger, NodeInfo, ConnectionProtector, ConnectionEncrypter, ConnectionGater, ContentRouting, Metrics, PeerDiscovery, PeerId, PeerRouting, StreamMuxerFactory, Transport, PrivateKey } from '@libp2p/interface'
 import type { PersistentPeerStoreInit } from '@libp2p/peer-store'
 import type { DNS } from '@multiformats/dns'
 import type { Datastore } from 'interface-datastore'
+
+export type { Components } from './components.js'
 
 export type ServiceFactoryMap<T extends Record<string, unknown> = Record<string, unknown>> = {
   [Property in keyof T]: (components: Components) => T[Property]


### PR DESCRIPTION
## Title
fix(libp2p): Export Components type for use in apps that use libp2p

## Description
See https://github.com/libp2p/js-libp2p/issues/2452

## Notes & open questions

See https://github.com/libp2p/js-libp2p/issues/2452

## Change checklist

- [x] I have performed a self-review of my own code
- [ ] I have made corresponding changes to the documentation if necessary (this includes comments as well)
- [ ] I have added tests that prove my fix is effective or that my feature works