### PR TITLE
fix: expose progress events in dial/dialProtocol types

### DIFF
--- a/packages/interface-internal/src/connection-manager/index.ts
+++ b/packages/interface-internal/src/connection-manager/index.ts
@@ -1,17 +1,7 @@
-import type { TransportManagerDialProgressEvents } from '../transport-manager/index.js'
-import type { AbortOptions, PendingDial, Connection, MultiaddrConnection, PeerId, IsDialableOptions, Address, OutboundConnectionUpgradeEvents } from '@libp2p/interface'
+import type { AbortOptions, PendingDial, Connection, MultiaddrConnection, PeerId, IsDialableOptions, OpenConnectionProgressEvents } from '@libp2p/interface'
 import type { PeerMap } from '@libp2p/peer-collections'
 import type { Multiaddr } from '@multiformats/multiaddr'
-import type { ProgressOptions, ProgressEvent } from 'progress-events'
-
-export type OpenConnectionProgressEvents =
-  TransportManagerDialProgressEvents |
-  ProgressEvent<'dial-queue:already-connected'> |
-  ProgressEvent<'dial-queue:already-in-dial-queue'> |
-  ProgressEvent<'dial-queue:add-to-dial-queue'> |
-  ProgressEvent<'dial-queue:start-dial'> |
-  ProgressEvent<'dial-queue:calculated-addresses', Address[]> |
-  OutboundConnectionUpgradeEvents
+import type { ProgressOptions } from 'progress-events'
 
 export interface OpenConnectionOptions extends AbortOptions, ProgressOptions<OpenConnectionProgressEvents> {
   /**

--- a/packages/interface-internal/src/transport-manager/index.ts
+++ b/packages/interface-internal/src/transport-manager/index.ts
@@ -1,9 +1,6 @@
-import type { AbortOptions, Connection, Listener, Transport } from '@libp2p/interface'
+import type { AbortOptions, Connection, Listener, Transport, TransportManagerDialProgressEvents } from '@libp2p/interface'
 import type { Multiaddr } from '@multiformats/multiaddr'
-import type { ProgressOptions, ProgressEvent } from 'progress-events'
-
-export type TransportManagerDialProgressEvents =
-  ProgressEvent<'transport-manager:selected-transport', string>
+import type { ProgressOptions } from 'progress-events'
 
 export interface TransportManagerDialOptions extends AbortOptions, ProgressOptions<TransportManagerDialProgressEvents> {
 

--- a/packages/interface/src/index.ts
+++ b/packages/interface/src/index.ts
@@ -25,9 +25,9 @@ import type { Address, Peer, PeerStore } from './peer-store/index.js'
 import type { Startable } from './startable.js'
 import type { StreamHandler, StreamHandlerOptions } from './stream-handler/index.js'
 import type { Topology } from './topology/index.js'
-import type { Listener } from './transport/index.js'
+import type { Listener, OutboundConnectionUpgradeEvents } from './transport/index.js'
 import type { Multiaddr } from '@multiformats/multiaddr'
-import type { ProgressOptions } from 'progress-events'
+import type { ProgressOptions, ProgressEvent } from 'progress-events'
 
 /**
  * Used by the connection manager to sort addresses into order before dialling
@@ -334,6 +334,26 @@ export interface IsDialableOptions extends AbortOptions {
   runOnTransientConnection?: boolean
 }
 
+export type TransportManagerDialProgressEvents =
+  ProgressEvent<'transport-manager:selected-transport', string>
+
+export type OpenConnectionProgressEvents =
+  TransportManagerDialProgressEvents |
+  ProgressEvent<'dial-queue:already-connected'> |
+  ProgressEvent<'dial-queue:already-in-dial-queue'> |
+  ProgressEvent<'dial-queue:add-to-dial-queue'> |
+  ProgressEvent<'dial-queue:start-dial'> |
+  ProgressEvent<'dial-queue:calculated-addresses', Address[]> |
+  OutboundConnectionUpgradeEvents
+
+export interface DialOptions extends AbortOptions, ProgressOptions {
+
+}
+
+export interface DialProtocolOptions extends NewStreamOptions {
+
+}
+
 /**
  * Libp2p nodes implement this interface.
  */
@@ -515,7 +535,7 @@ export interface Libp2p<T extends ServiceMap = ServiceMap> extends Startable, Ty
    * await conn.close()
    * ```
    */
-  dial(peer: PeerId | Multiaddr | Multiaddr[], options?: AbortOptions): Promise<Connection>
+  dial(peer: PeerId | Multiaddr | Multiaddr[], options?: DialOptions): Promise<Connection>
 
   /**
    * Dials to the provided peer and tries to handshake with the given protocols in order.
@@ -533,7 +553,7 @@ export interface Libp2p<T extends ServiceMap = ServiceMap> extends Startable, Ty
    * pipe([1, 2, 3], stream, consume)
    * ```
    */
-  dialProtocol(peer: PeerId | Multiaddr | Multiaddr[], protocols: string | string[], options?: NewStreamOptions): Promise<Stream>
+  dialProtocol(peer: PeerId | Multiaddr | Multiaddr[], protocols: string | string[], options?: DialProtocolOptions): Promise<Stream>
 
   /**
    * Attempts to gracefully close an open connection to the given peer. If the

--- a/packages/interface/src/transport/index.ts
+++ b/packages/interface/src/transport/index.ts
@@ -40,7 +40,7 @@ export interface CreateListenerOptions {
   upgrader: Upgrader
 }
 
-export interface DialOptions<DialEvents extends ProgressEvent = ProgressEvent> extends AbortOptions, ProgressOptions<DialEvents> {
+export interface DialTransportOptions<DialEvents extends ProgressEvent = ProgressEvent> extends AbortOptions, ProgressOptions<DialEvents> {
   upgrader: Upgrader
 }
 
@@ -61,7 +61,7 @@ export interface Transport<DialEvents extends ProgressEvent = ProgressEvent> {
   /**
    * Dial a given multiaddr.
    */
-  dial(ma: Multiaddr, options: DialOptions<DialEvents>): Promise<Connection>
+  dial(ma: Multiaddr, options: DialTransportOptions<DialEvents>): Promise<Connection>
 
   /**
    * Create transport listeners.

--- a/packages/libp2p/src/connection-manager/dial-queue.ts
+++ b/packages/libp2p/src/connection-manager/dial-queue.ts
@@ -20,8 +20,8 @@ import {
 } from './constants.js'
 import { resolveMultiaddrs } from './utils.js'
 import { DEFAULT_DIAL_PRIORITY } from './index.js'
-import type { AddressSorter, ComponentLogger, Logger, Connection, ConnectionGater, Metrics, PeerId, Address, PeerStore, PeerRouting, IsDialableOptions } from '@libp2p/interface'
-import type { OpenConnectionOptions, OpenConnectionProgressEvents, TransportManager } from '@libp2p/interface-internal'
+import type { AddressSorter, ComponentLogger, Logger, Connection, ConnectionGater, Metrics, PeerId, Address, PeerStore, PeerRouting, IsDialableOptions, OpenConnectionProgressEvents } from '@libp2p/interface'
+import type { OpenConnectionOptions, TransportManager } from '@libp2p/interface-internal'
 import type { DNS } from '@multiformats/dns'
 import type { ProgressOptions } from 'progress-events'
 

--- a/packages/libp2p/src/libp2p.ts
+++ b/packages/libp2p/src/libp2p.ts
@@ -24,7 +24,7 @@ import { DefaultUpgrader } from './upgrader.js'
 import * as pkg from './version.js'
 import type { Components } from './components.js'
 import type { Libp2p, Libp2pInit, Libp2pOptions } from './index.js'
-import type { PeerRouting, ContentRouting, Libp2pEvents, PendingDial, ServiceMap, AbortOptions, ComponentLogger, Logger, Connection, NewStreamOptions, Stream, Metrics, PeerId, PeerInfo, PeerStore, Topology, Libp2pStatus, IsDialableOptions } from '@libp2p/interface'
+import type { PeerRouting, ContentRouting, Libp2pEvents, PendingDial, ServiceMap, AbortOptions, ComponentLogger, Logger, Connection, NewStreamOptions, Stream, Metrics, PeerId, PeerInfo, PeerStore, Topology, Libp2pStatus, IsDialableOptions, DialOptions } from '@libp2p/interface'
 import type { StreamHandler, StreamHandlerOptions } from '@libp2p/interface-internal'
 
 export class Libp2pNode<T extends ServiceMap = ServiceMap> extends TypedEventEmitter<Libp2pEvents> implements Libp2p<T> {
@@ -272,7 +272,7 @@ export class Libp2pNode<T extends ServiceMap = ServiceMap> extends TypedEventEmi
     return Array.from(peerSet)
   }
 
-  async dial (peer: PeerId | Multiaddr | Multiaddr[], options: AbortOptions = {}): Promise<Connection> {
+  async dial (peer: PeerId | Multiaddr | Multiaddr[], options: DialOptions = {}): Promise<Connection> {
     return this.components.connectionManager.openConnection(peer, {
       // ensure any userland dials take top priority in the queue
       priority: 75,

--- a/packages/transport-circuit-relay-v2/src/transport/transport.ts
+++ b/packages/transport-circuit-relay-v2/src/transport/transport.ts
@@ -12,8 +12,8 @@ import { RelayDiscovery } from './discovery.js'
 import { createListener } from './listener.js'
 import { ReservationStore } from './reservation-store.js'
 import type { CircuitRelayTransportComponents, CircuitRelayTransportInit } from './index.js'
-import type { Transport, CreateListenerOptions, Listener, Upgrader, ComponentLogger, Logger, Connection, Stream, ConnectionGater, PeerId, PeerStore, OutboundConnectionUpgradeEvents, DialOptions } from '@libp2p/interface'
-import type { AddressManager, ConnectionManager, IncomingStreamData, OpenConnectionProgressEvents, Registrar, TransportManager } from '@libp2p/interface-internal'
+import type { Transport, CreateListenerOptions, Listener, Upgrader, ComponentLogger, Logger, Connection, Stream, ConnectionGater, PeerId, PeerStore, OutboundConnectionUpgradeEvents, DialTransportOptions, OpenConnectionProgressEvents } from '@libp2p/interface'
+import type { AddressManager, ConnectionManager, IncomingStreamData, Registrar, TransportManager } from '@libp2p/interface-internal'
 import type { Multiaddr } from '@multiformats/multiaddr'
 import type { ProgressEvent, ProgressOptions } from 'progress-events'
 
@@ -167,7 +167,7 @@ export class CircuitRelayTransport implements Transport<CircuitRelayDialEvents> 
   /**
    * Dial a peer over a relay
    */
-  async dial (ma: Multiaddr, options: DialOptions<CircuitRelayDialEvents>): Promise<Connection> {
+  async dial (ma: Multiaddr, options: DialTransportOptions<CircuitRelayDialEvents>): Promise<Connection> {
     if (ma.protoCodes().filter(code => code === CIRCUIT_PROTO_CODE).length !== 1) {
       const errMsg = 'Invalid circuit relay address'
       this.log.error(errMsg, ma)

--- a/packages/transport-tcp/src/index.ts
+++ b/packages/transport-tcp/src/index.ts
@@ -35,7 +35,7 @@ import { CODE_CIRCUIT, CODE_P2P, CODE_UNIX } from './constants.js'
 import { type CloseServerOnMaxConnectionsOpts, TCPListener } from './listener.js'
 import { toMultiaddrConnection } from './socket-to-conn.js'
 import { multiaddrToNetConfig } from './utils.js'
-import type { ComponentLogger, Logger, Connection, CounterGroup, Metrics, CreateListenerOptions, DialOptions, Transport, Listener, OutboundConnectionUpgradeEvents } from '@libp2p/interface'
+import type { ComponentLogger, Logger, Connection, CounterGroup, Metrics, CreateListenerOptions, DialTransportOptions, Transport, Listener, OutboundConnectionUpgradeEvents } from '@libp2p/interface'
 import type { AbortOptions, Multiaddr } from '@multiformats/multiaddr'
 import type { Socket, IpcSocketConnectOpts, TcpSocketConnectOpts } from 'net'
 import type { ProgressEvent } from 'progress-events'
@@ -114,7 +114,7 @@ export type TCPDialEvents =
   OutboundConnectionUpgradeEvents |
   ProgressEvent<'tcp:open-connection'>
 
-export interface TCPDialOptions extends DialOptions<TCPDialEvents>, TCPSocketOptions {
+export interface TCPDialOptions extends DialTransportOptions<TCPDialEvents>, TCPSocketOptions {
 
 }
 

--- a/packages/transport-webrtc/src/private-to-private/transport.ts
+++ b/packages/transport-webrtc/src/private-to-private/transport.ts
@@ -11,8 +11,8 @@ import { initiateConnection } from './initiate-connection.js'
 import { WebRTCPeerListener } from './listener.js'
 import { handleIncomingStream } from './signaling-stream-handler.js'
 import type { DataChannelOptions } from '../index.js'
-import type { OutboundConnectionUpgradeEvents, CreateListenerOptions, DialOptions, Transport, Listener, Upgrader, ComponentLogger, Logger, Connection, PeerId, CounterGroup, Metrics, Startable } from '@libp2p/interface'
-import type { IncomingStreamData, Registrar, ConnectionManager, TransportManager, OpenConnectionProgressEvents } from '@libp2p/interface-internal'
+import type { OutboundConnectionUpgradeEvents, CreateListenerOptions, DialTransportOptions, Transport, Listener, Upgrader, ComponentLogger, Logger, Connection, PeerId, CounterGroup, Metrics, Startable, OpenConnectionProgressEvents } from '@libp2p/interface'
+import type { IncomingStreamData, Registrar, ConnectionManager, TransportManager } from '@libp2p/interface-internal'
 import type { ProgressEvent } from 'progress-events'
 
 const WEBRTC_TRANSPORT = '/webrtc'
@@ -145,7 +145,7 @@ export class WebRTCTransport implements Transport<WebRTCDialEvents>, Startable {
    * For a circuit relay, this will be of the form
    * <relay address>/p2p/<relay-peer>/p2p-circuit/webrtc/p2p/<destination-peer>
   */
-  async dial (ma: Multiaddr, options: DialOptions<WebRTCDialEvents>): Promise<Connection> {
+  async dial (ma: Multiaddr, options: DialTransportOptions<WebRTCDialEvents>): Promise<Connection> {
     this.log.trace('dialing address: %a', ma)
 
     const { remoteAddress, peerConnection, muxerFactory } = await initiateConnection({

--- a/packages/transport-webrtc/src/private-to-public/options.ts
+++ b/packages/transport-webrtc/src/private-to-public/options.ts
@@ -1,4 +1,4 @@
-import type { CreateListenerOptions, DialOptions } from '@libp2p/interface'
+import type { CreateListenerOptions, DialTransportOptions } from '@libp2p/interface'
 
 export interface WebRTCListenerOptions extends CreateListenerOptions {}
-export interface WebRTCDialOptions extends DialOptions {}
+export interface WebRTCDialOptions extends DialTransportOptions {}

--- a/packages/transport-websockets/src/index.ts
+++ b/packages/transport-websockets/src/index.ts
@@ -67,7 +67,7 @@ import { isBrowser, isWebWorker } from 'wherearewe'
 import * as filters from './filters.js'
 import { createListener } from './listener.js'
 import { socketToMaConn } from './socket-to-conn.js'
-import type { Transport, MultiaddrFilter, CreateListenerOptions, DialOptions, Listener, AbortOptions, ComponentLogger, Logger, Connection, OutboundConnectionUpgradeEvents } from '@libp2p/interface'
+import type { Transport, MultiaddrFilter, CreateListenerOptions, DialTransportOptions, Listener, AbortOptions, ComponentLogger, Logger, Connection, OutboundConnectionUpgradeEvents } from '@libp2p/interface'
 import type { Multiaddr } from '@multiformats/multiaddr'
 import type { Server } from 'http'
 import type { DuplexWebSocket } from 'it-ws/duplex'
@@ -107,7 +107,7 @@ class WebSockets implements Transport<WebSocketsDialEvents> {
     '@libp2p/transport'
   ]
 
-  async dial (ma: Multiaddr, options: DialOptions<WebSocketsDialEvents>): Promise<Connection> {
+  async dial (ma: Multiaddr, options: DialTransportOptions<WebSocketsDialEvents>): Promise<Connection> {
     this.log('dialing %s', ma)
     options = options ?? {}
 
@@ -122,7 +122,7 @@ class WebSockets implements Transport<WebSocketsDialEvents> {
     return conn
   }
 
-  async _connect (ma: Multiaddr, options: DialOptions<WebSocketsDialEvents>): Promise<DuplexWebSocket> {
+  async _connect (ma: Multiaddr, options: DialTransportOptions<WebSocketsDialEvents>): Promise<DuplexWebSocket> {
     options?.signal?.throwIfAborted()
 
     const cOpts = ma.toOptions()

--- a/packages/transport-webtransport/src/index.ts
+++ b/packages/transport-webtransport/src/index.ts
@@ -40,7 +40,7 @@ import { inertDuplex } from './utils/inert-duplex.js'
 import { isSubset } from './utils/is-subset.js'
 import { parseMultiaddr } from './utils/parse-multiaddr.js'
 import WebTransport from './webtransport.js'
-import type { Transport, CreateListenerOptions, DialOptions, Listener, ComponentLogger, Logger, Connection, MultiaddrConnection, CounterGroup, Metrics, PeerId, OutboundConnectionUpgradeEvents } from '@libp2p/interface'
+import type { Transport, CreateListenerOptions, DialTransportOptions, Listener, ComponentLogger, Logger, Connection, MultiaddrConnection, CounterGroup, Metrics, PeerId, OutboundConnectionUpgradeEvents } from '@libp2p/interface'
 import type { Multiaddr } from '@multiformats/multiaddr'
 import type { Source } from 'it-stream-types'
 import type { MultihashDigest } from 'multiformats/hashes/interface'
@@ -83,7 +83,7 @@ export type WebTransportDialEvents =
   ProgressEvent<'webtransport:secure-outbound-connection'> |
   ProgressEvent<'webtransport:close-authentication-stream'>
 
-interface AuthenticateWebTransportOptions extends DialOptions<WebTransportDialEvents> {
+interface AuthenticateWebTransportOptions extends DialTransportOptions<WebTransportDialEvents> {
   wt: WebTransport
   localPeer: PeerId
   remotePeer?: PeerId
@@ -123,7 +123,7 @@ class WebTransportTransport implements Transport<WebTransportDialEvents> {
     '@libp2p/transport'
   ]
 
-  async dial (ma: Multiaddr, options: DialOptions<WebTransportDialEvents>): Promise<Connection> {
+  async dial (ma: Multiaddr, options: DialTransportOptions<WebTransportDialEvents>): Promise<Connection> {
     if (options?.signal?.aborted === true) {
       throw new AbortError()
     }


### PR DESCRIPTION
Accept the `onProgress` event via types.

## Change checklist

- [x] I have performed a self-review of my own code
- [ ] I have made corresponding changes to the documentation if necessary (this includes comments as well)
- [ ] I have added tests that prove my fix is effective or that my feature works