### PR TITLE
feat: add url peer id

### DIFF
--- a/packages/interface/src/peer-id/index.ts
+++ b/packages/interface/src/peer-id/index.ts
@@ -19,6 +19,10 @@ export interface Secp256k1PeerId extends PeerId {
   readonly publicKey: Uint8Array
 }
 
+export interface URLPeerId extends PeerId {
+  readonly type: 'url'
+}
+
 export interface PeerId {
   type: PeerIdType
   multihash: MultihashDigest

--- a/packages/peer-id-factory/src/index.ts
+++ b/packages/peer-id-factory/src/index.ts
@@ -109,5 +109,13 @@ async function createFromParts (multihash: Uint8Array, privKey?: Uint8Array, pub
     return createFromPubKey(key)
   }
 
-  return peerIdFromBytes(multihash)
+  const peerId = peerIdFromBytes(multihash)
+
+  if (peerId.type !== 'Ed25519' && peerId.type !== 'secp256k1' && peerId.type !== 'RSA') {
+    // should not be possible since `multihash` is derived from keys and these
+    // are the cryptographic peer id types
+    throw new Error('Supplied PeerID is invalid')
+  }
+
+  return peerId
 }

--- a/packages/peer-id/test/index.spec.ts
+++ b/packages/peer-id/test/index.spec.ts
@@ -1,7 +1,12 @@
 /* eslint-env mocha */
 import { expect } from 'aegir/chai'
+import { CID } from 'multiformats/cid'
+import { identity } from 'multiformats/hashes/identity'
 import { fromString as uint8ArrayFromString } from 'uint8arrays/from-string'
-import { createPeerId, peerIdFromBytes, peerIdFromString } from '../src/index.js'
+import { createPeerId, peerIdFromBytes, peerIdFromCID, peerIdFromString } from '../src/index.js'
+
+// these values are from https://github.com/multiformats/multicodec/blob/master/table.csv
+const TRANSPORT_IPFS_GATEWAY_HTTP_CODE = 0x0920
 
 describe('PeerId', () => {
   it('create an id without \'new\'', () => {
@@ -110,5 +115,29 @@ describe('PeerId', () => {
     const res = JSON.parse(JSON.stringify({ id }))
 
     expect(res).to.have.property('id', id.toString())
+  })
+
+  it('creates a url peer id from a CID string', async () => {
+    const url = 'http://example.com/'
+    const cid = CID.createV1(TRANSPORT_IPFS_GATEWAY_HTTP_CODE, identity.digest(uint8ArrayFromString(url)))
+    const id = peerIdFromString(cid.toString())
+    expect(id).to.have.property('type', 'url')
+    expect(id.toString()).to.equal(cid.toString())
+  })
+
+  it('creates a url peer id from a CID bytes', async () => {
+    const url = 'http://example.com/'
+    const cid = CID.createV1(TRANSPORT_IPFS_GATEWAY_HTTP_CODE, identity.digest(uint8ArrayFromString(url)))
+    const id = peerIdFromBytes(cid.bytes)
+    expect(id).to.have.property('type', 'url')
+    expect(id.toString()).to.equal(cid.toString())
+  })
+
+  it('creates a url peer id from a CID', async () => {
+    const url = 'http://example.com/'
+    const cid = CID.createV1(TRANSPORT_IPFS_GATEWAY_HTTP_CODE, identity.digest(uint8ArrayFromString(url)))
+    const id = peerIdFromCID(cid)
+    expect(id).to.have.property('type', 'url')
+    expect(id.toString()).to.equal(cid.toString())
   })
 })


### PR DESCRIPTION
To parse non-cryptographic peer ids from http servers, add the url peer id type.

## Change checklist

- [x] I have performed a self-review of my own code
- [ ] I have made corresponding changes to the documentation if necessary (this includes comments as well)
- [x] I have added tests that prove my fix is effective or that my feature works