### PR TITLE
fix: make kad-dht init object optional

### DIFF
--- a/packages/kad-dht/src/index.ts
+++ b/packages/kad-dht/src/index.ts
@@ -459,6 +459,6 @@ export interface KadDHTComponents {
  * Creates a custom DHT implementation, please ensure you pass a `protocol`
  * string as an option.
  */
-export function kadDHT (init: KadDHTInit): (components: KadDHTComponents) => KadDHT {
+export function kadDHT (init: KadDHTInit = {}): (components: KadDHTComponents) => KadDHT {
   return (components: KadDHTComponents) => new KadDHTClass(components, init)
 }

--- a/packages/kad-dht/src/kad-dht.ts
+++ b/packages/kad-dht/src/kad-dht.ts
@@ -127,7 +127,7 @@ export class KadDHT extends TypedEventEmitter<PeerDiscoveryEvents> implements Ka
   /**
    * Create a new KadDHT
    */
-  constructor (components: KadDHTComponents, init: KadDHTInit) {
+  constructor (components: KadDHTComponents, init: KadDHTInit = {}) {
     super()
 
     const {


### PR DESCRIPTION
The default values set up an amino dht node so don't require an init arg since it can have no properties but still work.

## Change checklist

- [x] I have performed a self-review of my own code
- [ ] I have made corresponding changes to the documentation if necessary (this includes comments as well)
- [ ] I have added tests that prove my fix is effective or that my feature works