### PR TITLE
fix: use randomwalk when performing autonat

### DIFF
--- a/packages/protocol-autonat/package.json
+++ b/packages/protocol-autonat/package.json
@@ -55,7 +55,6 @@
     "@libp2p/interface": "^1.4.0",
     "@libp2p/interface-internal": "^1.2.2",
     "@libp2p/peer-id": "^4.1.2",
-    "@libp2p/peer-id-factory": "^4.1.2",
     "@libp2p/utils": "^5.4.2",
     "@multiformats/multiaddr": "^12.2.3",
     "it-first": "^3.0.6",
@@ -68,6 +67,7 @@
   },
   "devDependencies": {
     "@libp2p/logger": "^4.0.13",
+    "@libp2p/peer-id-factory": "^4.1.2",
     "aegir": "^43.0.1",
     "it-all": "^3.0.6",
     "it-pushable": "^3.2.3",

--- a/packages/protocol-autonat/src/autonat.ts
+++ b/packages/protocol-autonat/src/autonat.ts
@@ -1,6 +1,5 @@
 import { CodeError, ERR_TIMEOUT, setMaxListeners } from '@libp2p/interface'
 import { peerIdFromBytes } from '@libp2p/peer-id'
-import { createEd25519PeerId } from '@libp2p/peer-id-factory'
 import { isPrivateIp } from '@libp2p/utils/private-ip'
 import { multiaddr, protocols } from '@multiformats/multiaddr'
 import first from 'it-first'
@@ -374,9 +373,6 @@ export class AutoNATService implements Startable {
           }
         }
       })
-      // find some random peers
-      const randomPeer = await createEd25519PeerId()
-      const randomCid = randomPeer.toBytes()
 
       const results: Record<string, { success: number, failure: number }> = {}
       const networkSegments: string[] = []
@@ -449,7 +445,8 @@ export class AutoNATService implements Startable {
         }
       }
 
-      for await (const dialResponse of parallel(map(this.components.peerRouting.getClosestPeers(randomCid, {
+      // find some random peers
+      for await (const dialResponse of parallel(map(this.components.randomWalk.walk({
         signal
       }), (peer) => async () => verifyAddress(peer)), {
         concurrency: REQUIRED_SUCCESSFUL_DIALS

--- a/packages/protocol-autonat/src/index.ts
+++ b/packages/protocol-autonat/src/index.ts
@@ -31,8 +31,8 @@
  */
 
 import { AutoNATService } from './autonat.js'
-import type { ComponentLogger, PeerId, PeerRouting } from '@libp2p/interface'
-import type { AddressManager, ConnectionManager, Registrar, TransportManager } from '@libp2p/interface-internal'
+import type { ComponentLogger, PeerId } from '@libp2p/interface'
+import type { AddressManager, ConnectionManager, RandomWalk, Registrar, TransportManager } from '@libp2p/interface-internal'
 
 export interface AutoNATServiceInit {
   /**
@@ -72,8 +72,8 @@ export interface AutoNATComponents {
   transportManager: TransportManager
   peerId: PeerId
   connectionManager: ConnectionManager
-  peerRouting: PeerRouting
   logger: ComponentLogger
+  randomWalk: RandomWalk
 }
 
 export function autoNAT (init: AutoNATServiceInit = {}): (components: AutoNATComponents) => unknown {

--- a/packages/protocol-autonat/test/index.spec.ts
+++ b/packages/protocol-autonat/test/index.spec.ts
@@ -17,8 +17,8 @@ import { AutoNATService } from '../src/autonat.js'
 import { PROTOCOL_NAME, PROTOCOL_PREFIX, PROTOCOL_VERSION } from '../src/constants.js'
 import { Message } from '../src/pb/index.js'
 import type { AutoNATComponents, AutoNATServiceInit } from '../src/index.js'
-import type { Connection, Stream, PeerId, PeerInfo, PeerRouting, Transport } from '@libp2p/interface'
-import type { AddressManager, ConnectionManager, Registrar, TransportManager } from '@libp2p/interface-internal'
+import type { Connection, Stream, PeerId, PeerInfo, Transport } from '@libp2p/interface'
+import type { AddressManager, ConnectionManager, RandomWalk, Registrar, TransportManager } from '@libp2p/interface-internal'
 import type { Multiaddr } from '@multiformats/multiaddr'
 import type { StubbedInstance } from 'sinon-ts'
 
@@ -34,14 +34,14 @@ const defaultInit: AutoNATServiceInit = {
 describe('autonat', () => {
   let service: any
   let components: AutoNATComponents
-  let peerRouting: StubbedInstance<PeerRouting>
+  let randomWalk: StubbedInstance<RandomWalk>
   let registrar: StubbedInstance<Registrar>
   let addressManager: StubbedInstance<AddressManager>
   let connectionManager: StubbedInstance<ConnectionManager>
   let transportManager: StubbedInstance<TransportManager>
 
   beforeEach(async () => {
-    peerRouting = stubInterface<PeerRouting>()
+    randomWalk = stubInterface<RandomWalk>()
     registrar = stubInterface<Registrar>()
     addressManager = stubInterface<AddressManager>()
     addressManager.getAddresses.returns([])
@@ -52,7 +52,7 @@ describe('autonat', () => {
     components = {
       peerId: await createEd25519PeerId(),
       logger: defaultLogger(),
-      peerRouting,
+      randomWalk,
       registrar,
       addressManager,
       connectionManager,
@@ -126,7 +126,7 @@ describe('autonat', () => {
         })
       ]
 
-      peerRouting.getClosestPeers.returns(async function * () {
+      randomWalk.walk.returns(async function * () {
         yield * peers
       }())
 
@@ -156,7 +156,7 @@ describe('autonat', () => {
         })
       ]
 
-      peerRouting.getClosestPeers.returns(async function * () {
+      randomWalk.walk.returns(async function * () {
         yield * peers
       }())
 
@@ -195,7 +195,7 @@ describe('autonat', () => {
         })
       ]
 
-      peerRouting.getClosestPeers.returns(async function * () {
+      randomWalk.walk.returns(async function * () {
         yield * peers
       }())
 
@@ -240,7 +240,7 @@ describe('autonat', () => {
         })
       ]
 
-      peerRouting.getClosestPeers.returns(async function * () {
+      randomWalk.walk.returns(async function * () {
         yield * peers
       }())
 
@@ -287,7 +287,7 @@ describe('autonat', () => {
         })
       ]
 
-      peerRouting.getClosestPeers.returns(async function * () {
+      randomWalk.walk.returns(async function * () {
         yield * peers
       }())
 
@@ -339,7 +339,7 @@ describe('autonat', () => {
         })
       ]
 
-      peerRouting.getClosestPeers.returns(async function * () {
+      randomWalk.walk.returns(async function * () {
         yield * peers
       }())
 
@@ -372,7 +372,7 @@ describe('autonat', () => {
         })
       ]
 
-      peerRouting.getClosestPeers.returns(async function * () {
+      randomWalk.walk.returns(async function * () {
         yield * peers
       }())
 


### PR DESCRIPTION
Refactor to reuse the randomwalk component rather than rolling our own during autonat address verification.

## Change checklist

- [x] I have performed a self-review of my own code
- [ ] I have made corresponding changes to the documentation if necessary (this includes comments as well)
- [ ] I have added tests that prove my fix is effective or that my feature works