### PR TITLE
fix: use prefix binary tree for routing table

### DIFF
--- a/packages/kad-dht/src/index.ts
+++ b/packages/kad-dht/src/index.ts
@@ -308,6 +308,20 @@ export interface KadDHTInit {
   kBucketSize?: number
 
   /**
+   * The threshold at which a kBucket will be split into two smaller kBuckets
+   *
+   * @default kBucketSize
+   */
+  kBucketSplitThreshold?: number
+
+  /**
+   * How many bits of the KAD-ID of peers to use when creating the routing table
+   *
+   * @default 128
+   */
+  prefixLength?: number
+
+  /**
    * If true, only ever be a DHT client. If false, be a DHT client until told
    * to be a DHT server via `setMode`.
    *

--- a/packages/kad-dht/src/query/query-path.ts
+++ b/packages/kad-dht/src/query/query-path.ts
@@ -3,16 +3,17 @@ import { anySignal } from 'any-signal'
 import Queue from 'p-queue'
 import { toString } from 'uint8arrays/to-string'
 import { xor } from 'uint8arrays/xor'
-import { convertPeerId, convertBuffer } from '../utils.js'
+import { convertPeerId, convertBuffer, getDistance } from '../utils.js'
 import { queryErrorEvent } from './events.js'
 import { queueToGenerator } from './utils.js'
 import type { CleanUpEvents } from './manager.js'
 import type { QueryEvent } from '../index.js'
 import type { QueryFunc } from '../query/types.js'
 import type { Logger, TypedEventTarget, PeerId, RoutingOptions } from '@libp2p/interface'
+import type { ConnectionManager } from '@libp2p/interface-internal'
 import type { PeerSet } from '@libp2p/peer-collections'
 
-const MAX_XOR = BigInt('0xFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFF')
+export const MAX_XOR = BigInt('0xFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFF')
 
 export interface QueryPathOptions extends RoutingOptions {
   /**
@@ -74,6 +75,11 @@ export interface QueryPathOptions extends RoutingOptions {
    * Set of peers seen by this and other paths
    */
   peersSeen: PeerSet
+
+  /**
+   * The libp2p connection manager
+   */
+  connectionManager: ConnectionManager
 }
 
 /**
@@ -81,7 +87,7 @@ export interface QueryPathOptions extends RoutingOptions {
  * every peer encountered that we have not seen before
  */
 export async function * queryPath (options: QueryPathOptions): AsyncGenerator<QueryEvent, void, undefined> {
-  const { key, startingPeer, ourPeerId, signal, query, alpha, pathIndex, numPaths, cleanUp, queryFuncTimeout, log, peersSeen } = options
+  const { key, startingPeer, ourPeerId, signal, query, alpha, pathIndex, numPaths, cleanUp, queryFuncTimeout, log, peersSeen, connectionManager } = options
   // Only ALPHA node/value lookups are allowed at any given time for each process
   // https://github.com/libp2p/specs/tree/master/kad-dht#alpha-concurrency-parameter-%CE%B1
   const queue = new Queue({
@@ -141,8 +147,13 @@ export async function * queryPath (options: QueryPathOptions): AsyncGenerator<Qu
                 continue
               }
 
+              if (!(await connectionManager.isDialable(closerPeer.multiaddrs))) { // eslint-disable-line max-depth
+                log('not querying undialable peer')
+                continue
+              }
+
               const closerPeerKadId = await convertPeerId(closerPeer.id)
-              const closerPeerXor = BigInt('0x' + toString(xor(closerPeerKadId, kadId), 'base16'))
+              const closerPeerXor = getDistance(closerPeerKadId, kadId)
 
               // only continue query if closer peer is actually closer
               if (closerPeerXor > peerXor) { // eslint-disable-line max-depth

--- a/packages/kad-dht/src/routing-table/index.ts
+++ b/packages/kad-dht/src/routing-table/index.ts
@@ -4,19 +4,22 @@ import { PeerQueue } from '@libp2p/utils/peer-queue'
 import { pbStream } from 'it-protobuf-stream'
 import { Message, MessageType } from '../message/dht.js'
 import * as utils from '../utils.js'
-import { KBucket, type PingEventDetails } from './k-bucket.js'
+import { KBucket, isLeafBucket, type Bucket, type PingEventDetails } from './k-bucket.js'
 import type { ComponentLogger, Logger, Metric, Metrics, PeerId, PeerStore, Startable, Stream } from '@libp2p/interface'
 import type { ConnectionManager } from '@libp2p/interface-internal'
 
 export const KAD_CLOSE_TAG_NAME = 'kad-close'
 export const KAD_CLOSE_TAG_VALUE = 50
 export const KBUCKET_SIZE = 20
+export const PREFIX_LENGTH = 128
 export const PING_TIMEOUT = 10000
 export const PING_CONCURRENCY = 10
 
 export interface RoutingTableInit {
   logPrefix: string
   protocol: string
+  prefixLength?: number
+  splitThreshold?: number
   kBucketSize?: number
   pingTimeout?: number
   pingConcurrency?: number
@@ -48,6 +51,8 @@ export class RoutingTable extends TypedEventEmitter<RoutingTableEvents> implemen
 
   private readonly log: Logger
   private readonly components: RoutingTableComponents
+  private readonly prefixLength: number
+  private readonly splitThreshold: number
   private readonly pingTimeout: number
   private readonly pingConcurrency: number
   private running: boolean
@@ -56,26 +61,29 @@ export class RoutingTable extends TypedEventEmitter<RoutingTableEvents> implemen
   private readonly tagValue: number
   private readonly metrics?: {
     routingTableSize: Metric
+    routingTableKadBucketTotal: Metric
+    routingTableKadBucketAverageOccupancy: Metric
+    routingTableKadBucketMaxDepth: Metric
   }
 
   constructor (components: RoutingTableComponents, init: RoutingTableInit) {
     super()
 
-    const { kBucketSize, pingTimeout, logPrefix, pingConcurrency, protocol, tagName, tagValue } = init
-
     this.components = components
-    this.log = components.logger.forComponent(`${logPrefix}:routing-table`)
-    this.kBucketSize = kBucketSize ?? KBUCKET_SIZE
-    this.pingTimeout = pingTimeout ?? PING_TIMEOUT
-    this.pingConcurrency = pingConcurrency ?? PING_CONCURRENCY
+    this.log = components.logger.forComponent(`${init.logPrefix}:routing-table`)
+    this.kBucketSize = init.kBucketSize ?? KBUCKET_SIZE
+    this.pingTimeout = init.pingTimeout ?? PING_TIMEOUT
+    this.pingConcurrency = init.pingConcurrency ?? PING_CONCURRENCY
     this.running = false
-    this.protocol = protocol
-    this.tagName = tagName ?? KAD_CLOSE_TAG_NAME
-    this.tagValue = tagValue ?? KAD_CLOSE_TAG_VALUE
+    this.protocol = init.protocol
+    this.tagName = init.tagName ?? KAD_CLOSE_TAG_NAME
+    this.tagValue = init.tagValue ?? KAD_CLOSE_TAG_VALUE
+    this.prefixLength = init.prefixLength ?? PREFIX_LENGTH
+    this.splitThreshold = init.splitThreshold ?? KBUCKET_SIZE
 
     this.pingQueue = new PeerQueue({
       concurrency: this.pingConcurrency,
-      metricName: `${logPrefix.replaceAll(':', '_')}_ping_queue`,
+      metricName: `${init.logPrefix.replaceAll(':', '_')}_ping_queue`,
       metrics: this.components.metrics
     })
     this.pingQueue.addEventListener('error', evt => {
@@ -84,7 +92,10 @@ export class RoutingTable extends TypedEventEmitter<RoutingTableEvents> implemen
 
     if (this.components.metrics != null) {
       this.metrics = {
-        routingTableSize: this.components.metrics.registerMetric(`${logPrefix.replaceAll(':', '_')}_routing_table_size`)
+        routingTableSize: this.components.metrics.registerMetric(`${init.logPrefix.replaceAll(':', '_')}_routing_table_size`),
+        routingTableKadBucketTotal: this.components.metrics.registerMetric(`${init.logPrefix.replaceAll(':', '_')}_routing_table_kad_bucket_total`),
+        routingTableKadBucketAverageOccupancy: this.components.metrics.registerMetric(`${init.logPrefix.replaceAll(':', '_')}_routing_table_kad_bucket_average_occupancy`),
+        routingTableKadBucketMaxDepth: this.components.metrics.registerMetric(`${init.logPrefix.replaceAll(':', '_')}_routing_table_kad_bucket_max_depth`)
       }
     }
   }
@@ -97,8 +108,13 @@ export class RoutingTable extends TypedEventEmitter<RoutingTableEvents> implemen
     this.running = true
 
     const kBuck = new KBucket({
-      localNodeId: await utils.convertPeerId(this.components.peerId),
-      numberOfNodesPerKBucket: this.kBucketSize,
+      localPeer: {
+        kadId: await utils.convertPeerId(this.components.peerId),
+        peerId: this.components.peerId
+      },
+      kBucketSize: this.kBucketSize,
+      prefixLength: this.prefixLength,
+      splitThreshold: this.splitThreshold,
       numberOfNodesToPing: 1
     })
     this.kb = kBuck
@@ -110,14 +126,19 @@ export class RoutingTable extends TypedEventEmitter<RoutingTableEvents> implemen
       })
     })
 
+    let peerStorePeers = 0
+
     // add existing peers from the peer store to routing table
     for (const peer of await this.components.peerStore.all()) {
       if (peer.protocols.includes(this.protocol)) {
         const id = await utils.convertPeerId(peer.id)
 
-        this.kb.add({ id, peer: peer.id })
+        this.kb.add({ kadId: id, peerId: peer.id })
+        peerStorePeers++
       }
     }
+
+    this.log('added %d peer store peers to the routing table', peerStorePeers)
 
     // tag kad-close peers
     this._tagPeers(kBuck)
@@ -139,7 +160,7 @@ export class RoutingTable extends TypedEventEmitter<RoutingTableEvents> implemen
 
     const updatePeerTags = utils.debounce(() => {
       const newClosest = new PeerSet(
-        kBuck.closest(kBuck.localNodeId, KBUCKET_SIZE).map(contact => contact.peer)
+        kBuck.closest(kBuck.localPeer.kadId, KBUCKET_SIZE)
       )
       const addedPeers = newClosest.difference(kClosest)
       const removedPeers = kClosest.difference(newClosest)
@@ -174,12 +195,12 @@ export class RoutingTable extends TypedEventEmitter<RoutingTableEvents> implemen
     kBuck.addEventListener('added', (evt) => {
       updatePeerTags()
 
-      this.safeDispatchEvent('peer:add', { detail: evt.detail.peer })
+      this.safeDispatchEvent('peer:add', { detail: evt.detail.peerId })
     })
     kBuck.addEventListener('removed', (evt) => {
       updatePeerTags()
 
-      this.safeDispatchEvent('peer:remove', { detail: evt.detail.peer })
+      this.safeDispatchEvent('peer:remove', { detail: evt.detail.peerId })
     })
   }
 
@@ -206,7 +227,7 @@ export class RoutingTable extends TypedEventEmitter<RoutingTableEvents> implemen
     const results = await Promise.all(
       oldContacts.map(async oldContact => {
         // if a previous ping wants us to ping this contact, re-use the result
-        const pingJob = this.pingQueue.find(oldContact.peer)
+        const pingJob = this.pingQueue.find(oldContact.peerId)
 
         if (pingJob != null) {
           return pingJob.join()
@@ -220,8 +241,8 @@ export class RoutingTable extends TypedEventEmitter<RoutingTableEvents> implemen
               signal: AbortSignal.timeout(this.pingTimeout)
             }
 
-            this.log('pinging old contact %p', oldContact.peer)
-            const connection = await this.components.connectionManager.openConnection(oldContact.peer, options)
+            this.log('pinging old contact %p', oldContact.peerId)
+            const connection = await this.components.connectionManager.openConnection(oldContact.peerId, options)
             stream = await connection.newStream(this.protocol, options)
 
             const pb = pbStream(stream)
@@ -241,9 +262,9 @@ export class RoutingTable extends TypedEventEmitter<RoutingTableEvents> implemen
             if (this.running && this.kb != null) {
               // only evict peers if we are still running, otherwise we evict
               // when dialing is cancelled due to shutdown in progress
-              this.log.error('could not ping peer %p', oldContact.peer, err)
-              this.log('evicting old contact after ping failed %p', oldContact.peer)
-              this.kb.remove(oldContact.id)
+              this.log.error('could not ping peer %p', oldContact.peerId, err)
+              this.log('evicting old contact after ping failed %p', oldContact.peerId)
+              this.kb.remove(oldContact.kadId)
             }
 
             stream?.abort(err)
@@ -253,7 +274,7 @@ export class RoutingTable extends TypedEventEmitter<RoutingTableEvents> implemen
             this.metrics?.routingTableSize.update(this.size)
           }
         }, {
-          peerId: oldContact.peer
+          peerId: oldContact.peerId
         })
       })
     )
