### PR TITLE
fix: decrease max buffered amount for WebRTC datachannels

### DIFF
--- a/packages/transport-webrtc/src/stream.ts
+++ b/packages/transport-webrtc/src/stream.ts
@@ -27,7 +27,7 @@ export interface WebRTCStreamInit extends AbstractStreamInit, DataChannelOptions
 /**
  * How much can be buffered to the DataChannel at once
  */
-export const MAX_BUFFERED_AMOUNT = 16 * 1024 * 1024
+export const MAX_BUFFERED_AMOUNT = 10 * 1024 * 1024
 
 /**
  * How long time we wait for the 'bufferedamountlow' event to be emitted

--- a/packages/transport-webrtc/src/stream.ts
+++ b/packages/transport-webrtc/src/stream.ts
@@ -27,7 +27,7 @@ export interface WebRTCStreamInit extends AbstractStreamInit, DataChannelOptions
 /**
  * How much can be buffered to the DataChannel at once
  */
-export const MAX_BUFFERED_AMOUNT = 10 * 1024 * 1024
+export const MAX_BUFFERED_AMOUNT = 2 * 1024 * 1024
 
 /**
  * How long time we wait for the 'bufferedamountlow' event to be emitted


### PR DESCRIPTION
From experimental testing, 16MB is too big for Chrome to handle, when sending large amounts of data - the `bufferedamountlow` event never fires.

Lower it to 2MB which seems to actually work when running the Helia transport benchmarks.

## Change checklist

- [x] I have performed a self-review of my own code
- [ ] I have made corresponding changes to the documentation if necessary (this includes comments as well)
- [ ] I have added tests that prove my fix is effective or that my feature works