### PR TITLE
fix: parameterise max message size in SDP messages

### DIFF
--- a/packages/transport-webrtc/src/private-to-public/sdp.ts
+++ b/packages/transport-webrtc/src/private-to-public/sdp.ts
@@ -1,6 +1,7 @@
 import { type Multiaddr } from '@multiformats/multiaddr'
 import { bases, digest } from 'multiformats/basics'
 import { inappropriateMultiaddr, invalidArgument, invalidFingerprint, unsupportedHashAlgorithmCode } from '../error.js'
+import { MAX_MESSAGE_SIZE } from '../stream.js'
 import { CERTHASH_CODE } from './transport.js'
 import type { LoggerOptions } from '@libp2p/interface'
 import type { MultihashDigest } from 'multiformats/hashes/interface'
@@ -42,6 +43,7 @@ export function getFingerprintFromSdp (sdp: string): string | undefined {
   const searchResult = sdp.match(fingerprintRegex)
   return searchResult?.groups?.fingerprint
 }
+
 /**
  * Get base2 | identity decoders
  */
@@ -127,7 +129,7 @@ a=ice-ufrag:${ufrag}
 a=ice-pwd:${ufrag}
 a=fingerprint:${CERTFP}
 a=sctp-port:5000
-a=max-message-size:16384
+a=max-message-size:${MAX_MESSAGE_SIZE}
 a=candidate:1467250027 1 UDP 1467250027 ${host} ${port} typ host\r\n`
 }
 

--- a/packages/transport-webrtc/test/sdp.spec.ts
+++ b/packages/transport-webrtc/test/sdp.spec.ts
@@ -1,6 +1,7 @@
 import { multiaddr } from '@multiformats/multiaddr'
 import { expect } from 'aegir/chai'
 import * as underTest from '../src/private-to-public/sdp.js'
+import { MAX_MESSAGE_SIZE } from '../src/stream.js'
 
 const sampleMultiAddr = multiaddr('/ip4/0.0.0.0/udp/56093/webrtc/certhash/uEiByaEfNSLBexWBNFZy_QB1vAKEj7JAXDizRs4_SnTflsQ')
 const sampleCerthash = 'uEiByaEfNSLBexWBNFZy_QB1vAKEj7JAXDizRs4_SnTflsQ'
@@ -17,7 +18,7 @@ a=ice-ufrag:MyUserFragment
 a=ice-pwd:MyUserFragment
 a=fingerprint:SHA-256 72:68:47:CD:48:B0:5E:C5:60:4D:15:9C:BF:40:1D:6F:00:A1:23:EC:90:17:0E:2C:D1:B3:8F:D2:9D:37:E5:B1
 a=sctp-port:5000
-a=max-message-size:16384
+a=max-message-size:${MAX_MESSAGE_SIZE}
 a=candidate:1467250027 1 UDP 1467250027 0.0.0.0 56093 typ host`
 
 describe('SDP', () => {
@@ -72,7 +73,7 @@ a=ice-ufrag:someotheruserfragmentstring
 a=ice-pwd:someotheruserfragmentstring
 a=fingerprint:SHA-256 72:68:47:CD:48:B0:5E:C5:60:4D:15:9C:BF:40:1D:6F:00:A1:23:EC:90:17:0E:2C:D1:B3:8F:D2:9D:37:E5:B1
 a=sctp-port:5000
-a=max-message-size:16384
+a=max-message-size:${MAX_MESSAGE_SIZE}
 a=candidate:1467250027 1 UDP 1467250027 0.0.0.0 56093 typ host`
 
     expect(result.sdp).to.equal(expected)


### PR DESCRIPTION
Do not hard code the `max-message-size` SDP directive, instead reuse the `MAX_MESSAGE_SIZE` constant.

## Change checklist

- [x] I have performed a self-review of my own code
- [ ] I have made corresponding changes to the documentation if necessary (this includes comments as well)
- [ ] I have added tests that prove my fix is effective or that my feature works