### PR TITLE
fix: WebTransport fail gracefully in Safari

### DIFF
--- a/packages/transport-webtransport/src/index.ts
+++ b/packages/transport-webtransport/src/index.ts
@@ -315,6 +315,11 @@ class WebTransportTransport implements Transport {
    * Filter check for all Multiaddrs that this transport can dial
    */
   dialFilter (multiaddrs: Multiaddr[]): Multiaddr[] {
+    // test for WebTransport support
+    if (globalThis.WebTransport == null) {
+      return []
+    }
+
     return multiaddrs.filter(ma => {
       if (!WebTransportMatcher.exactMatch(ma)) {
         return false

--- a/packages/transport-webtransport/src/webtransport.browser.ts
+++ b/packages/transport-webtransport/src/webtransport.browser.ts
@@ -1,1 +1,3 @@
-export default WebTransport
+// exporting property of globalThis allows us to fail gracefully in browsers
+// without WebTransport support
+export default globalThis.WebTransport


### PR DESCRIPTION
Make sure the WebTransport transport can load in Safari without erroring.

## Change checklist

- [x] I have performed a self-review of my own code
- [ ] I have made corresponding changes to the documentation if necessary (this includes comments as well)
- [ ] I have added tests that prove my fix is effective or that my feature works