### PR TITLE
fix: remove CustomEvent polyfill

### DIFF
--- a/packages/interface/src/event-target.ts
+++ b/packages/interface/src/event-target.ts
@@ -105,22 +105,4 @@ export class TypedEventEmitter<EventMap extends Record<string, any>> extends Eve
   }
 }
 
-/**
- * CustomEvent is a standard event but it's not supported by node.
- *
- * Remove this when https://github.com/nodejs/node/issues/40678 is closed.
- *
- * Ref: https://developer.mozilla.org/en-US/docs/Web/API/CustomEvent
- */
-class CustomEventPolyfill<T = any> extends Event {
-  /** Returns any custom data event was created with. Typically used for synthetic events. */
-  public detail: T
-
-  constructor (message: string, data?: EventInit & { detail: T }) {
-    super(message, data)
-    // @ts-expect-error could be undefined
-    this.detail = data?.detail
-  }
-}
-
-export const CustomEvent = globalThis.CustomEvent ?? CustomEventPolyfill
+export const CustomEvent = globalThis.CustomEvent


### PR DESCRIPTION
## Description

The EventTarget implementation of libp2p contained workarounds for incomplete runtime support for the feature. One of the workarounds was specifically marked to be removed once CustomEvent was implemented in NodeJS and the [upstream ticket](https://github.com/nodejs/node/issues/40678) was closed. This has happened two years ago. The implementation of the standard event in Node18 and the subsequent removal of the experimental flag in Node19 broke the current workaround and causes tsc to error. Some of these were suppressed with @ts-ignore, others were not. This fix closes #2420.

The fix removes the workaround as instructed by the source code and restores compatibility with recent versions of Node:
```
/**
 * CustomEvent is a standard event but it's not supported by node.
 *
 * Remove this when https://github.com/nodejs/node/issues/40678 is closed.
 *
 * Ref: https://developer.mozilla.org/en-US/docs/Web/API/CustomEvent
 */
class CustomEventPolyfill<T = any> extends Event {
  /** Returns any custom data event was created with. Typically used for synthetic events. */
  public detail: T

  constructor (message: string, data?: EventInit & { detail: T }) {
    super(message, data)
    // @ts-expect-error could be undefined
    this.detail = data?.detail
  }
}

export const CustomEvent = globalThis.CustomEvent ?? CustomEventPolyfill
```

## Change checklist

- [X] I have performed a self-review of my own code
- [X] I have made corresponding changes to the documentation if necessary (this includes comments as well)
  - I don't believe documentation is needed.
- [ ] I have added tests that prove my fix is effective or that my feature works
  - I have not been able to setup the test environment on my MacOS, but the tests in my personal libp2p application pass. Please test the fix against the libp2p tests as well.