### PR TITLE
fix: export tls key as pkcs8

### DIFF
--- a/packages/connection-encrypter-tls/src/utils.ts
+++ b/packages/connection-encrypter-tls/src/utils.ts
@@ -179,11 +179,11 @@ export async function generateCertificate (peerId: PeerId): Promise<{ cert: stri
     ]
   })
 
-  const certPrivateKeySpki = await crypto.subtle.exportKey('spki', keys.privateKey)
+  const certPrivateKeyPkcs8 = await crypto.subtle.exportKey('pkcs8', keys.privateKey)
 
   return {
     cert: selfCert.toString(),
-    key: spkiToPEM(certPrivateKeySpki)
+    key: pkcs8ToPEM(certPrivateKeyPkcs8)
   }
 }
 
@@ -213,7 +213,7 @@ export function encodeSignatureData (certPublicKey: ArrayBuffer): Uint8Array {
   ])
 }
 
-function spkiToPEM (keydata: ArrayBuffer): string {
+function pkcs8ToPEM (keydata: ArrayBuffer): string {
   return formatAsPem(uint8ArrayToString(new Uint8Array(keydata), 'base64'))
 }
 


### PR DESCRIPTION
The WebCrypto polyfill has [improved it's validation](https://github.com/PeculiarVentures/webcrypto-core/commit/4ef9eaab136fdee833884762f865f4b6dce28465) and we now fail to export the private key of the generated cert correctly.

Update to export in pkcs8 format instead, which we can just base64 encode to turn it into the PEM format.

## Change checklist

- [x] I have performed a self-review of my own code
- [ ] I have made corresponding changes to the documentation if necessary (this includes comments as well)
- [ ] I have added tests that prove my fix is effective or that my feature works