### PR TITLE
feat: add connection monitor

### DIFF
--- a/packages/interface/src/connection/index.ts
+++ b/packages/interface/src/connection/index.ts
@@ -288,6 +288,13 @@ export interface Connection {
   transient: boolean
 
   /**
+   * The time in milliseconds it takes to make a round trip to the remote peer.
+   *
+   * This is updated periodically by the connection monitor.
+   */
+  rtt?: number
+
+  /**
    * Create a new stream on this connection and negotiate one of the passed protocols
    */
   newStream(protocols: string | string[], options?: NewStreamOptions): Promise<Stream>

--- a/packages/libp2p/src/connection-monitor.ts
+++ b/packages/libp2p/src/connection-monitor.ts
@@ -1,0 +1,121 @@
+import { serviceCapabilities } from '@libp2p/interface'
+import { anySignal } from 'any-signal'
+import { byteStream } from 'it-byte-stream'
+import type { ComponentLogger, Logger, Startable } from '@libp2p/interface'
+import type { ConnectionManager } from '@libp2p/interface-internal'
+
+const DEFAULT_PING_INTERVAL_MS = 10000
+const DEFAULT_PING_TIMEOUT_MS = 2000
+
+export interface ConnectionMonitorInit {
+  /**
+   * How often to ping remote peers in ms
+   *
+   * @default 10000
+   */
+  pingInterval?: number
+
+  /**
+   * How long the ping is allowed to take before the connection will be judged
+   * inactive and aborted
+   *
+   * @default 2000
+   */
+  pingTimeout?: number
+
+  /**
+   * If true, any connection that fails the ping will be aborted
+   *
+   * @default true
+   */
+  abortConnectionOnPingFailure?: boolean
+}
+
+export interface ConnectionMonitorComponents {
+  logger: ComponentLogger
+  connectionManager: ConnectionManager
+}
+
+export class ConnectionMonitor implements Startable {
+  private readonly components: ConnectionMonitorComponents
+  private readonly log: Logger
+  private heartbeatInterval?: ReturnType<typeof setInterval>
+  private readonly pingIntervalMs: number
+  private readonly pingTimeoutMs: number
+  private abortController?: AbortController
+
+  constructor (components: ConnectionMonitorComponents, init: ConnectionMonitorInit = {}) {
+    this.components = components
+
+    this.log = components.logger.forComponent('libp2p:connection-monitor')
+    this.pingIntervalMs = init.pingInterval ?? DEFAULT_PING_INTERVAL_MS
+    this.pingTimeoutMs = init.pingTimeout ?? DEFAULT_PING_TIMEOUT_MS
+  }
+
+  readonly [Symbol.toStringTag] = '@libp2p/connection-monitor'
+
+  readonly [serviceCapabilities]: string[] = [
+    '@libp2p/connection-monitor'
+  ]
+
+  start (): void {
+    this.abortController = new AbortController()
+
+    this.heartbeatInterval = setInterval(() => {
+      this.components.connectionManager.getConnections().forEach(conn => {
+        Promise.resolve().then(async () => {
+          let start = Date.now()
+          try {
+            const signal = anySignal([
+              this.abortController?.signal,
+              AbortSignal.timeout(this.pingTimeoutMs)
+            ])
+            const stream = await conn.newStream('/ipfs/ping/1.0.0', {
+              signal,
+              runOnTransientConnection: true
+            })
+            const bs = byteStream(stream)
+            start = Date.now()
+
+            await Promise.all([
+              bs.write(new Uint8Array(1), {
+                signal
+              }),
+              bs.read(1, {
+                signal
+              })
+            ])
+
+            conn.rtt = Date.now() - start
+
+            await bs.unwrap().close({
+              signal
+            })
+          } catch (err: any) {
+            if (err.code !== 'ERR_UNSUPPORTED_PROTOCOL') {
+              throw err
+            }
+
+            // protocol was unsupported, but that's ok as it means the remote
+            // peer was still alive. We ran multistream-select which means two
+            // round trips (e.g. 1x for the mss header, then another for the
+            // protocol) so divide the time it took by two
+            conn.rtt = (Date.now() - start) / 2
+          }
+        })
+          .catch(err => {
+            this.log.error('error during heartbeat, aborting connection', err)
+            conn.abort(err)
+          })
+      })
+    }, this.pingIntervalMs)
+  }
+
+  stop (): void {
+    this.abortController?.abort()
+
+    if (this.heartbeatInterval != null) {
+      clearInterval(this.heartbeatInterval)
+    }
+  }
+}

--- a/packages/libp2p/src/index.ts
+++ b/packages/libp2p/src/index.ts
@@ -18,6 +18,7 @@ import { createLibp2pNode } from './libp2p.js'
 import type { AddressManagerInit } from './address-manager/index.js'
 import type { Components } from './components.js'
 import type { ConnectionManagerInit } from './connection-manager/index.js'
+import type { ConnectionMonitorInit } from './connection-monitor.js'
 import type { TransportManagerInit } from './transport-manager.js'
 import type { Libp2p, ServiceMap, ComponentLogger, NodeInfo, ConnectionProtector, ConnectionEncrypter, ConnectionGater, ContentRouting, Metrics, PeerDiscovery, PeerId, PeerRouting, StreamMuxerFactory, Transport, PrivateKey } from '@libp2p/interface'
 import type { PersistentPeerStoreInit } from '@libp2p/peer-store'
@@ -56,6 +57,11 @@ export interface Libp2pInit<T extends ServiceMap = ServiceMap> {
    * libp2p Connection Manager configuration
    */
   connectionManager?: ConnectionManagerInit
+
+  /**
+   * libp2p Connection Monitor configuration
+   */
+  connectionMonitor?: ConnectionMonitorInit
 
   /**
    * A connection gater can deny new connections based on user criteria

--- a/packages/libp2p/src/libp2p.ts
+++ b/packages/libp2p/src/libp2p.ts
@@ -14,6 +14,7 @@ import { checkServiceDependencies, defaultComponents } from './components.js'
 import { connectionGater } from './config/connection-gater.js'
 import { validateConfig } from './config.js'
 import { DefaultConnectionManager } from './connection-manager/index.js'
+import { ConnectionMonitor } from './connection-monitor.js'
 import { CompoundContentRouting } from './content-routing.js'
 import { codes } from './errors.js'
 import { DefaultPeerRouting } from './peer-routing.js'
@@ -120,6 +121,9 @@ export class Libp2pNode<T extends ServiceMap = ServiceMap> extends TypedEventEmi
 
     // Create the Connection Manager
     this.configureComponent('connectionManager', new DefaultConnectionManager(this.components, init.connectionManager))
+
+    // Create the Connection Monitor
+    this.configureComponent('connectionMonitor', new ConnectionMonitor(this.components, init.connectionMonitor))
 
     // Create the Registrar
     this.configureComponent('registrar', new DefaultRegistrar(this.components))

--- a/packages/libp2p/test/connection-monitor/index.spec.ts
+++ b/packages/libp2p/test/connection-monitor/index.spec.ts
@@ -1,0 +1,113 @@
+/* eslint-env mocha */
+
+import { CodeError, start, stop } from '@libp2p/interface'
+import { defaultLogger } from '@libp2p/logger'
+import { expect } from 'aegir/chai'
+import delay from 'delay'
+import { pair } from 'it-pair'
+import { type StubbedInstance, stubInterface } from 'sinon-ts'
+import { ConnectionMonitor } from '../../src/connection-monitor.js'
+import type { ComponentLogger, Stream, Connection } from '@libp2p/interface'
+import type { ConnectionManager } from '@libp2p/interface-internal'
+
+interface StubbedConnectionMonitorComponents {
+  logger: ComponentLogger
+  connectionManager: StubbedInstance<ConnectionManager>
+}
+
+describe('connection monitor', () => {
+  let monitor: ConnectionMonitor
+  let components: StubbedConnectionMonitorComponents
+
+  beforeEach(() => {
+    components = {
+      logger: defaultLogger(),
+      connectionManager: stubInterface<ConnectionManager>()
+    }
+  })
+
+  afterEach(async () => {
+    await stop(monitor)
+  })
+
+  it('should monitor the liveness of a connection', async () => {
+    monitor = new ConnectionMonitor(components, {
+      pingInterval: 10
+    })
+
+    await start(monitor)
+
+    const connection = stubInterface<Connection>()
+    const stream = stubInterface<Stream>({
+      ...pair<any>()
+    })
+    connection.newStream.withArgs('/ipfs/ping/1.0.0').resolves(stream)
+
+    components.connectionManager.getConnections.returns([connection])
+
+    await delay(100)
+
+    expect(connection.rtt).to.be.gte(0)
+  })
+
+  it('should monitor the liveness of a connection that does not support ping', async () => {
+    monitor = new ConnectionMonitor(components, {
+      pingInterval: 10
+    })
+
+    await start(monitor)
+
+    const connection = stubInterface<Connection>()
+    connection.newStream.withArgs('/ipfs/ping/1.0.0').callsFake(async () => {
+      await delay(10)
+      throw new CodeError('Unsupported protocol', 'ERR_UNSUPPORTED_PROTOCOL')
+    })
+
+    components.connectionManager.getConnections.returns([connection])
+
+    await delay(100)
+
+    expect(connection.rtt).to.be.gte(0)
+  })
+
+  it('should abort a connection that times out', async () => {
+    monitor = new ConnectionMonitor(components, {
+      pingInterval: 50,
+      pingTimeout: 10
+    })
+
+    await start(monitor)
+
+    const connection = stubInterface<Connection>()
+    connection.newStream.withArgs('/ipfs/ping/1.0.0').callsFake(async (protocols, opts) => {
+      await delay(200)
+      opts?.signal?.throwIfAborted()
+      return stubInterface<Stream>()
+    })
+
+    components.connectionManager.getConnections.returns([connection])
+
+    await delay(500)
+
+    expect(connection.abort).to.have.property('called', true)
+  })
+
+  it('should abort a connection that fails', async () => {
+    monitor = new ConnectionMonitor(components, {
+      pingInterval: 10
+    })
+
+    await start(monitor)
+
+    const connection = stubInterface<Connection>()
+    connection.newStream.withArgs('/ipfs/ping/1.0.0').callsFake(async (protocols, opts) => {
+      throw new CodeError('Connection closed', 'ERR_CONNECTION_CLOSED')
+    })
+
+    components.connectionManager.getConnections.returns([connection])
+
+    await delay(100)
+
+    expect(connection.abort).to.have.property('called', true)
+  })
+})


### PR DESCRIPTION
Adds a connection monitor that periodically ensures remote peers are still online and contactable by trying to send a single byte via the ping protocol, and sets the `.rtt` property of the connection to how long it took.

If the ping protocol is not supported by the remote, it tries to infer the round trip time by how long it took to fail.

If the remote is unresponsive or opening the stream fails for any other reason, the connection is aborted with the throw error.

It's possible to configure the ping interval, how long we wait before considering a peer to be inactive and whether or not to close the connection on failure.

Closes #2643

## Change checklist

- [x] I have performed a self-review of my own code
- [x] I have made corresponding changes to the documentation if necessary (this includes comments as well)
- [x] I have added tests that prove my fix is effective or that my feature works