### PR TITLE
fix: limit default WebRTC STUN servers to 4x

### DIFF
--- a/packages/transport-webrtc/src/constants.ts
+++ b/packages/transport-webrtc/src/constants.ts
@@ -1,16 +1,14 @@
 /**
- * STUN servers help clients discover their own public IPs
+ * STUN servers help clients discover their own public IPs.
+ *
+ * Using five or more servers causes warnings to be printed so
+ * ensure we limit it to max x4
  *
  * @see https://gist.github.com/mondain/b0ec1cf5f60ae726202e
  */
 export const DEFAULT_ICE_SERVERS = [
   'stun:stun.l.google.com:19302',
-  'stun:stun1.l.google.com:19302',
-  'stun:stun2.l.google.com:19302',
-  'stun:stun3.l.google.com:19302',
-  'stun:stun4.l.google.com:19302',
   'stun:global.stun.twilio.com:3478',
   'stun:stun.cloudflare.com:3478',
-  'stun:stun.services.mozilla.com:3478',
-  'stun:stun.1und1.de:3478'
+  'stun:stun.services.mozilla.com:3478'
 ]


### PR DESCRIPTION
Using 5x or more causes the following error to be printed in the console so only use 4x servers:

```
WebRTC: Using five or more STUN/TURN servers slows down discovery
```

## Change checklist

- [x] I have performed a self-review of my own code
- [ ] I have made corresponding changes to the documentation if necessary (this includes comments as well)
- [ ] I have added tests that prove my fix is effective or that my feature works