### PR TITLE
chore: import multiaddr and daemon client modules dynamically

### DIFF
--- a/packages/transport-webtransport/.aegir.js
+++ b/packages/transport-webtransport/.aegir.js
@@ -1,5 +1,3 @@
-import { createClient } from '@libp2p/daemon-client'
-import { multiaddr } from '@multiformats/multiaddr'
 import { execa } from 'execa'
 import { path as p2pd } from 'go-libp2p'
 import pDefer from 'p-defer'
@@ -27,6 +25,10 @@ export default {
 }
 
 async function createGoLibp2p () {
+  // dynamic import is necessary because these modules have dependencies on
+  // modules in this monorepo which may not have been built yet
+  const { multiaddr } = await import('@multiformats/multiaddr')
+  const { createClient } = await import('@libp2p/daemon-client')
   const controlPort = Math.floor(Math.random() * (50000 - 10000 + 1)) + 10000
   const apiAddr = multiaddr(`/ip4/127.0.0.1/tcp/${controlPort}`)
   const deferred = pDefer()


### PR DESCRIPTION
These modules have dependencies on `@libp2p/interface` which is part of this monorepo so may not be built yet if they are statically imported at the top of the file.

Instead import them dynamically when they are used during the test phase.

## Change checklist

- [x] I have performed a self-review of my own code
- [ ] I have made corresponding changes to the documentation if necessary (this includes comments as well)
- [ ] I have added tests that prove my fix is effective or that my feature works