### PR TITLE
fix: begin routing table refresh after routing table has started

### DIFF
--- a/packages/kad-dht/src/kad-dht.ts
+++ b/packages/kad-dht/src/kad-dht.ts
@@ -1,4 +1,4 @@
-import { CodeError, CustomEvent, TypedEventEmitter, contentRoutingSymbol, peerDiscoverySymbol, peerRoutingSymbol } from '@libp2p/interface'
+import { CodeError, CustomEvent, TypedEventEmitter, contentRoutingSymbol, peerDiscoverySymbol, peerRoutingSymbol, start, stop } from '@libp2p/interface'
 import drain from 'it-drain'
 import pDefer from 'p-defer'
 import { PROTOCOL } from './constants.js'
@@ -379,16 +379,15 @@ export class KadDHT extends TypedEventEmitter<PeerDiscoveryEvents> implements Ka
     // Only respond to queries when not in client mode
     await this.setMode(this.clientMode ? 'client' : 'server')
 
-    this.querySelf.start()
-
-    await Promise.all([
-      this.providers.start(),
-      this.queryManager.start(),
-      this.network.start(),
-      this.routingTable.start(),
-      this.topologyListener.start(),
-      this.routingTableRefresh.start()
-    ])
+    await start(
+      this.querySelf,
+      this.providers,
+      this.queryManager,
+      this.network,
+      this.routingTable,
+      this.topologyListener,
+      this.routingTableRefresh
+    )
   }
 
   /**
@@ -398,16 +397,15 @@ export class KadDHT extends TypedEventEmitter<PeerDiscoveryEvents> implements Ka
   async stop (): Promise<void> {
     this.running = false
 
-    this.querySelf.stop()
-
-    await Promise.all([
-      this.providers.stop(),
-      this.queryManager.stop(),
-      this.network.stop(),
-      this.routingTable.stop(),
-      this.routingTableRefresh.stop(),
-      this.topologyListener.stop()
-    ])
+    await stop(
+      this.querySelf,
+      this.providers,
+      this.queryManager,
+      this.network,
+      this.routingTable,
+      this.routingTableRefresh,
+      this.topologyListener
+    )
   }
 
   /**

--- a/packages/kad-dht/src/routing-table/refresh.ts
+++ b/packages/kad-dht/src/routing-table/refresh.ts
@@ -51,7 +51,7 @@ export class RoutingTableRefresh {
     this.refreshTable = this.refreshTable.bind(this)
   }
 
-  async start (): Promise<void> {
+  async afterStart (): Promise<void> {
     this.log(`refreshing routing table every ${this.refreshInterval}ms`)
     this.refreshTable(true)
   }


### PR DESCRIPTION
Fixes an error in the logs where we try to refresh the routing table before it's started.

Switch to doing it in `afterStart` so the routing table is available.

## Change checklist

- [x] I have performed a self-review of my own code
- [ ] I have made corresponding changes to the documentation if necessary (this includes comments as well)
- [ ] I have added tests that prove my fix is effective or that my feature works