### PR TITLE
chore: update tls version in integration tests

### DIFF
--- a/packages/integration-tests/package.json
+++ b/packages/integration-tests/package.json
@@ -58,7 +58,7 @@
     "@libp2p/ping": "^1.0.11",
     "@libp2p/plaintext": "^1.0.15",
     "@libp2p/tcp": "^9.0.15",
-    "@libp2p/tls": "^0.0.0",
+    "@libp2p/tls": "^1.0.2",
     "@libp2p/webrtc": "^4.0.19",
     "@libp2p/websockets": "^8.0.15",
     "@multiformats/mafmt": "^12.1.6",


### PR DESCRIPTION
@libp2p/tls is v1 so update the dep version.

## Change checklist

- [x] I have performed a self-review of my own code
- [ ] I have made corresponding changes to the documentation if necessary (this includes comments as well)
- [ ] I have added tests that prove my fix is effective or that my feature works