@@ -263,7 +284,7 @@ export class RoutingTable extends TypedEventEmitter<RoutingTableEvents> implemen
       .length
 
     if (this.running && responded < oldContacts.length && this.kb != null) {
-      this.log('adding new contact %p', newContact.peer)
+      this.log('adding new contact %p', newContact.peerId)
       this.kb.add(newContact)
     }
   }
@@ -286,13 +307,7 @@ export class RoutingTable extends TypedEventEmitter<RoutingTableEvents> implemen
    */
   async find (peer: PeerId): Promise<PeerId | undefined> {
     const key = await utils.convertPeerId(peer)
-    const closest = this.closestPeer(key)
-
-    if (closest != null && peer.equals(closest)) {
-      return closest
-    }
-
-    return undefined
+    return this.kb?.get(key)?.peerId
   }
 
   /**
@@ -316,26 +331,24 @@ export class RoutingTable extends TypedEventEmitter<RoutingTableEvents> implemen
       return []
     }
 
-    const closest = this.kb.closest(key, count)
-
-    return closest.map(p => p.peer)
+    return [...this.kb.closest(key, count)]
   }
 
   /**
    * Add or update the routing table with the given peer
    */
-  async add (peer: PeerId): Promise<void> {
+  async add (peerId: PeerId): Promise<void> {
     if (this.kb == null) {
       throw new Error('RoutingTable is not started')
     }
 
-    const id = await utils.convertPeerId(peer)
+    const kadId = await utils.convertPeerId(peerId)
 
-    this.kb.add({ id, peer })
+    this.kb.add({ kadId, peerId })
 
-    this.log('added %p with kad id %b', peer, id)
+    this.log('added %p with kad id %b', peerId, kadId)
 
-    this.metrics?.routingTableSize.update(this.size)
+    this.updateMetrics()
   }
 
   /**
@@ -350,6 +363,38 @@ export class RoutingTable extends TypedEventEmitter<RoutingTableEvents> implemen
 
     this.kb.remove(id)
 
-    this.metrics?.routingTableSize.update(this.size)
+    this.updateMetrics()
+  }
+
+  private updateMetrics (): void {
+    if (this.metrics == null || this.kb == null) {
+      return
+    }
+
+    let size = 0
+    let buckets = 0
+    let maxDepth = 0
+
+    function count (bucket: Bucket): void {
+      if (isLeafBucket(bucket)) {
+        if (bucket.depth > maxDepth) {
+          maxDepth = bucket.depth
+        }
+
+        buckets++
+        size += bucket.peers.length
+        return
+      }
+
+      count(bucket.left)
+      count(bucket.right)
+    }
+
+    count(this.kb.root)
+
+    this.metrics.routingTableSize.update(size)
+    this.metrics.routingTableKadBucketTotal.update(buckets)
+    this.metrics.routingTableKadBucketAverageOccupancy.update(Math.round(size / buckets))
+    this.metrics.routingTableKadBucketMaxDepth.update(maxDepth)
   }
 }

--- a/packages/kad-dht/src/routing-table/k-bucket.ts
+++ b/packages/kad-dht/src/routing-table/k-bucket.ts
@@ -1,33 +1,8 @@
-/*
-index.js - Kademlia DHT K-bucket implementation as a binary tree.
-
-The MIT License (MIT)
-
-Copyright (c) 2013-2021 Tristan Slominski
-
-Permission is hereby granted, free of charge, to any person
-obtaining a copy of this software and associated documentation
-files (the "Software"), to deal in the Software without
-restriction, including without limitation the rights to use,
-copy, modify, merge, publish, distribute, sublicense, and/or sell
-copies of the Software, and to permit persons to whom the
-Software is furnished to do so, subject to the following
-conditions:
-
-The above copyright notice and this permission notice shall be
-included in all copies or substantial portions of the Software.
-
-THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND,
-EXPRESS OR IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES
-OF MERCHANTABILITY, FITNESS FOR A PARTICULAR PURPOSE AND
-NONINFRINGEMENT. IN NO EVENT SHALL THE AUTHORS OR COPYRIGHT
-HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER LIABILITY,
-WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING
-FROM, OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR
-OTHER DEALINGS IN THE SOFTWARE.
-*/
-
 import { TypedEventEmitter } from '@libp2p/interface'
+import { toString as uint8ArrayToString } from 'uint8arrays/to-string'
+import { xor as uint8ArrayXor } from 'uint8arrays/xor'
+import { PeerDistanceList } from '../peer-list/peer-distance-list.js'
+import { KBUCKET_SIZE } from './index.js'
 import type { PeerId } from '@libp2p/interface'
 
 function arrayEquals (array1: Uint8Array, array2: Uint8Array): boolean {
@@ -45,44 +20,56 @@ function arrayEquals (array1: Uint8Array, array2: Uint8Array): boolean {
   return true
 }
 
-function createNode (): Bucket {
-  // @ts-expect-error loose types
-  return { contacts: [], dontSplit: false, left: null, right: null }
-}
-
 function ensureInt8 (name: string, val?: Uint8Array): void {
   if (!(val instanceof Uint8Array)) {
     throw new TypeError(name + ' is not a Uint8Array')
   }
+
+  if (val.byteLength !== 32) {
+    throw new TypeError(name + ' had incorrect length')
+  }
 }
 
 export interface PingEventDetails {
-  oldContacts: Contact[]
-  newContact: Contact
-}
-
-export interface UpdatedEventDetails {
-  incumbent: Contact
-  selection: Contact
+  oldContacts: Peer[]
+  newContact: Peer
 }
 
 export interface KBucketEvents {
   'ping': CustomEvent<PingEventDetails>
-  'added': CustomEvent<Contact>
-  'removed': CustomEvent<Contact>
-  'updated': CustomEvent<UpdatedEventDetails>
+  'added': CustomEvent<Peer>
+  'removed': CustomEvent<Peer>
 }
 
 export interface KBucketOptions {
   /**
-   * A Uint8Array representing the local node id
+   * The current peer. All subsequently added peers must have a KadID that is
+   * the same length as this peer.
    */
-  localNodeId: Uint8Array
+  localPeer: Peer
 
   /**
-   * The number of nodes that a k-bucket can contain before being full or split.
+   * How many bits of the key to use when forming the bucket trie. The larger
+   * this value, the deeper the tree will grow and the slower the lookups will
+   * be but the peers returned will be more specific to the key.
    */
-  numberOfNodesPerKBucket?: number
+  prefixLength: number
+
+  /**
+   * The number of nodes that a max-depth k-bucket can contain before being
+   * full.
+   *
+   * @default 20
+   */
+  kBucketSize?: number
+
+  /**
+   * The number of nodes that an intermediate k-bucket can contain before being
+   * split.
+   *
+   * @default kBucketSize
+   */
+  splitThreshold?: number
 
   /**
    * The number of nodes to ping when a bucket that should not be split becomes
@@ -90,188 +77,127 @@ export interface KBucketOptions {
    * nodes that have not been contacted the longest.
    */
   numberOfNodesToPing?: number
-
-  /**
-   * An optional `distance` function that gets two `id` Uint8Arrays and return
-   * distance (as number) between them.
-   */
-  distance?(a: Uint8Array, b: Uint8Array): number
-
-  /**
-   * An optional `arbiter` function that given two `contact` objects with the
-   * same `id` returns the desired object to be used for updating the k-bucket.
-   * For more details, see [arbiter function](#arbiter-function).
-   */
-  arbiter?(incumbent: Contact, candidate: Contact): Contact
 }
 
-export interface Contact {
-  id: Uint8Array
-  peer: PeerId
-  vectorClock?: number
+export interface Peer {
+  kadId: Uint8Array
+  peerId: PeerId
 }
 
-export interface Bucket {
-  id: Uint8Array
-  contacts: Contact[]
-  dontSplit: boolean
+export interface LeafBucket {
+  prefix: string
+  depth: number
+  peers: Peer[]
+}
+
+export interface InternalBucket {
+  prefix: string
+  depth: number
   left: Bucket
   right: Bucket
 }
 
+export type Bucket = LeafBucket | InternalBucket
+
+export function isLeafBucket (obj: any): obj is LeafBucket {
+  return Array.isArray(obj?.peers)
+}
+
 /**
- * Implementation of a Kademlia DHT k-bucket used for storing
- * contact (peer node) information.
+ * Implementation of a Kademlia DHT routing table as a prefix binary trie with
+ * configurable prefix length, bucket split threshold and size.
  */
 export class KBucket extends TypedEventEmitter<KBucketEvents> {
-  public localNodeId: Uint8Array
   public root: Bucket
-  private readonly numberOfNodesPerKBucket: number
+  public localPeer: Peer
+  private readonly prefixLength: number
+  private readonly splitThreshold: number
+  private readonly kBucketSize: number
   private readonly numberOfNodesToPing: number
-  private readonly distance: (a: Uint8Array, b: Uint8Array) => number
-  private readonly arbiter: (incumbent: Contact, candidate: Contact) => Contact
 
   constructor (options: KBucketOptions) {
     super()
 
-    this.localNodeId = options.localNodeId
-    this.numberOfNodesPerKBucket = options.numberOfNodesPerKBucket ?? 20
+    this.localPeer = options.localPeer
+    this.prefixLength = options.prefixLength
+    this.kBucketSize = options.kBucketSize ?? KBUCKET_SIZE
+    this.splitThreshold = options.splitThreshold ?? this.kBucketSize
     this.numberOfNodesToPing = options.numberOfNodesToPing ?? 3
-    this.distance = options.distance ?? KBucket.distance
-    // use an arbiter from options or vectorClock arbiter by default
-    this.arbiter = options.arbiter ?? KBucket.arbiter
 
-    ensureInt8('option.localNodeId as parameter 1', this.localNodeId)
+    ensureInt8('options.localPeer.kadId', options.localPeer.kadId)
 
-    this.root = createNode()
-  }
-
-  /**
-   * Default arbiter function for contacts with the same id. Uses
-   * contact.vectorClock to select which contact to update the k-bucket with.
-   * Contact with larger vectorClock field will be selected. If vectorClock is
-   * the same, candidate will be selected.
-   *
-   * @param {object} incumbent - Contact currently stored in the k-bucket.
-   * @param {object} candidate - Contact being added to the k-bucket.
-   * @returns {object} Contact to updated the k-bucket with.
-   */
-  static arbiter (incumbent: Contact, candidate: Contact): Contact {
-    return (incumbent.vectorClock ?? 0) > (candidate.vectorClock ?? 0) ? incumbent : candidate
-  }
-
-  /**
-   * Default distance function. Finds the XOR
-   * distance between firstId and secondId.
-   *
-   * @param  {Uint8Array} firstId -  Uint8Array containing first id.
-   * @param  {Uint8Array} secondId -  Uint8Array containing second id.
-   * @returns {number} Integer The XOR distance between firstId and secondId.
-   */
-  static distance (firstId: Uint8Array, secondId: Uint8Array): number {
-    let distance = 0
-    let i = 0
-    const min = Math.min(firstId.length, secondId.length)
-    const max = Math.max(firstId.length, secondId.length)
-    for (; i < min; ++i) {
-      distance = distance * 256 + (firstId[i] ^ secondId[i])
+    this.root = {
+      prefix: '',
+      depth: 0,
+      peers: []
     }
-    for (; i < max; ++i) distance = distance * 256 + 255
-    return distance
   }
 
   /**
    * Adds a contact to the k-bucket.
    *
-   * @param {object} contact - the contact object to add
+   * @param {Peer} peer - the contact object to add
    */
-  add (contact: Contact): KBucket {
-    ensureInt8('contact.id', contact?.id)
+  add (peer: Peer): void {
+    ensureInt8('peer.kadId', peer?.kadId)
 
-    let bitIndex = 0
-    let node = this.root
-
-    while (node.contacts === null) {
-      // this is not a leaf node but an inner node with 'low' and 'high'
-      // branches; we will check the appropriate bit of the identifier and
-      // delegate to the appropriate node for further processing
-      node = this._determineNode(node, contact.id, bitIndex++)
-    }
+    const bucket = this._determineBucket(peer.kadId)
 
     // check if the contact already exists
-    const index = this._indexOf(node, contact.id)
-    if (index >= 0) {
-      this._update(node, index, contact)
-      return this
+    if (this._indexOf(bucket, peer.kadId) > -1) {
+      return
     }
 
-    if (node.contacts.length < this.numberOfNodesPerKBucket) {
-      node.contacts.push(contact)
-      this.safeDispatchEvent('added', { detail: contact })
-      return this
+    // are the too many peers in the bucket?
+    if (bucket.peers.length === this.splitThreshold) {
+      // split the bucket
+      this._split(bucket)
+
+      // try again
+      this.add(peer)
+
+      return
     }
 
-    // the bucket is full
-    if (node.dontSplit) {
-      // we are not allowed to split the bucket
-      // we need to ping the first this.numberOfNodesToPing
-      // in order to determine if they are alive
-      // only if one of the pinged nodes does not respond, can the new contact
-      // be added (this prevents DoS flodding with new invalid contacts)
-      this.safeDispatchEvent('ping', {
-        detail: {
-          oldContacts: node.contacts.slice(0, this.numberOfNodesToPing),
-          newContact: contact
-        }
-      })
-      return this
+    // is there space in the bucket?
+    if (bucket.peers.length < this.kBucketSize) {
+      bucket.peers.push(peer)
+      this.safeDispatchEvent('added', { detail: peer })
+
+      return
     }
 
-    this._split(node, bitIndex)
-    return this.add(contact)
+    // we are at the bottom of the trie and the bucket is full so we can't add
+    // any more peers.
+    //
+    // instead ping the first this.numberOfNodesToPing in order to determine
+    // if they are still online.
+    //
+    // only add the new peer if one of the pinged nodes does not respond, this
+    // prevents DoS flooding with new invalid contacts.
+    this.safeDispatchEvent('ping', {
+      detail: {
+        oldContacts: bucket.peers.slice(0, this.numberOfNodesToPing),
+        newContact: peer
+      }
+    })
   }
 
   /**
-   * Get the n closest contacts to the provided node id. "Closest" here means:
+   * Get 0-n closest contacts to the provided node id. "Closest" here means:
    * closest according to the XOR metric of the contact node id.
    *
    * @param {Uint8Array} id - Contact node id
-   * @param {number} n - Integer (Default: Infinity) The maximum number of closest contacts to return
-   * @returns {Array} Array Maximum of n closest contacts to the node id
+   * @returns {Generator<Peer, void, undefined>} Array Maximum of n closest contacts to the node id
    */
-  closest (id: Uint8Array, n = Infinity): Contact[] {
-    ensureInt8('id', id)
+  * closest (id: Uint8Array, n: number = this.kBucketSize): Generator<PeerId, void, undefined> {
+    const list = new PeerDistanceList(id, n)
 
-    if ((!Number.isInteger(n) && n !== Infinity) || n <= 0) {
-      throw new TypeError('n is not positive number')
+    for (const peer of this.toIterable()) {
+      list.addWitKadId(peer.peerId, peer.kadId)
     }
 
-    let contacts: Contact[] = []
-
-    for (let nodes = [this.root], bitIndex = 0; nodes.length > 0 && contacts.length < n;) {
-      const node = nodes.pop()
-
-      if (node == null) {
-        continue
-      }
-
-      if (node.contacts === null) {
-        const detNode = this._determineNode(node, id, bitIndex++)
-        nodes.push(node.left === detNode ? node.right : node.left)
-        nodes.push(detNode)
-      } else {
-        contacts = contacts.concat(node.contacts)
-      }
-    }
-
-    return contacts
-      .map(a => ({
-        distance: this.distance(a.id, id),
-        contact: a
-      }))
-      .sort((a, b) => a.distance - b.distance)
-      .slice(0, n)
-      .map(a => a.contact)
+    yield * list.peers
   }
 
   /**
@@ -280,65 +206,25 @@ export class KBucket extends TypedEventEmitter<KBucketEvents> {
    * @returns {number} The number of contacts held in the tree
    */
   count (): number {
-    // return this.toArray().length
-    let count = 0
-    for (const nodes = [this.root]; nodes.length > 0;) {
-      const node = nodes.pop()
-
-      if (node == null) {
-        continue
+    function countBucket (bucket: Bucket): number {
+      if (isLeafBucket(bucket)) {
+        return bucket.peers.length
       }
 
-      if (node.contacts === null) {
-        nodes.push(node.right, node.left)
-      } else {
-        count += node.contacts.length
+      let count = 0
+
+      if (bucket.left != null) {
+        count += countBucket(bucket.left)
       }
+
+      if (bucket.right != null) {
+        count += countBucket(bucket.right)
+      }
+
+      return count
     }
 
-    return count
-  }
-
-  /**
-   * Determines whether the id at the bitIndex is 0 or 1.
-   * Return left leaf if `id` at `bitIndex` is 0, right leaf otherwise
-   *
-   * @param {object} node - internal object that has 2 leafs: left and right
-   * @param {Uint8Array} id - Id to compare localNodeId with.
-   * @param {number} bitIndex - Integer (Default: 0) The bit index to which bit to check in the id Uint8Array.
-   * @returns {object} left leaf if id at bitIndex is 0, right leaf otherwise.
-   */
-  _determineNode (node: any, id: Uint8Array, bitIndex: number): Bucket {
-    // **NOTE** remember that id is a Uint8Array and has granularity of
-    // bytes (8 bits), whereas the bitIndex is the _bit_ index (not byte)
-
-    // id's that are too short are put in low bucket (1 byte = 8 bits)
-    // (bitIndex >> 3) finds how many bytes the bitIndex describes
-    // bitIndex % 8 checks if we have extra bits beyond byte multiples
-    // if number of bytes is <= no. of bytes described by bitIndex and there
-    // are extra bits to consider, this means id has less bits than what
-    // bitIndex describes, id therefore is too short, and will be put in low
-    // bucket
-    const bytesDescribedByBitIndex = bitIndex >> 3
-    const bitIndexWithinByte = bitIndex % 8
-    if ((id.length <= bytesDescribedByBitIndex) && (bitIndexWithinByte !== 0)) {
-      return node.left
-    }
-
-    const byteUnderConsideration = id[bytesDescribedByBitIndex]
-
-    // byteUnderConsideration is an integer from 0 to 255 represented by 8 bits
-    // where 255 is 11111111 and 0 is 00000000
-    // in order to find out whether the bit at bitIndexWithinByte is set
-    // we construct (1 << (7 - bitIndexWithinByte)) which will consist
-    // of all bits being 0, with only one bit set to 1
-    // for example, if bitIndexWithinByte is 3, we will construct 00010000 by
-    // (1 << (7 - 3)) -> (1 << 4) -> 16
-    if ((byteUnderConsideration & (1 << (7 - bitIndexWithinByte))) !== 0) {
-      return node.right
-    }
-
-    return node.left
+    return countBucket(this.root)
   }
 
   /**
@@ -347,118 +233,31 @@ export class KBucket extends TypedEventEmitter<KBucketEvents> {
    * contact if we have it or null if not. If this is an inner node, determine
    * which branch of the tree to traverse and repeat.
    *
-   * @param {Uint8Array} id - The ID of the contact to fetch.
-   * @returns {object | null} The contact if available, otherwise null
+   * @param {Uint8Array} kadId - The ID of the contact to fetch.
+   * @returns {object | undefined} The contact if available, otherwise null
    */
-  get (id: Uint8Array): Contact | undefined {
-    ensureInt8('id', id)
+  get (kadId: Uint8Array): Peer | undefined {
+    const bucket = this._determineBucket(kadId)
+    const index = this._indexOf(bucket, kadId)
 
-    let bitIndex = 0
-
-    let node: Bucket = this.root
-    while (node.contacts === null) {
-      node = this._determineNode(node, id, bitIndex++)
-    }
-
-    // index of uses contact id for matching
-    const index = this._indexOf(node, id)
-    return index >= 0 ? node.contacts[index] : undefined
-  }
-
-  /**
-   * Returns the index of the contact with provided
-   * id if it exists, returns -1 otherwise.
-   *
-   * @param {object} node - internal object that has 2 leafs: left and right
-   * @param {Uint8Array} id - Contact node id.
-   * @returns {number} Integer Index of contact with provided id if it exists, -1 otherwise.
-   */
-  _indexOf (node: Bucket, id: Uint8Array): number {
-    for (let i = 0; i < node.contacts.length; ++i) {
-      if (arrayEquals(node.contacts[i].id, id)) return i
-    }
-
-    return -1
+    return bucket.peers[index]
   }
 
   /**
    * Removes contact with the provided id.
    *
-   * @param {Uint8Array} id - The ID of the contact to remove
-   * @returns {object} The k-bucket itself
+   * @param {Uint8Array} kadId - The ID of the contact to remove
    */
-  remove (id: Uint8Array): KBucket {
-    ensureInt8('the id as parameter 1', id)
+  remove (kadId: Uint8Array): void {
+    const bucket = this._determineBucket(kadId)
+    const index = this._indexOf(bucket, kadId)
 
-    let bitIndex = 0
-    let node = this.root
-
-    while (node.contacts === null) {
-      node = this._determineNode(node, id, bitIndex++)
-    }
-
-    const index = this._indexOf(node, id)
-    if (index >= 0) {
-      const contact = node.contacts.splice(index, 1)[0]
+    if (index > -1) {
+      const peer = bucket.peers.splice(index, 1)[0]
       this.safeDispatchEvent('removed', {
-        detail: contact
+        detail: peer
       })
     }
-
-    return this
-  }
-
-  /**
-   * Splits the node, redistributes contacts to the new nodes, and marks the
-   * node that was split as an inner node of the binary tree of nodes by
-   * setting this.root.contacts = null
-   *
-   * @param {object} node - node for splitting
-   * @param {number} bitIndex - the bitIndex to which byte to check in the Uint8Array for navigating the binary tree
-   */
-  _split (node: Bucket, bitIndex: number): void {
-    node.left = createNode()
-    node.right = createNode()
-
-    // redistribute existing contacts amongst the two newly created nodes
-    for (const contact of node.contacts) {
-      this._determineNode(node, contact.id, bitIndex).contacts.push(contact)
-    }
-
-    // @ts-expect-error loose types
-    node.contacts = null // mark as inner tree node
-
-    // don't split the "far away" node
-    // we check where the local node would end up and mark the other one as
-    // "dontSplit" (i.e. "far away")
-    const detNode = this._determineNode(node, this.localNodeId, bitIndex)
-    const otherNode = node.left === detNode ? node.right : node.left
-    otherNode.dontSplit = true
-  }
-
-  /**
-   * Returns all the contacts contained in the tree as an array.
-   * If this is a leaf, return a copy of the bucket. If this is not a leaf,
-   * return the union of the low and high branches (themselves also as arrays).
-   *
-   * @returns {Array} All of the contacts in the tree, as an array
-   */
-  toArray (): Contact[] {
-    let result: Contact[] = []
-    for (const nodes = [this.root]; nodes.length > 0;) {
-      const node = nodes.pop()
-
-      if (node == null) {
-        continue
-      }
-
-      if (node.contacts === null) {
-        nodes.push(node.right, node.left)
-      } else {
-        result = result.concat(node.contacts)
-      }
-    }
-    return result
   }
 
   /**
@@ -468,54 +267,109 @@ export class KBucket extends TypedEventEmitter<KBucketEvents> {
    *
    * @returns {Iterable} All of the contacts in the tree, as an iterable
    */
-  * toIterable (): Iterable<Contact> {
-    for (const nodes = [this.root]; nodes.length > 0;) {
-      const node = nodes.pop()
-
-      if (node == null) {
-        continue
+  * toIterable (): Generator<Peer, void, undefined> {
+    function * iterate (bucket: Bucket): Generator<Peer, void, undefined> {
+      if (isLeafBucket(bucket)) {
+        yield * bucket.peers
+        return
       }
 
-      if (node.contacts === null) {
-        nodes.push(node.right, node.left)
-      } else {
-        yield * node.contacts
-      }
+      yield * iterate(bucket.left)
+      yield * iterate(bucket.right)
     }
+
+    yield * iterate(this.root)
   }
 
   /**
-   * Updates the contact selected by the arbiter.
-   * If the selection is our old contact and the candidate is some new contact
-   * then the new contact is abandoned (not added).
-   * If the selection is our old contact and the candidate is our old contact
-   * then we are refreshing the contact and it is marked as most recently
-   * contacted (by being moved to the right/end of the bucket array).
-   * If the selection is our new contact, the old contact is removed and the new
-   * contact is marked as most recently contacted.
+   * Default distance function. Finds the XOR distance between firstId and
+   * secondId.
    *
-   * @param {object} node - internal object that has 2 leafs: left and right
-   * @param {number} index - the index in the bucket where contact exists (index has already been computed in a previous calculation)
-   * @param {object} contact - The contact object to update
+   * @param  {Uint8Array} firstId - Uint8Array containing first id.
+   * @param  {Uint8Array} secondId - Uint8Array containing second id.
+   * @returns {number} Integer The XOR distance between firstId and secondId.
    */
-  _update (node: Bucket, index: number, contact: Contact): void {
-    // sanity check
-    if (!arrayEquals(node.contacts[index].id, contact.id)) {
-      throw new Error('wrong index for _update')
+  distance (firstId: Uint8Array, secondId: Uint8Array): bigint {
+    return BigInt('0x' + uint8ArrayToString(uint8ArrayXor(firstId, secondId), 'base16'))
+  }
+
+  /**
+   * Determines whether the id at the bitIndex is 0 or 1
+   * Return left leaf if `id` at `bitIndex` is 0, right leaf otherwise
+   *
+   * @param {Uint8Array} kadId - Id to compare localNodeId with
+   * @returns {LeafBucket} left leaf if id at bitIndex is 0, right leaf otherwise.
+   */
+  private _determineBucket (kadId: Uint8Array): LeafBucket {
+    const bitString = uint8ArrayToString(kadId, 'base2')
+    const prefix = bitString.substring(0, this.prefixLength)
+
+    function findBucket (bucket: Bucket, bitIndex: number = 0): LeafBucket {
+      if (isLeafBucket(bucket)) {
+        return bucket
+      }
+
+      const bit = prefix[bitIndex]
+
+      if (bit === '0') {
+        return findBucket(bucket.left, bitIndex + 1)
+      }
+
+      return findBucket(bucket.right, bitIndex + 1)
     }
 
-    const incumbent = node.contacts[index]
-    const selection = this.arbiter(incumbent, contact)
-    // if the selection is our old contact and the candidate is some new
-    // contact, then there is nothing to do
-    if (selection === incumbent && incumbent !== contact) return
+    return findBucket(this.root)
+  }
 
-    node.contacts.splice(index, 1) // remove old contact
-    node.contacts.push(selection) // add more recent contact version
-    this.safeDispatchEvent('updated', {
-      detail: {
-        incumbent, selection
+  /**
+   * Returns the index of the contact with provided
+   * id if it exists, returns -1 otherwise.
+   *
+   * @param {object} bucket - internal object that has 2 leafs: left and right
+   * @param {Uint8Array} kadId - KadId of peer
+   * @returns {number} Integer Index of contact with provided id if it exists, -1 otherwise.
+   */
+  private _indexOf (bucket: LeafBucket, kadId: Uint8Array): number {
+    return bucket.peers.findIndex(peer => arrayEquals(peer.kadId, kadId))
+  }
+
+  /**
+   * Modify the bucket, turn it from a leaf bucket to an internal bucket
+   *
+   * @param {any} bucket - bucket for splitting
+   */
+  private _split (bucket: LeafBucket): void {
+    const depth = bucket.depth + 1
+
+    // create child buckets
+    const left: LeafBucket = {
+      prefix: '0',
+      depth,
+      peers: []
+    }
+    const right: LeafBucket = {
+      prefix: '1',
+      depth,
+      peers: []
+    }
+
+    // redistribute peers
+    for (const peer of bucket.peers) {
+      const bitString = uint8ArrayToString(peer.kadId, 'base2')
+
+      if (bitString[depth] === '0') {
+        left.peers.push(peer)
+      } else {
+        right.peers.push(peer)
       }
-    })
+    }
+
+    // convert leaf bucket to internal bucket
+    // @ts-expect-error peers is not a property of LeafBucket
+    delete bucket.peers
+    // @ts-expect-error left is not a property of LeafBucket
+    bucket.left = left
+    // @ts-expect-error right is not a property of LeafBucket
+    bucket.right = right
   }
 }

--- a/packages/kad-dht/src/routing-table/refresh.ts
+++ b/packages/kad-dht/src/routing-table/refresh.ts
@@ -165,7 +165,7 @@ export class RoutingTableRefresh {
     const randomData = randomBytes(2)
     const randomUint16 = (randomData[1] << 8) + randomData[0]
 
-    const key = await this._makePeerId(this.routingTable.kb.localNodeId, randomUint16, targetCommonPrefixLength)
+    const key = await this._makePeerId(this.routingTable.kb.localPeer.kadId, randomUint16, targetCommonPrefixLength)
 
     return peerIdFromBytes(key)
   }
@@ -241,8 +241,8 @@ export class RoutingTableRefresh {
       return
     }
 
-    for (const { id } of this.routingTable.kb.toIterable()) {
-      const distance = uint8ArrayXor(this.routingTable.kb.localNodeId, id)
+    for (const { kadId } of this.routingTable.kb.toIterable()) {
+      const distance = uint8ArrayXor(this.routingTable.kb.localPeer.kadId, kadId)
       let leadingZeros = 0
 
       for (const byte of distance) {

--- a/packages/kad-dht/src/utils.ts
+++ b/packages/kad-dht/src/utils.ts
@@ -6,6 +6,7 @@ import { sha256 } from 'multiformats/hashes/sha2'
 import { concat as uint8ArrayConcat } from 'uint8arrays/concat'
 import { fromString as uint8ArrayFromString } from 'uint8arrays/from-string'
 import { toString as uint8ArrayToString } from 'uint8arrays/to-string'
+import { xor as uint8ArrayXor } from 'uint8arrays/xor'
 import { RECORD_KEY_PREFIX } from './constants.js'
 import type { PeerId, PeerInfo } from '@libp2p/interface'
 import type { Multiaddr } from '@multiformats/multiaddr'
@@ -186,4 +187,8 @@ export function multiaddrIsPublic (multiaddr: Multiaddr): boolean {
   }
 
   return false
+}
+
+export function getDistance (from: Uint8Array, to: Uint8Array): bigint {
+  return BigInt('0x' + uint8ArrayToString(uint8ArrayXor(from, to), 'base16'))
 }

--- a/packages/kad-dht/test/libp2p-routing.spec.ts
+++ b/packages/kad-dht/test/libp2p-routing.spec.ts
@@ -98,7 +98,9 @@ describe('content routing', () => {
       peerStore: stubInterface<PeerStore>({
         all: async () => []
       }),
-      connectionManager: stubInterface<ConnectionManager>(),
+      connectionManager: stubInterface<ConnectionManager>({
+        isDialable: async () => true
+      }),
       datastore: new MemoryDatastore(),
       events: new TypedEventEmitter<any>(),
       logger: defaultLogger()
@@ -225,7 +227,9 @@ describe('peer routing', () => {
       peerStore: stubInterface<PeerStore>({
         all: async () => []
       }),
-      connectionManager: stubInterface<ConnectionManager>(),
+      connectionManager: stubInterface<ConnectionManager>({
+        isDialable: async () => true
+      }),
       datastore: new MemoryDatastore(),
       events: new TypedEventEmitter<any>(),
       logger: defaultLogger()

--- a/packages/kad-dht/test/query.spec.ts
+++ b/packages/kad-dht/test/query.spec.ts
@@ -22,6 +22,7 @@ import { sortClosestPeers } from './utils/sort-closest-peers.js'
 import type { QueryContext, QueryFunc } from '../src/query/types.js'
 import type { RoutingTable } from '../src/routing-table/index.js'
 import type { PeerId } from '@libp2p/interface'
+import type { ConnectionManager } from '@libp2p/interface-internal'
 
 interface TopologyEntry {
   delay?: number
@@ -126,7 +127,10 @@ describe('QueryManager', () => {
   it('does not run queries before start', async () => {
     const manager = new QueryManager({
       peerId: ourPeerId,
-      logger: defaultLogger()
+      logger: defaultLogger(),
+      connectionManager: stubInterface<ConnectionManager>({
+        isDialable: async () => true
+      })
     }, {
       ...defaultInit(),
       disjointPaths: 1
@@ -139,7 +143,10 @@ describe('QueryManager', () => {
   it('does not run queries after stop', async () => {
     const manager = new QueryManager({
       peerId: ourPeerId,
-      logger: defaultLogger()
+      logger: defaultLogger(),
+      connectionManager: stubInterface<ConnectionManager>({
+        isDialable: async () => true
+      })
     }, {
       ...defaultInit(),
       disjointPaths: 1
@@ -155,7 +162,10 @@ describe('QueryManager', () => {
   it('should pass query context', async () => {
     const manager = new QueryManager({
       peerId: ourPeerId,
-      logger: defaultLogger()
+      logger: defaultLogger(),
+      connectionManager: stubInterface<ConnectionManager>({
+        isDialable: async () => true
+      })
     }, {
       ...defaultInit(),
       disjointPaths: 1
@@ -189,7 +199,10 @@ describe('QueryManager', () => {
   it('simple run - succeed finding value', async () => {
     const manager = new QueryManager({
       peerId: ourPeerId,
-      logger: defaultLogger()
+      logger: defaultLogger(),
+      connectionManager: stubInterface<ConnectionManager>({
+        isDialable: async () => true
+      })
     }, {
       ...defaultInit(),
       disjointPaths: 1,
@@ -242,7 +255,10 @@ describe('QueryManager', () => {
   it('simple run - fail to find value', async () => {
     const manager = new QueryManager({
       peerId: ourPeerId,
-      logger: defaultLogger()
+      logger: defaultLogger(),
+      connectionManager: stubInterface<ConnectionManager>({
+        isDialable: async () => true
+      })
     }, {
       ...defaultInit(),
       disjointPaths: 1,
@@ -285,7 +301,10 @@ describe('QueryManager', () => {
   it('should abort a query', async () => {
     const manager = new QueryManager({
       peerId: ourPeerId,
-      logger: defaultLogger()
+      logger: defaultLogger(),
+      connectionManager: stubInterface<ConnectionManager>({
+        isDialable: async () => true
+      })
     }, {
       ...defaultInit(),
       disjointPaths: 2,
@@ -331,7 +350,10 @@ describe('QueryManager', () => {
   it('should allow a sub-query to timeout without aborting the whole query', async () => {
     const manager = new QueryManager({
       peerId: ourPeerId,
-      logger: defaultLogger()
+      logger: defaultLogger(),
+      connectionManager: stubInterface<ConnectionManager>({
+        isDialable: async () => true
+      })
     }, {
       ...defaultInit(),
       disjointPaths: 2,
@@ -383,7 +405,10 @@ describe('QueryManager', () => {
   it('does not return an error if only some queries error', async () => {
     const manager = new QueryManager({
       peerId: ourPeerId,
-      logger: defaultLogger()
+      logger: defaultLogger(),
+      connectionManager: stubInterface<ConnectionManager>({
+        isDialable: async () => true
+      })
     }, {
       ...defaultInit(),
       disjointPaths: 10
@@ -422,7 +447,10 @@ describe('QueryManager', () => {
   it('returns empty run if initial peer list is empty', async () => {
     const manager = new QueryManager({
       peerId: ourPeerId,
-      logger: defaultLogger()
+      logger: defaultLogger(),
+      connectionManager: stubInterface<ConnectionManager>({
+        isDialable: async () => true
+      })
     }, {
       ...defaultInit(),
       disjointPaths: 10
@@ -444,7 +472,10 @@ describe('QueryManager', () => {
   it('should query closer peers first', async () => {
     const manager = new QueryManager({
       peerId: ourPeerId,
-      logger: defaultLogger()
+      logger: defaultLogger(),
+      connectionManager: stubInterface<ConnectionManager>({
+        isDialable: async () => true
+      })
     }, {
       ...defaultInit(),
       disjointPaths: 1,
@@ -497,7 +528,10 @@ describe('QueryManager', () => {
   it('should stop when passing through the same node twice', async () => {
     const manager = new QueryManager({
       peerId: ourPeerId,
-      logger: defaultLogger()
+      logger: defaultLogger(),
+      connectionManager: stubInterface<ConnectionManager>({
+        isDialable: async () => true
+      })
     }, {
       ...defaultInit(),
       disjointPaths: 20,
@@ -534,7 +568,10 @@ describe('QueryManager', () => {
   it('only closerPeers', async () => {
     const manager = new QueryManager({
       peerId: ourPeerId,
-      logger: defaultLogger()
+      logger: defaultLogger(),
+      connectionManager: stubInterface<ConnectionManager>({
+        isDialable: async () => true
+      })
     }, {
       ...defaultInit(),
       disjointPaths: 1,
@@ -566,7 +603,10 @@ describe('QueryManager', () => {
   it('only closerPeers concurrent', async () => {
     const manager = new QueryManager({
       peerId: ourPeerId,
-      logger: defaultLogger()
+      logger: defaultLogger(),
+      connectionManager: stubInterface<ConnectionManager>({
+        isDialable: async () => true
+      })
     }, {
       ...defaultInit(),
       disjointPaths: 3
@@ -602,7 +642,10 @@ describe('QueryManager', () => {
   it('queries stop after shutdown', async () => {
     const manager = new QueryManager({
       peerId: ourPeerId,
-      logger: defaultLogger()
+      logger: defaultLogger(),
+      connectionManager: stubInterface<ConnectionManager>({
+        isDialable: async () => true
+      })
     }, {
       ...defaultInit(),
       disjointPaths: 1,
@@ -656,7 +699,10 @@ describe('QueryManager', () => {
   it('disjoint path values', async () => {
     const manager = new QueryManager({
       peerId: ourPeerId,
-      logger: defaultLogger()
+      logger: defaultLogger(),
+      connectionManager: stubInterface<ConnectionManager>({
+        isDialable: async () => true
+      })
     }, {
       ...defaultInit(),
       disjointPaths: 2
@@ -698,7 +744,10 @@ describe('QueryManager', () => {
   it('disjoint path continue other paths after error on one path', async () => {
     const manager = new QueryManager({
       peerId: ourPeerId,
-      logger: defaultLogger()
+      logger: defaultLogger(),
+      connectionManager: stubInterface<ConnectionManager>({
+        isDialable: async () => true
+      })
     }, {
       ...defaultInit(),
       disjointPaths: 2
@@ -737,7 +786,10 @@ describe('QueryManager', () => {
   it('should allow the self-query query to run', async () => {
     const manager = new QueryManager({
       peerId: ourPeerId,
-      logger: defaultLogger()
+      logger: defaultLogger(),
+      connectionManager: stubInterface<ConnectionManager>({
+        isDialable: async () => true
+      })
     }, {
       initialQuerySelfHasRun: pDefer<any>(),
       routingTable,
@@ -772,7 +824,10 @@ describe('QueryManager', () => {
 
     const manager = new QueryManager({
       peerId: ourPeerId,
-      logger: defaultLogger()
+      logger: defaultLogger(),
+      connectionManager: stubInterface<ConnectionManager>({
+        isDialable: async () => true
+      })
     }, {
       initialQuerySelfHasRun,
       alpha: 2,
@@ -826,7 +881,10 @@ describe('QueryManager', () => {
   it('should end paths when they have no closer peers to those already queried', async () => {
     const manager = new QueryManager({
       peerId: ourPeerId,
-      logger: defaultLogger()
+      logger: defaultLogger(),
+      connectionManager: stubInterface<ConnectionManager>({
+        isDialable: async () => true
+      })
     }, {
       ...defaultInit(),
       disjointPaths: 1,
@@ -874,7 +932,10 @@ describe('QueryManager', () => {
   it('should abort the query if we break out of the loop early', async () => {
     const manager = new QueryManager({
       peerId: ourPeerId,
-      logger: defaultLogger()
+      logger: defaultLogger(),
+      connectionManager: stubInterface<ConnectionManager>({
+        isDialable: async () => true
+      })
     }, {
       ...defaultInit(),
       disjointPaths: 2

--- a/packages/kad-dht/test/routing-table.spec.ts
+++ b/packages/kad-dht/test/routing-table.spec.ts
@@ -95,17 +95,17 @@ describe('Routing Table', () => {
   })
 
   it('remove', async function () {
-    this.timeout(20 * 1000)
-
     const peers = await createPeerIds(10)
     await Promise.all(peers.map(async (peer) => { await table.add(peer) }))
 
     const key = await kadUtils.convertPeerId(peers[2])
     expect(table.closestPeers(key, 10)).to.have.length(10)
+    await expect(table.find(peers[5])).to.eventually.be.ok()
+    expect(table.size).to.equal(10)
 
     await table.remove(peers[5])
-    expect(table.closestPeers(key, 10)).to.have.length(9)
-    expect(table.size).to.be.eql(9)
+    await expect(table.find(peers[5])).to.eventually.be.undefined()
+    expect(table.size).to.equal(9)
   })
 
   it('emits peer:remove event', async () => {
@@ -147,12 +147,12 @@ describe('Routing Table', () => {
     ]
 
     const oldPeer = {
-      id: peerIds[0].toBytes(),
-      peer: peerIds[0]
+      kadId: await kadUtils.convertPeerId(peerIds[0]),
+      peerId: peerIds[0]
     }
     const newPeer = {
-      id: peerIds[1].toBytes(),
-      peer: peerIds[1]
+      kadId: await kadUtils.convertPeerId(peerIds[1]),
+      peerId: peerIds[1]
     }
 
     if (table.kb == null) {
@@ -175,7 +175,7 @@ describe('Routing Table', () => {
 
     // simulate connection succeeding
     const newStreamStub = sinon.stub().withArgs(PROTOCOL).resolves(stream)
-    const openConnectionStub = sinon.stub().withArgs(oldPeer.peer).resolves({
+    const openConnectionStub = sinon.stub().withArgs(oldPeer.peerId).resolves({
       newStream: newStreamStub
     })
     components.connectionManager.openConnection = openConnectionStub
@@ -183,16 +183,16 @@ describe('Routing Table', () => {
     await table._onPing(new CustomEvent('ping', { detail: { oldContacts: [oldPeer], newContact: newPeer } }))
 
     expect(openConnectionStub.calledOnce).to.be.true()
-    expect(openConnectionStub.calledWith(oldPeer.peer)).to.be.true()
+    expect(openConnectionStub.calledWith(oldPeer.peerId)).to.be.true()
 
     expect(newStreamStub.callCount).to.equal(1)
     expect(newStreamStub.calledWith(PROTOCOL)).to.be.true()
 
     // did not add the new peer
-    expect(table.kb.get(newPeer.id)).to.be.undefined()
+    expect(table.kb.get(newPeer.kadId)).to.be.undefined()
 
     // kept the old peer
-    expect(table.kb.get(oldPeer.id)).to.not.be.undefined()
+    expect(table.kb.get(oldPeer.kadId)).to.not.be.undefined()
   })
 
   it('evicts oldest peer that does not respond to ping', async () => {
@@ -202,16 +202,16 @@ describe('Routing Table', () => {
     ]
 
     const oldPeer = {
-      id: peerIds[0].toBytes(),
-      peer: peerIds[0]
+      kadId: await kadUtils.convertPeerId(peerIds[0]),
+      peerId: peerIds[0]
     }
     const newPeer = {
-      id: peerIds[1].toBytes(),
-      peer: peerIds[1]
+      kadId: await kadUtils.convertPeerId(peerIds[1]),
+      peerId: peerIds[1]
     }
 
     // libp2p fails to dial the old peer
-    const openConnectionStub = sinon.stub().withArgs(oldPeer.peer).rejects(new Error('Could not dial peer'))
+    const openConnectionStub = sinon.stub().withArgs(oldPeer.peerId).rejects(new Error('Could not dial peer'))
     components.connectionManager.openConnection = openConnectionStub
 
     if (table.kb == null) {
@@ -225,13 +225,13 @@ describe('Routing Table', () => {
     await table.pingQueue.onIdle()
 
     expect(openConnectionStub.callCount).to.equal(1)
-    expect(openConnectionStub.calledWith(oldPeer.peer)).to.be.true()
+    expect(openConnectionStub.calledWith(oldPeer.peerId)).to.be.true()
 
     // added the new peer
-    expect(table.kb.get(newPeer.id)).to.not.be.undefined()
+    expect(table.kb.get(newPeer.kadId)).to.not.be.undefined()
 
     // evicted the old peer
-    expect(table.kb.get(oldPeer.id)).to.be.undefined()
+    expect(table.kb.get(oldPeer.kadId)).to.be.undefined()
   })
 
   it('tags newly found kad-close peers', async () => {
@@ -291,9 +291,9 @@ describe('Routing Table', () => {
 
     // should have all added contacts in the root kbucket
     expect(table.kb?.count()).to.equal(KBUCKET_SIZE, 'did not fill kbuckets')
-    expect(table.kb?.root.contacts).to.have.lengthOf(KBUCKET_SIZE, 'split root kbucket when we should not have')
-    expect(table.kb?.root.left).to.be.null('split root kbucket when we should not have')
-    expect(table.kb?.root.right).to.be.null('split root kbucket when we should not have')
+    expect(table.kb?.root).to.have.property('peers').with.lengthOf(KBUCKET_SIZE, 'split root kbucket when we should not have')
+    expect(table.kb?.root).to.not.have.property('left', 'split root kbucket when we should not have')
+    expect(table.kb?.root).to.not.have.property('right', 'split root kbucket when we should not have')
 
     await pWaitFor(() => {
       return tagPeerSpy.callCount === KBUCKET_SIZE
@@ -308,8 +308,8 @@ describe('Routing Table', () => {
     await table.add(sortedPeerList[sortedPeerList.length - 1])
 
     expect(table.kb?.count()).to.equal(KBUCKET_SIZE + 1, 'did not fill kbuckets')
-    expect(table.kb?.root.left).to.not.be.null('did not split root kbucket when we should have')
-    expect(table.kb?.root.right).to.not.be.null('did not split root kbucket when we should have')
+    expect(table.kb?.root).to.have.property('left').that.is.not.null('did not split root kbucket when we should have')
+    expect(table.kb?.root).to.have.property('right').that.is.not.null('did not split root kbucket when we should have')
 
     // wait for tag new peer and untag old peer
     await pWaitFor(() => {


### PR DESCRIPTION
The Kademlia paper shows a simple binary tree as a data structure for the routing table.  This can grow very deep for long keys so an optimisation is to only use a prefix of the KAD-ID when constructing the table.

This results in faster lookups for better performance.

## Change checklist

- [x] I have performed a self-review of my own code
- [ ] I have made corresponding changes to the documentation if necessary (this includes comments as well)
- [x] I have added tests that prove my fix is effective or that my feature works