### PR TITLE
feat: add optional topology filter

### DIFF
--- a/packages/interface/src/topology/index.ts
+++ b/packages/interface/src/topology/index.ts
@@ -1,10 +1,36 @@
 import type { Connection } from '../connection/index.js'
 import type { PeerId } from '../peer-id/index.js'
 
+/**
+ * A topology filter
+ *
+ * @see https://libp2p.github.io/js-libp2p/functions/_libp2p_peer_collections.peerFilter-1.html
+ */
+export interface TopologyFilter {
+  has (peerId: PeerId): boolean
+  add (peerId: PeerId): void
+  remove (peerId: PeerId): void
+}
+
+/**
+ * A topology is a network overlay that contains a subset of peers in the
+ * complete network.
+ *
+ * It is a way to be notified when peers that support a given protocol connect
+ * to or disconnect from the current node.
+ */
 export interface Topology {
   /**
+   * An optional filter can prevent duplicate topology notifications for the
+   * same peer.
+   */
+  filter?: TopologyFilter
+
+  /**
    * If true, invoke `onConnect` for this topology on transient (e.g. short-lived
-   * and/or data-limited) connections. (default: false)
+   * and/or data-limited) connections
+   *
+   * @default false
    */
   notifyOnTransient?: boolean
 

--- a/packages/libp2p/src/registrar.ts
+++ b/packages/libp2p/src/registrar.ts
@@ -164,6 +164,11 @@ export class DefaultRegistrar implements Registrar {
           }
 
           for (const topology of topologies.values()) {
+            if (topology.filter?.has(remotePeer) === false) {
+              continue
+            }
+
+            topology.filter?.remove(remotePeer)
             topology.onDisconnect?.(remotePeer)
           }
         }
@@ -195,6 +200,11 @@ export class DefaultRegistrar implements Registrar {
       }
 
       for (const topology of topologies.values()) {
+        if (topology.filter?.has(peer.id) === false) {
+          continue
+        }
+
+        topology.filter?.remove(peer.id)
         topology.onDisconnect?.(peer.id)
       }
     }
@@ -222,6 +232,11 @@ export class DefaultRegistrar implements Registrar {
           continue
         }
 
+        if (topology.filter?.has(peerId) === true) {
+          continue
+        }
+
+        topology.filter?.add(peerId)
         topology.onConnect?.(peerId, connection)
       }
     }

--- a/packages/libp2p/test/registrar/errors.spec.ts
+++ b/packages/libp2p/test/registrar/errors.spec.ts
@@ -1,0 +1,54 @@
+/* eslint-env mocha */
+
+import { TypedEventEmitter, type ConnectionGater, type PeerId } from '@libp2p/interface'
+import { mockUpgrader } from '@libp2p/interface-compliance-tests/mocks'
+import { createEd25519PeerId } from '@libp2p/peer-id-factory'
+import { PersistentPeerStore } from '@libp2p/peer-store'
+import { expect } from 'aegir/chai'
+import { MemoryDatastore } from 'datastore-core/memory'
+import { stubInterface } from 'sinon-ts'
+import { defaultComponents } from '../../src/components.js'
+import { DefaultConnectionManager } from '../../src/connection-manager/index.js'
+import { DefaultRegistrar } from '../../src/registrar.js'
+import type { Components } from '../../src/components.js'
+import type { Registrar, TransportManager } from '@libp2p/interface-internal'
+
+describe('registrar errors', () => {
+  let components: Components
+  let registrar: Registrar
+  let peerId: PeerId
+
+  before(async () => {
+    peerId = await createEd25519PeerId()
+    const events = new TypedEventEmitter()
+    components = defaultComponents({
+      peerId,
+      events,
+      datastore: new MemoryDatastore(),
+      upgrader: mockUpgrader({ events }),
+      transportManager: stubInterface<TransportManager>(),
+      connectionGater: stubInterface<ConnectionGater>()
+    })
+    components.peerStore = new PersistentPeerStore(components)
+    components.connectionManager = new DefaultConnectionManager(components, {
+      minConnections: 50,
+      maxConnections: 1000,
+      inboundUpgradeTimeout: 1000
+    })
+    registrar = new DefaultRegistrar(components)
+  })
+
+  it('should fail to register a protocol if no multicodec is provided', () => {
+    // @ts-expect-error invalid parameters
+    return expect(registrar.register()).to.eventually.be.rejected()
+  })
+
+  it('should fail to register a protocol if an invalid topology is provided', () => {
+    const fakeTopology = {
+      random: 1
+    }
+
+    // @ts-expect-error invalid parameters
+    return expect(registrar.register(fakeTopology)).to.eventually.be.rejected()
+  })
+})

