### PR TITLE
fix: reduce TLS cert validity time

### DIFF
--- a/packages/connection-encrypter-tls/src/tls.ts
+++ b/packages/connection-encrypter-tls/src/tls.ts
@@ -38,11 +38,11 @@ export class TLS implements ConnectionEncrypter {
   }
 
   async secureInbound <Stream extends Duplex<AsyncGenerator<Uint8Array | Uint8ArrayList>> = MultiaddrConnection> (localId: PeerId, conn: Stream, remoteId?: PeerId): Promise<SecuredConnection<Stream>> {
-    return this._encrypt(localId, conn, false, remoteId)
+    return this._encrypt(localId, conn, true, remoteId)
   }
 
   async secureOutbound <Stream extends Duplex<AsyncGenerator<Uint8Array | Uint8ArrayList>> = MultiaddrConnection> (localId: PeerId, conn: Stream, remoteId?: PeerId): Promise<SecuredConnection<Stream>> {
-    return this._encrypt(localId, conn, true, remoteId)
+    return this._encrypt(localId, conn, false, remoteId)
   }
 
   /**
@@ -106,7 +106,7 @@ export class TLS implements ConnectionEncrypter {
         reject(err)
         clearTimeout(abortTimeout)
       })
-      socket.on('secure', (evt) => {
+      socket.once('secure', (evt) => {
         this.log('verifying remote certificate')
         verifyRemote()
       })

--- a/packages/connection-encrypter-tls/src/utils.ts
+++ b/packages/connection-encrypter-tls/src/utils.ts
@@ -23,8 +23,12 @@ const LIBP2P_PUBLIC_KEY_EXTENSION = '1.3.6.1.4.1.53594.1.1'
 const CERT_PREFIX = 'libp2p-tls-handshake:'
 // https://github.com/libp2p/go-libp2p/blob/28c0f6ab32cd69e4b18e9e4b550ef6ce059a9d1a/p2p/security/tls/crypto.go#L265
 const CERT_VALIDITY_PERIOD_FROM = 60 * 60 * 1000 // ~1 hour
+
+// N.b. have to keep expiry date before 2050 - when https://github.com/PeculiarVentures/x509/issues/73
+// is fixed we can revert to 100 years
+const CERT_VALIDITY_PERIOD_TO = 10 * 365 * 24 * 60 * 60 * 1000 // ~10 years
 // https://github.com/libp2p/go-libp2p/blob/28c0f6ab32cd69e4b18e9e4b550ef6ce059a9d1a/p2p/security/tls/crypto.go#L24C28-L24C44
-const CERT_VALIDITY_PERIOD_TO = 100 * 365 * 24 * 60 * 60 * 1000 // ~100 years
+// const CERT_VALIDITY_PERIOD_TO = 100 * 365 * 24 * 60 * 60 * 1000 // ~100 years
 
 export async function verifyPeerCertificate (rawCertificate: Uint8Array, expectedPeerId?: PeerId, log?: Logger): Promise<PeerId> {
   const now = Date.now()


### PR DESCRIPTION
`@peculiar/x509` cannot represent dates as far in advance as go-libp2p so the certs are rejected.

Reduce the maximum validity of certificates to keep them under 2050 - this can be re-evaluated after https://github.com/PeculiarVentures/x509/issues/73 is fixed.

## Change checklist

- [x] I have performed a self-review of my own code
- [ ] I have made corresponding changes to the documentation if necessary (this includes comments as well)
- [ ] I have added tests that prove my fix is effective or that my feature works