### PR TITLE
fix: increase default DHT query timeout

### DIFF
--- a/packages/kad-dht/src/constants.ts
+++ b/packages/kad-dht/src/constants.ts
@@ -50,4 +50,4 @@ export const TABLE_REFRESH_INTERVAL = 5 * minute
 export const TABLE_REFRESH_QUERY_TIMEOUT = 30 * second
 
 // When a timeout is not specified, run a query for this long
-export const DEFAULT_QUERY_TIMEOUT = 30 * second
+export const DEFAULT_QUERY_TIMEOUT = 180 * second


### PR DESCRIPTION
30s is not enough for a typical query with an empty routing table.

A typical time is more like 60s so increase to 180s to give headroom.

## Change checklist

- [x] I have performed a self-review of my own code
- [ ] I have made corresponding changes to the documentation if necessary (this includes comments as well)
- [ ] I have added tests that prove my fix is effective or that my feature works