### PR TITLE
fix: split listeners and dialers in transport interface tests

### DIFF
--- a/packages/interface-compliance-tests/src/transport/filter-test.ts
+++ b/packages/interface-compliance-tests/src/transport/filter-test.ts
@@ -8,10 +8,11 @@ export default (common: TestSetup<TransportTestFixtures>): void => {
   describe('filter', () => {
     let listenAddrs: Multiaddr[]
     let dialAddrs: Multiaddr[]
-    let transport: Transport
+    let dialer: Transport
+    let listener: Transport
 
     before(async () => {
-      ({ listenAddrs, dialAddrs, transport } = await common.setup())
+      ({ listenAddrs, dialAddrs, dialer, listener } = await common.setup())
     })
 
     after(async () => {
@@ -19,12 +20,12 @@ export default (common: TestSetup<TransportTestFixtures>): void => {
     })
 
     it('filters listen addresses', () => {
-      const filteredAddrs = transport.listenFilter(listenAddrs)
+      const filteredAddrs = listener.listenFilter(listenAddrs)
       expect(filteredAddrs).to.eql(listenAddrs)
     })
 
     it('filters dial addresses', () => {
-      const filteredAddrs = transport.dialFilter(dialAddrs)
+      const filteredAddrs = dialer.dialFilter(dialAddrs)
       expect(filteredAddrs).to.eql(dialAddrs)
     })
   })

--- a/packages/interface-compliance-tests/src/transport/index.ts
+++ b/packages/interface-compliance-tests/src/transport/index.ts
@@ -13,7 +13,8 @@ export interface Connector {
 export interface TransportTestFixtures {
   listenAddrs: Multiaddr[]
   dialAddrs: Multiaddr[]
-  transport: Transport
+  dialer: Transport
+  listener: Transport
   connector: Connector
 }
 

--- a/packages/transport-tcp/test/compliance.spec.ts
+++ b/packages/transport-tcp/test/compliance.spec.ts
@@ -38,7 +38,7 @@ describe('interface-transport compliance', () => {
         }
       }
 
-      return { transport, listenAddrs: addrs, dialAddrs: addrs, connector }
+      return { dialer: transport, listener: transport, listenAddrs: addrs, dialAddrs: addrs, connector }
     },
     async teardown () {}
   })

--- a/packages/transport-websockets/test/compliance.node.ts
+++ b/packages/transport-websockets/test/compliance.node.ts
@@ -56,7 +56,7 @@ describe('interface-transport compliance', () => {
         restore () { delayMs = 0 }
       }
 
-      return { transport: wsProxy, listenAddrs: addrs, dialAddrs: addrs, connector }
+      return { dialer: wsProxy, listener: wsProxy, listenAddrs: addrs, dialAddrs: addrs, connector }
     },
     async teardown () {}
   })


### PR DESCRIPTION
To support asymmetric transports, call `.listen` and `.dial` on separate properties of the transport interface setup return value.

For symmetric transports these can be the same transport instance.

## Change checklist

- [x] I have performed a self-review of my own code
- [ ] I have made corresponding changes to the documentation if necessary (this includes comments as well)
- [x] I have added tests that prove my fix is effective or that my feature works