### PR TITLE
fix: allow importing the self key

### DIFF
--- a/packages/keychain/src/keychain.ts
+++ b/packages/keychain/src/keychain.ts
@@ -196,7 +196,7 @@ export class Keychain implements KeychainInterface {
   }
 
   async importKey (name: string, key: PrivateKey): Promise<KeyInfo> {
-    if (!validateKeyName(name) || name === 'self') {
+    if (!validateKeyName(name)) {
       await randomDelay()
       throw new InvalidParametersError(`Invalid key name '${name}'`)
     }

--- a/packages/keychain/test/keychain.spec.ts
+++ b/packages/keychain/test/keychain.spec.ts
@@ -174,13 +174,6 @@ describe('keychain', () => {
       const importedKey = await ks.importKey(keyName, exportedKey)
       expect(importedKey.id).to.eql(keyInfo.id)
     })
-
-    it('cannot create the "self" key', async () => {
-      const key = await generateKeyPair('Ed25519')
-
-      await expect(ks.importKey('self', key)).to.eventually.be.rejected
-        .with.property('name', 'InvalidParametersError')
-    })
   })
 
   describe('query', () => {
@@ -265,11 +258,6 @@ describe('keychain', () => {
 
     it('does not overwrite existing key', async () => {
       await expect(ks.renameKey(rsaKeyName, rsaKeyName)).to.eventually.be.rejected
-        .with.property('name', 'InvalidParametersError')
-    })
-
-    it('cannot create the "self" key', async () => {
-      await expect(ks.renameKey(rsaKeyName, 'self')).to.eventually.be.rejected
         .with.property('name', 'InvalidParametersError')
     })
 


### PR DESCRIPTION
Because the keychain doesn't create keys, only accepts them, allow importing the "self" key.

If the key already exists it will fail, and you still can't remove or rename it.

## Change checklist

- [x] I have performed a self-review of my own code
- [ ] I have made corresponding changes to the documentation if necessary (this includes comments as well)
- [ ] I have added tests that prove my fix is effective or that my feature works