### PR TITLE
chore: add a funding JSON file to apply for Optimism rPGF round 5

### DIFF
--- a/funding.json
+++ b/funding.json
@@ -1,5 +1,5 @@
 {
   "opRetro": {
-    "projectId": "0xc71faa1bcb4ceb785816c3f22823377e9e5e7c48649badd9f0a0ce491f20d4b3"
+    "projectId": "0x5a7e7c7acb21521e99021d746740b368801cbfe531301e50bdbaafdc24a0aac5"
   }
 }

--- a/funding.json
+++ b/funding.json
@@ -1,5 +1,5 @@
 {
   "opRetro": {
-    "projectId": "0x966804cb492e1a4bde5d781a676a44a23d69aa5dd2562fa7a4f95bb606021c8b"
+    "projectId": "0xc71faa1bcb4ceb785816c3f22823377e9e5e7c48649badd9f0a0ce491f20d4b3"
   }
 }


### PR DESCRIPTION
This funding.json file is added here in order to apply for Optimism's rPGF round 5: https://retrofunding.optimism.io/application/5

The application process requires this file to exist in public github repositories that are linked to applications.
The js-libp2p repo will be listed in IP Shipyard's application for round 5.

The contents of this file were autogenerated:
<img width="461" alt="image" src="https://github.com/user-attachments/assets/0d64aa16-3d4d-4385-b783-c57bd1cd0a82">

