### PR TITLE
fix: bind redis proxy to all interfaces

### DIFF
--- a/interop/.aegir.js
+++ b/interop/.aegir.js
@@ -68,7 +68,7 @@ export default {
       }
 
       const proxyServer = http.createServer(requestListener)
-      await new Promise(resolve => { proxyServer.listen(0, 'localhost', () => { resolve() }) })
+      await new Promise(resolve => { proxyServer.listen(0, () => { resolve() }) })
 
       return {
         redisClient,


### PR DESCRIPTION
Sometimes docker in CI resolves localhost to an ip4 address, sometimes an ip6 address so just bind to all interfaces.

## Change checklist

- [x] I have performed a self-review of my own code
- [ ] I have made corresponding changes to the documentation if necessary (this includes comments as well)
- [x] I have added tests that prove my fix is effective or that my feature works