### PR TITLE
fix: increase WebRTC max datachannel message size

### DIFF
--- a/packages/transport-webrtc/src/stream.ts
+++ b/packages/transport-webrtc/src/stream.ts
@@ -46,8 +46,11 @@ export const VARINT_LENGTH = 2
 
 /**
  * Max message size that can be sent to the DataChannel
+ *
+ * @see https://blog.mozilla.org/webrtc/large-data-channel-messages/
+ * @see https://issues.webrtc.org/issues/40644524
  */
-export const MAX_MESSAGE_SIZE = 16 * 1024
+export const MAX_MESSAGE_SIZE = 256 * 1024
 
 /**
  * When closing streams we send a FIN then wait for the remote to

--- a/packages/transport-webrtc/src/stream.ts
+++ b/packages/transport-webrtc/src/stream.ts
@@ -35,9 +35,9 @@ export const MAX_BUFFERED_AMOUNT = 16 * 1024 * 1024
 export const BUFFERED_AMOUNT_LOW_TIMEOUT = 30 * 1000
 
 /**
- * protobuf field definition overhead
+ * protobuf field definition overhead + length encoding prefix length
  */
-export const PROTOBUF_OVERHEAD = 5
+export const PROTOBUF_OVERHEAD = 7
 
 /**
  * Length of varint, in bytes


### PR DESCRIPTION
The 16KB limit was fixed in browsers quite a while back so we should be able to increase the max datachannel message size to 256KB at least.

Fixes #2612

## Change checklist

- [x] I have performed a self-review of my own code
- [ ] I have made corresponding changes to the documentation if necessary (this includes comments as well)
- [ ] I have added tests that prove my fix is effective or that my feature works