### PR TITLE
fix!: rename connectionEncryption option to connectionEncrypters

### DIFF
--- a/doc/CONFIGURATION.md
+++ b/doc/CONFIGURATION.md
@@ -207,7 +207,7 @@ When [creating a libp2p node](https://github.com/libp2p/js-libp2p/blob/main/doc/
 const modules = {
   transports: [],
   streamMuxers: [],
-  connectionEncryption: [],
+  connectionEncrypters: [],
   contentRouting: [],
   peerRouting: [],
   peerDiscovery: [],
@@ -267,7 +267,7 @@ const node = await createLibp2p({
     webSockets()
   ],
   streamMuxers: [yamux(), mplex()],
-  connectionEncryption: [noise()],
+  connectionEncrypters: [noise()],
   peerDiscovery: [MulticastDNS],
   services: {
     dht: kadDHT(),
@@ -290,7 +290,7 @@ import { bootstrap } from '@libp2p/bootstrap'
 const node = await createLibp2p({
   transports: [tcp()],
   streamMuxers: [yamux(), mplex()],
-  connectionEncryption: [noise()],
+  connectionEncrypters: [noise()],
   peerDiscovery: [
     mdns({
       interval: 1000
@@ -336,7 +336,7 @@ const node = await createLibp2p({
       yamux(),
       mplex()
     ],
-    connectionEncryption: [
+    connectionEncrypters: [
       noise()
     ],
     services: {
@@ -373,7 +373,7 @@ const node = await createLibp2p({
     yamux(),
     mplex()
   ],
-  connectionEncryption: [
+  connectionEncrypters: [
     noise()
   ],
   services: {
@@ -421,7 +421,7 @@ const node = await createLibp2p({
     yamux(),
     mplex()
   ],
-  connectionEncryption: [
+  connectionEncrypters: [
     noise()
   ],
   contentRouting: [
@@ -466,7 +466,7 @@ const node = await createLibp2p({
     yamux(),
     mplex()
   ],
-  connectionEncryption: [
+  connectionEncrypters: [
     noise()
   ],
   connectionGater: {
@@ -521,7 +521,7 @@ const node = await createLibp2p({
     yamux(),
     mplex()
   ],
-  connectionEncryption: [
+  connectionEncrypters: [
     noise()
   ]
 })
@@ -552,7 +552,7 @@ const node = await createLibp2p({
     yamux(),
     mplex()
   ],
-  connectionEncryption: [
+  connectionEncrypters: [
     noise()
   ]
 })
@@ -589,7 +589,7 @@ const node = await createLibp2p({
     yamux(),
     mplex()
   ],
-  connectionEncryption: [
+  connectionEncrypters: [
     noise()
   ],
   keychain: {
@@ -622,7 +622,7 @@ const node = await createLibp2p({
     yamux(),
     mplex()
   ],
-  connectionEncryption: [
+  connectionEncrypters: [
     noise()
   ],
   connectionManager: {
@@ -772,7 +772,7 @@ const node = await createLibp2p({
     yamux(),
     mplex()
   ],
-  connectionEncryption: [
+  connectionEncrypters: [
     noise()
   ],
   transportManager: {
@@ -810,7 +810,7 @@ const node = await createLibp2p({
     yamux(),
     mplex()
   ],
-  connectionEncryption: [
+  connectionEncrypters: [
     noise()
   ],
   metrics: {
@@ -860,7 +860,7 @@ const node = await createLibp2p({
     yamux(),
     mplex()
   ],
-  connectionEncryption: [
+  connectionEncrypters: [
     noise()
   ],
   peerStore: {
@@ -892,7 +892,7 @@ const node = await createLibp2p({
   streamMuxers: [
     yamux()
   ],
-  connectionEncryption: [
+  connectionEncrypters: [
     noise()
   ]
 })
@@ -917,7 +917,7 @@ const node = await createLibp2p({
   streamMuxers: [
     yamux()
   ],
-  connectionEncryption: [
+  connectionEncrypters: [
     noise()
   ],
   addresses: {

--- a/doc/GETTING_STARTED.md
+++ b/doc/GETTING_STARTED.md
@@ -107,7 +107,7 @@ import { noise } from '@chainsafe/libp2p-noise'
 
 const node = await createLibp2p({
   transports: [webSockets()],
-  connectionEncryption: [noise()]
+  connectionEncrypters: [noise()]
 })
 ```
 
@@ -138,7 +138,7 @@ import { yamux } from '@chainsafe/libp2p-yamux'
 
 const node = await createLibp2p({
   transports: [webSockets()],
-  connectionEncryption: [noise()],
+  connectionEncrypters: [noise()],
   streamMuxers: [yamux()]
 })
 ```
@@ -168,7 +168,7 @@ const node = await createLibp2p({
     listen: ['/ip4/127.0.0.1/tcp/8000/ws']
   },
   transports: [webSockets()],
-  connectionEncryption: [noise()],
+  connectionEncrypters: [noise()],
   streamMuxers: [yamux()]
 })
 
@@ -224,7 +224,7 @@ const bootstrapMultiaddrs = [
 
 const node = await createLibp2p({
   transports: [webSockets()],
-  connectionEncryption: [noise()],
+  connectionEncrypters: [noise()],
   streamMuxers: [yamux()],
   peerDiscovery: [
     bootstrap({

--- a/doc/migrations/v1.0.0-v2.0.0.md
+++ b/doc/migrations/v1.0.0-v2.0.0.md
@@ -17,6 +17,7 @@ A migration guide for refactoring your application code from libp2p `v1.0.0` to 
 - [`localPeer` is no longer passed to Connection Encrypters](#localpeer-is-no-longer-passed-to-connection-encrypters)
 - [The `.code` property has been removed from thrown errors, use `.name` instead](#the-code-property-has-been-removed-from-thrown-errors-use-name-instead)
 - [pubsub, identify, circuit-relay v2 and record envelope sealing use `privateKey` component](#pubsub-identify-circuit-relay-v2-and-record-envelope-sealing-use-privatekey-component)
+- [The `connectionEncryption` option has been renamed `connectionEncrypters`](#the-connectionencryption-option-has-been-renamed-connectionencrypters)
 
 ## The `PeerId` interface is now a union type
 
@@ -484,3 +485,36 @@ for use by libp2p services that contains the deserialized private key.
 
 There are no migration instructions to take advantage of this other than
 ensuring you have upgraded to the latest version of all libp2p services.
+
+## The `connectionEncryption` option has been renamed `connectionEncrypters`
+
+This makes it consistent with other options such as `streamMuxers`,
+`transports`, etc.
+
+**Before**
+
+```ts
+import { noise } from '@chainsafe/libp2p-noise'
+import { tls } from '@libp2p/tls'
+import { createLibp2p } from 'libp2p'
+
+const node = await createLibp2p({
+  connectionEncryption: [
+    noise(), tls()
+  ]
+})
+```
+
+**After**
+
+```ts
+import { noise } from '@chainsafe/libp2p-noise'
+import { tls } from '@libp2p/tls'
+import { createLibp2p } from 'libp2p'
+
+const node = await createLibp2p({
+  connectionEncrypters: [
+    noise(), tls()
+  ]
+})
+```

--- a/interop/test/fixtures/get-libp2p.ts
+++ b/interop/test/fixtures/get-libp2p.ts
@@ -94,7 +94,7 @@ export async function getLibp2p (): Promise<Libp2p<{ ping: PingService }>> {
       skipMuxer = true
       // Setup yamux and noise to connect to the relay node
       options.streamMuxers = [yamux()]
-      options.connectionEncryption = [noise()]
+      options.connectionEncrypters = [noise()]
       break
     default:
       // Do nothing
@@ -103,7 +103,7 @@ export async function getLibp2p (): Promise<Libp2p<{ ping: PingService }>> {
   if (!skipSecureChannel) {
     switch (SECURE_CHANNEL) {
       case 'noise':
-        options.connectionEncryption = [noise()]
+        options.connectionEncrypters = [noise()]
         break
       default:
         throw new Error(`Unknown secure channel: ${SECURE_CHANNEL ?? ''}`)

--- a/interop/test/fixtures/relay.ts
+++ b/interop/test/fixtures/relay.ts
@@ -17,7 +17,7 @@ export async function createRelay (): Promise<Libp2p> {
         filter: filters.all
       })
     ],
-    connectionEncryption: [noise()],
+    connectionEncrypters: [noise()],
     streamMuxers: [yamux()],
     services: {
       identify: identify(),

--- a/packages/connection-encrypter-plaintext/README.md
+++ b/packages/connection-encrypter-plaintext/README.md
@@ -36,7 +36,7 @@ import { plaintext } from '@libp2p/plaintext'
 
 const node = await createLibp2p({
   // ...other options
-  connectionEncryption: [
+  connectionEncrypters: [
     plaintext()
   ]
 })

--- a/packages/connection-encrypter-plaintext/src/index.ts
+++ b/packages/connection-encrypter-plaintext/src/index.ts
@@ -13,7 +13,7 @@
  *
  * const node = await createLibp2p({
  *   // ...other options
- *   connectionEncryption: [
+ *   connectionEncrypters: [
  *     plaintext()
  *   ]
  * })

--- a/packages/connection-encrypter-tls/README.md
+++ b/packages/connection-encrypter-tls/README.md
@@ -34,7 +34,7 @@ import { tls } from '@libp2p/tls'
 
 const node = await createLibp2p({
   // ...other options
-  connectionEncryption: [
+  connectionEncrypters: [
     tls()
   ]
 })

--- a/packages/connection-encrypter-tls/src/index.ts
+++ b/packages/connection-encrypter-tls/src/index.ts
@@ -11,7 +11,7 @@
  *
  * const node = await createLibp2p({
  *   // ...other options
- *   connectionEncryption: [
+ *   connectionEncrypters: [
  *     tls()
  *   ]
  * })

--- a/packages/connection-encrypter-tls/src/tls.ts
+++ b/packages/connection-encrypter-tls/src/tls.ts
@@ -11,7 +11,7 @@
  *
  * const node = await createLibp2p({
  *   // ...other options
- *   connectionEncryption: [
+ *   connectionEncrypters: [
  *     tls()
  *   ]
  * })

--- a/packages/integration-tests/.aegir.js
+++ b/packages/integration-tests/.aegir.js
@@ -37,7 +37,7 @@ export default {
           yamux(),
           mplex()
         ],
-        connectionEncryption: [
+        connectionEncrypters: [
           noise(),
           plaintext()
         ],

--- a/packages/integration-tests/test/bootstrap.spec.ts
+++ b/packages/integration-tests/test/bootstrap.spec.ts
@@ -114,7 +114,7 @@ describe('bootstrap', () => {
     ]
 
     libp2p = await createLibp2p({
-      connectionEncryption: [
+      connectionEncrypters: [
         plaintext()
       ],
       transports: [

--- a/packages/integration-tests/test/circuit-relay-discovery.node.ts
+++ b/packages/integration-tests/test/circuit-relay-discovery.node.ts
@@ -33,7 +33,7 @@ describe('circuit-relay discovery', () => {
       streamMuxers: [
         yamux()
       ],
-      connectionEncryption: [
+      connectionEncrypters: [
         plaintext()
       ],
       services: {
@@ -61,7 +61,7 @@ describe('circuit-relay discovery', () => {
       streamMuxers: [
         yamux()
       ],
-      connectionEncryption: [
+      connectionEncrypters: [
         plaintext()
       ],
       services: {
@@ -103,7 +103,7 @@ describe('circuit-relay discovery', () => {
         streamMuxers: [
           yamux()
         ],
-        connectionEncryption: [
+        connectionEncrypters: [
           plaintext()
         ],
         services: {
@@ -128,7 +128,7 @@ describe('circuit-relay discovery', () => {
         streamMuxers: [
           yamux()
         ],
-        connectionEncryption: [
+        connectionEncrypters: [
           plaintext()
         ],
         services: {

--- a/packages/integration-tests/test/circuit-relay-discovery.spec.ts
+++ b/packages/integration-tests/test/circuit-relay-discovery.spec.ts
@@ -35,7 +35,7 @@ describe('circuit-relay discovery', () => {
         yamux(),
         mplex()
       ],
-      connectionEncryption: [
+      connectionEncrypters: [
         plaintext(),
         noise()
       ],

--- a/packages/integration-tests/test/circuit-relay.node.ts
+++ b/packages/integration-tests/test/circuit-relay.node.ts
@@ -39,7 +39,7 @@ async function createClient (options: Libp2pOptions = {}): Promise<Libp2p> {
       yamux(),
       mplex()
     ],
-    connectionEncryption: [
+    connectionEncrypters: [
       plaintext()
     ],
     services: {
@@ -62,7 +62,7 @@ async function createRelay (options: Libp2pOptions = {}): Promise<Libp2p<{ relay
       yamux(),
       mplex()
     ],
-    connectionEncryption: [
+    connectionEncrypters: [
       plaintext()
     ],
     ...options,

--- a/packages/integration-tests/test/circuit-relay.spec.ts
+++ b/packages/integration-tests/test/circuit-relay.spec.ts
@@ -32,7 +32,7 @@ describe('circuit-relay', () => {
           yamux(),
           mplex()
         ],
-        connectionEncryption: [
+        connectionEncrypters: [
           plaintext()
         ],
         connectionGater: {
@@ -58,7 +58,7 @@ describe('circuit-relay', () => {
           yamux(),
           mplex()
         ],
-        connectionEncryption: [
+        connectionEncrypters: [
           plaintext()
         ],
         connectionGater: {

--- a/packages/integration-tests/test/dht.node.ts
+++ b/packages/integration-tests/test/dht.node.ts
@@ -50,7 +50,7 @@ describe('DHT subsystem operates correctly', () => {
         transports: [
           tcp()
         ],
-        connectionEncryption: [
+        connectionEncrypters: [
           plaintext()
         ],
         streamMuxers: [
@@ -73,7 +73,7 @@ describe('DHT subsystem operates correctly', () => {
         transports: [
           tcp()
         ],
-        connectionEncryption: [
+        connectionEncrypters: [
           plaintext()
         ],
         streamMuxers: [

--- a/packages/integration-tests/test/fixtures/base-options.browser.ts
+++ b/packages/integration-tests/test/fixtures/base-options.browser.ts
@@ -29,7 +29,7 @@ export function createBaseOptions <T extends ServiceMap = Record<string, unknown
       yamux(),
       mplex()
     ],
-    connectionEncryption: [
+    connectionEncrypters: [
       plaintext()
     ],
     connectionGater: mockConnectionGater(),

--- a/packages/integration-tests/test/fixtures/base-options.ts
+++ b/packages/integration-tests/test/fixtures/base-options.ts
@@ -32,7 +32,7 @@ export function createBaseOptions <T extends ServiceMap = Record<string, unknown
       yamux(),
       mplex()
     ],
-    connectionEncryption: [
+    connectionEncrypters: [
       plaintext()
     ],
     services: {

--- a/packages/integration-tests/test/interop.ts
+++ b/packages/integration-tests/test/interop.ts
@@ -133,7 +133,7 @@ async function createJsPeer (options: SpawnOptions): Promise<Daemon> {
     },
     transports: [tcp(), circuitRelayTransport()],
     streamMuxers: [],
-    connectionEncryption: [noise()]
+    connectionEncrypters: [noise()]
   }
 
   if (options.noListen !== true) {
@@ -153,11 +153,11 @@ async function createJsPeer (options: SpawnOptions): Promise<Daemon> {
   }
 
   if (options.encryption === 'noise') {
-    opts.connectionEncryption?.push(noise())
+    opts.connectionEncrypters?.push(noise())
   } else if (options.encryption === 'tls') {
-    opts.connectionEncryption?.push(tls())
+    opts.connectionEncrypters?.push(tls())
   } else if (options.encryption === 'plaintext') {
-    opts.connectionEncryption?.push(plaintext())
+    opts.connectionEncrypters?.push(plaintext())
   }
 
   if (options.muxer === 'mplex') {

--- a/packages/libp2p/.aegir.js
+++ b/packages/libp2p/.aegir.js
@@ -33,7 +33,7 @@ export default {
           yamux(),
           mplex()
         ],
-        connectionEncryption: [
+        connectionEncrypters: [
           plaintext()
         ],
         services: {

--- a/packages/libp2p/src/index.ts
+++ b/packages/libp2p/src/index.ts
@@ -103,7 +103,7 @@ export interface Libp2pInit<T extends ServiceMap = ServiceMap> {
    * eavesdropped on, and that the remote peer posesses the private key that
    * corresponds to the public key that it's Peer ID is derived from.
    */
-  connectionEncryption?: Array<(components: Components) => ConnectionEncrypter>
+  connectionEncrypters?: Array<(components: Components) => ConnectionEncrypter>
 
   /**
    * Peer discovery mechanisms allow finding peers on the network
@@ -187,7 +187,7 @@ export type Libp2pOptions<T extends ServiceMap = ServiceMap> = Libp2pInit<T> & {
  * const options = {
  *   transports: [tcp()],
  *   streamMuxers: [yamux(), mplex()],
- *   connectionEncryption: [noise()]
+ *   connectionEncrypters: [noise()]
  * }
  *
  * // create libp2p

--- a/packages/libp2p/src/libp2p.ts
+++ b/packages/libp2p/src/libp2p.ts
@@ -108,8 +108,8 @@ export class Libp2p<T extends ServiceMap = ServiceMap> extends TypedEventEmitter
 
     // Set up the Upgrader
     this.components.upgrader = new DefaultUpgrader(this.components, {
-      connectionEncryption: (init.connectionEncryption ?? []).map((fn, index) => this.configureComponent(`connection-encryption-${index}`, fn(this.components))),
-      muxers: (init.streamMuxers ?? []).map((fn, index) => this.configureComponent(`stream-muxers-${index}`, fn(this.components))),
+      connectionEncrypters: (init.connectionEncrypters ?? []).map((fn, index) => this.configureComponent(`connection-encryption-${index}`, fn(this.components))),
+      streamMuxers: (init.streamMuxers ?? []).map((fn, index) => this.configureComponent(`stream-muxers-${index}`, fn(this.components))),
       inboundUpgradeTimeout: init.connectionManager?.inboundUpgradeTimeout
     })
 

--- a/packages/libp2p/test/addresses/addresses.node.ts
+++ b/packages/libp2p/test/addresses/addresses.node.ts
@@ -190,7 +190,7 @@ describe('libp2p.addressManager', () => {
         transports: [
           webSockets()
         ],
-        connectionEncryption: [
+        connectionEncrypters: [
           plaintext()
         ]
       }
@@ -211,7 +211,7 @@ describe('libp2p.addressManager', () => {
         transports: [
           webSockets()
         ],
-        connectionEncryption: [
+        connectionEncrypters: [
           plaintext()
         ]
       }
@@ -243,7 +243,7 @@ describe('libp2p.addressManager', () => {
         transports: [
           webSockets()
         ],
-        connectionEncryption: [
+        connectionEncrypters: [
           plaintext()
         ]
       }

--- a/packages/libp2p/test/connection-manager/direct.node.ts
+++ b/packages/libp2p/test/connection-manager/direct.node.ts
@@ -293,7 +293,7 @@ describe('libp2p.dialer (direct, TCP)', () => {
         yamux(),
         mplex()
       ],
-      connectionEncryption: [
+      connectionEncrypters: [
         plaintext()
       ],
       services: {
@@ -326,7 +326,7 @@ describe('libp2p.dialer (direct, TCP)', () => {
         yamux(),
         mplex()
       ],
-      connectionEncryption: [
+      connectionEncrypters: [
         plaintext()
       ]
     })
@@ -354,7 +354,7 @@ describe('libp2p.dialer (direct, TCP)', () => {
         yamux(),
         mplex()
       ],
-      connectionEncryption: [
+      connectionEncrypters: [
         plaintext()
       ]
     })
@@ -417,7 +417,7 @@ describe('libp2p.dialer (direct, TCP)', () => {
         yamux(),
         mplex()
       ],
-      connectionEncryption: [
+      connectionEncrypters: [
         plaintext()
       ]
     })
@@ -443,7 +443,7 @@ describe('libp2p.dialer (direct, TCP)', () => {
         yamux(),
         mplex()
       ],
-      connectionEncryption: [
+      connectionEncrypters: [
         plaintext()
       ]
     })
@@ -472,7 +472,7 @@ describe('libp2p.dialer (direct, TCP)', () => {
         yamux(),
         mplex()
       ],
-      connectionEncryption: [
+      connectionEncrypters: [
         plaintext()
       ],
       connectionProtector: () => protector
@@ -500,7 +500,7 @@ describe('libp2p.dialer (direct, TCP)', () => {
         yamux(),
         mplex()
       ],
-      connectionEncryption: [
+      connectionEncrypters: [
         plaintext()
       ]
     })
@@ -539,7 +539,7 @@ describe('libp2p.dialer (direct, TCP)', () => {
         yamux(),
         mplex()
       ],
-      connectionEncryption: [
+      connectionEncrypters: [
         plaintext()
       ]
     })
@@ -598,7 +598,7 @@ describe('libp2p.dialer (direct, TCP)', () => {
         yamux(),
         mplex()
       ],
-      connectionEncryption: [
+      connectionEncrypters: [
         plaintext()
       ]
     })
@@ -615,7 +615,7 @@ describe('libp2p.dialer (direct, TCP)', () => {
         yamux(),
         mplex()
       ],
-      connectionEncryption: [
+      connectionEncrypters: [
         plaintext()
       ]
     })
@@ -640,7 +640,7 @@ describe('libp2p.dialer (direct, TCP)', () => {
       streamMuxers: [
         yamux()
       ],
-      connectionEncryption: [
+      connectionEncrypters: [
         plaintext()
       ]
     })
@@ -652,7 +652,7 @@ describe('libp2p.dialer (direct, TCP)', () => {
       streamMuxers: [
         yamux()
       ],
-      connectionEncryption: [
+      connectionEncrypters: [
         plaintext()
       ]
     })
@@ -689,7 +689,7 @@ describe('libp2p.dialer (direct, TCP)', () => {
       streamMuxers: [
         yamux()
       ],
-      connectionEncryption: [
+      connectionEncrypters: [
         plaintext()
       ]
     })
@@ -701,7 +701,7 @@ describe('libp2p.dialer (direct, TCP)', () => {
       streamMuxers: [
         yamux()
       ],
-      connectionEncryption: [
+      connectionEncrypters: [
         plaintext()
       ]
     })

--- a/packages/libp2p/test/connection-manager/direct.spec.ts
+++ b/packages/libp2p/test/connection-manager/direct.spec.ts
@@ -346,7 +346,7 @@ describe('libp2p.dialer (direct, WebSockets)', () => {
         yamux(),
         mplex()
       ],
-      connectionEncryption: [
+      connectionEncrypters: [
         plaintext()
       ],
       services: {
@@ -389,7 +389,7 @@ describe('libp2p.dialer (direct, WebSockets)', () => {
       streamMuxers: [
         yamux()
       ],
-      connectionEncryption: [
+      connectionEncrypters: [
         plaintext()
       ],
       services: {
@@ -431,7 +431,7 @@ describe('libp2p.dialer (direct, WebSockets)', () => {
         yamux(),
         mplex()
       ],
-      connectionEncryption: [
+      connectionEncrypters: [
         plaintext()
       ],
       connectionGater: mockConnectionGater()
@@ -460,7 +460,7 @@ describe('libp2p.dialer (direct, WebSockets)', () => {
         yamux(),
         mplex()
       ],
-      connectionEncryption: [
+      connectionEncrypters: [
         plaintext()
       ],
       connectionGater: mockConnectionGater()
@@ -480,7 +480,7 @@ describe('libp2p.dialer (direct, WebSockets)', () => {
         yamux(),
         mplex()
       ],
-      connectionEncryption: [
+      connectionEncrypters: [
         plaintext()
       ],
       connectionGater: mockConnectionGater()

--- a/packages/libp2p/test/connection-manager/resolver.spec.ts
+++ b/packages/libp2p/test/connection-manager/resolver.spec.ts
@@ -55,7 +55,7 @@ describe('dialing (resolvable addresses)', () => {
             dnsaddr: resolver
           }
         },
-        connectionEncryption: [
+        connectionEncrypters: [
           plaintext()
         ],
         connectionGater: mockConnectionGater(),
@@ -82,7 +82,7 @@ describe('dialing (resolvable addresses)', () => {
             dnsaddr: resolver
           }
         },
-        connectionEncryption: [
+        connectionEncrypters: [
           plaintext()
         ],
         services: {

--- a/packages/libp2p/test/core/consume-peer-record.spec.ts
+++ b/packages/libp2p/test/core/consume-peer-record.spec.ts
@@ -14,7 +14,7 @@ describe('Consume peer record', () => {
       transports: [
         webSockets()
       ],
-      connectionEncryption: [
+      connectionEncrypters: [
         plaintext()
       ]
     })

--- a/packages/libp2p/test/core/encryption.spec.ts
+++ b/packages/libp2p/test/core/encryption.spec.ts
@@ -11,7 +11,7 @@ describe('Connection encryption configuration', () => {
       transports: [
         webSockets()
       ],
-      connectionEncryption: [
+      connectionEncrypters: [
         plaintext()
       ]
     }

--- a/packages/libp2p/test/core/events.spec.ts
+++ b/packages/libp2p/test/core/events.spec.ts
@@ -22,7 +22,7 @@ describe('events', () => {
       transports: [
         webSockets()
       ],
-      connectionEncryption: [
+      connectionEncrypters: [
         plaintext()
       ]
     })
@@ -38,7 +38,7 @@ describe('events', () => {
       transports: [
         webSockets()
       ],
-      connectionEncryption: [
+      connectionEncrypters: [
         plaintext()
       ]
     })

--- a/packages/libp2p/test/core/listening.node.ts
+++ b/packages/libp2p/test/core/listening.node.ts
@@ -23,7 +23,7 @@ describe('Listening', () => {
       transports: [
         tcp()
       ],
-      connectionEncryption: [
+      connectionEncrypters: [
         plaintext()
       ]
     })

--- a/packages/libp2p/test/core/peer-id.spec.ts
+++ b/packages/libp2p/test/core/peer-id.spec.ts
@@ -19,7 +19,7 @@ describe('peer-id', () => {
       transports: [
         webSockets()
       ],
-      connectionEncryption: [
+      connectionEncrypters: [
         plaintext()
       ]
     })

--- a/packages/libp2p/test/core/status.node.ts
+++ b/packages/libp2p/test/core/status.node.ts
@@ -24,7 +24,7 @@ describe('status', () => {
       transports: [
         tcp()
       ],
-      connectionEncryption: [
+      connectionEncrypters: [
         plaintext()
       ]
     })

--- a/packages/libp2p/test/fixtures/base-options.browser.ts
+++ b/packages/libp2p/test/fixtures/base-options.browser.ts
@@ -21,7 +21,7 @@ export function createBaseOptions <T extends ServiceMap = Record<string, unknown
       mplex(),
       mplex()
     ],
-    connectionEncryption: [
+    connectionEncrypters: [
       plaintext()
     ],
     connectionGater: mockConnectionGater(),

--- a/packages/libp2p/test/fixtures/base-options.ts
+++ b/packages/libp2p/test/fixtures/base-options.ts
@@ -26,7 +26,7 @@ export function createBaseOptions <T extends ServiceMap = Record<string, unknown
       yamux(),
       mplex()
     ],
-    connectionEncryption: [
+    connectionEncrypters: [
       plaintext()
     ],
     services: {

--- a/packages/libp2p/test/registrar/protocols.spec.ts
+++ b/packages/libp2p/test/registrar/protocols.spec.ts
@@ -28,7 +28,7 @@ describe('registrar protocols', () => {
         yamux(),
         mplex()
       ],
-      connectionEncryption: [
+      connectionEncrypters: [
         plaintext()
       ],
       services: {

--- a/packages/libp2p/test/transports/transport-manager.spec.ts
+++ b/packages/libp2p/test/transports/transport-manager.spec.ts
@@ -125,7 +125,7 @@ describe('libp2p.transportManager (dial only)', () => {
         listen: ['/ip4/127.0.0.1/tcp/0']
       },
       transports: [webSockets()],
-      connectionEncryption: [plaintext()],
+      connectionEncrypters: [plaintext()],
       start: false
     })
 
@@ -144,7 +144,7 @@ describe('libp2p.transportManager (dial only)', () => {
       transports: [
         webSockets()
       ],
-      connectionEncryption: [
+      connectionEncrypters: [
         plaintext()
       ],
       start: false
@@ -164,7 +164,7 @@ describe('libp2p.transportManager (dial only)', () => {
       transports: [
         webSockets()
       ],
-      connectionEncryption: [
+      connectionEncrypters: [
         plaintext()
       ],
       start: false

--- a/packages/libp2p/test/upgrading/upgrader.spec.ts
+++ b/packages/libp2p/test/upgrading/upgrader.spec.ts
@@ -77,10 +77,10 @@ describe('Upgrader', () => {
     localYamuxerFactory = yamux()(localComponents)
     localConnectionEncrypter = plaintext()(localComponents)
     localUpgrader = new DefaultUpgrader(localComponents, {
-      connectionEncryption: [
+      connectionEncrypters: [
         localConnectionEncrypter
       ],
-      muxers: [
+      streamMuxers: [
         localMuxerFactory,
         localYamuxerFactory
       ],
@@ -105,10 +105,10 @@ describe('Upgrader', () => {
     remoteYamuxerFactory = yamux()(remoteComponents)
     remoteConnectionEncrypter = plaintext()(remoteComponents)
     remoteUpgrader = new DefaultUpgrader(remoteComponents, {
-      connectionEncryption: [
+      connectionEncrypters: [
         remoteConnectionEncrypter
       ],
-      muxers: [
+      streamMuxers: [
         remoteMuxerFactory,
         remoteYamuxerFactory
       ],
@@ -166,17 +166,17 @@ describe('Upgrader', () => {
 
     // No available muxers
     localUpgrader = new DefaultUpgrader(localComponents, {
-      connectionEncryption: [
+      connectionEncrypters: [
         plaintext()(localComponents)
       ],
-      muxers: [],
+      streamMuxers: [],
       inboundUpgradeTimeout: 1000
     })
     remoteUpgrader = new DefaultUpgrader(remoteComponents, {
-      connectionEncryption: [
+      connectionEncrypters: [
         plaintext()(remoteComponents)
       ],
-      muxers: [],
+      streamMuxers: [],
       inboundUpgradeTimeout: 1000
     })
 
@@ -248,17 +248,17 @@ describe('Upgrader', () => {
     }
 
     localUpgrader = new DefaultUpgrader(localComponents, {
-      connectionEncryption: [
+      connectionEncrypters: [
         new BoomCrypto()
       ],
-      muxers: [],
+      streamMuxers: [],
       inboundUpgradeTimeout: 1000
     })
     remoteUpgrader = new DefaultUpgrader(remoteComponents, {
-      connectionEncryption: [
+      connectionEncrypters: [
         new BoomCrypto()
       ],
-      muxers: [],
+      streamMuxers: [],
       inboundUpgradeTimeout: 1000
     })
 
@@ -280,19 +280,19 @@ describe('Upgrader', () => {
     const { inbound, outbound } = mockMultiaddrConnPair({ addrs, remotePeer })
 
     localUpgrader = new DefaultUpgrader(localComponents, {
-      connectionEncryption: [
+      connectionEncrypters: [
         plaintext()(localComponents)
       ],
-      muxers: [
+      streamMuxers: [
         yamux()(localComponents)
       ],
       inboundUpgradeTimeout: 1000
     })
     remoteUpgrader = new DefaultUpgrader(remoteComponents, {
-      connectionEncryption: [
+      connectionEncrypters: [
         plaintext()(remoteComponents)
       ],
-      muxers: [
+      streamMuxers: [
         yamux()(remoteComponents)
       ],
       inboundUpgradeTimeout: 1000
@@ -350,20 +350,20 @@ describe('Upgrader', () => {
     }
 
     localUpgrader = new DefaultUpgrader(localComponents, {
-      connectionEncryption: [
+      connectionEncrypters: [
         plaintext()(localComponents)
       ],
-      muxers: [
+      streamMuxers: [
         new OtherMuxerFactory(),
         new OtherOtherMuxerFactory()
       ],
       inboundUpgradeTimeout: 1000
     })
     remoteUpgrader = new DefaultUpgrader(remoteComponents, {
-      connectionEncryption: [
+      connectionEncrypters: [
         plaintext()(remoteComponents)
       ],
-      muxers: [
+      streamMuxers: [
         yamux()(remoteComponents),
         mplex()(remoteComponents)
       ],
@@ -637,7 +637,7 @@ describe('libp2p.upgrader', () => {
         yamux(),
         mplex()
       ],
-      connectionEncryption: [
+      connectionEncrypters: [
         plaintext()
       ],
       connectionProtector: () => protector,
@@ -668,7 +668,7 @@ describe('libp2p.upgrader', () => {
         yamux(),
         mplex()
       ],
-      connectionEncryption: [
+      connectionEncrypters: [
         plaintext()
       ],
       services: {
@@ -689,7 +689,7 @@ describe('libp2p.upgrader', () => {
         yamux(),
         mplex()
       ],
-      connectionEncryption: [
+      connectionEncrypters: [
         plaintext()
       ],
       services: {
@@ -736,7 +736,7 @@ describe('libp2p.upgrader', () => {
         yamux(),
         mplex()
       ],
-      connectionEncryption: [
+      connectionEncrypters: [
         plaintext()
       ],
       connectionGater: mockConnectionGater(),
@@ -758,7 +758,7 @@ describe('libp2p.upgrader', () => {
         yamux(),
         mplex()
       ],
-      connectionEncryption: [
+      connectionEncrypters: [
         plaintext()
       ],
       connectionGater: mockConnectionGater(),
@@ -808,7 +808,7 @@ describe('libp2p.upgrader', () => {
       streamMuxers: [
         mplex()
       ],
-      connectionEncryption: [
+      connectionEncrypters: [
         plaintext()
       ],
       services: {
@@ -827,7 +827,7 @@ describe('libp2p.upgrader', () => {
       streamMuxers: [
         mplex()
       ],
-      connectionEncryption: [
+      connectionEncrypters: [
         plaintext()
       ],
       services: {
@@ -887,7 +887,7 @@ describe('libp2p.upgrader', () => {
       streamMuxers: [
         yamux()
       ],
-      connectionEncryption: [
+      connectionEncrypters: [
         plaintext()
       ],
       services: {
@@ -906,7 +906,7 @@ describe('libp2p.upgrader', () => {
       streamMuxers: [
         yamux()
       ],
-      connectionEncryption: [
+      connectionEncrypters: [
         plaintext()
       ],
       services: {
@@ -963,7 +963,7 @@ describe('libp2p.upgrader', () => {
       streamMuxers: [
         yamux()
       ],
-      connectionEncryption: [
+      connectionEncrypters: [
         plaintext()
       ],
       services: {
@@ -982,7 +982,7 @@ describe('libp2p.upgrader', () => {
       streamMuxers: [
         yamux()
       ],
-      connectionEncryption: [
+      connectionEncrypters: [
         plaintext()
       ],
       services: {

--- a/packages/protocol-echo/README.md
+++ b/packages/protocol-echo/README.md
@@ -41,7 +41,7 @@ const receiver = await createLibp2p({
   addresses: {
     listen: ['/ip4/0.0.0.0/tcp/0']
   },
-  connectionEncryption: [noise()],
+  connectionEncrypters: [noise()],
   streamMuxers: [yamux()],
   services: {
     echo: echo()
@@ -52,7 +52,7 @@ const sender = await createLibp2p({
   addresses: {
     listen: ['/ip4/0.0.0.0/tcp/0']
   },
-  connectionEncryption: [noise()],
+  connectionEncrypters: [noise()],
   streamMuxers: [yamux()],
   services: {
     echo: echo()

--- a/packages/protocol-echo/src/index.ts
+++ b/packages/protocol-echo/src/index.ts
@@ -18,7 +18,7 @@
  *   addresses: {
  *     listen: ['/ip4/0.0.0.0/tcp/0']
  *   },
- *   connectionEncryption: [noise()],
+ *   connectionEncrypters: [noise()],
  *   streamMuxers: [yamux()],
  *   services: {
  *     echo: echo()
@@ -29,7 +29,7 @@
  *   addresses: {
  *     listen: ['/ip4/0.0.0.0/tcp/0']
  *   },
- *   connectionEncryption: [noise()],
+ *   connectionEncrypters: [noise()],
  *   streamMuxers: [yamux()],
  *   services: {
  *     echo: echo()

--- a/packages/protocol-perf/README.md
+++ b/packages/protocol-perf/README.md
@@ -51,7 +51,7 @@ async function createNode (): Promise<Libp2p<{ perf: Perf }>> {
     transports: [
       tcp()
     ],
-    connectionEncryption: [
+    connectionEncrypters: [
       noise(), plaintext()
     ],
     streamMuxers: [

--- a/packages/protocol-perf/src/index.ts
+++ b/packages/protocol-perf/src/index.ts
@@ -28,7 +28,7 @@
  *     transports: [
  *       tcp()
  *     ],
- *     connectionEncryption: [
+ *     connectionEncrypters: [
  *       noise(), plaintext()
  *     ],
  *     streamMuxers: [

--- a/packages/transport-webrtc/.aegir.js
+++ b/packages/transport-webrtc/.aegir.js
@@ -21,7 +21,7 @@ export default {
         transports: [
           webSockets()
         ],
-        connectionEncryption: [
+        connectionEncrypters: [
           noise()
         ],
         streamMuxers: [

--- a/packages/transport-webrtc/README.md
+++ b/packages/transport-webrtc/README.md
@@ -84,7 +84,7 @@ const relay = await createLibp2p({
   transports: [
     webSockets({filter: filters.all})
   ],
-  connectionEncryption: [noise()],
+  connectionEncrypters: [noise()],
   streamMuxers: [yamux()],
   services: {
     identify: identify(),
@@ -106,7 +106,7 @@ const listener = await createLibp2p({
       discoverRelays: 1
     })
   ],
-  connectionEncryption: [noise()],
+  connectionEncrypters: [noise()],
   streamMuxers: [yamux()],
   services: {
     identify: identify(),
@@ -143,7 +143,7 @@ const dialer = await createLibp2p({
     webRTC(),
     circuitRelayTransport()
   ],
-  connectionEncryption: [noise()],
+  connectionEncrypters: [noise()],
   streamMuxers: [yamux()],
   services: {
     identify: identify(),
@@ -189,7 +189,7 @@ const node = await createLibp2p({
   transports: [
     webRTCDirect()
   ],
-  connectionEncryption: [
+  connectionEncrypters: [
     noise()
   ]
 })

--- a/packages/transport-webrtc/src/index.ts
+++ b/packages/transport-webrtc/src/index.ts
@@ -61,7 +61,7 @@
  *   transports: [
  *     webSockets({filter: filters.all})
  *   ],
- *   connectionEncryption: [noise()],
+ *   connectionEncrypters: [noise()],
  *   streamMuxers: [yamux()],
  *   services: {
  *     identify: identify(),
@@ -83,7 +83,7 @@
  *       discoverRelays: 1
  *     })
  *   ],
- *   connectionEncryption: [noise()],
+ *   connectionEncrypters: [noise()],
  *   streamMuxers: [yamux()],
  *   services: {
  *     identify: identify(),
@@ -120,7 +120,7 @@
  *     webRTC(),
  *     circuitRelayTransport()
  *   ],
- *   connectionEncryption: [noise()],
+ *   connectionEncrypters: [noise()],
  *   streamMuxers: [yamux()],
  *   services: {
  *     identify: identify(),
@@ -166,7 +166,7 @@
  *   transports: [
  *     webRTCDirect()
  *   ],
- *   connectionEncryption: [
+ *   connectionEncrypters: [
  *     noise()
  *   ]
  * })

--- a/packages/transport-webrtc/test/basics.spec.ts
+++ b/packages/transport-webrtc/test/basics.spec.ts
@@ -35,7 +35,7 @@ async function createNode (): Promise<Libp2p> {
       circuitRelayTransport(),
       webRTC()
     ],
-    connectionEncryption: [
+    connectionEncrypters: [
       noise()
     ],
     streamMuxers: [

--- a/packages/transport-webtransport/README.md
+++ b/packages/transport-webtransport/README.md
@@ -43,7 +43,7 @@ const node = await createLibp2p({
   transports: [
     webTransport()
   ],
-  connectionEncryption: [
+  connectionEncrypters: [
     noise()
   ]
 })

--- a/packages/transport-webtransport/src/index.ts
+++ b/packages/transport-webtransport/src/index.ts
@@ -22,7 +22,7 @@
  *   transports: [
  *     webTransport()
  *   ],
- *   connectionEncryption: [
+ *   connectionEncrypters: [
  *     noise()
  *   ]
  * })

--- a/packages/transport-webtransport/test/browser.ts
+++ b/packages/transport-webtransport/test/browser.ts
@@ -17,7 +17,7 @@ describe('libp2p-webtransport', () => {
   beforeEach(async () => {
     node = await createLibp2p({
       transports: [webTransport()],
-      connectionEncryption: [noise()],
+      connectionEncrypters: [noise()],
       connectionGater: {
         denyDialMultiaddr: async () => false
       },


### PR DESCRIPTION
To make the options more consistent, rename `connectionEncryption` to `connectionEncrypters` in line with `streamMuxers`, `transports`, etc.

BREAKING CHANGE: the `connectionEncryption` option has been renamed `connectionEncrypters`

## Change checklist

- [x] I have performed a self-review of my own code
- [x] I have made corresponding changes to the documentation if necessary (this includes comments as well)
- [x] I have added tests that prove my fix is effective or that my feature works