### PR TITLE
fix!: rename "transient" connections to "limited"

### DIFF
--- a/packages/integration-tests/test/dcutr.node.ts
+++ b/packages/integration-tests/test/dcutr.node.ts
@@ -24,7 +24,7 @@ describe('dcutr', () => {
   async function waitForOnlyDirectConnections (): Promise<void> {
     await pRetry(async () => {
       const connections = libp2pA.getConnections(libp2pB.peerId)
-      const onlyDirect = connections.filter(conn => !conn.transient)
+      const onlyDirect = connections.filter(conn => conn.limits == null)
 
       if (onlyDirect.length === connections.length) {
         // all connections are direct
@@ -109,8 +109,8 @@ describe('dcutr', () => {
       const relayedAddress = multiaddr(`/ip4/127.0.0.1/tcp/${RELAY_PORT}/p2p/${relay.peerId}/p2p-circuit/p2p/${libp2pB.peerId}`)
       const connection = await libp2pA.dial(relayedAddress)
 
-      // connection should be transient
-      expect(connection).to.have.property('transient', true)
+      // connection should be limited
+      expect(connection).to.have.property('limited', true)
 
       // wait for DCUtR unilateral upgrade
       await waitForOnlyDirectConnections()
@@ -166,8 +166,8 @@ describe('dcutr', () => {
       const relayedAddress = multiaddr(`/ip4/127.0.0.1/tcp/${RELAY_PORT}/p2p/${relay.peerId}/p2p-circuit/p2p/${libp2pB.peerId}`)
       const connection = await libp2pA.dial(relayedAddress)
 
-      // connection should be transient
-      expect(connection).to.have.property('transient', true)
+      // connection should be limited
+      expect(connection).to.have.property('limited', true)
 
       // wait for DCUtR unilateral upgrade
       await waitForOnlyDirectConnections()

--- a/packages/integration-tests/test/dcutr.node.ts
+++ b/packages/integration-tests/test/dcutr.node.ts
@@ -110,7 +110,7 @@ describe('dcutr', () => {
       const connection = await libp2pA.dial(relayedAddress)
 
       // connection should be limited
-      expect(connection).to.have.property('limited', true)
+      expect(connection).to.have.property('limits').that.is.ok()
 
       // wait for DCUtR unilateral upgrade
       await waitForOnlyDirectConnections()
@@ -167,7 +167,7 @@ describe('dcutr', () => {
       const connection = await libp2pA.dial(relayedAddress)
 
       // connection should be limited
-      expect(connection).to.have.property('limited', true)
+      expect(connection).to.have.property('limits').that.is.ok()
 
       // wait for DCUtR unilateral upgrade
       await waitForOnlyDirectConnections()

--- a/packages/integration-tests/test/fetch.spec.ts
+++ b/packages/integration-tests/test/fetch.spec.ts
@@ -21,7 +21,7 @@ async function createNode (): Promise<Libp2p<{ fetch: Fetch }>> {
 
 describe('fetch', () => {
   if (isWebWorker) {
-    it.skip('tests are skipped because WebWorkers can only have transient connections', () => {
+    it.skip('tests are skipped because WebWorkers can only have limited connections', () => {
 
     })
     return

--- a/packages/integration-tests/test/ping.spec.ts
+++ b/packages/integration-tests/test/ping.spec.ts
@@ -76,7 +76,7 @@ describe('ping', () => {
         stream
       )
     }, {
-      runOnTransientConnection: true
+      runOnLimitedConnection: true
     })
 
     const latency = await nodes[0].services.ping.ping(nodes[1].getMultiaddrs())

--- a/packages/interface-compliance-tests/src/mocks/connection.ts
+++ b/packages/interface-compliance-tests/src/mocks/connection.ts
@@ -9,7 +9,7 @@ import { Uint8ArrayList } from 'uint8arraylist'
 import { mockMultiaddrConnection } from './multiaddr-connection.js'
 import { mockMuxer } from './muxer.js'
 import { mockRegistrar } from './registrar.js'
-import type { AbortOptions, ComponentLogger, Logger, MultiaddrConnection, Connection, Stream, Direction, ConnectionTimeline, ConnectionStatus, PeerId, StreamMuxer, StreamMuxerFactory, NewStreamOptions } from '@libp2p/interface'
+import type { AbortOptions, ComponentLogger, Logger, MultiaddrConnection, Connection, Stream, Direction, ConnectionTimeline, ConnectionStatus, PeerId, StreamMuxer, StreamMuxerFactory, NewStreamOptions, ConnectionLimits } from '@libp2p/interface'
 import type { Registrar } from '@libp2p/interface-internal'
 import type { Multiaddr } from '@multiformats/multiaddr'
 import type { Duplex, Source } from 'it-stream-types'
@@ -41,7 +41,7 @@ class MockConnection implements Connection {
   public status: ConnectionStatus
   public streams: Stream[]
   public tags: string[]
-  public transient: boolean
+  public limits?: ConnectionLimits
   public log: Logger
 
   private readonly muxer: StreamMuxer
@@ -64,7 +64,6 @@ class MockConnection implements Connection {
     this.tags = []
     this.muxer = muxer
     this.maConn = maConn
-    this.transient = false
     this.logger = logger
     this.log = logger.forComponent(this.id)
   }

--- a/packages/interface-internal/src/registrar/index.ts
+++ b/packages/interface-internal/src/registrar/index.ts
@@ -30,9 +30,11 @@ export interface StreamHandlerOptions {
   /**
    * If true, allow this protocol to run on limited connections (e.g.
    * connections with data or duration limits such as circuit relay
-   * connections) (default: false)
+   * connections)
+   *
+   * @default false
    */
-  runOnTransientConnection?: boolean
+  runOnLimitedConnection?: boolean
 }
 
 export interface StreamHandlerRecord {

--- a/packages/interface/src/connection/index.ts
+++ b/packages/interface/src/connection/index.ts
@@ -185,12 +185,16 @@ export interface NewStreamOptions extends AbortOptions {
   maxOutboundStreams?: number
 
   /**
-   * Opt-in to running over a transient connection - one that has time/data limits
-   * placed on it.
+   * Opt-in to running over a limited connection - one that has restrictions
+   * on the amount of data that may be transferred or how long it may be open for.
+   *
+   * These limits are typically enforced by a relay server, if the protocol
+   * will be transferring a lot of data or the stream will be open for a long time
+   * consider upgrading to a direct connection before opening the stream.
    *
    * @default false
    */
-  runOnTransientConnection?: boolean
+  runOnLimitedConnection?: boolean
 
   /**
    * By default when negotiating a protocol the dialer writes then protocol name
@@ -221,6 +225,11 @@ export interface NewStreamOptions extends AbortOptions {
 }
 
 export type ConnectionStatus = 'open' | 'closing' | 'closed'
+
+export interface ConnectionLimits {
+  bytes?: number
+  seconds?: number
+}
 
 /**
  * A Connection is a high-level representation of a connection
@@ -280,12 +289,11 @@ export interface Connection {
   status: ConnectionStatus
 
   /**
-   * A transient connection is one that is not expected to be open for very long
-   * or one that cannot transfer very much data, such as one being used as a
-   * circuit relay connection. Protocols need to explicitly opt-in to being run
-   * over transient connections.
+   * If present, this connection has limits applied to it, perhaps by an
+   * intermediate relay. Once the limits have been reached the connection will
+   * be closed by the relay.
    */
-  transient: boolean
+  limits?: ConnectionLimits
 
   /**
    * Create a new stream on this connection and negotiate one of the passed protocols

--- a/packages/interface/src/connection/index.ts
+++ b/packages/interface/src/connection/index.ts
@@ -226,8 +226,26 @@ export interface NewStreamOptions extends AbortOptions {
 
 export type ConnectionStatus = 'open' | 'closing' | 'closed'
 
+/**
+ * Connection limits are present on connections that are only allowed to
+ * transfer a certain amount of bytes or be open for a certain number
+ * of seconds.
+ *
+ * These limits are applied by Circuit Relay v2 servers, for example and
+ * the connection will normally be closed abruptly if the limits are
+ * exceeded.
+ */
 export interface ConnectionLimits {
-  bytes?: number
+  /**
+   * If present this is the number of bytes remaining that may be
+   * transferred over this connection
+   */
+  bytes?: bigint
+
+  /**
+   * If present this is the number of seconds that this connection will
+   * remain open for
+   */
   seconds?: number
 }
 

--- a/packages/interface/src/index.ts
+++ b/packages/interface/src/index.ts
@@ -331,7 +331,7 @@ export interface IsDialableOptions extends AbortOptions {
    * because that protocol would not be allowed to run over a data/time limited
    * connection.
    */
-  runOnTransientConnection?: boolean
+  runOnLimitedConnection?: boolean
 }
 
 export type TransportManagerDialProgressEvents =

--- a/packages/interface/src/stream-handler/index.ts
+++ b/packages/interface/src/stream-handler/index.ts
@@ -21,10 +21,10 @@ export interface StreamHandlerOptions {
   maxOutboundStreams?: number
 
   /**
-   * Opt-in to running over a transient connection - one that has time/data limits
-   * placed on it.
+   * Opt-in to running over connections with limits on how much data can be
+   * transferred or how long it can be open for.
    */
-  runOnTransientConnection?: boolean
+  runOnLimitedConnection?: boolean
 }
 
 export interface StreamHandlerRecord {

--- a/packages/interface/src/topology/index.ts
+++ b/packages/interface/src/topology/index.ts
@@ -27,12 +27,13 @@ export interface Topology {
   filter?: TopologyFilter
 
   /**
-   * If true, invoke `onConnect` for this topology on transient (e.g. short-lived
-   * and/or data-limited) connections
+   * If true, invoke `onConnect` for this topology on limited connections, e.g.
+   * ones with limits on how much data can be transferred or how long they can
+   * be open for.
    *
    * @default false
    */
-  notifyOnTransient?: boolean
+  notifyOnLimitedConnection?: boolean
 
   /**
    * Invoked when a new connection is opened to a peer that supports the

--- a/packages/interface/src/transport/index.ts
+++ b/packages/interface/src/transport/index.ts
@@ -1,4 +1,4 @@
-import type { Connection, MultiaddrConnection } from '../connection/index.js'
+import type { Connection, ConnectionLimits, MultiaddrConnection } from '../connection/index.js'
 import type { TypedEventTarget } from '../event-target.js'
 import type { AbortOptions } from '../index.js'
 import type { StreamMuxerFactory } from '../stream-muxer/index.js'
@@ -104,12 +104,7 @@ export interface UpgraderOptions<ConnectionUpgradeEvents extends ProgressEvent =
   skipEncryption?: boolean
   skipProtection?: boolean
   muxerFactory?: StreamMuxerFactory
-
-  /**
-   * The passed MultiaddrConnection has limits place on duration and/or data
-   * transfer amounts so is not expected to be open for very long.
-   */
-  transient?: boolean
+  limits?: ConnectionLimits
 }
 
 export type InboundConnectionUpgradeEvents =

--- a/packages/libp2p/src/connection-manager/dial-queue.ts
+++ b/packages/libp2p/src/connection-manager/dial-queue.ts
@@ -471,7 +471,7 @@ export class DialQueue {
     try {
       const addresses = await this.calculateMultiaddrs(undefined, new Set(multiaddr.map(ma => ma.toString())), options)
 
-      if (options.runOnTransientConnection === false) {
+      if (options.runOnLimitedConnection === false) {
         // return true if any resolved multiaddrs are not relay addresses
         return addresses.find(addr => {
           return !Circuit.matches(addr.multiaddr)

--- a/packages/libp2p/src/connection-manager/index.ts
+++ b/packages/libp2p/src/connection-manager/index.ts
@@ -505,10 +505,10 @@ export class DefaultConnectionManager implements ConnectionManager, Startable {
     if (peerId != null && options.force !== true) {
       this.log('dial %p', peerId)
       const existingConnection = this.getConnections(peerId)
-        .find(conn => !conn.transient)
+        .find(conn => conn.limits == null)
 
       if (existingConnection != null) {
-        this.log('had an existing non-transient connection to %p', peerId)
+        this.log('had an existing non-limited connection to %p', peerId)
 
         options.onProgress?.(new CustomProgressEvent('dial-queue:already-connected'))
         return existingConnection

--- a/packages/libp2p/src/connection/index.ts
+++ b/packages/libp2p/src/connection/index.ts
@@ -128,7 +128,7 @@ export class ConnectionImpl implements Connection {
     }
 
     if (this.limits != null && options?.runOnLimitedConnection !== true) {
-      throw new CodeError('Cannot open protocol stream on transient connection', 'ERR_TRANSIENT_CONNECTION')
+      throw new CodeError('Cannot open protocol stream on limited connection', 'ERR_LIMITED_CONNECTION')
     }
 
     const stream = await this._newStream(protocols, options)

--- a/packages/libp2p/src/connection/index.ts
+++ b/packages/libp2p/src/connection/index.ts
@@ -1,5 +1,5 @@
 import { connectionSymbol, CodeError, setMaxListeners } from '@libp2p/interface'
-import type { AbortOptions, Logger, ComponentLogger, Direction, Connection, Stream, ConnectionTimeline, ConnectionStatus, NewStreamOptions, PeerId } from '@libp2p/interface'
+import type { AbortOptions, Logger, ComponentLogger, Direction, Connection, Stream, ConnectionTimeline, ConnectionStatus, NewStreamOptions, PeerId, ConnectionLimits } from '@libp2p/interface'
 import type { Multiaddr } from '@multiformats/multiaddr'
 
 const CLOSE_TIMEOUT = 500
@@ -16,7 +16,7 @@ interface ConnectionInit {
   timeline: ConnectionTimeline
   multiplexer?: string
   encryption?: string
-  transient?: boolean
+  limits?: ConnectionLimits
   logger: ComponentLogger
 }
 
@@ -45,7 +45,7 @@ export class ConnectionImpl implements Connection {
   public multiplexer?: string
   public encryption?: string
   public status: ConnectionStatus
-  public transient: boolean
+  public limits?: ConnectionLimits
   public readonly log: Logger
 
   /**
@@ -86,7 +86,7 @@ export class ConnectionImpl implements Connection {
     this.timeline = init.timeline
     this.multiplexer = init.multiplexer
     this.encryption = init.encryption
-    this.transient = init.transient ?? false
+    this.limits = init.limits
     this.log = init.logger.forComponent(`libp2p:connection:${this.direction}:${this.id}`)
 
     if (this.remoteAddr.getPeerId() == null) {
@@ -127,7 +127,7 @@ export class ConnectionImpl implements Connection {
       protocols = [protocols]
     }
 
-    if (this.transient && options?.runOnTransientConnection !== true) {
+    if (this.limits != null && options?.runOnLimitedConnection !== true) {
       throw new CodeError('Cannot open protocol stream on transient connection', 'ERR_TRANSIENT_CONNECTION')
     }
 

--- a/packages/libp2p/src/registrar.ts
+++ b/packages/libp2p/src/registrar.ts
@@ -230,7 +230,7 @@ export class DefaultRegistrar implements Registrar {
       }
 
       for (const topology of topologies.values()) {
-        if (connection.transient && topology.notifyOnTransient !== true) {
+        if (connection.limits != null && topology.notifyOnLimitedConnection !== true) {
           continue
         }
 

--- a/packages/libp2p/src/upgrader.ts
+++ b/packages/libp2p/src/upgrader.ts
@@ -618,7 +618,7 @@ export class DefaultUpgrader implements Upgrader {
     const { handler, options } = this.components.registrar.getHandler(protocol)
 
     if (connection.limits != null && options.runOnLimitedConnection !== true) {
-      throw new CodeError('Cannot open protocol stream on transient connection', 'ERR_TRANSIENT_CONNECTION')
+      throw new CodeError('Cannot open protocol stream on limited connection', 'ERR_LIMITED_CONNECTION')
     }
 
     handler({ connection, stream })

--- a/packages/libp2p/src/upgrader.ts
+++ b/packages/libp2p/src/upgrader.ts
@@ -6,7 +6,7 @@ import { createConnection } from './connection/index.js'
 import { INBOUND_UPGRADE_TIMEOUT } from './connection-manager/constants.js'
 import { codes } from './errors.js'
 import { DEFAULT_MAX_INBOUND_STREAMS, DEFAULT_MAX_OUTBOUND_STREAMS } from './registrar.js'
-import type { Libp2pEvents, AbortOptions, ComponentLogger, MultiaddrConnection, Connection, Stream, ConnectionProtector, NewStreamOptions, ConnectionEncrypter, SecuredConnection, ConnectionGater, TypedEventTarget, Metrics, PeerId, PeerStore, StreamMuxer, StreamMuxerFactory, Upgrader, UpgraderOptions } from '@libp2p/interface'
+import type { Libp2pEvents, AbortOptions, ComponentLogger, MultiaddrConnection, Connection, Stream, ConnectionProtector, NewStreamOptions, ConnectionEncrypter, SecuredConnection, ConnectionGater, TypedEventTarget, Metrics, PeerId, PeerStore, StreamMuxer, StreamMuxerFactory, Upgrader, UpgraderOptions, ConnectionLimits } from '@libp2p/interface'
 import type { ConnectionManager, Registrar } from '@libp2p/interface-internal'
 
 const DEFAULT_PROTOCOL_SELECT_TIMEOUT = 30000
@@ -18,7 +18,7 @@ interface CreateConnectionOptions {
   upgradedConn: MultiaddrConnection
   remotePeer: PeerId
   muxerFactory?: StreamMuxerFactory
-  transient?: boolean
+  limits?: ConnectionLimits
 }
 
 interface OnStreamOptions {
@@ -243,7 +243,7 @@ export class DefaultUpgrader implements Upgrader {
         upgradedConn,
         muxerFactory,
         remotePeer,
-        transient: opts?.transient
+        limits: opts?.limits
       })
     } finally {
       signal.removeEventListener('abort', onAbort)
@@ -342,7 +342,7 @@ export class DefaultUpgrader implements Upgrader {
       upgradedConn,
       muxerFactory,
       remotePeer,
-      transient: opts?.transient
+      limits: opts?.limits
     })
   }
 
@@ -357,7 +357,7 @@ export class DefaultUpgrader implements Upgrader {
       upgradedConn,
       remotePeer,
       muxerFactory,
-      transient
+      limits
     } = opts
 
     let muxer: StreamMuxer | undefined
@@ -578,7 +578,7 @@ export class DefaultUpgrader implements Upgrader {
       timeline: maConn.timeline,
       multiplexer: muxer?.protocol,
       encryption: cryptoProtocol,
-      transient,
+      limits,
       logger: this.components.logger,
       newStream: newStream ?? errConnectionNotMultiplexed,
       getStreams: () => { if (muxer != null) { return muxer.streams } else { return [] } },
@@ -617,7 +617,7 @@ export class DefaultUpgrader implements Upgrader {
     const { connection, stream, protocol } = opts
     const { handler, options } = this.components.registrar.getHandler(protocol)
 
-    if (connection.transient && options.runOnTransientConnection !== true) {
+    if (connection.limits != null && options.runOnLimitedConnection !== true) {
       throw new CodeError('Cannot open protocol stream on transient connection', 'ERR_TRANSIENT_CONNECTION')
     }
 

--- a/packages/libp2p/test/connection-manager/index.spec.ts
+++ b/packages/libp2p/test/connection-manager/index.spec.ts
@@ -516,7 +516,7 @@ describe('Connection Manager', () => {
       .to.eventually.be.true()
   })
 
-  it('should allow dialing peers when an existing transient connection exists', async () => {
+  it('should allow dialing peers when an existing limited connection exists', async () => {
     connectionManager = new DefaultConnectionManager(defaultComponents(libp2p.peerId), {
       ...defaultOptions,
       maxIncomingPendingConnections: 1
@@ -528,7 +528,7 @@ describe('Connection Manager', () => {
 
     const existingConnection = stubInterface<Connection>({
       limits: {
-        bytes: 100
+        bytes: 100n
       }
     })
     const newConnection = stubInterface<Connection>()
@@ -537,7 +537,7 @@ describe('Connection Manager', () => {
       .withArgs(addr)
       .resolves(newConnection)
 
-    // we have an existing transient connection
+    // we have an existing limited connection
     const map = connectionManager.getConnectionsMap()
     map.set(targetPeer, [
       existingConnection

--- a/packages/libp2p/test/connection-manager/index.spec.ts
+++ b/packages/libp2p/test/connection-manager/index.spec.ts
@@ -527,7 +527,9 @@ describe('Connection Manager', () => {
     const addr = multiaddr(`/ip4/123.123.123.123/tcp/123/p2p/${targetPeer}`)
 
     const existingConnection = stubInterface<Connection>({
-      transient: true
+      limits: {
+        bytes: 100
+      }
     })
     const newConnection = stubInterface<Connection>()
 

--- a/packages/libp2p/test/core/core.spec.ts
+++ b/packages/libp2p/test/core/core.spec.ts
@@ -45,7 +45,7 @@ describe('core', () => {
     await expect(libp2p.isDialable(ma)).to.eventually.be.true()
   })
 
-  it('should test if a protocol can run over a transient connection', async () => {
+  it('should test if a protocol can run over a limited connection', async () => {
     libp2p = await createLibp2p({
       transports: [
         webSockets(),

--- a/packages/libp2p/test/core/core.spec.ts
+++ b/packages/libp2p/test/core/core.spec.ts
@@ -57,15 +57,15 @@ describe('core', () => {
     })
 
     await expect(libp2p.isDialable(multiaddr('/dns4/example.com/tls/ws'), {
-      runOnTransientConnection: false
+      runOnLimitedConnection: false
     })).to.eventually.be.true()
 
     await expect(libp2p.isDialable(multiaddr('/dns4/example.com/tls/ws/p2p/12D3KooWSExt8hTzoaHEhn435BTK6BPNSY1LpTc1j2o9Gw53tXE1/p2p-circuit/p2p/12D3KooWSExt8hTzoaHEhn435BTK6BPNSY1LpTc1j2o9Gw53tXE2'), {
-      runOnTransientConnection: true
+      runOnLimitedConnection: true
     })).to.eventually.be.true()
 
     await expect(libp2p.isDialable(multiaddr('/dns4/example.com/tls/ws/p2p/12D3KooWSExt8hTzoaHEhn435BTK6BPNSY1LpTc1j2o9Gw53tXE1/p2p-circuit/p2p/12D3KooWSExt8hTzoaHEhn435BTK6BPNSY1LpTc1j2o9Gw53tXE2'), {
-      runOnTransientConnection: false
+      runOnLimitedConnection: false
     })).to.eventually.be.false()
   })
 })

--- a/packages/libp2p/test/registrar/registrar.spec.ts
+++ b/packages/libp2p/test/registrar/registrar.spec.ts
@@ -221,7 +221,9 @@ describe('registrar topologies', () => {
     const conn = mockConnection(mockMultiaddrConnection(mockDuplex(), remotePeerId))
 
     // connection is transient
-    conn.transient = true
+    conn.limits = {
+      bytes: 100
+    }
 
     // return connection from connection manager
     connectionManager.getConnections.withArgs(matchPeerId(remotePeerId)).returns([conn])
@@ -265,14 +267,16 @@ describe('registrar topologies', () => {
     const remotePeerId = await createEd25519PeerId()
     const conn = mockConnection(mockMultiaddrConnection(mockDuplex(), remotePeerId))
 
-    // connection is transient
-    conn.transient = true
+    // connection is limited
+    conn.limits = {
+      bytes: 100
+    }
 
     // return connection from connection manager
     connectionManager.getConnections.withArgs(matchPeerId(remotePeerId)).returns([conn])
 
     const topology: Topology = {
-      notifyOnTransient: true,
+      notifyOnLimitedConnection: true,
       onConnect: () => {
         onConnectDefer.resolve()
       }
@@ -298,7 +302,7 @@ describe('registrar topologies', () => {
     let callCount = 0
 
     const topology: Topology = {
-      notifyOnTransient: true,
+      notifyOnLimitedConnection: true,
       onConnect: () => {
         callCount++
 
@@ -314,10 +318,14 @@ describe('registrar topologies', () => {
     // setup connections before registrar
     const remotePeerId = await createEd25519PeerId()
     const transientConnection = mockConnection(mockMultiaddrConnection(mockDuplex(), remotePeerId))
-    transientConnection.transient = true
+    transientConnection.limits = {
+      bytes: 100
+    }
 
     const nonTransientConnection = mockConnection(mockMultiaddrConnection(mockDuplex(), remotePeerId))
-    nonTransientConnection.transient = false
+    nonTransientConnection.limits = {
+      bytes: 100
+    }
 
     // return connection from connection manager
     connectionManager.getConnections.withArgs(matchPeerId(remotePeerId)).returns([

--- a/packages/protocol-dcutr/README.md
+++ b/packages/protocol-dcutr/README.md
@@ -63,7 +63,7 @@ await node.dial(ma)
 while (true) {
   const connections = node.getConnections()
 
-  if (connections.find(conn => conn.transient === false)) {
+  if (connections.find(conn => conn.limits == null)) {
     console.info('have direct connection')
     break
   } else {

--- a/packages/protocol-dcutr/src/dcutr.ts
+++ b/packages/protocol-dcutr/src/dcutr.ts
@@ -257,7 +257,7 @@ export class DefaultDCUtRService implements Startable {
           force: true
         })
 
-        if (!Circuit.exactMatch(connection.remoteAddr)) {
+        if (Circuit.exactMatch(connection.remoteAddr)) {
           throw new Error('Could not open a new, non-limited, connection')
         }
 

--- a/packages/protocol-dcutr/src/dcutr.ts
+++ b/packages/protocol-dcutr/src/dcutr.ts
@@ -258,7 +258,7 @@ export class DefaultDCUtRService implements Startable {
         })
 
         if (!Circuit.exactMatch(connection.remoteAddr)) {
-          throw new Error('Could not open a new, non-transient, connection')
+          throw new Error('Could not open a new, non-limited, connection')
         }
 
         this.log('unilateral connection upgrade to %p succeeded via %a, closing relayed connection', relayedConnection.remotePeer, connection.remoteAddr)

--- a/packages/protocol-dcutr/src/index.ts
+++ b/packages/protocol-dcutr/src/index.ts
@@ -36,7 +36,7 @@
  * await node.dial(ma)
  *
  * // after a while the connection should automatically get upgraded to a
- * // direct connection (e.g. non-transient)
+ * // direct connection (e.g. non-limited)
  * while (true) {
  *   const connections = node.getConnections()
  *

--- a/packages/protocol-dcutr/src/index.ts
+++ b/packages/protocol-dcutr/src/index.ts
@@ -40,7 +40,7 @@
  * while (true) {
  *   const connections = node.getConnections()
  *
- *   if (connections.find(conn => conn.transient === false)) {
+ *   if (connections.find(conn => conn.limits == null)) {
  *     console.info('have direct connection')
  *     break
  *   } else {

--- a/packages/protocol-identify/src/identify-push.ts
+++ b/packages/protocol-identify/src/identify-push.ts
@@ -82,7 +82,7 @@ export class IdentifyPush extends AbstractIdentify implements Startable, Identif
           try {
             stream = await connection.newStream(self.protocol, {
               signal,
-              runOnTransientConnection: self.runOnTransientConnection
+              runOnLimitedConnection: self.runOnLimitedConnection
             })
 
             const pb = pbStream(stream, {

--- a/packages/protocol-identify/src/identify.ts
+++ b/packages/protocol-identify/src/identify.ts
@@ -53,7 +53,7 @@ export class Identify extends AbstractIdentify implements Startable, IdentifyInt
     try {
       stream = await connection.newStream(this.protocol, {
         ...options,
-        runOnTransientConnection: this.runOnTransientConnection
+        runOnLimitedConnection: this.runOnLimitedConnection
       })
 
       const pb = pbStream(stream, {

--- a/packages/protocol-identify/src/index.ts
+++ b/packages/protocol-identify/src/index.ts
@@ -99,7 +99,7 @@ export interface IdentifyInit {
    *
    * @default true
    */
-  runOnTransientConnection?: boolean
+  runOnLimitedConnection?: boolean
 
   /**
    * Whether to automatically run identify on newly opened connections

--- a/packages/protocol-identify/src/utils.ts
+++ b/packages/protocol-identify/src/utils.ts
@@ -19,7 +19,7 @@ export const defaultValues = {
   maxMessageSize: MAX_IDENTIFY_MESSAGE_SIZE,
   runOnConnectionOpen: true,
   runOnSelfUpdate: true,
-  runOnTransientConnection: true,
+  runOnLimitedConnection: true,
   concurrency: MAX_PUSH_CONCURRENCY
 }
 
@@ -207,7 +207,7 @@ export abstract class AbstractIdentify implements Startable {
   protected readonly maxMessageSize: number
   protected readonly maxObservedAddresses: number
   protected readonly events: TypedEventTarget<Libp2pEvents>
-  protected readonly runOnTransientConnection: boolean
+  protected readonly runOnLimitedConnection: boolean
   protected readonly log: Logger
 
   constructor (components: IdentifyComponents, init: AbstractIdentifyInit) {
@@ -225,7 +225,7 @@ export abstract class AbstractIdentify implements Startable {
     this.maxOutboundStreams = init.maxOutboundStreams ?? defaultValues.maxOutboundStreams
     this.maxMessageSize = init.maxMessageSize ?? defaultValues.maxMessageSize
     this.maxObservedAddresses = init.maxObservedAddresses ?? defaultValues.maxObservedAddresses
-    this.runOnTransientConnection = init.runOnTransientConnection ?? defaultValues.runOnTransientConnection
+    this.runOnLimitedConnection = init.runOnLimitedConnection ?? defaultValues.runOnLimitedConnection
 
     // Store self host metadata
     this.host = {
@@ -257,7 +257,7 @@ export abstract class AbstractIdentify implements Startable {
     }, {
       maxInboundStreams: this.maxInboundStreams,
       maxOutboundStreams: this.maxOutboundStreams,
-      runOnTransientConnection: this.runOnTransientConnection
+      runOnLimitedConnection: this.runOnLimitedConnection
     })
 
     this.started = true

--- a/packages/protocol-perf/src/constants.ts
+++ b/packages/protocol-perf/src/constants.ts
@@ -2,4 +2,4 @@ export const PROTOCOL_NAME = '/perf/1.0.0'
 export const WRITE_BLOCK_SIZE = 64 << 10
 export const MAX_INBOUND_STREAMS = 1
 export const MAX_OUTBOUND_STREAMS = 1
-export const RUN_ON_TRANSIENT_CONNECTION = false
+export const RUN_ON_LIMITED_CONNECTION = false

--- a/packages/protocol-perf/src/index.ts
+++ b/packages/protocol-perf/src/index.ts
@@ -83,7 +83,7 @@ export interface PerfInit {
   protocolName?: string
   maxInboundStreams?: number
   maxOutboundStreams?: number
-  runOnTransientConnection?: boolean
+  runOnLimitedConnection?: boolean
 
   /**
    * Data sent/received will be sent in chunks of this size (default: 64KiB)

--- a/packages/protocol-perf/src/perf-service.ts
+++ b/packages/protocol-perf/src/perf-service.ts
@@ -1,5 +1,5 @@
 import { pushable } from 'it-pushable'
-import { MAX_INBOUND_STREAMS, MAX_OUTBOUND_STREAMS, PROTOCOL_NAME, RUN_ON_TRANSIENT_CONNECTION, WRITE_BLOCK_SIZE } from './constants.js'
+import { MAX_INBOUND_STREAMS, MAX_OUTBOUND_STREAMS, PROTOCOL_NAME, RUN_ON_LIMITED_CONNECTION, WRITE_BLOCK_SIZE } from './constants.js'
 import type { PerfOptions, PerfOutput, PerfComponents, PerfInit, Perf as PerfInterface } from './index.js'
 import type { Logger, Startable } from '@libp2p/interface'
 import type { IncomingStreamData } from '@libp2p/interface-internal'
@@ -25,7 +25,7 @@ export class Perf implements Startable, PerfInterface {
     this.databuf = new ArrayBuffer(this.writeBlockSize)
     this.maxInboundStreams = init.maxInboundStreams ?? MAX_INBOUND_STREAMS
     this.maxOutboundStreams = init.maxOutboundStreams ?? MAX_OUTBOUND_STREAMS
-    this.runOnLimitedConnection = init.runOnLimitedConnection ?? RUN_ON_TRANSIENT_CONNECTION
+    this.runOnLimitedConnection = init.runOnLimitedConnection ?? RUN_ON_LIMITED_CONNECTION
   }
 
   readonly [Symbol.toStringTag] = '@libp2p/perf'

--- a/packages/protocol-perf/src/perf-service.ts
+++ b/packages/protocol-perf/src/perf-service.ts
@@ -14,7 +14,7 @@ export class Perf implements Startable, PerfInterface {
   private readonly writeBlockSize: number
   private readonly maxInboundStreams: number
   private readonly maxOutboundStreams: number
-  private readonly runOnTransientConnection: boolean
+  private readonly runOnLimitedConnection: boolean
 
   constructor (components: PerfComponents, init: PerfInit = {}) {
     this.components = components
@@ -25,7 +25,7 @@ export class Perf implements Startable, PerfInterface {
     this.databuf = new ArrayBuffer(this.writeBlockSize)
     this.maxInboundStreams = init.maxInboundStreams ?? MAX_INBOUND_STREAMS
     this.maxOutboundStreams = init.maxOutboundStreams ?? MAX_OUTBOUND_STREAMS
-    this.runOnTransientConnection = init.runOnTransientConnection ?? RUN_ON_TRANSIENT_CONNECTION
+    this.runOnLimitedConnection = init.runOnLimitedConnection ?? RUN_ON_TRANSIENT_CONNECTION
   }
 
   readonly [Symbol.toStringTag] = '@libp2p/perf'
@@ -38,7 +38,7 @@ export class Perf implements Startable, PerfInterface {
     }, {
       maxInboundStreams: this.maxInboundStreams,
       maxOutboundStreams: this.maxOutboundStreams,
-      runOnTransientConnection: this.runOnTransientConnection
+      runOnLimitedConnection: this.runOnLimitedConnection
     })
     this.started = true
   }

--- a/packages/protocol-ping/src/index.ts
+++ b/packages/protocol-ping/src/index.ts
@@ -35,7 +35,7 @@ export interface PingServiceInit {
   protocolPrefix?: string
   maxInboundStreams?: number
   maxOutboundStreams?: number
-  runOnTransientConnection?: boolean
+  runOnLimitedConnection?: boolean
 
   /**
    * How long we should wait for a ping response

--- a/packages/protocol-ping/src/ping.ts
+++ b/packages/protocol-ping/src/ping.ts
@@ -16,7 +16,7 @@ export class PingService implements Startable, PingServiceInterface {
   private readonly timeout: number
   private readonly maxInboundStreams: number
   private readonly maxOutboundStreams: number
-  private readonly runOnTransientConnection: boolean
+  private readonly runOnLimitedConnection: boolean
   private readonly log: Logger
 
   constructor (components: PingServiceComponents, init: PingServiceInit = {}) {
@@ -27,7 +27,7 @@ export class PingService implements Startable, PingServiceInterface {
     this.timeout = init.timeout ?? TIMEOUT
     this.maxInboundStreams = init.maxInboundStreams ?? MAX_INBOUND_STREAMS
     this.maxOutboundStreams = init.maxOutboundStreams ?? MAX_OUTBOUND_STREAMS
-    this.runOnTransientConnection = init.runOnTransientConnection ?? true
+    this.runOnLimitedConnection = init.runOnLimitedConnection ?? true
 
     this.handleMessage = this.handleMessage.bind(this)
   }
@@ -38,7 +38,7 @@ export class PingService implements Startable, PingServiceInterface {
     await this.components.registrar.handle(this.protocol, this.handleMessage, {
       maxInboundStreams: this.maxInboundStreams,
       maxOutboundStreams: this.maxOutboundStreams,
-      runOnTransientConnection: this.runOnTransientConnection
+      runOnLimitedConnection: this.runOnLimitedConnection
     })
     this.started = true
   }
@@ -96,7 +96,7 @@ export class PingService implements Startable, PingServiceInterface {
     try {
       stream = await connection.newStream(this.protocol, {
         ...options,
-        runOnTransientConnection: this.runOnTransientConnection
+        runOnLimitedConnection: this.runOnLimitedConnection
       })
 
       onAbort = () => {

--- a/packages/transport-circuit-relay-v2/src/server/index.ts
+++ b/packages/transport-circuit-relay-v2/src/server/index.ts
@@ -144,7 +144,7 @@ class CircuitRelayServer extends TypedEventEmitter<RelayServerEvents> implements
     }, {
       maxInboundStreams: this.maxInboundHopStreams,
       maxOutboundStreams: this.maxOutboundHopStreams,
-      runOnTransientConnection: true
+      runOnLimitedConnection: true
     })
 
     this.reservationStore.start()
@@ -383,7 +383,7 @@ class CircuitRelayServer extends TypedEventEmitter<RelayServerEvents> implements
     this.log('starting circuit relay v2 stop request to %s', connection.remotePeer)
     const stream = await connection.newStream([RELAY_V2_STOP_CODEC], {
       maxOutboundStreams: this.maxOutboundStopStreams,
-      runOnTransientConnection: true
+      runOnLimitedConnection: true
     })
     const pbstr = pbStream(stream)
     const stopstr = pbstr.pb(StopMessage)

--- a/packages/transport-circuit-relay-v2/src/utils.ts
+++ b/packages/transport-circuit-relay-v2/src/utils.ts
@@ -4,7 +4,7 @@ import { CID } from 'multiformats/cid'
 import { sha256 } from 'multiformats/hashes/sha2'
 import { ERR_TRANSFER_LIMIT_EXCEEDED } from './constants.js'
 import type { Limit } from './pb/index.js'
-import type { LoggerOptions, Stream } from '@libp2p/interface'
+import type { ConnectionLimits, LoggerOptions, Stream } from '@libp2p/interface'
 import type { Source } from 'it-stream-types'
 import type { Uint8ArrayList } from 'uint8arraylist'
 
@@ -124,4 +124,65 @@ export function getExpirationMilliseconds (expireTimeSeconds: bigint): number {
 
   // downcast to number to use with setTimeout
   return Number(expireTimeMillis - BigInt(currentTime))
+}
+
+export class LimitTracker {
+  private readonly expires?: number
+  private bytes?: bigint
+
+  constructor (limits?: Limit) {
+    if (limits?.duration != null && limits?.duration !== 0) {
+      this.expires = Date.now() + (limits.duration * 1000)
+    }
+
+    this.bytes = limits?.data
+
+    if (this.bytes === 0n) {
+      this.bytes = undefined
+    }
+
+    this.onData = this.onData.bind(this)
+  }
+
+  onData (buf: Uint8ArrayList | Uint8Array): void {
+    if (this.bytes == null) {
+      return
+    }
+
+    this.bytes -= BigInt(buf.byteLength)
+
+    if (this.bytes < 0n) {
+      this.bytes = 0n
+    }
+  }
+
+  getLimits (): ConnectionLimits | undefined {
+    if (this.expires == null && this.bytes == null) {
+      return
+    }
+
+    const output = {}
+
+    if (this.bytes != null) {
+      const self = this
+
+      Object.defineProperty(output, 'bytes', {
+        get () {
+          return self.bytes
+        }
+      })
+    }
+
+    if (this.expires != null) {
+      const self = this
+
+      Object.defineProperty(output, 'seconds', {
+        get () {
+          return Math.round(((self.expires ?? 0) - Date.now()) / 1000)
+        }
+      })
+    }
+
+    return output
+  }
 }

--- a/packages/transport-webrtc/src/private-to-private/initiate-connection.ts
+++ b/packages/transport-webrtc/src/private-to-private/initiate-connection.ts
@@ -72,7 +72,7 @@ export async function initiateConnection ({ rtcConfiguration, dataChannel, signa
 
     const stream = await connection.newStream(SIGNALING_PROTO_ID, {
       signal,
-      runOnTransientConnection: true
+      runOnLimitedConnection: true
     })
 
     const messageStream = pbStream(stream).pb(Message)

--- a/packages/transport-webrtc/src/private-to-private/transport.ts
+++ b/packages/transport-webrtc/src/private-to-private/transport.ts
@@ -108,7 +108,7 @@ export class WebRTCTransport implements Transport<WebRTCDialEvents>, Startable {
     await this.components.registrar.handle(SIGNALING_PROTO_ID, (data: IncomingStreamData) => {
       this._onProtocol(data).catch(err => { this.log.error('failed to handle incoming connect from %p', data.connection.remotePeer, err) })
     }, {
-      runOnTransientConnection: true
+      runOnLimitedConnection: true
     })
     this._started = true
   }

--- a/packages/transport-webrtc/test/basics.spec.ts
+++ b/packages/transport-webrtc/test/basics.spec.ts
@@ -71,7 +71,7 @@ describe('basics', () => {
     await remoteNode.handle(echo, (info) => {
       streamHandler(info)
     }, {
-      runOnTransientConnection: true
+      runOnLimitedConnection: true
     })
 
     const connection = await localNode.dial(remoteAddr)
@@ -138,7 +138,7 @@ describe('basics', () => {
 
     // open a stream on the echo protocol
     const stream = await connection.newStream(echo, {
-      runOnTransientConnection: true
+      runOnLimitedConnection: true
     })
 
     // send and receive some data
@@ -170,7 +170,7 @@ describe('basics', () => {
 
     // open a stream on the echo protocol
     const stream = await connection.newStream(echo, {
-      runOnTransientConnection: true
+      runOnLimitedConnection: true
     })
 
     // close for reading
@@ -204,7 +204,7 @@ describe('basics', () => {
 
     // open a stream on the echo protocol
     const stream = await connection.newStream(echo, {
-      runOnTransientConnection: true
+      runOnLimitedConnection: true
     })
 
     // close for reading
@@ -241,7 +241,7 @@ describe('basics', () => {
 
     // open a stream on the echo protocol
     const stream = await connection.newStream(echo, {
-      runOnTransientConnection: true
+      runOnLimitedConnection: true
     })
 
     // close the write end immediately
@@ -302,7 +302,7 @@ describe('basics', () => {
 
     // open a stream on the echo protocol
     const stream = await connection.newStream(echo, {
-      runOnTransientConnection: true
+      runOnLimitedConnection: true
     })
 
     // keep the remote write end open, this should delay the FIN_ACK reply to the local stream

--- a/packages/utils/package.json
+++ b/packages/utils/package.json
@@ -163,6 +163,8 @@
     "delay": "^6.0.0",
     "get-iterator": "^2.0.1",
     "is-loopback-addr": "^2.0.2",
+    "it-foreach": "^2.1.1",
+    "it-pipe": "^3.0.1",
     "it-pushable": "^3.2.3",
     "it-stream-types": "^2.0.1",
     "murmurhash3js-revisited": "^3.0.0",
@@ -181,7 +183,6 @@
     "it-all": "^3.0.6",
     "it-drain": "^3.0.7",
     "it-pair": "^2.0.6",
-    "it-pipe": "^3.0.1",
     "sinon": "^18.0.0",
     "sinon-ts": "^2.0.0"
   },


### PR DESCRIPTION
To better align with [go-libp2p@0.34.0](https://github.com/libp2p/go-libp2p/releases/tag/v0.34.0) rename "transient" connections to "limited".

BREAKING CHANGE: There are three breaking API changes:
  * The `.transient` boolean property has been replaced with a `.limits` object that may be undefined or may have `.bytes` and/or `.seconds` properties - the value of these properties decreases as the limits are used up
  * The `runOnTransientConnection` property of `libp2p.handle` and `libp2p.dialProtocol` has been renamed to `runOnLimitedConnection`
  * The `notifyOnTransient` property of `libp2p.register` has been renamed `notifyOnLimitedConnection`

Refs: #2622

## Change checklist

- [x] I have performed a self-review of my own code
- [x] I have made corresponding changes to the documentation if necessary (this includes comments as well)
- [x] I have added tests that prove my fix is effective or that my feature works