### PR TITLE
fix: do not run webrtc cleanup on transport close

### DIFF
--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -148,14 +148,14 @@ jobs:
 
   test-electron-main:
     needs: build
-    runs-on: macos-latest
+    runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@v4
       - uses: actions/setup-node@v4
         with:
           node-version: lts/*
       - uses: ipfs/aegir/actions/cache-node-modules@master
-      - run: npm run --if-present test:electron-main
+      - run: npx xvfb-maybe npm run --if-present test:electron-main
       - uses: codecov/codecov-action@84508663e988701840491b86de86b666e8a86bed # v4.3.0
         with:
           flags: electron-main

--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -148,14 +148,14 @@ jobs:
 
   test-electron-main:
     needs: build
-    runs-on: ubuntu-latest
+    runs-on: macos-latest
     steps:
       - uses: actions/checkout@v4
       - uses: actions/setup-node@v4
         with:
           node-version: lts/*
       - uses: ipfs/aegir/actions/cache-node-modules@master
-      - run: npx xvfb-maybe npm run --if-present test:electron-main
+      - run: npm run --if-present test:electron-main
       - uses: codecov/codecov-action@84508663e988701840491b86de86b666e8a86bed # v4.3.0
         with:
           flags: electron-main

--- a/packages/transport-webrtc/package.json
+++ b/packages/transport-webrtc/package.json
@@ -43,7 +43,6 @@
     "test:node": "aegir test -t node --cov",
     "test:chrome": "aegir test -t browser --cov",
     "test:firefox": "aegir test -t browser -- --browser firefox",
-    "test:electron-main": "aegir test -t electron-main",
     "lint": "aegir lint",
     "lint:fix": "aegir lint --fix",
     "clean": "aegir clean",

--- a/packages/transport-webrtc/src/private-to-private/transport.ts
+++ b/packages/transport-webrtc/src/private-to-private/transport.ts
@@ -6,7 +6,7 @@ import { WebRTC } from '@multiformats/multiaddr-matcher'
 import { codes } from '../error.js'
 import { WebRTCMultiaddrConnection } from '../maconn.js'
 import { DataChannelMuxerFactory } from '../muxer.js'
-import { cleanup, RTCPeerConnection } from '../webrtc/index.js'
+import { RTCPeerConnection } from '../webrtc/index.js'
 import { initiateConnection } from './initiate-connection.js'
 import { WebRTCPeerListener } from './listener.js'
 import { handleIncomingStream } from './signaling-stream-handler.js'
@@ -87,7 +87,6 @@ export class WebRTCTransport implements Transport, Startable {
 
   async stop (): Promise<void> {
     await this.components.registrar.unhandle(SIGNALING_PROTO_ID)
-    cleanup()
     this._started = false
   }
 

--- a/packages/transport-webrtc/src/webrtc/index.browser.ts
+++ b/packages/transport-webrtc/src/webrtc/index.browser.ts
@@ -1,4 +1,3 @@
 export const RTCPeerConnection = globalThis.RTCPeerConnection
 export const RTCSessionDescription = globalThis.RTCSessionDescription
 export const RTCIceCandidate = globalThis.RTCIceCandidate
-export function cleanup (): void {}

--- a/packages/transport-webrtc/src/webrtc/index.ts
+++ b/packages/transport-webrtc/src/webrtc/index.ts
@@ -1,7 +1,1 @@
-import node from 'node-datachannel'
-
 export { RTCSessionDescription, RTCIceCandidate, RTCPeerConnection } from 'node-datachannel/polyfill'
-
-export function cleanup (): void {
-  node.cleanup()
-}


### PR DESCRIPTION
The cleanup function from `node-datachannel` closes all open peer connections/datachannels - if there are multiple transports/nodes in the same process they will all be closed.

Fixes #2425

## Change checklist

- [x] I have performed a self-review of my own code
- [ ] I have made corresponding changes to the documentation if necessary (this includes comments as well)
- [ ] I have added tests that prove my fix is effective or that my feature works