### PR TITLE
feat: allow passing a function for rtcConfiguration

### DIFF
--- a/packages/transport-webrtc/src/private-to-private/transport.ts
+++ b/packages/transport-webrtc/src/private-to-private/transport.ts
@@ -19,7 +19,7 @@ export const SIGNALING_PROTO_ID = '/webrtc-signaling/0.0.1'
 const INBOUND_CONNECTION_TIMEOUT = 30 * 1000
 
 export interface WebRTCTransportInit {
-  rtcConfiguration?: RTCConfiguration
+  rtcConfiguration?: RTCConfiguration | (() => RTCConfiguration | Promise<RTCConfiguration>)
   dataChannel?: DataChannelOptions
 
   /**
@@ -133,7 +133,7 @@ export class WebRTCTransport implements Transport, Startable {
   async dial (ma: Multiaddr, options: DialOptions): Promise<Connection> {
     this.log.trace('dialing address: %a', ma)
 
-    const peerConnection = new RTCPeerConnection(this.init.rtcConfiguration)
+    const peerConnection = new RTCPeerConnection(typeof this.init.rtcConfiguration === 'function' ? await this.init.rtcConfiguration() : this.init.rtcConfiguration)
     const muxerFactory = new DataChannelMuxerFactory(this.components, {
       peerConnection,
       dataChannelOptions: this.init.dataChannel
@@ -170,7 +170,7 @@ export class WebRTCTransport implements Transport, Startable {
 
   async _onProtocol ({ connection, stream }: IncomingStreamData): Promise<void> {
     const signal = AbortSignal.timeout(this.init.inboundConnectionTimeout ?? INBOUND_CONNECTION_TIMEOUT)
-    const peerConnection = new RTCPeerConnection(this.init.rtcConfiguration)
+    const peerConnection = new RTCPeerConnection(typeof this.init.rtcConfiguration === 'function' ? await this.init.rtcConfiguration() : this.init.rtcConfiguration)
     const muxerFactory = new DataChannelMuxerFactory(this.components, {
       peerConnection,
       dataChannelOptions: this.init.dataChannel

--- a/packages/transport-webrtc/src/private-to-public/transport.ts
+++ b/packages/transport-webrtc/src/private-to-public/transport.ts
@@ -52,6 +52,7 @@ export interface WebRTCMetrics {
 }
 
 export interface WebRTCTransportDirectInit {
+  rtcConfiguration?: RTCConfiguration | (() => RTCConfiguration | Promise<RTCConfiguration>)
   dataChannel?: DataChannelOptions
 }
 
@@ -137,7 +138,10 @@ export class WebRTCDirectTransport implements Transport {
       hash: sdp.toSupportedHashFunction(remoteCerthash.name)
     } as any)
 
-    const peerConnection = new RTCPeerConnection({ certificates: [certificate] })
+    const peerConnection = new RTCPeerConnection({
+      ...(typeof this.init.rtcConfiguration === 'function' ? await this.init.rtcConfiguration() : this.init.rtcConfiguration ?? {}),
+      certificates: [certificate]
+    })
 
     try {
       // create data channel for running the noise handshake. Once the data channel is opened,


### PR DESCRIPTION
In order to allow refreshing STUN/TURN credentials between dials, allow passing a function that returns rtc config.

Fixes #2554

## Change checklist

- [x] I have performed a self-review of my own code
- [x] I have made corresponding changes to the documentation if necessary (this includes comments as well)
- [ ] I have added tests that prove my fix is effective or that my feature works