### PR TITLE
docs: update `connection.newStream` return value

### DIFF
--- a/packages/interface/src/index.ts
+++ b/packages/interface/src/index.ts
@@ -527,7 +527,7 @@ export interface Libp2p<T extends ServiceMap = ServiceMap> extends Startable, Ty
    * const conn = await libp2p.dial(remotePeerId)
    *
    * // create a new stream within the connection
-   * const { stream, protocol } = await conn.newStream(['/echo/1.1.0', '/echo/1.0.0'])
+   * const stream = await conn.newStream(['/echo/1.1.0', '/echo/1.0.0'])
    *
    * // protocol negotiated: 'echo/1.0.0' means that the other party only supports the older version
    *


### PR DESCRIPTION
## Title
docs: update newStream return value

## Description

newStream doesn't return an object with a stream property


## Change checklist

- [ ] I have performed a self-review of my own code
- [x] I have made corresponding changes to the documentation if necessary (this includes comments as well)
- [ ] I have added tests that prove my fix is effective or that my feature works