### PR TITLE
fix: log error correctly

### DIFF
--- a/packages/libp2p/src/upgrader.ts
+++ b/packages/libp2p/src/upgrader.ts
@@ -641,7 +641,7 @@ export class DefaultUpgrader implements Upgrader {
         protocol
       }
     } catch (err: any) {
-      connection.log.error('encrypting inbound connection to %p failed', remotePeerId, err)
+      connection.log.error('encrypting inbound connection failed', err)
       throw new CodeError(err.message, codes.ERR_ENCRYPTION_FAILED)
     }
   }

--- a/packages/libp2p/src/upgrader.ts
+++ b/packages/libp2p/src/upgrader.ts
@@ -641,7 +641,7 @@ export class DefaultUpgrader implements Upgrader {
         protocol
       }
     } catch (err: any) {
-      connection.log.error('encrypting inbound connection to %p failed', err)
+      connection.log.error('encrypting inbound connection to %p failed', remotePeerId, err)
       throw new CodeError(err.message, codes.ERR_ENCRYPTION_FAILED)
     }
   }
@@ -678,7 +678,7 @@ export class DefaultUpgrader implements Upgrader {
         protocol
       }
     } catch (err: any) {
-      connection.log.error('encrypting outbound connection to %p failed', err)
+      connection.log.error('encrypting outbound connection to %p failed', remotePeerId, err)
       throw new CodeError(err.message, codes.ERR_ENCRYPTION_FAILED)
     }
   }


### PR DESCRIPTION
The peer id was meant to be passed to the format string with the error afterwards.

## Change checklist

- [x] I have performed a self-review of my own code
- [ ] I have made corresponding changes to the documentation if necessary (this includes comments as well)
- [ ] I have added tests that prove my fix is effective or that my feature works