### PR TITLE
docs: update webrtc-direct support

### DIFF
--- a/packages/transport-webrtc/README.md
+++ b/packages/transport-webrtc/README.md
@@ -52,7 +52,7 @@ At the time of writing, WebRTC Direct is dial-only in browsers and not supported
 
 Support in Node.js is possible but PRs will need to be opened to [libdatachannel](https://github.com/paullouisageneau/libdatachannel) and the appropriate APIs exposed in [node-datachannel](https://github.com/murat-dogan/node-datachannel).
 
-For both WebRTC and WebRTC Direct, support is arriving soon in go-libp2p but they are unsupported in rust-libp2p.
+WebRTC Direct support is available in rust-libp2p and arriving soon in go-libp2p.
 
 See the WebRTC section of <https://connectivity.libp2p.io> for more information.
 

--- a/packages/transport-webrtc/src/index.ts
+++ b/packages/transport-webrtc/src/index.ts
@@ -29,7 +29,7 @@
  *
  * Support in Node.js is possible but PRs will need to be opened to [libdatachannel](https://github.com/paullouisageneau/libdatachannel) and the appropriate APIs exposed in [node-datachannel](https://github.com/murat-dogan/node-datachannel).
  *
- * For both WebRTC and WebRTC Direct, support is arriving soon in go-libp2p but they are unsupported in rust-libp2p.
+ * WebRTC Direct support is available in rust-libp2p and arriving soon in go-libp2p.
  *
  * See the WebRTC section of https://connectivity.libp2p.io for more information.
  *


### PR DESCRIPTION
## Title

Update comment about WebRTC direct support in Go and Rust libp2p

## Change checklist

- [ ] I have performed a self-review of my own code
- [ ] I have made corresponding changes to the documentation if necessary (this includes comments as well)
- [ ] I have added tests that prove my fix is effective or that my feature works