### PR TITLE
fix: close MultiaddrConnection once

### DIFF
--- a/packages/transport-tcp/src/socket-to-conn.ts
+++ b/packages/transport-tcp/src/socket-to-conn.ts
@@ -199,7 +199,10 @@ export const toMultiaddrConnection = (socket: Socket, options: ToConnectionOptio
     abort: (err: Error) => {
       log('%s socket abort due to error', lOptsStr, err)
 
-      socket.destroy(err)
+      // the abortSignalListener may already destroyed the socket with an error
+      if (!socket.destroyed) {
+        socket.destroy(err)
+      }
 
       if (maConn.timeline.close == null) {
         maConn.timeline.close = Date.now()

--- a/packages/transport-tcp/src/socket-to-conn.ts
+++ b/packages/transport-tcp/src/socket-to-conn.ts
@@ -23,6 +23,7 @@ interface ToConnectionOptions {
  * https://github.com/libp2p/interface-transport#multiaddrconnection
  */
 export const toMultiaddrConnection = (socket: Socket, options: ToConnectionOptions): MultiaddrConnection => {
+  let status: 'open' | 'closing' | 'closed' = 'open'
   const log = options.logger.forComponent('libp2p:tcp:socket')
   const metrics = options.metrics
   const metricPrefix = options.metricPrefix ?? ''
@@ -126,10 +127,11 @@ export const toMultiaddrConnection = (socket: Socket, options: ToConnectionOptio
     timeline: { open: Date.now() },
 
     async close (options: AbortOptions = {}) {
-      if (socket.destroyed) {
-        log('%s socket was already destroyed when trying to close', lOptsStr)
+      if (status === 'closed' || status === 'closing' || socket.destroyed) {
+        log('%s socket was already destroyed or closed or closing', lOptsStr)
         return
       }
+      status = 'closing'
 
       if (options.signal == null) {
         const signal = AbortSignal.timeout(closeTimeout)
@@ -153,6 +155,7 @@ export const toMultiaddrConnection = (socket: Socket, options: ToConnectionOptio
             // socket completely closed
             log('%s socket closed', lOptsStr)
 
+            status = 'closed'
             resolve()
           })
           socket.once('error', (err: Error) => {
@@ -163,6 +166,7 @@ export const toMultiaddrConnection = (socket: Socket, options: ToConnectionOptio
               maConn.timeline.close = Date.now()
             }
 
+            status = 'closed'
             reject(err)
           })
 

--- a/packages/transport-tcp/src/socket-to-conn.ts
+++ b/packages/transport-tcp/src/socket-to-conn.ts
@@ -128,7 +128,7 @@ export const toMultiaddrConnection = (socket: Socket, options: ToConnectionOptio
 
     async close (options: AbortOptions = {}) {
       if (status === 'closed' || status === 'closing' || socket.destroyed) {
-        log('%s socket was already destroyed or closed or closing', lOptsStr)
+        log('The %s socket is either closed, closing, or already destroyed', lOptsStr)
         return
       }
       status = 'closing'

--- a/packages/transport-tcp/test/socket-to-conn.spec.ts
+++ b/packages/transport-tcp/test/socket-to-conn.spec.ts
@@ -292,7 +292,7 @@ describe('socket-to-conn', () => {
     ({ server, clientSocket, serverSocket } = await setup())
     // proxyServerSocket.writableLength returns 100 which cause socket cannot be destroyed immediately
     const proxyServerSocket = new Proxy(serverSocket, {
-      get(target, prop, receiver) {
+      get (target, prop, receiver) {
         if (prop === 'writableLength') {
           return 100
         }
@@ -304,7 +304,7 @@ describe('socket-to-conn', () => {
     const serverSocketDestroySpy = Sinon.spy(serverSocket, 'destroy')
     // promise that is resolved when our outgoing socket is closed
     const serverClosed = defer<boolean>()
-    const socketCloseTimeout = 10;
+    const socketCloseTimeout = 10
 
     const inboundMaConn = toMultiaddrConnection(proxyServerSocket, {
       socketInactivityTimeout: 100,
@@ -324,7 +324,7 @@ describe('socket-to-conn', () => {
     clientSocket.write('hello')
     serverSocket.write('goodbye')
 
-    const signal = AbortSignal.timeout(socketCloseTimeout);
+    const signal = AbortSignal.timeout(socketCloseTimeout)
     const addEventListenerSpy = Sinon.spy(signal, 'addEventListener')
 
     // the 2nd and 3rd call should return immediately
@@ -343,9 +343,9 @@ describe('socket-to-conn', () => {
     // server socket is destroyed
     expect(serverSocket.destroyed).to.be.true()
 
-     // the server socket was only closed once
-     expect(serverSocketDestroySpy.callCount).to.equal(1)
-     expect(addEventListenerSpy.callCount).to.equal(1)
+    // the server socket was only closed once
+    expect(serverSocketDestroySpy.callCount).to.equal(1)
+    expect(addEventListenerSpy.callCount).to.equal(1)
   })
 
   it('should destroy a socket by timeout when containing MultiaddrConnection is closed', async () => {

--- a/packages/transport-tcp/test/socket-to-conn.spec.ts
+++ b/packages/transport-tcp/test/socket-to-conn.spec.ts
@@ -1,10 +1,10 @@
 import { createServer, Socket, type Server, type ServerOpts, type SocketConstructorOpts } from 'net'
 import os from 'os'
 import { defaultLogger } from '@libp2p/logger'
-import Sinon from 'sinon'
-import { expect } from 'aegir/chai'
 import { type ComponentLogger, type Logger } from '@libp2p/logger'
+import { expect } from 'aegir/chai'
 import defer from 'p-defer'
+import Sinon from 'sinon'
 import { toMultiaddrConnection } from '../src/socket-to-conn.js'
 
 async function setup (opts?: { server?: ServerOpts, client?: SocketConstructorOpts }): Promise<{ server: Server, serverSocket: Socket, clientSocket: Socket }> {
@@ -290,7 +290,7 @@ describe('socket-to-conn', () => {
   })
 
   it('should not close MultiaddrConnection twice', async () => {
-    const loggerStub = Sinon.stub();
+    const loggerStub = Sinon.stub()
     const logger: ComponentLogger = {
       forComponent: () => loggerStub as unknown as Logger
     };
@@ -302,7 +302,7 @@ describe('socket-to-conn', () => {
     const inboundMaConn = toMultiaddrConnection(serverSocket, {
       socketInactivityTimeout: 100,
       socketCloseTimeout: 10,
-      logger: logger
+      logger
     })
     expect(inboundMaConn.timeline.open).to.be.ok()
     expect(inboundMaConn.timeline.close).to.not.be.ok()
@@ -318,10 +318,12 @@ describe('socket-to-conn', () => {
     serverSocket.write('goodbye')
 
     // the 2nd call should return immediately
-    inboundMaConn.close()
-    inboundMaConn.close()
+    await Promise.all([
+      inboundMaConn.close(),
+      inboundMaConn.close()
+    ])
 
-    expect(loggerStub.calledWithMatch("socket is either closed, closing, or already destroyed")).to.be.true()
+    expect(loggerStub.calledWithMatch('socket is either closed, closing, or already destroyed')).to.be.true()
 
     // server socket was closed for reading and writing
     await expect(serverClosed.promise).to.eventually.be.true()


### PR DESCRIPTION
## Title
Close MultiaddrConnection once

## Description

- It's designed to close MultiaddrConnection once, however in case there are some writable data remaining, socket is not destroyed yet https://github.com/libp2p/js-libp2p/blob/c5003d40207bc3be15645b5af93f8dec1fd5d55b/packages/transport-tcp/src/socket-to-conn.ts#L177 and when there is a called to `close()` again it'll run the function again
- Instead use a variable to control it like other places

## Notes & open questions
this could fix #2477 see https://github.com/libp2p/js-libp2p/issues/2477#issuecomment-2049121628

## Change checklist

- [x] I have performed a self-review of my own code
- [x] No need documentation as the change is straightforward and small, the same pattern is applied in a lot of places
- [x] I thought about unit tests however not sure how to do it. This change is quite straightforward and scanned through the current tests through