### PR TITLE
fix: accept custom ping protocol prefix in connection monitor

### DIFF
--- a/packages/libp2p/src/connection-monitor.ts
+++ b/packages/libp2p/src/connection-monitor.ts
@@ -6,6 +6,9 @@ import type { ConnectionManager } from '@libp2p/interface-internal'
 import type { AdaptiveTimeoutInit } from '@libp2p/utils/adaptive-timeout'
 
 const DEFAULT_PING_INTERVAL_MS = 10000
+const PROTOCOL_VERSION = '1.0.0'
+const PROTOCOL_NAME = 'ping'
+const PROTOCOL_PREFIX = 'ipfs'
 
 export interface ConnectionMonitorInit {
   /**
@@ -37,6 +40,13 @@ export interface ConnectionMonitorInit {
    * @default true
    */
   abortConnectionOnPingFailure?: boolean
+
+  /**
+   * Override the ping protocol prefix
+   *
+   * @default 'ipfs'
+   */
+  protocolPrefix?: string
 }
 
 export interface ConnectionMonitorComponents {
@@ -46,6 +56,7 @@ export interface ConnectionMonitorComponents {
 }
 
 export class ConnectionMonitor implements Startable {
+  private readonly protocol: string
   private readonly components: ConnectionMonitorComponents
   private readonly log: Logger
   private heartbeatInterval?: ReturnType<typeof setInterval>
@@ -55,6 +66,7 @@ export class ConnectionMonitor implements Startable {
 
   constructor (components: ConnectionMonitorComponents, init: ConnectionMonitorInit = {}) {
     this.components = components
+    this.protocol = `/${init.protocolPrefix ?? PROTOCOL_PREFIX}/${PROTOCOL_NAME}/${PROTOCOL_VERSION}`
 
     this.log = components.logger.forComponent('libp2p:connection-monitor')
     this.pingIntervalMs = init.pingInterval ?? DEFAULT_PING_INTERVAL_MS
@@ -83,7 +95,7 @@ export class ConnectionMonitor implements Startable {
             const signal = this.timeout.getTimeoutSignal({
               signal: this.abortController?.signal
             })
-            const stream = await conn.newStream('/ipfs/ping/1.0.0', {
+            const stream = await conn.newStream(this.protocol, {
               signal,
               runOnTransientConnection: true
             })

--- a/packages/libp2p/test/connection-monitor/index.spec.ts
+++ b/packages/libp2p/test/connection-monitor/index.spec.ts
@@ -50,6 +50,27 @@ describe('connection monitor', () => {
     expect(connection.rtt).to.be.gte(0)
   })
 
+  it('should monitor the liveness of a connection with a custom ping protocol prefix', async () => {
+    monitor = new ConnectionMonitor(components, {
+      pingInterval: 10,
+      protocolPrefix: 'foobar',
+    })
+
+    await start(monitor)
+
+    const connection = stubInterface<Connection>()
+    const stream = stubInterface<Stream>({
+      ...pair<any>()
+    })
+    connection.newStream.withArgs('/foobar/ping/1.0.0').resolves(stream)
+
+    components.connectionManager.getConnections.returns([connection])
+
+    await delay(100)
+
+    expect(connection.rtt).to.be.gte(0)
+  })
+
   it('should monitor the liveness of a connection that does not support ping', async () => {
     monitor = new ConnectionMonitor(components, {
       pingInterval: 10

--- a/packages/libp2p/test/connection-monitor/index.spec.ts
+++ b/packages/libp2p/test/connection-monitor/index.spec.ts
@@ -53,7 +53,7 @@ describe('connection monitor', () => {
   it('should monitor the liveness of a connection with a custom ping protocol prefix', async () => {
     monitor = new ConnectionMonitor(components, {
       pingInterval: 10,
-      protocolPrefix: 'foobar',
+      protocolPrefix: 'foobar'
     })
 
     await start(monitor)


### PR DESCRIPTION
## Description

The new connection monitor currently uses the hard-coded default ping protocol `'/ipfs/ping/1.0.0'`. The ping service lets the developer override the `ipfs` component with a custom protocol prefix, and some apps are already doing this. This PR adds support for a `protocolPrefix` option in `ConnectionMonitorInit` that matches the option in `PingServiceInit`.

## Change checklist

- [x] I have performed a self-review of my own code
- [x] I have made corresponding changes to the documentation if necessary (this includes comments as well)
- [x] I have added tests that prove my fix is effective or that my feature works