### PR TITLE
fix: load peerstore peers into routing table at startup

### DIFF
--- a/packages/kad-dht/src/routing-table/index.ts
+++ b/packages/kad-dht/src/routing-table/index.ts
@@ -110,6 +110,15 @@ export class RoutingTable extends TypedEventEmitter<RoutingTableEvents> implemen
       })
     })
 
+    // add existing peers from the peer store to routing table
+    for (const peer of await this.components.peerStore.all()) {
+      if (peer.protocols.includes(this.protocol)) {
+        const id = await utils.convertPeerId(peer.id)
+
+        this.kb.add({ id, peer: peer.id })
+      }
+    }
+
     // tag kad-close peers
     this._tagPeers(kBuck)
   }

--- a/packages/kad-dht/test/libp2p-routing.spec.ts
+++ b/packages/kad-dht/test/libp2p-routing.spec.ts
@@ -95,7 +95,9 @@ describe('content routing', () => {
       peerId: peers[peers.length - 1],
       registrar: stubInterface<Registrar>(),
       addressManager: stubInterface<AddressManager>(),
-      peerStore: stubInterface<PeerStore>(),
+      peerStore: stubInterface<PeerStore>({
+        all: async () => []
+      }),
       connectionManager: stubInterface<ConnectionManager>(),
       datastore: new MemoryDatastore(),
       events: new TypedEventEmitter<any>(),
@@ -220,7 +222,9 @@ describe('peer routing', () => {
       peerId: peers[peers.length - 1],
       registrar: stubInterface<Registrar>(),
       addressManager: stubInterface<AddressManager>(),
-      peerStore: stubInterface<PeerStore>(),
+      peerStore: stubInterface<PeerStore>({
+        all: async () => []
+      }),
       connectionManager: stubInterface<ConnectionManager>(),
       datastore: new MemoryDatastore(),
       events: new TypedEventEmitter<any>(),


### PR DESCRIPTION
On startup, query the peerstore for every peer that supports the configured KAD protocol and add them to the routing table.

## Change checklist

- [x] I have performed a self-review of my own code
- [ ] I have made corresponding changes to the documentation if necessary (this includes comments as well)
- [x] I have added tests that prove my fix is effective or that my feature works