### PR TITLE
fix: remove while loop for setbit & getbit

### DIFF
--- a/packages/utils/benchmark/filter/bloom-filter.cjs
+++ b/packages/utils/benchmark/filter/bloom-filter.cjs
@@ -3,7 +3,7 @@ const Benchmark = require('benchmark')
 
 const suite = new Benchmark.Suite('bloom-filter')
 
-const bits = [8, 64, 512, 4096, 32768, 262144, 262145, 2097152]
+const bits = [8, 64, 512, 4096, 32768, 262144, 2097152, 251658240]
 
 bits.forEach((bit) => {
   suite.add(`Loop ${bit}bits`, () => {

--- a/packages/utils/benchmark/filter/bloom-filter.cjs
+++ b/packages/utils/benchmark/filter/bloom-filter.cjs
@@ -1,0 +1,26 @@
+/* eslint-disable no-console */
+const Benchmark = require('benchmark')
+
+const suite = new Benchmark.Suite('bloom-filter')
+
+const bits = [8, 64, 512, 4096, 32768, 262144, 262145, 2097152]
+
+bits.forEach((bit) => {
+  suite.add(`Loop ${bit}bits`, () => {
+    let pos = 0
+    let shift = bit
+    while (shift > 7) {
+      pos++
+      shift -= 8
+    }
+  })
+
+  suite.add(`Math Ops ${bit}bits`, () => {
+    _ = Math.floor(bit / 8)
+    _ = bit % 8
+  })
+})
+
+suite
+  .on('cycle', (event) => console.log(String(event.target)))
+  .run({ async: true })

--- a/packages/utils/package.json
+++ b/packages/utils/package.json
@@ -178,6 +178,7 @@
   "devDependencies": {
     "@types/netmask": "^2.0.5",
     "aegir": "^44.0.1",
+    "benchmark": "^2.1.4",
     "delay": "^6.0.0",
     "it-all": "^3.0.6",
     "it-drain": "^3.0.7",

--- a/packages/utils/src/filters/bloom-filter.ts
+++ b/packages/utils/src/filters/bloom-filter.ts
@@ -78,12 +78,8 @@ export class BloomFilter implements Filter {
   }
 
   setbit (bit: number): void {
-    let pos = 0
-    let shift = bit
-    while (shift > 7) {
-      pos++
-      shift -= 8
-    }
+    const pos = Math.floor(bit / 8)
+    const shift = bit % 8
 
     let bitfield = this.buffer[pos]
     bitfield |= (0x1 << shift)
@@ -91,12 +87,8 @@ export class BloomFilter implements Filter {
   }
 
   getbit (bit: number): boolean {
-    let pos = 0
-    let shift = bit
-    while (shift > 7) {
-      pos++
-      shift -= 8
-    }
+    const pos = Math.floor(bit / 8)
+    const shift = bit % 8
 
     const bitfield = this.buffer[pos]
     return (bitfield & (0x1 << shift)) !== 0


### PR DESCRIPTION
## Description

Constant time `setbit` and `getbit` in the bloom filter - was hitting performance issues when using a 30mb bloom filter

## Notes & open questions

Benchmarks below

```
Loop 8bits x 171,777,298 ops/sec ±2.70% (89 runs sampled)
Math Ops 8bits x 216,520,449 ops/sec ±6.46% (77 runs sampled)

Loop 64bits x 127,603,004 ops/sec ±3.28% (85 runs sampled)
Math Ops 64bits x 225,485,149 ops/sec ±5.94% (81 runs sampled)

Loop 512bits x 35,893,950 ops/sec ±0.76% (97 runs sampled)
Math Ops 512bits x 223,396,999 ops/sec ±5.05% (79 runs sampled)

Loop 4096bits x 4,824,731 ops/sec ±0.91% (97 runs sampled)
Math Ops 4096bits x 211,234,954 ops/sec ±5.26% (77 runs sampled)

Loop 32768bits x 579,890 ops/sec ±0.40% (100 runs sampled)
Math Ops 32768bits x 206,112,847 ops/sec ±5.97% (74 runs sampled)

Loop 262144bits x 60,922 ops/sec ±0.15% (98 runs sampled)
Math Ops 262144bits x 203,502,874 ops/sec ±6.71% (72 runs sampled)

Loop 2097152bits x 7,626 ops/sec ±0.26% (101 runs sampled)
Math Ops 2097152bits x 210,668,544 ops/sec ±5.40% (76 runs sampled)

Loop 251658240bits x 63.70 ops/sec ±0.18% (68 runs sampled)
Math Ops 251658240bits x 209,501,599 ops/sec ±6.41% (73 runs sampled)
```

## Change checklist

- [x] I have performed a self-review of my own code
- [ ] I have made corresponding changes to the documentation if necessary (this includes comments as well)
- [x] I have added tests that prove my fix is effective or that my feature works