### PR TITLE
fix: create RTCPeerConnection after dialing remote peer

### DIFF
--- a/packages/transport-webrtc/src/private-to-private/initiate-connection.ts
+++ b/packages/transport-webrtc/src/private-to-private/initiate-connection.ts
@@ -80,7 +80,7 @@ export async function initiateConnection ({ rtcConfiguration, signal, metrics, m
         // see - https://www.w3.org/TR/webrtc/#rtcpeerconnectioniceevent
         const data = JSON.stringify(candidate?.toJSON() ?? null)
 
-        log.trace('initiator sending ICE candidate %s', data)
+        log.trace('initiator sending ICE candidate %o', candidate)
 
         void messageStream.write({
           type: Message.Type.ICE_CANDIDATE,

--- a/packages/transport-webrtc/src/private-to-private/transport.ts
+++ b/packages/transport-webrtc/src/private-to-private/transport.ts
@@ -133,14 +133,7 @@ export class WebRTCTransport implements Transport, Startable {
   async dial (ma: Multiaddr, options: DialOptions): Promise<Connection> {
     this.log.trace('dialing address: %a', ma)
 
-    const peerConnection = new RTCPeerConnection(this.init.rtcConfiguration)
-    const muxerFactory = new DataChannelMuxerFactory(this.components, {
-      peerConnection,
-      dataChannelOptions: this.init.dataChannel
-    })
-
-    const { remoteAddress } = await initiateConnection({
-      peerConnection,
+    const { remoteAddress, peerConnection } = await initiateConnection({
       multiaddr: ma,
       dataChannelOptions: this.init.dataChannel,
       signal: options.signal,
@@ -154,6 +147,11 @@ export class WebRTCTransport implements Transport, Startable {
       timeline: { open: Date.now() },
       remoteAddr: remoteAddress,
       metrics: this.metrics?.dialerEvents
+    })
+
+    const muxerFactory = new DataChannelMuxerFactory(this.components, {
+      peerConnection,
+      dataChannelOptions: this.init.dataChannel
     })
 
     const connection = await options.upgrader.upgradeOutbound(webRTCConn, {

--- a/packages/transport-webrtc/src/private-to-private/util.ts
+++ b/packages/transport-webrtc/src/private-to-private/util.ts
@@ -48,7 +48,7 @@ export const readCandidatesUntilConnected = async (pc: RTCPeerConnection, stream
 
       const candidate = new RTCIceCandidate(candidateInit)
 
-      options.log.trace('%s received new ICE candidate', options.direction, candidate)
+      options.log.trace('%s received new ICE candidate %o', options.direction, candidateInit)
 
       try {
         await pc.addIceCandidate(candidate)

--- a/packages/transport-webrtc/src/private-to-private/util.ts
+++ b/packages/transport-webrtc/src/private-to-private/util.ts
@@ -23,11 +23,14 @@ export const readCandidatesUntilConnected = async (pc: RTCPeerConnection, stream
         connectedPromise.promise,
         stream.read({
           signal: options.signal
-        })
+        }).catch(() => {})
       ])
 
       // stream ended or we became connected
       if (message == null) {
+        // throw if we timed out
+        options.signal?.throwIfAborted()
+
         break
       }
 

--- a/packages/transport-webrtc/test/peer.spec.ts
+++ b/packages/transport-webrtc/test/peer.spec.ts
@@ -15,7 +15,7 @@ import { Message } from '../src/private-to-private/pb/message.js'
 import { handleIncomingStream } from '../src/private-to-private/signaling-stream-handler.js'
 import { SIGNALING_PROTO_ID, WebRTCTransport, splitAddr } from '../src/private-to-private/transport.js'
 import { RTCPeerConnection, RTCSessionDescription } from '../src/webrtc/index.js'
-import type { Logger, Connection, Stream } from '@libp2p/interface'
+import type { Logger, Connection, Stream, ComponentLogger } from '@libp2p/interface'
 import type { ConnectionManager, TransportManager } from '@libp2p/interface-internal'
 
 const browser = detect()
@@ -27,6 +27,7 @@ interface Initiator {
   connection: StubbedInstance<Connection>
   stream: Stream
   log: Logger
+  logger: ComponentLogger
 }
 
 interface Recipient {
@@ -70,7 +71,8 @@ async function getComponents (): Promise<PrivateToPrivateComponents> {
       transportManager: stubInterface<TransportManager>(),
       connection: stubInterface<Connection>(),
       stream: initiatorStream,
-      log: logger('test')
+      log: logger('test'),
+      logger: defaultLogger()
     },
     recipient: {
       peerConnection: new RTCPeerConnection(),

--- a/packages/transport-webrtc/test/peer.spec.ts
+++ b/packages/transport-webrtc/test/peer.spec.ts
@@ -22,7 +22,6 @@ const browser = detect()
 
 interface Initiator {
   multiaddr: Multiaddr
-  peerConnection: RTCPeerConnection
   connectionManager: StubbedInstance<ConnectionManager>
   transportManager: StubbedInstance<TransportManager>
   connection: StubbedInstance<Connection>
@@ -67,7 +66,6 @@ async function getComponents (): Promise<PrivateToPrivateComponents> {
   return {
     initiator: {
       multiaddr: receiverMultiaddr,
-      peerConnection: new RTCPeerConnection(),
       connectionManager: stubInterface<ConnectionManager>(),
       transportManager: stubInterface<TransportManager>(),
       connection: stubInterface<Connection>(),
@@ -91,9 +89,10 @@ describe('webrtc basic', () => {
   const isFirefox = ((browser != null) && browser.name === 'firefox')
   let initiator: Initiator
   let recipient: Recipient
+  let initiatorPeerConnection: RTCPeerConnection
 
   afterEach(() => {
-    initiator?.peerConnection?.close()
+    initiatorPeerConnection?.close()
     recipient?.peerConnection?.close()
   })
 
@@ -109,7 +108,7 @@ describe('webrtc basic', () => {
     // signalling stream opens successfully
     initiator.connection.newStream.withArgs(SIGNALING_PROTO_ID).resolves(initiator.stream)
 
-    await expect(
+    ;[{ peerConnection: initiatorPeerConnection }] = await expect(
       Promise.all([
         initiateConnection(initiator),
         handleIncomingStream(recipient)
@@ -118,11 +117,11 @@ describe('webrtc basic', () => {
 
     await pRetry(async () => {
       if (isFirefox) {
-        expect(initiator.peerConnection.iceConnectionState).eq('connected')
+        expect(initiatorPeerConnection.iceConnectionState).eq('connected')
         expect(recipient.peerConnection.iceConnectionState).eq('connected')
         return
       }
-      expect(initiator.peerConnection.connectionState).eq('connected')
+      expect(initiatorPeerConnection.connectionState).eq('connected')
       expect(recipient.peerConnection.connectionState).eq('connected')
     })
   })
@@ -137,18 +136,14 @@ describe('webrtc basic', () => {
     // transport manager dials recipient
     initiator.transportManager.dial.resolves(initiator.connection)
 
-    const createOffer = initiator.peerConnection.setRemoteDescription.bind(initiator.peerConnection)
-
-    initiator.peerConnection.setRemoteDescription = async (name) => {
-      // the dial is aborted
+    initiator.connection.newStream.callsFake(async () => {
+      // the operation is aborted
       abortController.abort(new Error('Oh noes!'))
-      // setting the description takes some time
+      // opening the stream takes some time
       await delay(100)
-      return createOffer(name)
-    }
-
-    // signalling stream opens successfully
-    initiator.connection.newStream.withArgs(SIGNALING_PROTO_ID).resolves(initiator.stream)
+      // signalling stream opens successfully
+      return initiator.stream
+    })
 
     await expect(Promise.all([
       initiateConnection({
@@ -164,9 +159,10 @@ describe('webrtc basic', () => {
 describe('webrtc receiver', () => {
   let initiator: Initiator
   let recipient: Recipient
+  let initiatorPeerConnection: RTCPeerConnection
 
   afterEach(() => {
-    initiator?.peerConnection?.close()
+    initiatorPeerConnection?.close()
     recipient?.peerConnection?.close()
   })
 
@@ -177,18 +173,16 @@ describe('webrtc receiver', () => {
 
     await stream.write({ type: Message.Type.SDP_OFFER, data: 'bad' })
     await expect(receiverPeerConnectionPromise).to.be.rejectedWith(/Failed to set remoteDescription/)
-
-    initiator.peerConnection.close()
-    recipient.peerConnection.close()
   })
 })
 
 describe('webrtc dialer', () => {
   let initiator: Initiator
   let recipient: Recipient
+  let initiatorPeerConnection: RTCPeerConnection
 
   afterEach(() => {
-    initiator?.peerConnection?.close()
+    initiatorPeerConnection?.close()
     recipient?.peerConnection?.close()
   })
 

--- a/packages/transport-webrtc/test/stream.spec.ts
+++ b/packages/transport-webrtc/test/stream.spec.ts
@@ -105,7 +105,7 @@ describe('Max message size', () => {
     await expect(webrtcStream.sink([new Uint8Array(1)])).to.eventually.be.rejected
       .with.property('code', 'ERR_BUFFER_CLEAR_TIMEOUT')
     const t1 = Date.now()
-    expect(t1 - t0).greaterThan(timeout)
+    expect(t1 - t0).greaterThanOrEqual(timeout)
     expect(t1 - t0).lessThan(timeout + 1000) // Some upper bound
     await closed.promise
     expect(webrtcStream.timeline.close).to.be.greaterThan(webrtcStream.timeline.open)


### PR DESCRIPTION
Chrome limits how many RTCPeerConnections a given tab can instantiated during it's lifetime - https://issues.chromium.org/issues/41378764

To delay hitting this limit, only create the dial-end RTCPeerConnection once a relayed connection has successfully been opened to the dial target, this prevents needlessly creating RTCPeerConnections when the dial fails before they are actually used.

Fixes #2591

## Change checklist

- [x] I have performed a self-review of my own code
- [ ] I have made corresponding changes to the documentation if necessary (this includes comments as well)
- [ ] I have added tests that prove my fix is effective or that my feature works