### PR TITLE
fix: revert WebRTC message size increase

### DIFF
--- a/packages/transport-webrtc/package.json
+++ b/packages/transport-webrtc/package.json
@@ -72,6 +72,7 @@
     "protons-runtime": "^5.4.0",
     "race-signal": "^1.0.2",
     "react-native-webrtc": "^118.0.7",
+    "uint8-varint": "^2.0.4",
     "uint8arraylist": "^2.4.8",
     "uint8arrays": "^5.1.0"
   },

--- a/packages/transport-webrtc/test/stream.spec.ts
+++ b/packages/transport-webrtc/test/stream.spec.ts
@@ -26,8 +26,12 @@ describe('Max message size', () => {
       }
     })
 
-    // Make sure that the data that ought to be sent will result in a message with exactly MAX_MESSAGE_SIZE
-    const messageLengthEncoded = lengthPrefixed.encode.single(Message.encode({ message: data }))
+    // Make sure that a message with all fields will be exactly MAX_MESSAGE_SIZE
+    const messageLengthEncoded = lengthPrefixed.encode.single(Message.encode({
+      flag: Message.Flag.STOP_SENDING,
+      message: data
+    }))
+
     expect(messageLengthEncoded.length).eq(MAX_MESSAGE_SIZE)
     const webrtcStream = createStream({
       channel,


### PR DESCRIPTION
go-libp2p and rust-libp2p close incoming streams when the message size is greater than 16KiB so reset to the previous limit.

Reverts #2627

## Change checklist

- [x] I have performed a self-review of my own code
- [ ] I have made corresponding changes to the documentation if necessary (this includes comments as well)
- [x] I have added tests that prove my fix is effective or that my feature works