--- a/packages/libp2p/test/registrar/protocols.spec.ts
+++ b/packages/libp2p/test/registrar/protocols.spec.ts
@@ -1,0 +1,58 @@
+/* eslint-env mocha */
+
+import { yamux } from '@chainsafe/libp2p-yamux'
+import { mplex } from '@libp2p/mplex'
+import { createEd25519PeerId } from '@libp2p/peer-id-factory'
+import { plaintext } from '@libp2p/plaintext'
+import { webSockets } from '@libp2p/websockets'
+import { expect } from 'aegir/chai'
+import pDefer from 'p-defer'
+import { createLibp2pNode } from '../../src/libp2p.js'
+import type { Components } from '../../src/components.js'
+import type { Libp2pNode } from '../../src/libp2p.js'
+
+describe('registrar protocols', () => {
+  let libp2p: Libp2pNode
+
+  it('should be able to register and unregister a handler', async () => {
+    const deferred = pDefer<Components>()
+
+    libp2p = await createLibp2pNode({
+      peerId: await createEd25519PeerId(),
+      transports: [
+        webSockets()
+      ],
+      streamMuxers: [
+        yamux(),
+        mplex()
+      ],
+      connectionEncryption: [
+        plaintext()
+      ],
+      services: {
+        test: (components: any) => {
+          deferred.resolve(components)
+        }
+      }
+    })
+
+    const components = await deferred.promise
+
+    const registrar = components.registrar
+
+    expect(registrar.getProtocols()).to.not.have.any.keys(['/echo/1.0.0', '/echo/1.0.1'])
+
+    const echoHandler = (): void => {}
+    await libp2p.handle(['/echo/1.0.0', '/echo/1.0.1'], echoHandler)
+    expect(registrar.getHandler('/echo/1.0.0')).to.have.property('handler', echoHandler)
+    expect(registrar.getHandler('/echo/1.0.1')).to.have.property('handler', echoHandler)
+
+    await libp2p.unhandle(['/echo/1.0.0'])
+    expect(registrar.getProtocols()).to.not.have.any.keys(['/echo/1.0.0'])
+    expect(registrar.getHandler('/echo/1.0.1')).to.have.property('handler', echoHandler)
+
+    await expect(libp2p.peerStore.get(libp2p.peerId)).to.eventually.have.deep.property('protocols', [
+      '/echo/1.0.1'
+    ])
+  })
+})

--- a/packages/libp2p/test/registrar/registrar.spec.ts
+++ b/packages/libp2p/test/registrar/registrar.spec.ts
@@ -1,437 +1,416 @@
 /* eslint-env mocha */
 
-import { yamux } from '@chainsafe/libp2p-yamux'
-import { TypedEventEmitter, type TypedEventTarget, type Libp2pEvents, type ConnectionGater, type PeerId, type PeerStore, type Topology } from '@libp2p/interface'
+import { TypedEventEmitter } from '@libp2p/interface'
 import { matchPeerId } from '@libp2p/interface-compliance-tests/matchers'
-import { mockDuplex, mockMultiaddrConnection, mockUpgrader, mockConnection } from '@libp2p/interface-compliance-tests/mocks'
+import { mockDuplex, mockMultiaddrConnection, mockConnection } from '@libp2p/interface-compliance-tests/mocks'
 import { defaultLogger } from '@libp2p/logger'
-import { mplex } from '@libp2p/mplex'
+import { peerFilter } from '@libp2p/peer-collections'
 import { createEd25519PeerId } from '@libp2p/peer-id-factory'
-import { PersistentPeerStore } from '@libp2p/peer-store'
-import { plaintext } from '@libp2p/plaintext'
-import { webSockets } from '@libp2p/websockets'
 import { expect } from 'aegir/chai'
