### PR TITLE
fix: use same promise when closing maconn multiple times

### DIFF
--- a/packages/transport-tcp/src/socket-to-conn.ts
+++ b/packages/transport-tcp/src/socket-to-conn.ts
@@ -194,7 +194,7 @@ export const toMultiaddrConnection = (socket: Socket, options: ToConnectionOptio
           }
         })
 
-        return await closePromise
+        await closePromise
       } catch (err: any) {
         this.abort(err)
       } finally {


### PR DESCRIPTION
## Title
Use same promise when closing`MultiaddrConnection` multiple time

See https://github.com/libp2p/js-libp2p/pull/2478#pullrequestreview-2000610558
## Description
- Replace `status` variable introduced in #2478 with a `closePromise`
- use this `closePromise` for subsequent `maConn.close()` calls
- the new unit test in #2478 passed


related to #2477

## Change checklist

- [x] I have performed a self-review of my own code
- [x] I have made corresponding changes to the documentation if necessary (this includes comments as well)
- [x] I have added tests that prove my fix is effective or that my feature works