### PR TITLE
feat: add random walk component

### DIFF
--- a/packages/interface-internal/src/index.ts
+++ b/packages/interface-internal/src/index.ts
@@ -1,5 +1,6 @@
 export * from './address-manager/index.js'
 export * from './connection-manager/index.js'
+export * from './random-walk/index.js'
 export * from './record/index.js'
 export * from './registrar/index.js'
 export * from './transport-manager/index.js'

--- a/packages/interface-internal/src/random-walk/index.ts
+++ b/packages/interface-internal/src/random-walk/index.ts
@@ -1,0 +1,13 @@
+import type { AbortOptions, PeerInfo } from '@libp2p/interface'
+
+/**
+ * RandomWalk finds random peers on the network and dials them. Use this after
+ * registering a Topology if you need to discover common network services.
+ */
+export interface RandomWalk {
+  /**
+   * Begin or join an existing walk. Abort the passed signal if you wish to
+   * abort the walk early.
+   */
+  walk(options?: AbortOptions): AsyncGenerator<PeerInfo>
+}

--- a/packages/interface-internal/src/random-walk/index.ts
+++ b/packages/interface-internal/src/random-walk/index.ts
@@ -1,4 +1,4 @@
-import type { AbortOptions, PeerInfo } from '@libp2p/interface'
+import type { PeerInfo } from '@libp2p/interface'
 
 /**
  * RandomWalk finds random peers on the network and dials them. Use this after
@@ -6,8 +6,7 @@ import type { AbortOptions, PeerInfo } from '@libp2p/interface'
  */
 export interface RandomWalk {
   /**
-   * Begin or join an existing walk. Abort the passed signal if you wish to
-   * abort the walk early.
+   * Begin or join an existing walk
    */
-  walk(options?: AbortOptions): AsyncGenerator<PeerInfo>
+  walk(): AsyncGenerator<PeerInfo>
 }

--- a/packages/interface-internal/src/random-walk/index.ts
+++ b/packages/interface-internal/src/random-walk/index.ts
@@ -1,4 +1,4 @@
-import type { PeerInfo } from '@libp2p/interface'
+import type { AbortOptions, PeerInfo } from '@libp2p/interface'
 
 /**
  * RandomWalk finds random peers on the network and dials them. Use this after
@@ -6,7 +6,8 @@ import type { PeerInfo } from '@libp2p/interface'
  */
 export interface RandomWalk {
   /**
-   * Begin or join an existing walk
+   * Begin or join an existing walk. Abort the passed signal if you wish to
+   * abort the walk early.
    */
-  walk(): AsyncGenerator<PeerInfo>
+  walk(options?: AbortOptions): AsyncGenerator<PeerInfo>
 }

--- a/packages/libp2p/package.json
+++ b/packages/libp2p/package.json
@@ -105,6 +105,8 @@
     "it-parallel": "^3.0.6",
     "merge-options": "^3.0.4",
     "multiformats": "^13.1.0",
+    "p-defer": "^4.0.1",
+    "race-signal": "^1.0.2",
     "uint8arrays": "^5.0.3"
   },
   "devDependencies": {
@@ -125,7 +127,7 @@
     "it-pipe": "^3.0.1",
     "it-pushable": "^3.2.3",
     "it-stream-types": "^2.0.1",
-    "p-defer": "^4.0.1",
+    "it-take": "^3.0.4",
     "p-event": "^6.0.1",
     "p-wait-for": "^5.0.2",
     "sinon": "^17.0.1",

--- a/packages/libp2p/package.json
+++ b/packages/libp2p/package.json
@@ -123,7 +123,7 @@
     "delay": "^6.0.0",
     "it-all": "^3.0.4",
     "it-drain": "^3.0.5",
-    "it-map": "^3.0.5",
+    "it-map": "^3.1.0",
     "it-pipe": "^3.0.1",
     "it-pushable": "^3.2.3",
     "it-stream-types": "^2.0.1",

--- a/packages/libp2p/package.json
+++ b/packages/libp2p/package.json
@@ -106,6 +106,7 @@
     "merge-options": "^3.0.4",
     "multiformats": "^13.1.0",
     "p-defer": "^4.0.1",
+    "race-event": "^1.3.0",
     "race-signal": "^1.0.2",
     "uint8arrays": "^5.0.3"
   },

--- a/packages/libp2p/src/libp2p.ts
+++ b/packages/libp2p/src/libp2p.ts
@@ -17,6 +17,7 @@ import { DefaultConnectionManager } from './connection-manager/index.js'
 import { CompoundContentRouting } from './content-routing.js'
 import { codes } from './errors.js'
 import { DefaultPeerRouting } from './peer-routing.js'
