### PR TITLE
fix: move mplex capabilities to the factory

### DIFF
--- a/packages/stream-multiplexer-mplex/src/index.ts
+++ b/packages/stream-multiplexer-mplex/src/index.ts
@@ -31,6 +31,7 @@
  * ```
  */
 
+import { serviceCapabilities } from '@libp2p/interface'
 import { MplexStreamMuxer, type MplexComponents } from './mplex.js'
 import type { StreamMuxer, StreamMuxerFactory, StreamMuxerInit } from '@libp2p/interface'
 
@@ -90,6 +91,12 @@ class Mplex implements StreamMuxerFactory {
     this.components = components
     this._init = init
   }
+
+  readonly [Symbol.toStringTag] = '@libp2p/mplex'
+
+  readonly [serviceCapabilities]: string[] = [
+    '@libp2p/stream-multiplexing'
+  ]
 
   createStreamMuxer (init: StreamMuxerInit = {}): StreamMuxer {
     return new MplexStreamMuxer(this.components, {

--- a/packages/stream-multiplexer-mplex/src/mplex.ts
+++ b/packages/stream-multiplexer-mplex/src/mplex.ts
@@ -1,4 +1,4 @@
-import { CodeError, serviceCapabilities } from '@libp2p/interface'
+import { CodeError } from '@libp2p/interface'
 import { closeSource } from '@libp2p/utils/close-source'
 import { RateLimiter } from '@libp2p/utils/rate-limiter'
 import { pipe } from 'it-pipe'
@@ -119,12 +119,6 @@ export class MplexStreamMuxer implements StreamMuxer {
       duration: 1
     })
   }
-
-  readonly [Symbol.toStringTag] = '@libp2p/mplex'
-
-  readonly [serviceCapabilities]: string[] = [
-    '@libp2p/stream-multiplexing'
-  ]
 
   /**
    * Returns a Map of streams and their ids


### PR DESCRIPTION
These should be defined on the factory not the instance, since the factory is the component.

## Change checklist

- [x] I have performed a self-review of my own code
- [ ] I have made corresponding changes to the documentation if necessary (this includes comments as well)
- [ ] I have added tests that prove my fix is effective or that my feature works