### PR TITLE
fix: limit incoming ping bytes to 32

### DIFF
--- a/packages/protocol-ping/src/ping.ts
+++ b/packages/protocol-ping/src/ping.ts
@@ -1,5 +1,5 @@
 import { randomBytes } from '@libp2p/crypto'
-import { CodeError, ERR_TIMEOUT } from '@libp2p/interface'
+import { CodeError, ERR_INVALID_MESSAGE, ERR_TIMEOUT } from '@libp2p/interface'
 import first from 'it-first'
 import { pipe } from 'it-pipe'
 import { equals as uint8ArrayEquals } from 'uint8arrays/equals'
@@ -61,9 +61,32 @@ export class PingService implements Startable, PingServiceInterface {
     const { stream } = data
     const start = Date.now()
 
-    void pipe(stream, stream)
+    const signal = AbortSignal.timeout(this.timeout)
+    signal.addEventListener('abort', () => {
+      stream?.abort(new CodeError('ping timeout', ERR_TIMEOUT))
+    })
+
+    void pipe(
+      stream,
+      async function * (source) {
+        let received = 0
+
+        for await (const buf of source) {
+          received += buf.byteLength
+
+          if (received > PING_LENGTH) {
+            stream?.abort(new CodeError('Too much data received', ERR_INVALID_MESSAGE))
+            return
+          }
+
+          yield buf
+        }
+      },
+      stream
+    )
       .catch(err => {
         this.log.error('incoming ping from %p failed with error', data.connection.remotePeer, err)
+        stream?.abort(err)
       })
       .finally(() => {
         const ms = Date.now() - start

--- a/packages/protocol-ping/test/index.spec.ts
+++ b/packages/protocol-ping/test/index.spec.ts
@@ -33,6 +33,7 @@ function echoStream (): StubbedInstance<Stream> {
 
 describe('ping', () => {
   let components: StubbedPingServiceComponents
+  let ping: PingService
 
   beforeEach(async () => {
     components = {
@@ -40,13 +41,13 @@ describe('ping', () => {
       connectionManager: stubInterface<ConnectionManager>(),
       logger: defaultLogger()
     }
+
+    ping = new PingService(components)
+
+    await start(ping)
   })
 
   it('should be able to ping another peer', async () => {
-    const ping = new PingService(components)
-
-    await start(ping)
-
     const remotePeer = await createEd25519PeerId()
 
     const connection = stubInterface<Connection>()
@@ -61,10 +62,6 @@ describe('ping', () => {
 
   it('should time out pinging another peer when waiting for a pong', async () => {
     const timeout = 10
-    const ping = new PingService(components)
-
-    await start(ping)
-
     const remotePeer = await createEd25519PeerId()
 
     const connection = stubInterface<Connection>()
@@ -95,18 +92,6 @@ describe('ping', () => {
   })
 
   it('should handle incoming ping', async () => {
-    const ping = new PingService(components)
-
-    await start(ping)
-
-    const remotePeer = await createEd25519PeerId()
-
-    const connection = stubInterface<Connection>()
-    components.connectionManager.openConnection.withArgs(remotePeer).resolves(connection)
-
-    const stream = echoStream()
-    connection.newStream.withArgs(PING_PROTOCOL).resolves(stream)
-
     const duplex = duplexPair<any>()
     const incomingStream = stubInterface<Stream>(duplex[0])
     const outgoingStream = stubInterface<Stream>(duplex[1])
@@ -127,5 +112,36 @@ describe('ping', () => {
     const output = await b.read()
 
     expect(output).to.equalBytes(input)
+  })
+
+  it('should abort stream if too much ping data received', async () => {
+    const deferred = pDefer<Error>()
+
+    const duplex = duplexPair<any>()
+    const incomingStream = stubInterface<Stream>({
+      ...duplex[0],
+      abort: (err) => {
+        deferred.resolve(err)
+      }
+    })
+    const outgoingStream = stubInterface<Stream>(duplex[1])
+
+    const handler = components.registrar.handle.getCall(0).args[1]
+
+    // handle incoming ping stream
+    handler({
+      stream: incomingStream,
+      connection: stubInterface<Connection>()
+    })
+
+    const input = new Uint8Array(100)
+    const b = byteStream(outgoingStream)
+
+    void b.read(100)
+    void b.write(input)
+
+    const err = await deferred.promise
+
+    expect(err).to.have.property('code', 'ERR_INVALID_MESSAGE')
   })
 })


### PR DESCRIPTION
As per the spec only allow 32 bytes to be sent as a ping.

Reset the stream if more bytes are received.

## Change checklist

- [x] I have performed a self-review of my own code
- [ ] I have made corresponding changes to the documentation if necessary (this includes comments as well)
- [x] I have added tests that prove my fix is effective or that my feature works