### PR TITLE
fix: connection monitor compatible with other ping implementations

### DIFF
--- a/packages/libp2p/src/connection-monitor.ts
+++ b/packages/libp2p/src/connection-monitor.ts
@@ -1,3 +1,4 @@
+import { randomBytes } from '@libp2p/crypto'
 import { serviceCapabilities } from '@libp2p/interface'
 import { AdaptiveTimeout } from '@libp2p/utils/adaptive-timeout'
 import { byteStream } from 'it-byte-stream'
@@ -9,6 +10,7 @@ const DEFAULT_PING_INTERVAL_MS = 10000
 const PROTOCOL_VERSION = '1.0.0'
 const PROTOCOL_NAME = 'ping'
 const PROTOCOL_PREFIX = 'ipfs'
+const PING_LENGTH = 32
 
 export interface ConnectionMonitorInit {
   /**
@@ -103,10 +105,10 @@ export class ConnectionMonitor implements Startable {
             start = Date.now()
 
             await Promise.all([
-              bs.write(new Uint8Array(32), {
+              bs.write(randomBytes(PING_LENGTH), {
                 signal
               }),
-              bs.read(1, {
+              bs.read(PING_LENGTH, {
                 signal
               })
             ])

--- a/packages/libp2p/src/connection-monitor.ts
+++ b/packages/libp2p/src/connection-monitor.ts
@@ -103,7 +103,7 @@ export class ConnectionMonitor implements Startable {
             start = Date.now()
 
             await Promise.all([
-              bs.write(new Uint8Array(1), {
+              bs.write(new Uint8Array(32), {
                 signal
               }),
               bs.read(1, {


### PR DESCRIPTION
## Description

Update the number of bytes sent by the connection manager so that it is compatible with other `ping` implementations

https://github.com/libp2p/go-libp2p/blob/master/p2p/protocol/ping/ping.go#L23
https://github.com/libp2p/rust-libp2p/blob/master/protocols/ping/src/protocol.rs#L48
https://github.com/libp2p/js-libp2p/blob/main/packages/protocol-ping/src/constants.ts#L2

## Change checklist

- [x] I have performed a self-review of my own code
- [ ] I have made corresponding changes to the documentation if necessary (this includes comments as well)
- [ ] I have added tests that prove my fix is effective or that my feature works