### PR TITLE
fix: decrease default dial timeout

### DIFF
--- a/packages/libp2p/src/connection-manager/constants.defaults.ts
+++ b/packages/libp2p/src/connection-manager/constants.defaults.ts
@@ -1,12 +1,12 @@
 /**
  * @see https://libp2p.github.io/js-libp2p/interfaces/index._internal_.ConnectionManagerConfig.html#dialTimeout
  */
-export const DIAL_TIMEOUT = 30e3
+export const DIAL_TIMEOUT = 2e3
 
 /**
  * @see https://libp2p.github.io/js-libp2p/interfaces/index._internal_.ConnectionManagerConfig.html#inboundUpgradeTimeout
  */
-export const INBOUND_UPGRADE_TIMEOUT = 30e3
+export const INBOUND_UPGRADE_TIMEOUT = 1e3
 
 /**
  * @see https://libp2p.github.io/js-libp2p/interfaces/index._internal_.ConnectionManagerConfig.html#maxPeerAddrsToDial


### PR DESCRIPTION
30s is far too long for a default dial timeout and can cause dialing unresponsive peers with multiple valid addresses to block the dial queue. Decrease to 2s.

## Change checklist

- [x] I have performed a self-review of my own code
- [ ] I have made corresponding changes to the documentation if necessary (this includes comments as well)
- [ ] I have added tests that prove my fix is effective or that my feature works