+import { RandomWalk } from './random-walk.js'
 import { DefaultRegistrar } from './registrar.js'
 import { DefaultTransportManager } from './transport-manager.js'
 import { DefaultUpgrader } from './upgrader.js'
@@ -136,6 +137,9 @@ export class Libp2pNode<T extends ServiceMap = Record<string, unknown>> extends 
     this.contentRouting = this.components.contentRouting = this.configureComponent('contentRouting', new CompoundContentRouting(this.components, {
       routers: contentRouters
     }))
+
+    // Random walk
+    this.configureComponent('randomWalk', new RandomWalk(this.components))
 
     // Discovery modules
     ;(init.peerDiscovery ?? []).forEach((fn, index) => {

--- a/packages/libp2p/src/random-walk.ts
+++ b/packages/libp2p/src/random-walk.ts
@@ -48,11 +48,13 @@ export class RandomWalk extends TypedEventEmitter<RandomWalkEvents> implements R
 
   async * walk (): AsyncGenerator<PeerInfo> {
     if (!this.walking) {
+      // start the query that causes walk:peer events to be emitted
       this.startWalk()
     }
 
     this.walkers++
 
+    // promise that returns a peer info from the walk:peer event
     let deferred = pDefer<PeerInfo>()
     const onPeer = (event: CustomEvent<PeerInfo>): void => {
       deferred.resolve(event.detail)
@@ -66,6 +68,7 @@ export class RandomWalk extends TypedEventEmitter<RandomWalkEvents> implements R
         this.needNext?.resolve()
         this.needNext = pDefer()
 
+        // wait for a walk:peer event
         const peerInfo = await deferred.promise
         deferred = pDefer()
 

--- a/packages/libp2p/src/random-walk.ts
+++ b/packages/libp2p/src/random-walk.ts
@@ -4,9 +4,8 @@ import { anySignal } from 'any-signal'
 import pDefer, { type DeferredPromise } from 'p-defer'
 import { raceEvent } from 'race-event'
 import { raceSignal } from 'race-signal'
-import type { ComponentLogger, Logger, PeerInfo, PeerRouting, Startable } from '@libp2p/interface'
+import type { AbortOptions, ComponentLogger, Logger, PeerInfo, PeerRouting, Startable } from '@libp2p/interface'
 import type { RandomWalk as RandomWalkInterface } from '@libp2p/interface-internal'
-import type { AbortOptions } from 'it-pushable'
 
 export interface RandomWalkComponents {
   peerRouting: PeerRouting

--- a/packages/libp2p/src/random-walk.ts
+++ b/packages/libp2p/src/random-walk.ts
@@ -1,0 +1,130 @@
+import { randomBytes } from '@libp2p/crypto'
+import { TypedEventEmitter, setMaxListeners } from '@libp2p/interface'
+import { anySignal } from 'any-signal'
+import pDefer, { type DeferredPromise } from 'p-defer'
+import { raceSignal } from 'race-signal'
+import type { ComponentLogger, Logger, PeerInfo, PeerRouting, Startable } from '@libp2p/interface'
+import type { RandomWalk as RandomWalkInterface } from '@libp2p/interface-internal'
+
+export interface RandomWalkComponents {
+  peerRouting: PeerRouting
+  logger: ComponentLogger
+}
+
+interface RandomWalkEvents {
+  'walk:peer': CustomEvent<PeerInfo>
+}
+
+export class RandomWalk extends TypedEventEmitter<RandomWalkEvents> implements RandomWalkInterface, Startable {
+  private readonly peerRouting: PeerRouting
+  private readonly log: Logger
+  private walking: boolean
+  private walkers: number
+  private shutdownController: AbortController
+  private walkController?: AbortController
+  private needNext?: DeferredPromise<void>
+
+  constructor (components: RandomWalkComponents) {
+    super()
+
+    this.log = components.logger.forComponent('libp2p:random-walk')
+    this.peerRouting = components.peerRouting
+    this.walkers = 0
+    this.walking = false
+
+    // stops any in-progress walks when the node is shut down
+    this.shutdownController = new AbortController()
+    setMaxListeners(Infinity, this.shutdownController.signal)
+  }
+
+  start (): void {
+    this.shutdownController = new AbortController()
+    setMaxListeners(Infinity, this.shutdownController.signal)
+  }
+
+  stop (): void {
+    this.shutdownController.abort()
+  }
+
+  async * walk (): AsyncGenerator<PeerInfo> {
+    if (!this.walking) {
+      this.startWalk()
+    }
+
+    this.walkers++
+
+    let deferred = pDefer<PeerInfo>()
+    const onPeer = (event: CustomEvent<PeerInfo>): void => {
+      deferred.resolve(event.detail)
+    }
+
+    this.addEventListener('walk:peer', onPeer)
+
+    try {
+      while (true) {
+        this.needNext = pDefer()
+
+        const peerInfo = await deferred.promise
+        deferred = pDefer()
+
+        yield peerInfo
+        this.needNext.resolve()
+      }
+    } finally {
+      this.removeEventListener('walk:peer', onPeer)
+      this.walkers--
+
+      // stop the walk if no more consumers are interested
+      if (this.walkers === 0) {
+        this.walkController?.abort()
+        this.walkController = undefined
+      }
+    }
+  }
+
+  private startWalk (): void {
+    this.walking = true
+
+    // the signal for this controller will be aborted if no more random peers
+    // are required
+    this.walkController = new AbortController()
+    setMaxListeners(Infinity, this.walkController.signal)
+
+    const signal = anySignal([this.walkController.signal, this.shutdownController.signal])
+    setMaxListeners(Infinity, signal)
+
+    Promise.resolve().then(async () => {
+      const start = Date.now()
+      let found = 0
+
+      this.log('start walk')
+
+      // find peers until no more consumers are interested
+      while (this.walkers > 0) {
+        try {
+          for await (const peer of this.peerRouting.getClosestPeers(randomBytes(32), { signal })) {
+            this.log('found peer %p', peer.id)
+            found++
+            this.safeDispatchEvent('walk:peer', {
+              detail: peer
+            })
+
+            // if we only have one consumer, pause the query until they request
+            // another random peer or they signal they are no longer interested
+            if (this.walkers === 1 && this.needNext != null) {
+              await raceSignal(this.needNext.promise, signal)
+            }
+          }
+        } catch (err) {
+          this.log.error('randomwalk errored', err)
+        }
+      }
+
+      this.log('finished walk, found %d peers after %dms', found, Date.now() - start)
+      this.walking = false
+    })
+      .catch(err => {
+        this.log.error('randomwalk errored', err)
+      })
+  }
+}

--- a/packages/libp2p/src/random-walk.ts
+++ b/packages/libp2p/src/random-walk.ts
@@ -74,10 +74,9 @@ export class RandomWalk extends TypedEventEmitter<RandomWalkEvents> implements R
         this.needNext = pDefer()
 
         // wait for a walk:peer or walk:error event
-        const peerInfo = await deferred.promise
-        deferred = pDefer()
+        yield await deferred.promise
 
-        yield peerInfo
+        deferred = pDefer()
       }
     } finally {
       this.removeEventListener('walk:peer', onPeer)

--- a/packages/libp2p/test/core/random-walk.spec.ts
+++ b/packages/libp2p/test/core/random-walk.spec.ts
@@ -220,4 +220,13 @@ describe('random-walk', () => {
     expect(slowPeers).to.have.lengthOf(2)
     expect(fastPeers).to.have.lengthOf(5)
   })
+
+  it('should abort a slow query', async () => {
+    peerRouting.getClosestPeers.returns(slowIterator())
+
+    await expect(drain(randomwalk.walk({
+      signal: AbortSignal.timeout(10)
+    }))).to.eventually.be.rejected
+      .with.property('code', 'ABORT_ERR')
+  })
 })

--- a/packages/libp2p/test/core/random-walk.spec.ts
+++ b/packages/libp2p/test/core/random-walk.spec.ts
@@ -53,9 +53,9 @@ describe('random-walk', () => {
     const randomPeer = await createRandomPeerInfo()
 
     peerRouting.getClosestPeers
-      .onFirstCall().returns(async function * () {
+      .onFirstCall().callsFake(async function * () {
         yield randomPeer
-      }())
+      })
       .onSecondCall().returns(slowIterator())
 
     const peers = await all(take(randomwalk.walk(), 1))
@@ -67,13 +67,13 @@ describe('random-walk', () => {
     let yielded = 0
 
     peerRouting.getClosestPeers
-      .onFirstCall().returns(async function * (key, options?: AbortOptions) {
+      .onFirstCall().callsFake(async function * (key, options?: AbortOptions) {
         for (let i = 0; i < 100; i++) {
           options?.signal?.throwIfAborted()
           yielded++
           yield await createRandomPeerInfo()
         }
-      }())
+      })
       .onSecondCall().returns(slowIterator())
 
     await drain(take(randomwalk.walk(), 1))
@@ -86,10 +86,10 @@ describe('random-walk', () => {
     const randomPeer1 = await createRandomPeerInfo()
 
     peerRouting.getClosestPeers
-      .onFirstCall().returns(async function * () {
+      .onFirstCall().callsFake(async function * () {
         yield randomPeer1
         throw err
-      }())
+      })
       .onThirdCall().returns(slowIterator())
 
     await expect(all(randomwalk.walk())).to.eventually.be.rejectedWith(err)
@@ -100,12 +100,12 @@ describe('random-walk', () => {
     const randomPeer2 = await createRandomPeerInfo()
 
     peerRouting.getClosestPeers
-      .onFirstCall().returns(async function * () {
+      .onFirstCall().callsFake(async function * () {
         yield randomPeer1
-      }())
-      .onSecondCall().returns(async function * () {
+      })
+      .onSecondCall().callsFake(async function * () {
         yield randomPeer2
-      }())
+      })
 
     const peers = await all(take(randomwalk.walk(), 2))
 
@@ -117,13 +117,13 @@ describe('random-walk', () => {
 
   it('should join an existing random walk', async () => {
     peerRouting.getClosestPeers
-      .onFirstCall().returns(async function * (key, options?: AbortOptions) {
+      .onFirstCall().callsFake(async function * (key, options?: AbortOptions) {
         for (let i = 0; i < 100; i++) {
           options?.signal?.throwIfAborted()
           yield await createRandomPeerInfo()
           await delay(100)
         }
-      }())
+      })
       .onSecondCall().returns(slowIterator())
 
     const [
@@ -141,13 +141,13 @@ describe('random-walk', () => {
     let yielded = 0
 
     peerRouting.getClosestPeers
-      .onFirstCall().returns(async function * (key, options?: AbortOptions) {
+      .onFirstCall().callsFake(async function * (key, options?: AbortOptions) {
         for (let i = 0; i < 100; i++) {
           options?.signal?.throwIfAborted()
           yielded++
           yield await createRandomPeerInfo()
         }
-      }())
+      })
       .onSecondCall().returns(slowIterator())
 
     await Promise.all([
@@ -162,13 +162,13 @@ describe('random-walk', () => {
     let yielded = 0
 
     peerRouting.getClosestPeers
-      .onFirstCall().returns(async function * (key, options?: AbortOptions) {
+      .onFirstCall().callsFake(async function * (key, options?: AbortOptions) {
         for (let i = 0; i < 100; i++) {
           options?.signal?.throwIfAborted()
           yielded++
           yield await createRandomPeerInfo()
         }
-      }())
+      })
       .onSecondCall().returns(slowIterator())
 
     await Promise.all([
@@ -184,12 +184,12 @@ describe('random-walk', () => {
 
   it('should unpause query if second consumer requires peers', async () => {
     peerRouting.getClosestPeers
-      .onFirstCall().returns(async function * (key, options?: AbortOptions) {
+      .onFirstCall().callsFake(async function * (key, options?: AbortOptions) {
         for (let i = 0; i < 100; i++) {
           options?.signal?.throwIfAborted()
           yield await createRandomPeerInfo()
         }
-      }())
+      })
       .onSecondCall().returns(slowIterator())
 
     const deferred = pDefer()

--- a/packages/libp2p/test/core/random-walk.spec.ts
+++ b/packages/libp2p/test/core/random-walk.spec.ts
@@ -1,0 +1,169 @@
+import { stop } from '@libp2p/interface'
+import { defaultLogger } from '@libp2p/logger'
+import { createEd25519PeerId } from '@libp2p/peer-id-factory'
+import { multiaddr } from '@multiformats/multiaddr'
+import { expect } from 'aegir/chai'
+import delay from 'delay'
+import all from 'it-all'
+import drain from 'it-drain'
+import map from 'it-map'
+import take from 'it-take'
+import { stubInterface, type StubbedInstance } from 'sinon-ts'
+import { RandomWalk as RandomWalkClass } from '../../src/random-walk.js'
+import type { PeerRouting, PeerInfo, AbortOptions } from '@libp2p/interface'
+import type { RandomWalk } from '@libp2p/interface-internal'
+
+let port = 1234
+
+async function createRandomPeerInfo (): Promise<PeerInfo> {
+  port++
+
+  return {
+    id: await createEd25519PeerId(),
+    multiaddrs: [
+      multiaddr(`/ip4/123.123.123.123/tcp/${port}`)
+    ]
+  }
+}
+
+// eslint-disable-next-line require-yield
+async function * slowIterator (): any {
+  await delay(1000)
+}
+
+describe('random-walk', () => {
+  let randomwalk: RandomWalk
+  let peerRouting: StubbedInstance<PeerRouting>
+
+  beforeEach(async () => {
+    peerRouting = stubInterface<PeerRouting>()
+
+    randomwalk = new RandomWalkClass({
+      peerRouting,
+      logger: defaultLogger()
+    })
+  })
+
+  afterEach(async () => {
+    await stop(randomwalk)
+  })
+
+  it('should perform a random walk', async () => {
+    const randomPeer = await createRandomPeerInfo()
+
+    peerRouting.getClosestPeers
+      .onFirstCall().returns(async function * () {
+        yield randomPeer
+      }())
+      .onSecondCall().returns(slowIterator())
+
+    const peers = await all(take(randomwalk.walk(), 1))
+
+    expect(peers.map(peer => peer.id.toString())).to.include(randomPeer.id.toString())
+  })
+
+  it('should break out of a random walk', async () => {
+    let yielded = 0
+
+    peerRouting.getClosestPeers
+      .onFirstCall().returns(async function * (key, options?: AbortOptions) {
+        for (let i = 0; i < 100; i++) {
+          yielded++
+          yield await createRandomPeerInfo()
+          options?.signal?.throwIfAborted()
+        }
+      }())
+      .onSecondCall().returns(slowIterator())
+
+    await drain(take(randomwalk.walk(), 1))
+
+    expect(yielded).to.equal(1)
+  })
+
+  it('should keep walking until done', async () => {
+    const randomPeer1 = await createRandomPeerInfo()
+    const randomPeer2 = await createRandomPeerInfo()
+
+    peerRouting.getClosestPeers
+      .onFirstCall().returns(async function * () {
+        yield randomPeer1
+      }())
+      .onSecondCall().returns(async function * () {
+        yield randomPeer2
+      }())
+      .onThirdCall().returns(slowIterator())
+
+    const peers = await all(take(randomwalk.walk(), 2))
+
+    expect(peers.map(peer => peer.id.toString())).to.deep.equal([
+      randomPeer1.id.toString(),
+      randomPeer2.id.toString()
+    ])
+  })
+
+  it('should join an existing random walk', async () => {
+    peerRouting.getClosestPeers
+      .onFirstCall().returns(async function * () {
+        for (let i = 0; i < 100; i++) {
+          yield await createRandomPeerInfo()
+          await delay(100)
+        }
+      }())
+      .onSecondCall().returns(slowIterator())
+
+    const [
+      peers1,
+      peers2
+    ] = await Promise.all([
+      all(take(randomwalk.walk(), 2)),
+      all(take(randomwalk.walk(), 2))
+    ])
+
+    expect(peers1.map(peer => peer.id.toString())).to.deep.equal(peers2.map(peer => peer.id.toString()))
+  })
+
+  it('should continue random walk until all consumers satisfied', async () => {
+    let yielded = 0
+
+    peerRouting.getClosestPeers
+      .onFirstCall().returns(async function * (key, options?: AbortOptions) {
+        for (let i = 0; i < 100; i++) {
+          yielded++
+          yield await createRandomPeerInfo()
+          options?.signal?.throwIfAborted()
+        }
+      }())
+      .onSecondCall().returns(slowIterator())
+
+    await Promise.all([
+      drain(take(randomwalk.walk(), 1)),
+      drain(take(randomwalk.walk(), 2))
+    ])
+
+    expect(yielded).to.equal(2)
+  })
+
+  it('should not block walk on slow consumers', async () => {
+    let yielded = 0
+
+    peerRouting.getClosestPeers
+      .onFirstCall().returns(async function * (key, options?: AbortOptions) {
+        for (let i = 0; i < 100; i++) {
+          yielded++
+          yield await createRandomPeerInfo()
+          options?.signal?.throwIfAborted()
+        }
+      }())
+      .onSecondCall().returns(slowIterator())
+
+    await Promise.all([
+      drain(take(randomwalk.walk(), 5)),
+      drain(map(take(randomwalk.walk(), 2), async peer => {
+        await delay(100)
+        return peer
+      }))
+    ])
+
+    expect(yielded).to.equal(7)
+  })
+})


### PR DESCRIPTION
To allow finding network services, add a random walk component that lets services find random network peers in a scalable way.

If two services try to random walk at the same time, they will share the results.

## Change checklist

- [x] I have performed a self-review of my own code
- [x] I have made corresponding changes to the documentation if necessary (this includes comments as well)
- [x] I have added tests that prove my fix is effective or that my feature works