-import { MemoryDatastore } from 'datastore-core/memory'
 import pDefer from 'p-defer'
-import { type StubbedInstance, stubInterface } from 'sinon-ts'
-import { type Components, defaultComponents } from '../../src/components.js'
-import { DefaultConnectionManager } from '../../src/connection-manager/index.js'
-import { createLibp2pNode, type Libp2pNode } from '../../src/libp2p.js'
+import { stubInterface } from 'sinon-ts'
 import { DefaultRegistrar } from '../../src/registrar.js'
-import type { ConnectionManager, Registrar, TransportManager } from '@libp2p/interface-internal'
+import type { TypedEventTarget, Libp2pEvents, PeerId, PeerStore, Topology, Peer } from '@libp2p/interface'
+import type { ConnectionManager, Registrar } from '@libp2p/interface-internal'
+import type { StubbedInstance } from 'sinon-ts'
 
 const protocol = '/test/1.0.0'
 
-describe('registrar', () => {
-  let components: Components
+describe('registrar topologies', () => {
   let registrar: Registrar
   let peerId: PeerId
-  let libp2p: Libp2pNode
 
   before(async () => {
     peerId = await createEd25519PeerId()
   })
 
-  describe('errors', () => {
-    beforeEach(() => {
-      const events = new TypedEventEmitter()
-      components = defaultComponents({
-        peerId,
-        events,
-        datastore: new MemoryDatastore(),
-        upgrader: mockUpgrader({ events }),
-        transportManager: stubInterface<TransportManager>(),
-        connectionGater: stubInterface<ConnectionGater>()
-      })
-      components.peerStore = new PersistentPeerStore(components)
-      components.connectionManager = new DefaultConnectionManager(components, {
-        minConnections: 50,
-        maxConnections: 1000,
-        inboundUpgradeTimeout: 1000
-      })
-      registrar = new DefaultRegistrar(components)
-    })
+  let connectionManager: StubbedInstance<ConnectionManager>
+  let peerStore: StubbedInstance<PeerStore>
+  let events: TypedEventTarget<Libp2pEvents>
 
-    it('should fail to register a protocol if no multicodec is provided', () => {
-      // @ts-expect-error invalid parameters
-      return expect(registrar.register()).to.eventually.be.rejected()
-    })
+  beforeEach(async () => {
+    peerId = await createEd25519PeerId()
+    connectionManager = stubInterface<ConnectionManager>()
+    peerStore = stubInterface<PeerStore>()
+    events = new TypedEventEmitter<Libp2pEvents>()
 
-    it('should fail to register a protocol if an invalid topology is provided', () => {
-      const fakeTopology = {
-        random: 1
-      }
-
-      // @ts-expect-error invalid parameters
-      return expect(registrar.register(fakeTopology)).to.eventually.be.rejected()
+    registrar = new DefaultRegistrar({
+      peerId,
+      connectionManager,
+      peerStore,
+      events,
+      logger: defaultLogger()
     })
   })
 
-  describe('registration', () => {
-    let registrar: Registrar
-    let peerId: PeerId
-    let connectionManager: StubbedInstance<ConnectionManager>
-    let peerStore: StubbedInstance<PeerStore>
-    let events: TypedEventTarget<Libp2pEvents>
+  it('should be able to register a protocol', async () => {
+    const topology: Topology = {
+      onConnect: () => { },
+      onDisconnect: () => { }
+    }
 
-    beforeEach(async () => {
-      peerId = await createEd25519PeerId()
-      connectionManager = stubInterface<ConnectionManager>()
-      peerStore = stubInterface<PeerStore>()
-      events = new TypedEventEmitter<Libp2pEvents>()
+    expect(registrar.getTopologies(protocol)).to.have.lengthOf(0)
 
-      registrar = new DefaultRegistrar({
-        peerId,
-        connectionManager,
-        peerStore,
-        events,
-        logger: defaultLogger()
-      })
-    })
+    const identifier = await registrar.register(protocol, topology)
 
-    it('should be able to register a protocol', async () => {
-      const topology: Topology = {
-        onConnect: () => { },
-        onDisconnect: () => { }
+    expect(identifier).to.exist()
+    expect(registrar.getTopologies(protocol)).to.have.lengthOf(1)
+  })
+
+  it('should be able to unregister a protocol', async () => {
+    const topology: Topology = {
+      onConnect: () => { },
+      onDisconnect: () => { }
+    }
+
+    expect(registrar.getTopologies(protocol)).to.have.lengthOf(0)
+
+    const identifier = await registrar.register(protocol, topology)
+
+    expect(registrar.getTopologies(protocol)).to.have.lengthOf(1)
+
+    registrar.unregister(identifier)
+
+    expect(registrar.getTopologies(protocol)).to.have.lengthOf(0)
+  })
+
+  it('should not error if unregistering unregistered topology handler', () => {
+    registrar.unregister('bad-identifier')
+  })
+
+  it('should call onConnect handler for connected peers after register', async () => {
+    const onConnectDefer = pDefer()
+    const onDisconnectDefer = pDefer()
+
+    // setup connections before registrar
+    const remotePeerId = await createEd25519PeerId()
+    const conn = mockConnection(mockMultiaddrConnection(mockDuplex(), remotePeerId))
+
+    // return connection from connection manager
+    connectionManager.getConnections.withArgs(remotePeerId).returns([conn])
+
+    const topology: Topology = {
+      onConnect: (peerId, connection) => {
+        expect(peerId.equals(remotePeerId)).to.be.true()
+        expect(connection.id).to.eql(conn.id)
+
+        onConnectDefer.resolve()
+      },
+      onDisconnect: (peerId) => {
+        expect(peerId.equals(remotePeerId)).to.be.true()
+
+        onDisconnectDefer.resolve()
       }
+    }
 
-      expect(registrar.getTopologies(protocol)).to.have.lengthOf(0)
+    // Register protocol
+    await registrar.register(protocol, topology)
 
-      const identifier = await registrar.register(protocol, topology)
-
-      expect(identifier).to.exist()
-      expect(registrar.getTopologies(protocol)).to.have.lengthOf(1)
+    // Peer data is in the peer store
+    peerStore.get.withArgs(matchPeerId(remotePeerId)).resolves({
+      id: remotePeerId,
+      addresses: [],
+      protocols: [protocol],
+      metadata: new Map(),
+      tags: new Map()
     })
 
-    it('should be able to unregister a protocol', async () => {
-      const topology: Topology = {
-        onConnect: () => { },
-        onDisconnect: () => { }
+    // remote peer connects
+    events.safeDispatchEvent('peer:identify', {
+      detail: {
+        peerId: remotePeerId,
+        protocols: [protocol],
+        connection: conn
       }
+    })
+    await onConnectDefer.promise
 
-      expect(registrar.getTopologies(protocol)).to.have.lengthOf(0)
+    // remote peer disconnects
+    await conn.close()
+    events.safeDispatchEvent('peer:disconnect', {
+      detail: remotePeerId
+    })
+    await onDisconnectDefer.promise
+  })
 
-      const identifier = await registrar.register(protocol, topology)
+  it('should call onConnect handler after register, once a peer is connected and protocols are updated', async () => {
+    const onConnectDefer = pDefer()
+    const onDisconnectDefer = pDefer()
 
-      expect(registrar.getTopologies(protocol)).to.have.lengthOf(1)
+    // setup connections before registrar
+    const remotePeerId = await createEd25519PeerId()
+    const conn = mockConnection(mockMultiaddrConnection(mockDuplex(), remotePeerId))
 
-      registrar.unregister(identifier)
+    // return connection from connection manager
+    connectionManager.getConnections.withArgs(matchPeerId(remotePeerId)).returns([conn])
 
-      expect(registrar.getTopologies(protocol)).to.have.lengthOf(0)
+    const topology: Topology = {
+      onConnect: () => {
+        onConnectDefer.resolve()
+      },
+      onDisconnect: () => {
+        onDisconnectDefer.resolve()
+      }
+    }
+
+    // Register protocol
+    await registrar.register(protocol, topology)
+
+    // remote peer connects
+    events.safeDispatchEvent('peer:identify', {
+      detail: {
+        peerId: remotePeerId,
+        protocols: [protocol],
+        connection: conn
+      }
     })
 
-    it('should not error if unregistering unregistered topology handler', () => {
-      registrar.unregister('bad-identifier')
+    // Can get details after identify
+    peerStore.get.withArgs(matchPeerId(conn.remotePeer)).resolves({
+      id: conn.remotePeer,
+      addresses: [],
+      protocols: [protocol],
+      metadata: new Map(),
+      tags: new Map()
     })
 
-    it('should call onConnect handler for connected peers after register', async () => {
-      const onConnectDefer = pDefer()
-      const onDisconnectDefer = pDefer()
+    // we have a connection to this peer
+    connectionManager.getConnections.withArgs(matchPeerId(conn.remotePeer)).returns([conn])
 
-      // Setup connections before registrar
-      const remotePeerId = await createEd25519PeerId()
-      const conn = mockConnection(mockMultiaddrConnection(mockDuplex(), remotePeerId))
-
-      // return connection from connection manager
-      connectionManager.getConnections.withArgs(remotePeerId).returns([conn])
-
-      const topology: Topology = {
-        onConnect: (peerId, connection) => {
-          expect(peerId.equals(remotePeerId)).to.be.true()
-          expect(connection.id).to.eql(conn.id)
-
-          onConnectDefer.resolve()
-        },
-        onDisconnect: (peerId) => {
-          expect(peerId.equals(remotePeerId)).to.be.true()
-
-          onDisconnectDefer.resolve()
+    // identify completes
+    events.safeDispatchEvent('peer:update', {
+      detail: {
+        peer: {
+          id: conn.remotePeer,
+          protocols: [protocol],
+          addresses: [],
+          metadata: new Map()
         }
       }
+    })
 
-      // Register protocol
-      await registrar.register(protocol, topology)
+    await onConnectDefer.promise
 
-      // Peer data is in the peer store
-      peerStore.get.withArgs(matchPeerId(remotePeerId)).resolves({
-        id: remotePeerId,
-        addresses: [],
+    // Peer no longer supports the protocol our topology is registered for
+    events.safeDispatchEvent('peer:update', {
+      detail: {
+        peer: {
+          id: conn.remotePeer,
+          protocols: [],
+          addresses: [],
+          metadata: new Map()
+        },
+        previous: {
+          id: conn.remotePeer,
+          protocols: [protocol],
+          addresses: [],
+          metadata: new Map()
+        }
+      }
+    })
+
+    await onDisconnectDefer.promise
+  })
+
+  it('should not call topology handlers for transient connection', async () => {
+    const onConnectDefer = pDefer()
+    const onDisconnectDefer = pDefer()
+
+    // setup connections before registrar
+    const remotePeerId = await createEd25519PeerId()
+    const conn = mockConnection(mockMultiaddrConnection(mockDuplex(), remotePeerId))
+
+    // connection is transient
+    conn.transient = true
+
+    // return connection from connection manager
+    connectionManager.getConnections.withArgs(matchPeerId(remotePeerId)).returns([conn])
+
+    const topology: Topology = {
+      onConnect: () => {
+        onConnectDefer.reject(new Error('Topolgy onConnect called for transient connection'))
+      },
+      onDisconnect: () => {
+        onDisconnectDefer.reject(new Error('Topolgy onDisconnect called for transient connection'))
+      }
+    }
+
+    // register topology for protocol
+    await registrar.register(protocol, topology)
+
+    // remote peer connects
+    events.safeDispatchEvent('peer:identify', {
+      detail: {
+        peerId: remotePeerId,
         protocols: [protocol],
-        metadata: new Map(),
-        tags: new Map()
-      })
+        connection: conn
+      }
+    })
 
-      // remote peer connects
+    await expect(Promise.any([
+      onConnectDefer.promise,
+      onDisconnectDefer.promise,
+      new Promise<void>((resolve) => {
+        setTimeout(() => {
+          resolve()
+        }, 1000)
+      })
+    ])).to.eventually.not.be.rejected()
+  })
+
+  it('should call topology onConnect handler for transient connection when explicitly requested', async () => {
+    const onConnectDefer = pDefer()
+
+    // setup connections before registrar
+    const remotePeerId = await createEd25519PeerId()
+    const conn = mockConnection(mockMultiaddrConnection(mockDuplex(), remotePeerId))
+
+    // connection is transient
+    conn.transient = true
+
+    // return connection from connection manager
+    connectionManager.getConnections.withArgs(matchPeerId(remotePeerId)).returns([conn])
+
+    const topology: Topology = {
+      notifyOnTransient: true,
+      onConnect: () => {
+        onConnectDefer.resolve()
+      }
+    }
+
+    // register topology for protocol
+    await registrar.register(protocol, topology)
+
+    // remote peer connects
+    events.safeDispatchEvent('peer:identify', {
+      detail: {
+        peerId: remotePeerId,
+        protocols: [protocol],
+        connection: conn
+      }
+    })
+
+    await expect(onConnectDefer.promise).to.eventually.be.undefined()
+  })
+
+  it('should call topology handlers for non-transient connection opened after transient connection', async () => {
+    const onConnectDefer = pDefer()
+    let callCount = 0
+
+    const topology: Topology = {
+      notifyOnTransient: true,
+      onConnect: () => {
+        callCount++
+
+        if (callCount === 2) {
+          onConnectDefer.resolve()
+        }
+      }
+    }
+
+    // register topology for protocol
+    await registrar.register(protocol, topology)
+
+    // setup connections before registrar
+    const remotePeerId = await createEd25519PeerId()
+    const transientConnection = mockConnection(mockMultiaddrConnection(mockDuplex(), remotePeerId))
+    transientConnection.transient = true
+
+    const nonTransientConnection = mockConnection(mockMultiaddrConnection(mockDuplex(), remotePeerId))
+    nonTransientConnection.transient = false
+
+    // return connection from connection manager
+    connectionManager.getConnections.withArgs(matchPeerId(remotePeerId)).returns([
+      transientConnection,
+      nonTransientConnection
+    ])
+
+    // remote peer connects over transient connection
+    events.safeDispatchEvent('peer:identify', {
+      detail: {
+        peerId: remotePeerId,
+        protocols: [protocol],
+        connection: transientConnection
+      }
+    })
+
+    // remote peer opens non-transient connection
+    events.safeDispatchEvent('peer:identify', {
+      detail: {
+        peerId: remotePeerId,
+        protocols: [protocol],
+        connection: nonTransientConnection
+      }
+    })
+
+    await expect(onConnectDefer.promise).to.eventually.be.undefined()
+  })
+
+  it('should use a filter to prevent duplicate onConnect notifications', async () => {
+    const topology: Topology = stubInterface<Topology>({
+      filter: peerFilter(1024)
+    })
+
+    // register topology for protocol
+    await registrar.register(protocol, topology)
+
+    // setup connections before registrar
+    const remotePeerId = await createEd25519PeerId()
+    const connection = mockConnection(mockMultiaddrConnection(mockDuplex(), remotePeerId))
+
+    // remote peer runs identify a few times
+    for (let i = 0; i < 5; i++) {
       events.safeDispatchEvent('peer:identify', {
         detail: {
           peerId: remotePeerId,
           protocols: [protocol],
-          connection: conn
+          connection
         }
       })
-      await onConnectDefer.promise
+    }
 
-      // remote peer disconnects
-      await conn.close()
-      events.safeDispatchEvent('peer:disconnect', {
-        detail: remotePeerId
-      })
-      await onDisconnectDefer.promise
-    })
-
-    it('should call onConnect handler after register, once a peer is connected and protocols are updated', async () => {
-      const onConnectDefer = pDefer()
-      const onDisconnectDefer = pDefer()
-
-      // Setup connections before registrar
-      const remotePeerId = await createEd25519PeerId()
-      const conn = mockConnection(mockMultiaddrConnection(mockDuplex(), remotePeerId))
-
-      // return connection from connection manager
-      connectionManager.getConnections.withArgs(matchPeerId(remotePeerId)).returns([conn])
-
-      const topology: Topology = {
-        onConnect: () => {
-          onConnectDefer.resolve()
-        },
-        onDisconnect: () => {
-          onDisconnectDefer.resolve()
-        }
-      }
-
-      // Register protocol
-      await registrar.register(protocol, topology)
-
-      // remote peer connects
-      events.safeDispatchEvent('peer:identify', {
-        detail: {
-          peerId: remotePeerId,
-          protocols: [protocol],
-          connection: conn
-        }
-      })
-
-      // Can get details after identify
-      peerStore.get.withArgs(matchPeerId(conn.remotePeer)).resolves({
-        id: conn.remotePeer,
-        addresses: [],
-        protocols: [protocol],
-        metadata: new Map(),
-        tags: new Map()
-      })
-
-      // we have a connection to this peer
-      connectionManager.getConnections.withArgs(matchPeerId(conn.remotePeer)).returns([conn])
-
-      // identify completes
+    // remote peer updates details a few times
+    for (let i = 0; i < 5; i++) {
       events.safeDispatchEvent('peer:update', {
         detail: {
           peer: {
-            id: conn.remotePeer,
-            protocols: [protocol],
-            addresses: [],
-            metadata: new Map()
-          }
-        }
-      })
-
-      await onConnectDefer.promise
-
-      // Peer no longer supports the protocol our topology is registered for
-      events.safeDispatchEvent('peer:update', {
-        detail: {
-          peer: {
-            id: conn.remotePeer,
-            protocols: [],
-            addresses: [],
-            metadata: new Map()
+            id: remotePeerId,
+            protocols: [protocol]
           },
           previous: {
-            id: conn.remotePeer,
-            protocols: [protocol],
-            addresses: [],
-            metadata: new Map()
+            protocols: []
           }
         }
       })
+    }
 
-      await onDisconnectDefer.promise
+    // should only have notified once
+    expect(topology.onConnect).to.have.property('callCount', 1)
+  })
+
+  it('should use a filter to prevent onDisconnect notifications that had no previous onConnect notification', async () => {
+    const topology: Topology = stubInterface<Topology>({
+      filter: peerFilter(1024)
     })
 
-    it('should not call topology handlers for transient connection', async () => {
-      const onConnectDefer = pDefer()
-      const onDisconnectDefer = pDefer()
+    // register topology for protocol
+    await registrar.register(protocol, topology)
 
-      // Setup connections before registrar
-      const remotePeerId = await createEd25519PeerId()
-      const conn = mockConnection(mockMultiaddrConnection(mockDuplex(), remotePeerId))
+    // setup connections before registrar
+    const remotePeerId = await createEd25519PeerId()
 
-      // connection is transient
-      conn.transient = true
+    // peer exists in peer store with the regsitered protocol
+    peerStore.get.withArgs(remotePeerId).resolves(stubInterface<Peer>({
+      protocols: [protocol]
+    }))
 
-      // return connection from connection manager
-      connectionManager.getConnections.withArgs(matchPeerId(remotePeerId)).returns([conn])
-
-      const topology: Topology = {
-        onConnect: () => {
-          onConnectDefer.reject(new Error('Topolgy onConnect called for transient connection'))
-        },
-        onDisconnect: () => {
-          onDisconnectDefer.reject(new Error('Topolgy onDisconnect called for transient connection'))
-        }
-      }
-
-      // Register topology for protocol
-      await registrar.register(protocol, topology)
-
-      // remote peer connects
-      events.safeDispatchEvent('peer:identify', {
-        detail: {
-          peerId: remotePeerId,
-          protocols: [protocol],
-          connection: conn
-        }
-      })
-
-      await expect(Promise.any([
-        onConnectDefer.promise,
-        onDisconnectDefer.promise,
-        new Promise<void>((resolve) => {
-          setTimeout(() => {
-            resolve()
-          }, 1000)
-        })
-      ])).to.eventually.not.be.rejected()
+    // the peer disconnects
+    events.safeDispatchEvent('peer:disconnect', {
+      detail: remotePeerId
     })
 
-    it('should call topology onConnect handler for transient connection when explicitly requested', async () => {
-      const onConnectDefer = pDefer()
-
-      // Setup connections before registrar
-      const remotePeerId = await createEd25519PeerId()
-      const conn = mockConnection(mockMultiaddrConnection(mockDuplex(), remotePeerId))
-
-      // connection is transient
-      conn.transient = true
-
-      // return connection from connection manager
-      connectionManager.getConnections.withArgs(matchPeerId(remotePeerId)).returns([conn])
-
-      const topology: Topology = {
-        notifyOnTransient: true,
-        onConnect: () => {
-          onConnectDefer.resolve()
-        }
-      }
-
-      // Register topology for protocol
-      await registrar.register(protocol, topology)
-
-      // remote peer connects
-      events.safeDispatchEvent('peer:identify', {
-        detail: {
-          peerId: remotePeerId,
-          protocols: [protocol],
-          connection: conn
-        }
-      })
-
-      await expect(onConnectDefer.promise).to.eventually.be.undefined()
-    })
-
-    it('should call topology handlers for non-transient connection opened after transient connection', async () => {
-      const onConnectDefer = pDefer()
-      let callCount = 0
-
-      const topology: Topology = {
-        notifyOnTransient: true,
-        onConnect: () => {
-          callCount++
-
-          if (callCount === 2) {
-            onConnectDefer.resolve()
-          }
-        }
-      }
-
-      // Register topology for protocol
-      await registrar.register(protocol, topology)
-
-      // Setup connections before registrar
-      const remotePeerId = await createEd25519PeerId()
-      const transientConnection = mockConnection(mockMultiaddrConnection(mockDuplex(), remotePeerId))
-      transientConnection.transient = true
-
-      const nonTransientConnection = mockConnection(mockMultiaddrConnection(mockDuplex(), remotePeerId))
-      nonTransientConnection.transient = false
-
-      // return connection from connection manager
-      connectionManager.getConnections.withArgs(matchPeerId(remotePeerId)).returns([
-        transientConnection,
-        nonTransientConnection
-      ])
-
-      // remote peer connects over transient connection
-      events.safeDispatchEvent('peer:identify', {
-        detail: {
-          peerId: remotePeerId,
-          protocols: [protocol],
-          connection: transientConnection
-        }
-      })
-
-      // remote peer opens non-transient connection
-      events.safeDispatchEvent('peer:identify', {
-        detail: {
-          peerId: remotePeerId,
-          protocols: [protocol],
-          connection: nonTransientConnection
-        }
-      })
-
-      await expect(onConnectDefer.promise).to.eventually.be.undefined()
-    })
-
-    it('should be able to register and unregister a handler', async () => {
-      const deferred = pDefer<Components>()
-
-      libp2p = await createLibp2pNode({
-        peerId: await createEd25519PeerId(),
-        transports: [
-          webSockets()
-        ],
-        streamMuxers: [
-          yamux(),
-          mplex()
-        ],
-        connectionEncryption: [
-          plaintext()
-        ],
-        services: {
-          test: (components: any) => {
-            deferred.resolve(components)
-          }
-        }
-      })
-
-      const components = await deferred.promise
-
-      const registrar = components.registrar
-
-      expect(registrar.getProtocols()).to.not.have.any.keys(['/echo/1.0.0', '/echo/1.0.1'])
-
-      const echoHandler = (): void => {}
-      await libp2p.handle(['/echo/1.0.0', '/echo/1.0.1'], echoHandler)
-      expect(registrar.getHandler('/echo/1.0.0')).to.have.property('handler', echoHandler)
-      expect(registrar.getHandler('/echo/1.0.1')).to.have.property('handler', echoHandler)
-
-      await libp2p.unhandle(['/echo/1.0.0'])
-      expect(registrar.getProtocols()).to.not.have.any.keys(['/echo/1.0.0'])
-      expect(registrar.getHandler('/echo/1.0.1')).to.have.property('handler', echoHandler)
-
-      await expect(libp2p.peerStore.get(libp2p.peerId)).to.eventually.have.deep.property('protocols', [
-        '/echo/1.0.1'
-      ])
-    })
+    // should not have notified
+    expect(topology.onConnect).to.have.property('called', false)
+    expect(topology.onDisconnect).to.have.property('called', false)
   })
 })


### PR DESCRIPTION
Adds a `filter` option to topologies to allow filtering out duplicate notifications.

## Change checklist

- [x] I have performed a self-review of my own code
- [x] I have made corresponding changes to the documentation if necessary (this includes comments as well)
- [x] I have added tests that prove my fix is effective or that my feature works