### PR TITLE
fix: return self in FIND_NODE for self

### DIFF
--- a/packages/kad-dht/src/peer-routing/index.ts
+++ b/packages/kad-dht/src/peer-routing/index.ts
@@ -319,7 +319,7 @@ export class PeerRouting {
     if (output.length > 0) {
       this.log('getCloserPeersOffline found %d peer(s) closer to %b than %p', output.length, key, closerThan)
     } else {
-      this.log('getCloserPeersOffline could not find peer closer to %b than %p', key, closerThan)
+      this.log('getCloserPeersOffline could not find peer closer to %b than %p with %d peers in the routing table', key, closerThan, this.routingTable.size)
     }
 
     return output

--- a/packages/kad-dht/test/kad-dht.spec.ts
+++ b/packages/kad-dht/test/kad-dht.spec.ts
@@ -800,7 +800,7 @@ describe('KadDHT', () => {
       expect(res).to.not.be.empty()
     })
 
-    it('should not include itself in getClosestPeers PEER_RESPONSE', async function () {
+    it.skip('should not include itself in getClosestPeers PEER_RESPONSE', async function () {
       this.timeout(240 * 1000)
 
       const nDHTs = 30

--- a/packages/kad-dht/test/rpc/index.node.ts
+++ b/packages/kad-dht/test/rpc/index.node.ts
@@ -24,6 +24,7 @@ import { passthroughMapper } from '../../src/utils.js'
 import { createPeerId } from '../utils/create-peer-id.js'
 import type { Validators } from '../../src/index.js'
 import type { Libp2pEvents, Connection, PeerId, PeerStore } from '@libp2p/interface'
+import type { AddressManager } from '@libp2p/interface-internal'
 import type { Datastore } from 'interface-datastore'
 import type { Duplex, Source } from 'it-stream-types'
 
@@ -44,6 +45,7 @@ describe('rpc', () => {
       peerId,
       datastore,
       peerStore: stubInterface<PeerStore>(),
+      addressManager: stubInterface<AddressManager>(),
       logger: defaultLogger()
     }
     components.peerStore = new PersistentPeerStore({


### PR DESCRIPTION
Partial revert of #2499

If a node is queried for it's own peer id, return it's own peer info.

This is necessary because since https://github.com/libp2p/go-libp2p-kad-dht/pull/820 go-libp2p-kad-dht won't add a peer to it's routing tables that doesn't have any DHT peers that are KAD-futher from it's own ID already.

## Change checklist

- [x] I have performed a self-review of my own code
- [ ] I have made corresponding changes to the documentation if necessary (this includes comments as well)
- [ ] I have added tests that prove my fix is effective or that my feature works