### PR TITLE
fix: add default STUN servers to WebRTC transport

### DIFF
--- a/packages/transport-webrtc/src/constants.ts
+++ b/packages/transport-webrtc/src/constants.ts
@@ -1,0 +1,16 @@
+/**
+ * STUN servers help clients discover their own public IPs
+ *
+ * @see https://gist.github.com/mondain/b0ec1cf5f60ae726202e
+ */
+export const DEFAULT_ICE_SERVERS = [
+  'stun:stun.l.google.com:19302',
+  'stun:stun1.l.google.com:19302',
+  'stun:stun2.l.google.com:19302',
+  'stun:stun3.l.google.com:19302',
+  'stun:stun4.l.google.com:19302',
+  'stun:global.stun.twilio.com:3478',
+  'stun:stun.cloudflare.com:3478',
+  'stun:stun.services.mozilla.com:3478',
+  'stun:stun.1und1.de:3478'
+]

--- a/packages/transport-webrtc/src/private-to-private/transport.ts
+++ b/packages/transport-webrtc/src/private-to-private/transport.ts
@@ -6,6 +6,7 @@ import { WebRTC } from '@multiformats/multiaddr-matcher'
 import { codes } from '../error.js'
 import { WebRTCMultiaddrConnection } from '../maconn.js'
 import { DataChannelMuxerFactory } from '../muxer.js'
+import { getRtcConfiguration } from '../util.js'
 import { RTCPeerConnection } from '../webrtc/index.js'
 import { initiateConnection } from './initiate-connection.js'
 import { WebRTCPeerListener } from './listener.js'
@@ -134,7 +135,7 @@ export class WebRTCTransport implements Transport, Startable {
     this.log.trace('dialing address: %a', ma)
 
     const { remoteAddress, peerConnection, muxerFactory } = await initiateConnection({
-      rtcConfiguration: typeof this.init.rtcConfiguration === 'function' ? await this.init.rtcConfiguration() : this.init.rtcConfiguration,
+      rtcConfiguration: await getRtcConfiguration(this.init.rtcConfiguration),
       dataChannel: this.init.dataChannel,
       multiaddr: ma,
       dataChannelOptions: this.init.dataChannel,
@@ -166,7 +167,7 @@ export class WebRTCTransport implements Transport, Startable {
 
   async _onProtocol ({ connection, stream }: IncomingStreamData): Promise<void> {
     const signal = AbortSignal.timeout(this.init.inboundConnectionTimeout ?? INBOUND_CONNECTION_TIMEOUT)
-    const peerConnection = new RTCPeerConnection(typeof this.init.rtcConfiguration === 'function' ? await this.init.rtcConfiguration() : this.init.rtcConfiguration)
+    const peerConnection = new RTCPeerConnection(await getRtcConfiguration(this.init.rtcConfiguration))
     const muxerFactory = new DataChannelMuxerFactory(this.components, {
       peerConnection,
       dataChannelOptions: this.init.dataChannel

--- a/packages/transport-webrtc/src/private-to-public/transport.ts
+++ b/packages/transport-webrtc/src/private-to-public/transport.ts
@@ -10,7 +10,7 @@ import { dataChannelError, inappropriateMultiaddr, unimplemented, invalidArgumen
 import { WebRTCMultiaddrConnection } from '../maconn.js'
 import { DataChannelMuxerFactory } from '../muxer.js'
 import { createStream } from '../stream.js'
-import { isFirefox } from '../util.js'
+import { getRtcConfiguration, isFirefox } from '../util.js'
 import { RTCPeerConnection } from '../webrtc/index.js'
 import * as sdp from './sdp.js'
 import { genUfrag } from './util.js'
@@ -139,7 +139,7 @@ export class WebRTCDirectTransport implements Transport {
     } as any)
 
     const peerConnection = new RTCPeerConnection({
-      ...(typeof this.init.rtcConfiguration === 'function' ? await this.init.rtcConfiguration() : this.init.rtcConfiguration ?? {}),
+      ...(await getRtcConfiguration(this.init.rtcConfiguration)),
       certificates: [certificate]
     })
 

--- a/packages/transport-webrtc/src/util.ts
+++ b/packages/transport-webrtc/src/util.ts
@@ -1,7 +1,7 @@
 import { detect } from 'detect-browser'
 import pDefer from 'p-defer'
 import pTimeout from 'p-timeout'
-import { DEFAULT_ICE_SERVERS } from './constants'
+import { DEFAULT_ICE_SERVERS } from './constants.js'
 import type { LoggerOptions } from '@libp2p/interface'
 
 const browser = detect()

--- a/packages/transport-webrtc/src/util.ts
+++ b/packages/transport-webrtc/src/util.ts
@@ -1,6 +1,7 @@
 import { detect } from 'detect-browser'
 import pDefer from 'p-defer'
 import pTimeout from 'p-timeout'
+import { DEFAULT_ICE_SERVERS } from './constants'
 import type { LoggerOptions } from '@libp2p/interface'
 
 const browser = detect()
@@ -63,4 +64,20 @@ export function drainAndClose (channel: RTCDataChannel, direction: string, drain
 export interface AbortPromiseOptions {
   signal?: AbortSignal
   message?: string
+}
+
+export async function getRtcConfiguration (config?: RTCConfiguration | (() => RTCConfiguration | Promise<RTCConfiguration>)): Promise<RTCConfiguration> {
+  config = config ?? {}
+
+  if (typeof config === 'function') {
+    config = await config()
+  }
+
+  config.iceServers = config.iceServers ?? DEFAULT_ICE_SERVERS.map(url => ({
+    urls: [
+      url
+    ]
+  }))
+
+  return config
 }


### PR DESCRIPTION
To make it easier to connect to remote nodes behind NATs, add default STUN servers to the WebRTC transport.

## Change checklist

- [x] I have performed a self-review of my own code
- [ ] I have made corresponding changes to the documentation if necessary (this includes comments as well)
- [ ] I have added tests that prove my fix is effective or that my feature works