### PR TITLE
chore: increase ping test timeout

### DIFF
--- a/interop/test/ping.spec.ts
+++ b/interop/test/ping.spec.ts
@@ -49,7 +49,9 @@ describe('ping test', function () {
         denyDialMultiaddr: async () => false
       },
       services: {
-        ping: ping(),
+        ping: ping({
+          timeout: 120000
+        }),
         identify: identify()
       }
     }


### PR DESCRIPTION
Slow CI is slow so try increasing the default ping timeout.

## Change checklist

- [x] I have performed a self-review of my own code
- [ ] I have made corresponding changes to the documentation if necessary (this includes comments as well)
- [ ] I have added tests that prove my fix is effective or that my feature works