### PR TITLE
fix: count dht providers and abort when enough found

### DIFF
--- a/packages/kad-dht/src/content-routing/index.ts
+++ b/packages/kad-dht/src/content-routing/index.ts
@@ -128,6 +128,7 @@ export class ContentRouting {
    */
   async * findProviders (key: CID, options: RoutingOptions): AsyncGenerator<PeerResponseEvent | ProviderEvent | QueryEvent> {
     const toFind = this.routingTable.kBucketSize
+    let found = 0
     const target = key.multihash.bytes
     const self = this // eslint-disable-line @typescript-eslint/no-this-alias
 
@@ -158,11 +159,12 @@ export class ContentRouting {
 
       yield peerResponseEvent({ from: this.components.peerId, messageType: MessageType.GET_PROVIDERS, providers }, options)
       yield providerEvent({ from: this.components.peerId, providers }, options)
-    }
 
-    // All done
-    if (provs.length >= toFind) {
-      return
+      found += providers.length
+
+      if (found >= toFind) {
+        return
+      }
     }
 
     /**
@@ -201,10 +203,12 @@ export class ContentRouting {
 
         if (newProviders.length > 0) {
           yield providerEvent({ from: event.from, providers: newProviders }, options)
-        }
 
-        if (providers.size === toFind) {
-          return
+          found += newProviders.length
+
+          if (found >= toFind) {
+            return
+          }
         }
       }
     }

--- a/packages/kad-dht/src/query-self.ts
+++ b/packages/kad-dht/src/query-self.ts
@@ -106,10 +106,11 @@ export class QuerySelf implements Startable {
 
     if (this.started) {
       this.controller = new AbortController()
-      const signal = anySignal([this.controller.signal, AbortSignal.timeout(this.queryTimeout)])
+      const timeoutSignal = AbortSignal.timeout(this.queryTimeout)
+      const signal = anySignal([this.controller.signal, timeoutSignal])
 
       // this controller will get used for lots of dial attempts so make sure we don't cause warnings to be logged
-      setMaxListeners(Infinity, signal)
+      setMaxListeners(Infinity, signal, this.controller.signal, timeoutSignal)
 
       try {
         if (this.routingTable.size === 0) {

--- a/packages/kad-dht/src/query/query-path.ts
+++ b/packages/kad-dht/src/query/query-path.ts
@@ -1,3 +1,4 @@
+import { setMaxListeners } from '@libp2p/interface'
 import { anySignal } from 'any-signal'
 import Queue from 'p-queue'
 import { toString } from 'uint8arrays/to-string'
@@ -111,6 +112,9 @@ export async function * queryPath (options: QueryPathOptions): AsyncGenerator<Qu
       }
 
       const compoundSignal = anySignal(signals)
+
+      // this signal can get listened to a lot
+      setMaxListeners(Infinity, compoundSignal)
 
       try {
         for await (const event of query({


### PR DESCRIPTION
The way we were counting DHT providers was wrong, count the actual number found - this prevents queries continuing to execute after we've found K providers.

## Change checklist

- [x] I have performed a self-review of my own code
- [ ] I have made corresponding changes to the documentation if necessary (this includes comments as well)
- [ ] I have added tests that prove my fix is effective or that my feature works