### PR TITLE
fix!: remove CustomEvent export from `@libp2p/interface`

### DIFF
--- a/packages/interface-compliance-tests/src/transport/listen-test.ts
+++ b/packages/interface-compliance-tests/src/transport/listen-test.ts
@@ -1,5 +1,5 @@
 /* eslint max-nested-callbacks: ["error", 8] */
-import { CustomEvent, TypedEventEmitter } from '@libp2p/interface'
+import { TypedEventEmitter } from '@libp2p/interface'
 import { expect } from 'aegir/chai'
 import drain from 'it-drain'
 import { pipe } from 'it-pipe'

--- a/packages/interface/src/event-target.ts
+++ b/packages/interface/src/event-target.ts
@@ -104,5 +104,3 @@ export class TypedEventEmitter<EventMap extends Record<string, any>> extends Eve
     return this.dispatchEvent(new CustomEvent<Detail>(type as string, detail))
   }
 }
-
-export const CustomEvent = globalThis.CustomEvent

--- a/packages/kad-dht/src/kad-dht.ts
+++ b/packages/kad-dht/src/kad-dht.ts
@@ -1,4 +1,4 @@
-import { CodeError, CustomEvent, TypedEventEmitter, contentRoutingSymbol, peerDiscoverySymbol, peerRoutingSymbol, serviceCapabilities, serviceDependencies, start, stop } from '@libp2p/interface'
+import { CodeError, TypedEventEmitter, contentRoutingSymbol, peerDiscoverySymbol, peerRoutingSymbol, serviceCapabilities, serviceDependencies, start, stop } from '@libp2p/interface'
 import drain from 'it-drain'
 import pDefer from 'p-defer'
 import { PROTOCOL } from './constants.js'

--- a/packages/kad-dht/src/query/events.ts
+++ b/packages/kad-dht/src/query/events.ts
@@ -1,4 +1,3 @@
-import { CustomEvent } from '@libp2p/interface'
 import type { MessageType, SendQueryEvent, PeerResponseEvent, DialPeerEvent, AddPeerEvent, ValueEvent, ProviderEvent, QueryErrorEvent, FinalPeerEvent } from '../index.js'
 import type { PeerId, PeerInfo } from '@libp2p/interface'
 import type { Libp2pRecord } from '@libp2p/record'

--- a/packages/kad-dht/src/topology-listener.ts
+++ b/packages/kad-dht/src/topology-listener.ts
@@ -1,4 +1,4 @@
-import { CustomEvent, TypedEventEmitter } from '@libp2p/interface'
+import { TypedEventEmitter } from '@libp2p/interface'
 import type { KadDHTComponents } from '.'
 import type { Logger, PeerId, Startable } from '@libp2p/interface'
 

--- a/packages/kad-dht/test/query-self.spec.ts
+++ b/packages/kad-dht/test/query-self.spec.ts
@@ -1,6 +1,5 @@
 /* eslint-env mocha */
 
-import { CustomEvent } from '@libp2p/interface'
 import { defaultLogger } from '@libp2p/logger'
 import { createEd25519PeerId } from '@libp2p/peer-id-factory'
 import { expect } from 'aegir/chai'

--- a/packages/kad-dht/test/routing-table.spec.ts
+++ b/packages/kad-dht/test/routing-table.spec.ts
@@ -1,6 +1,6 @@
 /* eslint-env mocha */
 
-import { TypedEventEmitter, CustomEvent, stop, start } from '@libp2p/interface'
+import { TypedEventEmitter, stop, start } from '@libp2p/interface'
 import { mockConnectionManager } from '@libp2p/interface-compliance-tests/mocks'
 import { defaultLogger } from '@libp2p/logger'
 import { PeerSet } from '@libp2p/peer-collections'

--- a/packages/libp2p/src/libp2p.ts
+++ b/packages/libp2p/src/libp2p.ts
@@ -1,5 +1,5 @@
 import { unmarshalPrivateKey, unmarshalPublicKey } from '@libp2p/crypto/keys'
-import { contentRoutingSymbol, CodeError, TypedEventEmitter, CustomEvent, setMaxListeners, peerDiscoverySymbol, peerRoutingSymbol } from '@libp2p/interface'
+import { contentRoutingSymbol, CodeError, TypedEventEmitter, setMaxListeners, peerDiscoverySymbol, peerRoutingSymbol } from '@libp2p/interface'
 import { defaultLogger } from '@libp2p/logger'
 import { PeerSet } from '@libp2p/peer-collections'
 import { peerIdFromString } from '@libp2p/peer-id'

--- a/packages/peer-discovery-mdns/src/mdns.ts
+++ b/packages/peer-discovery-mdns/src/mdns.ts
@@ -1,4 +1,4 @@
-import { CustomEvent, TypedEventEmitter, peerDiscoverySymbol, serviceCapabilities } from '@libp2p/interface'
+import { TypedEventEmitter, peerDiscoverySymbol, serviceCapabilities } from '@libp2p/interface'
 import multicastDNS from 'multicast-dns'
 import * as query from './query.js'
 import { stringGen } from './utils.js'

--- a/packages/peer-discovery-mdns/test/compliance.spec.ts
+++ b/packages/peer-discovery-mdns/test/compliance.spec.ts
@@ -1,6 +1,5 @@
 /* eslint-env mocha */
 
-import { CustomEvent } from '@libp2p/interface'
 import tests from '@libp2p/interface-compliance-tests/peer-discovery'
 import { defaultLogger } from '@libp2p/logger'
 import { createEd25519PeerId } from '@libp2p/peer-id-factory'

--- a/packages/pubsub/src/index.ts
+++ b/packages/pubsub/src/index.ts
@@ -30,7 +30,7 @@
  * ```
  */
 
-import { CodeError, TypedEventEmitter, CustomEvent, TopicValidatorResult } from '@libp2p/interface'
+import { CodeError, TypedEventEmitter, TopicValidatorResult } from '@libp2p/interface'
 import { PeerMap, PeerSet } from '@libp2p/peer-collections'
 import { pipe } from 'it-pipe'
 import Queue from 'p-queue'

--- a/packages/pubsub/src/peer-streams.ts
+++ b/packages/pubsub/src/peer-streams.ts
@@ -1,4 +1,4 @@
-import { TypedEventEmitter, CustomEvent } from '@libp2p/interface'
+import { TypedEventEmitter } from '@libp2p/interface'
 import { closeSource } from '@libp2p/utils/close-source'
 import * as lp from 'it-length-prefixed'
 import { pipe } from 'it-pipe'

--- a/packages/transport-websockets/src/listener.ts
+++ b/packages/transport-websockets/src/listener.ts
@@ -1,5 +1,5 @@
 import os from 'os'
-import { TypedEventEmitter, CustomEvent } from '@libp2p/interface'
+import { TypedEventEmitter } from '@libp2p/interface'
 import { ipPortToMultiaddr as toMultiaddr } from '@libp2p/utils/ip-port-to-multiaddr'
 import { multiaddr, protocols } from '@multiformats/multiaddr'
 import { createServer } from 'it-ws/server'


### PR DESCRIPTION
`CustomEvent` is global in Node.js as of `v18.7.0`. We support LTS and Current which means `v20+`, and Electron has upgraded to node 20 so the polyfill isn't necessary any more.

BREAKING CHANGE: `@libp2p/interface` no longer exports a `CustomEvent` polyfill

## Change checklist

- [x] I have performed a self-review of my own code
- [x] I have made corresponding changes to the documentation if necessary (this includes comments as well)
- [ ] I have added tests that prove my fix is effective or that my feature works