### PR TITLE
chore: pin node version in transport interop tests

### DIFF
--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -192,7 +192,8 @@ jobs:
       - uses: actions/checkout@v4
       - uses: actions/setup-node@v4
         with:
-          node-version: lts/*
+          # Pinned because of https://github.com/npm/cli/issues/7657
+          node-version: 20.13.1
       - uses: ipfs/aegir/actions/cache-node-modules@master
         with:
           directories: |

--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -192,8 +192,7 @@ jobs:
       - uses: actions/checkout@v4
       - uses: actions/setup-node@v4
         with:
-          # Pinned because of https://github.com/npm/cli/issues/7657
-          node-version: 20.13.1
+          node-version: lts/*
       - uses: ipfs/aegir/actions/cache-node-modules@master
         with:
           directories: |

--- a/interop/Dockerfile
+++ b/interop/Dockerfile
@@ -1,6 +1,6 @@
 # Here because we want to fetch the node_modules within docker so that it's
 # installed on the same platform the test is run. Otherwise tools like `esbuild` will fail to run
-FROM node:20-bullseye-slim
+FROM node:lts
 
 WORKDIR /app
 

--- a/interop/Dockerfile
+++ b/interop/Dockerfile
@@ -1,6 +1,6 @@
 # Here because we want to fetch the node_modules within docker so that it's
 # installed on the same platform the test is run. Otherwise tools like `esbuild` will fail to run
-FROM node:22-bullseye-slim
+FROM node:20-bullseye-slim
 
 WORKDIR /app
 


### PR DESCRIPTION
There's a regression in the latest node lts that causes npm 10.7.0 to fail to install so pin to the last release with 10.6.0.

## Change checklist

- [x] I have performed a self-review of my own code
- [ ] I have made corresponding changes to the documentation if necessary (this includes comments as well)
- [ ] I have added tests that prove my fix is effective or that my feature works