### PR TITLE
fix: limit max dial queue size

### DIFF
--- a/packages/libp2p/src/connection-manager/constants.defaults.ts
+++ b/packages/libp2p/src/connection-manager/constants.defaults.ts
@@ -57,3 +57,8 @@ export const MAX_INCOMING_PENDING_CONNECTIONS = 10
  * failed to dial.
  */
 export const LAST_DIAL_FAILURE_KEY = 'last-dial-failure'
+
+/**
+ * @see https://libp2p.github.io/js-libp2p/interfaces/index._internal_.ConnectionManagerConfig.html#maxDialQueueLength
+ */
+export const MAX_DIAL_QUEUE_LENGTH = 500

--- a/packages/libp2p/src/connection-manager/dial-queue.ts
+++ b/packages/libp2p/src/connection-manager/dial-queue.ts
@@ -190,7 +190,9 @@ export class DialQueue {
       return existingDial.join(options)
     }
 
-    await this.queue.onSizeLessThan(this.maxDialQueueLength, options)
+    if (this.queue.size >= this.maxDialQueueLength) {
+      throw new CodeError('Dial queue is full', 'ERR_DIAL_QUEUE_FULL')
+    }
 
     this.log('creating dial target for %p', peerId, multiaddrs.map(ma => ma.toString()))
 

--- a/packages/libp2p/test/connection-manager/direct.spec.ts
+++ b/packages/libp2p/test/connection-manager/direct.spec.ts
@@ -27,7 +27,7 @@ import { DefaultConnectionManager } from '../../src/connection-manager/index.js'
 import { codes as ErrorCodes } from '../../src/errors.js'
 import { createLibp2p } from '../../src/index.js'
 import { DefaultTransportManager } from '../../src/transport-manager.js'
-import type { Libp2p, Connection, PeerId } from '@libp2p/interface'
+import type { Libp2p, Connection, PeerId, Transport } from '@libp2p/interface'
 import type { TransportManager } from '@libp2p/interface-internal'
 import type { Multiaddr } from '@multiformats/multiaddr'
 
@@ -503,5 +503,32 @@ describe('libp2p.dialer (direct, WebSockets)', () => {
     await expect(libp2p.dial(multiaddr(`/ip4/127.0.0.1/tcp/1234/ws/p2p/${peerId.toString()}`)))
       .to.eventually.be.rejected()
       .and.to.have.property('code', ErrorCodes.ERR_DIALED_SELF)
+  })
+
+  it('should limit the maximum dial queue size', async () => {
+    const transport = stubInterface<Transport>({
+      filter: (ma) => ma,
+      dial: async () => {
+        await delay(1000)
+        return stubInterface<Connection>()
+      }
+    })
+
+    libp2p = await createLibp2p({
+      peerId,
+      transports: [
+        () => transport
+      ],
+      connectionManager: {
+        maxDialQueueLength: 1,
+        maxParallelDials: 1
+      }
+    })
+
+    await expect(Promise.all([
+      libp2p.dial(multiaddr('/ip4/127.0.0.1/tcp/1234')),
+      libp2p.dial(multiaddr('/ip4/127.0.0.1/tcp/1235'))
+    ])).to.eventually.be.rejected
+      .with.property('code', 'ERR_DIAL_QUEUE_FULL')
   })
 })


### PR DESCRIPTION
Add an upper bound to the maximum length of the dial queue.

Any attempts to dial when the queue is full will throw.

## Change checklist

- [x] I have performed a self-review of my own code
- [ ] I have made corresponding changes to the documentation if necessary (this includes comments as well)
- [x] I have added tests that prove my fix is effective or that my feature works