### PR TITLE
fix: allow creating counter groups

### DIFF
--- a/packages/metrics-simple/src/index.ts
+++ b/packages/metrics-simple/src/index.ts
@@ -245,7 +245,7 @@ class SimpleMetrics implements Metrics, Startable {
       return
     }
 
-    const metric = new DefaultMetric()
+    const metric = new DefaultGroupMetric()
     this.metrics.set(name, metric)
 
     return metric
@@ -264,7 +264,7 @@ class SimpleMetrics implements Metrics, Startable {
       return
     }
 
-    const metric = new DefaultGroupMetric()
+    const metric = new DefaultMetric()
     this.metrics.set(name, metric)
 
     return metric

--- a/packages/metrics-simple/test/index.spec.ts
+++ b/packages/metrics-simple/test/index.spec.ts
@@ -55,4 +55,92 @@ describe('simple-metrics', () => {
 
     expect(list).to.not.have.nested.property('[1].foo.baz')
   })
+
+  it('should create a metric', async () => {
+    const deferred = pDefer<Record<string, any>>()
+
+    s = simpleMetrics({
+      onMetrics: (metrics) => {
+        deferred.resolve(metrics)
+      },
+      intervalMs: 10
+    })({})
+
+    await start(s)
+
+    const m = s.registerMetric('test_metric')
+    m.update(10)
+
+    const metrics = await deferred.promise
+    expect(metrics).to.have.property('test_metric', 10)
+  })
+
+  it('should create a counter metric', async () => {
+    const deferred = pDefer<Record<string, any>>()
+
+    s = simpleMetrics({
+      onMetrics: (metrics) => {
+        deferred.resolve(metrics)
+      },
+      intervalMs: 10
+    })({})
+
+    await start(s)
+
+    const m = s.registerCounter('test_metric')
+    m.increment()
+
+    const metrics = await deferred.promise
+    expect(metrics).to.have.property('test_metric', 1)
+  })
+
+  it('should create a metric group', async () => {
+    const deferred = pDefer<Record<string, any>>()
+
+    s = simpleMetrics({
+      onMetrics: (metrics) => {
+        deferred.resolve(metrics)
+      },
+      intervalMs: 10
+    })({})
+
+    await start(s)
+
+    const m = s.registerMetricGroup('test_metric')
+    m.update({
+      foo: 10,
+      bar: 20
+    })
+
+    const metrics = await deferred.promise
+    expect(metrics).to.have.deep.property('test_metric', {
+      foo: 10,
+      bar: 20
+    })
+  })
+
+  it('should create a metric counter group', async () => {
+    const deferred = pDefer<Record<string, any>>()
+
+    s = simpleMetrics({
+      onMetrics: (metrics) => {
+        deferred.resolve(metrics)
+      },
+      intervalMs: 10
+    })({})
+
+    await start(s)
+
+    const m = s.registerCounterGroup('test_metric')
+    m.increment({
+      foo: 10,
+      bar: 20
+    })
+
+    const metrics = await deferred.promise
+    expect(metrics).to.have.deep.property('test_metric', {
+      foo: 10,
+      bar: 20
+    })
+  })
 })


### PR DESCRIPTION
Fixes a small bug in the creation of in-memory metrics.

## Change checklist

- [x] I have performed a self-review of my own code
- [ ] I have made corresponding changes to the documentation if necessary (this includes comments as well)
- [x] I have added tests that prove my fix is effective or that my feature works