### PR TITLE
fix: add public/private key type disambiguators

### DIFF
--- a/packages/crypto/test/keys/ed25519.spec.ts
+++ b/packages/crypto/test/keys/ed25519.spec.ts
@@ -1,4 +1,5 @@
 /* eslint-env mocha */
+import { isPrivateKey, isPublicKey } from '@libp2p/interface'
 import { expect } from 'aegir/chai'
 import { Uint8ArrayList } from 'uint8arraylist'
 import { fromString as uint8ArrayFromString } from 'uint8arrays/from-string'
@@ -154,6 +155,20 @@ describe('ed25519', function () {
     const imported = publicKeyFromRaw(key.publicKey.raw)
 
     expect(key.publicKey.equals(imported)).to.be.true()
+  })
+
+  it('is PrivateKey', async () => {
+    const key = await generateKeyPair('Ed25519')
+
+    expect(isPrivateKey(key)).to.be.true()
+    expect(isPublicKey(key)).to.be.false()
+  })
+
+  it('is PublicKey', async () => {
+    const key = await generateKeyPair('Ed25519')
+
+    expect(isPrivateKey(key.publicKey)).to.be.false()
+    expect(isPublicKey(key.publicKey)).to.be.true()
   })
 
   describe('go interop', () => {

--- a/packages/crypto/test/keys/rsa.spec.ts
+++ b/packages/crypto/test/keys/rsa.spec.ts
@@ -1,5 +1,6 @@
 /* eslint max-nested-callbacks: ["error", 8] */
 /* eslint-env mocha */
+import { isPrivateKey, isPublicKey } from '@libp2p/interface'
 import { expect } from 'aegir/chai'
 import { Uint8ArrayList } from 'uint8arraylist'
 import { fromString as uint8ArrayFromString } from 'uint8arrays/from-string'
@@ -113,6 +114,20 @@ describe('RSA', function () {
     const imported = publicKeyFromRaw(key.publicKey.raw)
 
     expect(key.publicKey.equals(imported)).to.be.true()
+  })
+
+  it('is PrivateKey', async () => {
+    const key = await generateKeyPair('RSA', 512)
+
+    expect(isPrivateKey(key)).to.be.true()
+    expect(isPublicKey(key)).to.be.false()
+  })
+
+  it('is PublicKey', async () => {
+    const key = await generateKeyPair('RSA', 512)
+
+    expect(isPrivateKey(key.publicKey)).to.be.false()
+    expect(isPublicKey(key.publicKey)).to.be.true()
   })
 
   describe('key equals', () => {

--- a/packages/crypto/test/keys/secp256k1.spec.ts
+++ b/packages/crypto/test/keys/secp256k1.spec.ts
@@ -1,5 +1,6 @@
 /* eslint-disable @typescript-eslint/await-thenable */ // secp is sync in node, async in browsers
 /* eslint-env mocha */
+import { isPrivateKey, isPublicKey } from '@libp2p/interface'
 import { expect } from 'aegir/chai'
 import { Uint8ArrayList } from 'uint8arraylist'
 import { fromString as uint8ArrayFromString } from 'uint8arrays/from-string'
@@ -81,6 +82,20 @@ describe('secp256k1 keys', () => {
     const imported = publicKeyFromRaw(key.publicKey.raw)
 
     expect(key.publicKey.equals(imported)).to.be.true()
+  })
+
+  it('is PrivateKey', async () => {
+    const key = await generateKeyPair('secp256k1')
+
+    expect(isPrivateKey(key)).to.be.true()
+    expect(isPublicKey(key)).to.be.false()
+  })
+
+  it('is PublicKey', async () => {
+    const key = await generateKeyPair('secp256k1')
+
+    expect(isPrivateKey(key.publicKey)).to.be.false()
+    expect(isPublicKey(key.publicKey)).to.be.true()
   })
 
   describe('key equals', () => {

--- a/packages/interface/src/keys/index.ts
+++ b/packages/interface/src/keys/index.ts
@@ -57,6 +57,23 @@ export interface Secp256k1PublicKey extends PublicKeyBase<'secp256k1', 0x0> {}
 export type PublicKey = RSAPublicKey | Ed25519PublicKey | Secp256k1PublicKey
 
 /**
+ * Returns true if the passed argument has type overlap with the `PublicKey`
+ * interface. Can be used to disambiguate object types.
+ */
+export function isPublicKey (key?: any): key is PublicKey {
+  if (key == null) {
+    return false
+  }
+
+  return (key.type === 'RSA' || key.type === 'Ed25519' || key.type === 'secp256k1') &&
+    key.raw instanceof Uint8Array &&
+    typeof key.equals === 'function' &&
+    typeof key.toMultihash === 'function' &&
+    typeof key.toCID === 'function' &&
+    typeof key.verify === 'function'
+}
+
+/**
  * Generic private key interface
  */
 interface PrivateKeyBase<KeyType extends string, PublicKeyType extends PublicKeyBase<KeyType>> {
@@ -92,3 +109,19 @@ export interface RSAPrivateKey extends PrivateKeyBase<'RSA', RSAPublicKey> {}
 export interface Ed25519PrivateKey extends PrivateKeyBase<'Ed25519', Ed25519PublicKey> {}
 export interface Secp256k1PrivateKey extends PrivateKeyBase<'secp256k1', Secp256k1PublicKey> {}
 export type PrivateKey = RSAPrivateKey | Ed25519PrivateKey | Secp256k1PrivateKey
+
+/**
+ * Returns true if the passed argument has type overlap with the `PrivateKey`
+ * interface. Can be used to disambiguate object types.
+ */
+export function isPrivateKey (key?: any): key is PrivateKey {
+  if (key == null) {
+    return false
+  }
+
+  return (key.type === 'RSA' || key.type === 'Ed25519' || key.type === 'secp256k1') &&
+    isPublicKey(key.publicKey) &&
+    key.raw instanceof Uint8Array &&
+    typeof key.equals === 'function' &&
+    typeof key.sign === 'function'
+}


### PR DESCRIPTION
To give typescript some hints about object types, add `isPrivateKey` and `isPublicKey` functions.

## Change checklist

- [x] I have performed a self-review of my own code
- [x] I have made corresponding changes to the documentation if necessary (this includes comments as well)
- [x] I have added tests that prove my fix is effective or that my feature works