### PR TITLE
feat: add histogram and summary metric types

### DIFF
--- a/packages/interface-compliance-tests/package.json
+++ b/packages/interface-compliance-tests/package.json
@@ -138,10 +138,12 @@
     "p-wait-for": "^5.0.2",
     "protons-runtime": "^5.4.0",
     "sinon": "^18.0.0",
+    "tdigest": "^0.1.2",
     "uint8arraylist": "^2.4.8",
     "uint8arrays": "^5.1.0"
   },
   "devDependencies": {
+    "@types/tdigest": "^0.1.4",
     "protons": "^7.5.0"
   }
 }

--- a/packages/interface-compliance-tests/src/mocks/metrics.ts
+++ b/packages/interface-compliance-tests/src/mocks/metrics.ts
@@ -216,7 +216,6 @@ class DefaultSummaryGroup implements SummaryGroup {
   }
 }
 
-
 class MockMetrics implements Metrics {
   public metrics = new Map<string, any>()
 

--- a/packages/interface/src/metrics/index.ts
+++ b/packages/interface/src/metrics/index.ts
@@ -142,6 +142,146 @@ export interface CounterGroup<T extends string = any> {
   reset(): void
 }
 
+export interface HistogramOptions extends MetricOptions {
+  /**
+   * Buckets for the histogram
+   */
+  buckets?: number[]
+}
+
+/**
+ * Create tracked metrics that are expensive to calculate by passing
+ * a function that is only invoked when metrics are being scraped
+ */
+export interface CalculatedHistogramOptions<T = number> extends HistogramOptions {
+  /**
+   * An optional function invoked to calculate the component metric instead of
+   * using `.observe`
+   */
+  calculate: CalculateMetric<T>
+}
+
+export interface Histogram {
+  /**
+   * Observe the passed value
+   */
+  observe(value: number): void
+
+  /**
+   * Reset this histogram to its default value
+   */
+  reset(): void
+
+  /**
+   * Start a timed metric, call the returned function to
+   * stop the timer
+   */
+  timer(): StopTimer
+}
+
+export interface HistogramGroup<T extends string = any> {
+  /**
+   * Observe the passed value for the named key in the group
+   */
+  observe(values: Partial<Record<T, number>>): void
+
+  /**
+   * Reset the passed key in this histogram group to its default value
+   * or all keys if no key is passed
+   */
+  reset(): void
+
+  /**
+   * Start a timed metric for the named key in the group, call
+   * the returned function to stop the timer
+   */
+  timer(key: string): StopTimer
+}
+
+export interface SummaryOptions extends MetricOptions {
+  /**
+   * Percentiles for the summary
+   */
+  percentiles?: number[]
+
+  /**
+   * Configure how old a bucket can be before it is reset for sliding window
+   */
+  maxAgeSeconds?: number
+
+  /**
+   * Configure how many buckets in the sliding window
+   */
+  ageBuckets?: number
+
+  /**
+   * Remove entries without any new values in the last `maxAgeSeconds`
+   */
+  pruneAgedBuckets?: boolean
+
+  /**
+   * Control compression of data in t-digest
+   */
+  compressCount?: number
+}
+
+/**
+ * Create tracked metrics that are expensive to calculate by passing
+ * a function that is only invoked when metrics are being scraped
+ */
+export interface CalculatedSummaryOptions<T = number> extends SummaryOptions {
+  /**
+   * An optional function invoked to calculate the component metric instead of
+   * using `.observe`
+   */
+  calculate: CalculateMetric<T>
+}
+
+/**
+ * A tracked summary loosely based on the Summary interface exposed
+ * by the prom-client module
+ */
+export interface Summary {
+  /**
+   * Observe the passed value
+   */
+  observe(value: number): void
+
+  /**
+   * Reset this summary to its default value
+   */
+  reset(): void
+
+  /**
+   * Start a timed metric, call the returned function to
+   * stop the timer
+   */
+  timer(): StopTimer
+}
+
+/**
+ * A group of tracked summaries loosely based on the Summary interface
+ * exposed by the prom-client module
+ */
+export interface SummaryGroup<T extends string = any> {
+  /**
+   * Observe the passed value for the named key in the group
+   */
+  observe(values: Partial<Record<T, number>>): void
+
+  /**
+   * Reset the passed key in this summary group to its default value
+   * or all keys if no key is passed
+   */
+  reset(): void
+
+  /**
+   * Start a timed metric for the named key in the group, call
+   * the returned function to stop the timer
+   */
+  timer(key: string): StopTimer
+}
+
 /**
  * The libp2p metrics tracking object. This interface is only concerned
  * with the collection of metrics, please see the individual implementations
@@ -322,4 +462,30 @@ export interface Metrics {
    * method on the returned counter group object
    */
   registerCounterGroup: ((name: string, options?: MetricOptions) => CounterGroup) & ((name: string, options: CalculatedMetricOptions<Record<string, number>>) => void)
+
+  /**
+   * Register an arbitrary histogram. Call this to set help/labels for histograms
+   * and observe them by calling methods on the returned histogram object
+   */
+  registerHistogram: ((name: string, options?: HistogramOptions) => Histogram) & ((name: string, options: CalculatedHistogramOptions) => void)
+
+  /**
+   * Register a a group of related histograms. Call this to set help/labels for
+   * groups of related histograms that will be updated with by calling the `.observe`
+   * method on the returned histogram group object
+   */
+  registerHistogramGroup: ((name: string, options?: HistogramOptions) => HistogramGroup) & ((name: string, options: CalculatedHistogramOptions<Record<string, number>>) => void)
+
+  /**
+   * Register an arbitrary summary. Call this to set help/labels for summaries
+   * and observe them by calling methods on the returned summary object
+   */
+  registerSummary: ((name: string, options?: SummaryOptions) => Summary) & ((name: string, options: CalculatedSummaryOptions) => void)
+
+  /**
+   * Register a a group of related summaries. Call this to set help/labels for
+   * groups of related summaries that will be updated with by calling the `.observe`
+   * method on the returned summary group object
+   */
+  registerSummaryGroup: ((name: string, options?: SummaryOptions) => SummaryGroup) & ((name: string, options: CalculatedSummaryOptions<Record<string, number>>) => void)
 }

--- a/packages/metrics-devtools/src/index.ts
+++ b/packages/metrics-devtools/src/index.ts
@@ -218,6 +218,22 @@ class DevToolsMetrics implements Metrics, Startable {
     return this.simpleMetrics.registerCounterGroup(name, options)
   }
 
+  registerHistogram (name: any, options: any): any {
+    return this.simpleMetrics.registerHistogram(name, options)
+  }
+
+  registerHistogramGroup (name: any, options: any): any {
+    return this.simpleMetrics.registerHistogramGroup(name, options)
+  }
+
+  registerSummary (name: any, options: any): any {
+    return this.simpleMetrics.registerSummary(name, options)
+  }
+
+  registerSummaryGroup (name: any, options: any): any {
+    return this.simpleMetrics.registerSummaryGroup(name, options)
+  }
+
   async start (): Promise<void> {
     // send peer updates
     this.components.events.addEventListener('peer:connect', this.onPeersUpdate)

--- a/packages/metrics-prometheus/src/histogram-group.ts
+++ b/packages/metrics-prometheus/src/histogram-group.ts
@@ -1,0 +1,63 @@
+import { type CollectFunction, Histogram as PromHistogram } from 'prom-client'
+import { normaliseString, type CalculatedMetric } from './utils.js'
+import type { PrometheusCalculatedHistogramOptions } from './index.js'
+import type { CalculateMetric, HistogramGroup, StopTimer } from '@libp2p/interface'
+
+export class PrometheusHistogramGroup implements HistogramGroup, CalculatedMetric<Record<string, number>> {
+  private readonly histogram: PromHistogram
+  private readonly label: string
+  private readonly calculators: Array<CalculateMetric<Record<string, number>>>
+
+  constructor (name: string, opts: PrometheusCalculatedHistogramOptions<Record<string, number>>) {
+    name = normaliseString(name)
+    const help = normaliseString(opts.help ?? name)
+    const label = this.label = normaliseString(opts.label ?? name)
+    let collect: CollectFunction<PromHistogram<any>> | undefined
+    this.calculators = []
+
+    // calculated metric
+    if (opts?.calculate != null) {
+      this.calculators.push(opts.calculate)
+      const self = this
+
+      collect = async function () {
+        await Promise.all(self.calculators.map(async calculate => {
+          const values = await calculate()
+
+          Object.entries(values).forEach(([key, value]) => {
+            this.observe({ [label]: key }, value)
+          })
+        }))
+      }
+    }
+
+    this.histogram = new PromHistogram({
+      name,
+      help,
+      buckets: opts.buckets ?? [0.005, 0.01, 0.025, 0.05, 0.1, 0.25, 0.5, 1, 2.5, 5, 10],
+      labelNames: [this.label],
+      registers: opts.registry !== undefined ? [opts.registry] : undefined,
+      collect
+    })
+  }
+
+  addCalculator (calculator: CalculateMetric<Record<string, number>>): void {
+    this.calculators.push(calculator)
+  }
+
+  observe (values: Record<string, number>): void {
+    Object.entries(values).forEach(([key, value]) => {
+      this.histogram.observe({ [this.label]: key }, value)
+    })
+  }
+
+  reset (): void {
+    this.histogram.reset()
+  }
+
+  timer (key: string): StopTimer {
+    return this.histogram.startTimer({
+      [key]: 0
+    })
+  }
+}

--- a/packages/metrics-prometheus/src/histogram.ts
+++ b/packages/metrics-prometheus/src/histogram.ts
@@ -1,0 +1,55 @@
+import { type CollectFunction, Histogram as PromHistogram } from 'prom-client'
+import { normaliseString } from './utils.js'
+import type { PrometheusCalculatedHistogramOptions } from './index.js'
+import type { StopTimer, CalculateMetric, Histogram } from '@libp2p/interface'
+
+export class PrometheusHistogram implements Histogram {
+  private readonly histogram: PromHistogram
+  private readonly calculators: CalculateMetric[]
+
+  constructor (name: string, opts: PrometheusCalculatedHistogramOptions) {
+    name = normaliseString(name)
+    const help = normaliseString(opts.help ?? name)
+    const labels = opts.label != null ? [normaliseString(opts.label)] : []
+    let collect: CollectFunction<PromHistogram<any>> | undefined
+    this.calculators = []
+
+    // calculated metric
+    if (opts?.calculate != null) {
+      this.calculators.push(opts.calculate)
+      const self = this
+
+      collect = async function () {
+        const values = await Promise.all(self.calculators.map(async calculate => calculate()))
+        for (const value of values) {
+          this.observe(value)
+        }
+      }
+    }
+
+    this.histogram = new PromHistogram({
+      name,
+      help,
+      buckets: opts.buckets ?? [0.005, 0.01, 0.025, 0.05, 0.1, 0.25, 0.5, 1, 2.5, 5, 10],
+      labelNames: labels,
+      registers: opts.registry !== undefined ? [opts.registry] : undefined,
+      collect
+    })
+  }
+
+  addCalculator (calculator: CalculateMetric): void {
+    this.calculators.push(calculator)
+  }
+
+  observe (value: number): void {
+    this.histogram.observe(value)
+  }
+
+  reset (): void {
+    this.histogram.reset()
+  }
+
+  timer (): StopTimer {
+    return this.histogram.startTimer()
+  }
+}

--- a/packages/metrics-prometheus/src/summary-group.ts
+++ b/packages/metrics-prometheus/src/summary-group.ts
@@ -1,0 +1,67 @@
+import { type CollectFunction, Summary as PromSummary } from 'prom-client'
+import { normaliseString, type CalculatedMetric } from './utils.js'
+import type { PrometheusCalculatedSummaryOptions } from './index.js'
+import type { CalculateMetric, SummaryGroup, StopTimer } from '@libp2p/interface'
+
+export class PrometheusSummaryGroup implements SummaryGroup, CalculatedMetric<Record<string, number>> {
+  private readonly summary: PromSummary
+  private readonly label: string
+  private readonly calculators: Array<CalculateMetric<Record<string, number>>>
+
+  constructor (name: string, opts: PrometheusCalculatedSummaryOptions<Record<string, number>>) {
+    name = normaliseString(name)
+    const help = normaliseString(opts.help ?? name)
+    const label = this.label = normaliseString(opts.label ?? name)
+    let collect: CollectFunction<PromSummary<any>> | undefined
+    this.calculators = []
+
+    // calculated metric
+    if (opts?.calculate != null) {
+      this.calculators.push(opts.calculate)
+      const self = this
+
+      collect = async function () {
+        await Promise.all(self.calculators.map(async calculate => {
+          const values = await calculate()
+
+          Object.entries(values).forEach(([key, value]) => {
+            this.observe({ [label]: key }, value)
+          })
+        }))
+      }
+    }
+
+    this.summary = new PromSummary({
+      name,
+      help,
+      percentiles: opts.percentiles ?? [0.01, 0.05, 0.5, 0.9, 0.95, 0.99, 0.999],
+      maxAgeSeconds: opts.maxAgeSeconds,
+      ageBuckets: opts.ageBuckets,
+      pruneAgedBuckets: opts.pruneAgedBuckets,
+      compressCount: opts.compressCount ?? 1000,
+      labelNames: [this.label],
+      registers: opts.registry !== undefined ? [opts.registry] : undefined,
+      collect
+    })
+  }
+
+  addCalculator (calculator: CalculateMetric<Record<string, number>>): void {
+    this.calculators.push(calculator)
+  }
+
+  observe (values: Record<string, number>): void {
+    Object.entries(values).forEach(([key, value]) => {
+      this.summary.observe({ [this.label]: key }, value)
+    })
+  }
+
+  reset (): void {
+    this.summary.reset()
+  }
+
+  timer (key: string): StopTimer {
+    return this.summary.startTimer({
+      [key]: 0
+    })
+  }
+}

--- a/packages/metrics-prometheus/src/summary.ts
+++ b/packages/metrics-prometheus/src/summary.ts
@@ -1,0 +1,59 @@
+import { type CollectFunction, Summary as PromSummary } from 'prom-client'
+import { normaliseString } from './utils.js'
+import type { PrometheusCalculatedSummaryOptions } from './index.js'
+import type { StopTimer, CalculateMetric, Summary } from '@libp2p/interface'
+
+export class PrometheusSummary implements Summary {
+  private readonly summary: PromSummary
+  private readonly calculators: CalculateMetric[]
+
+  constructor (name: string, opts: PrometheusCalculatedSummaryOptions) {
+    name = normaliseString(name)
+    const help = normaliseString(opts.help ?? name)
+    const labels = opts.label != null ? [normaliseString(opts.label)] : []
+    let collect: CollectFunction<PromSummary<any>> | undefined
+    this.calculators = []
+
+    // calculated metric
+    if (opts?.calculate != null) {
+      this.calculators.push(opts.calculate)
+      const self = this
+
+      collect = async function () {
+        const values = await Promise.all(self.calculators.map(async calculate => calculate()))
+        for (const value of values) {
+          this.observe(value)
+        }
+      }
+    }
+
+    this.summary = new PromSummary({
+      name,
+      help,
+      percentiles: opts.percentiles ?? [0.01, 0.05, 0.5, 0.9, 0.95, 0.99, 0.999],
+      maxAgeSeconds: opts.maxAgeSeconds,
+      ageBuckets: opts.ageBuckets,
+      pruneAgedBuckets: opts.pruneAgedBuckets,
+      compressCount: opts.compressCount ?? 1000,
+      labelNames: labels,
+      registers: opts.registry !== undefined ? [opts.registry] : undefined,
+      collect
+    })
+  }
+
+  addCalculator (calculator: CalculateMetric): void {
+    this.calculators.push(calculator)
+  }
+
+  observe (value: number): void {
+    this.summary.observe(value)
+  }
+
+  reset (): void {
+    this.summary.reset()
+  }
+
+  timer (): StopTimer {
+    return this.summary.startTimer()
+  }
+}

--- a/packages/metrics-prometheus/test/histogram-groups.spec.ts
+++ b/packages/metrics-prometheus/test/histogram-groups.spec.ts
@@ -1,0 +1,116 @@
+import { defaultLogger } from '@libp2p/logger'
+import { expect } from 'aegir/chai'
+import client from 'prom-client'
+import { prometheusMetrics } from '../src/index.js'
+import { randomMetricName } from './fixtures/random-metric-name.js'
+
+describe('histogram groups', () => {
+  it('should set a histogram group', async () => {
+    const metricName = randomMetricName()
+    const metricKey = randomMetricName('key_')
+    const metricLabel = randomMetricName('label_')
+    const metricValue = 5
+    const metrics = prometheusMetrics()({
+      logger: defaultLogger()
+    })
+    const metric = metrics.registerHistogramGroup(metricName, {
+      label: metricLabel
+    })
+    metric.observe({
+      [metricKey]: metricValue
+    })
+
+    await expect(client.register.metrics()).to.eventually.include(`${metricName}_sum{${metricLabel}="${metricKey}"} ${metricValue}`, 'did not include updated metric')
+  })
+
+  it('should calculate a summary group value', async () => {
+    const metricName = randomMetricName()
+    const metricKey = randomMetricName('key_')
+    const metricLabel = randomMetricName('label_')
+    const metricValue = 5
+    const metrics = prometheusMetrics()({
+      logger: defaultLogger()
+    })
+    metrics.registerHistogramGroup(metricName, {
+      label: metricLabel,
+      calculate: () => {
+        return {
+          [metricKey]: metricValue
+        }
+      }
+    })
+
+    await expect(client.register.metrics()).to.eventually.include(`${metricName}_sum{${metricLabel}="${metricKey}"} ${metricValue}`, 'did not include updated metric')
+  })
+
+  it('should promise to calculate a summary group value', async () => {
+    const metricName = randomMetricName()
+    const metricKey = randomMetricName('key_')
+    const metricLabel = randomMetricName('label_')
+    const metricValue = 5
+    const metrics = prometheusMetrics()({
+      logger: defaultLogger()
+    })
+    metrics.registerHistogramGroup(metricName, {
+      label: metricLabel,
+      calculate: async () => {
+        return {
+          [metricKey]: metricValue
+        }
+      }
+    })
+
+    await expect(client.register.metrics()).to.eventually.include(`${metricName}_sum{${metricLabel}="${metricKey}"} ${metricValue}`, 'did not include updated metric')
+  })
+
+  it('should reset a summary group', async () => {
+    const metricName = randomMetricName()
+    const metricKey = randomMetricName('key_')
+    const metricLabel = randomMetricName('label_')
+    const metricValue = 5
+    const metrics = prometheusMetrics()({
+      logger: defaultLogger()
+    })
+    const metric = metrics.registerHistogramGroup(metricName, {
+      label: metricLabel
+    })
+    metric.observe({
+      [metricKey]: metricValue
+    })
+
+    await expect(client.register.metrics()).to.eventually.include(`${metricName}_sum{${metricLabel}="${metricKey}"} ${metricValue}`, 'did not include updated metric')
+
+    metric.reset()
+
+    await expect(client.register.metrics()).to.eventually.not.include(metricKey, 'still included metric key')
+  })
+
+  it('should allow use of the same summary group from multiple reporters', async () => {
+    const metricName = randomMetricName()
+    const metricKey1 = randomMetricName('key_')
+    const metricKey2 = randomMetricName('key_')
+    const metricLabel = randomMetricName('label_')
+    const metricValue1 = 5
+    const metricValue2 = 7
+    const metrics = prometheusMetrics()({
+      logger: defaultLogger()
+    })
+    const metric1 = metrics.registerHistogramGroup(metricName, {
+      label: metricLabel
+    })
+    metric1.observe({
+      [metricKey1]: metricValue1
+    })
+    const metric2 = metrics.registerHistogramGroup(metricName, {
+      label: metricLabel
+    })
+    metric2.observe({
+      [metricKey2]: metricValue2
+    })
+
+    const reportedMetrics = await client.register.metrics()
+
+    expect(reportedMetrics).to.include(`${metricName}_sum{${metricLabel}="${metricKey1}"} ${metricValue1}`, 'did not include updated metric')
+    expect(reportedMetrics).to.include(`${metricName}_sum{${metricLabel}="${metricKey2}"} ${metricValue2}`, 'did not include updated metric')
+  })
+})

--- a/packages/metrics-prometheus/test/histograms.spec.ts
+++ b/packages/metrics-prometheus/test/histograms.spec.ts
@@ -1,0 +1,87 @@
+import { defaultLogger } from '@libp2p/logger'
+import { expect } from 'aegir/chai'
+import client from 'prom-client'
+import { prometheusMetrics } from '../src/index.js'
+import { randomMetricName } from './fixtures/random-metric-name.js'
+
+describe('histograms', () => {
+  it('should set a histogram', async () => {
+    const metricName = randomMetricName()
+    const metricValue = 5
+    const metrics = prometheusMetrics()({
+      logger: defaultLogger()
+    })
+    const metric = metrics.registerHistogram(metricName)
+    metric.observe(metricValue)
+
+    const report = await client.register.metrics()
+    expect(report).to.include(`# TYPE ${metricName} histogram`, 'did not include metric type')
+    expect(report).to.include(`${metricName}_sum ${metricValue}`, 'did not include updated metric')
+  })
+
+  it('should calculate a histogram', async () => {
+    const metricName = randomMetricName()
+    const metricValue = 5
+    const metrics = prometheusMetrics()({
+      logger: defaultLogger()
+    })
+    metrics.registerHistogram(metricName, {
+      calculate: () => {
+        return metricValue
+      }
+    })
+
+    await expect(client.register.metrics()).to.eventually.include(`${metricName}_sum ${metricValue}`, 'did not include updated metric')
+  })
+
+  it('should promise to calculate a histogram', async () => {
+    const metricName = randomMetricName()
+    const metricValue = 5
+    const metrics = prometheusMetrics()({
+      logger: defaultLogger()
+    })
+    metrics.registerHistogram(metricName, {
+      calculate: async () => {
+        return metricValue
+      }
+    })
+
+    await expect(client.register.metrics()).to.eventually.include(`${metricName}_sum ${metricValue}`, 'did not include updated metric')
+  })
+
+  it('should reset a histogram', async () => {
+    const metricName = randomMetricName()
+    const metricValue = 5
+    const metrics = prometheusMetrics()({
+      logger: defaultLogger()
+    })
+    const metric = metrics.registerHistogram(metricName)
+    metric.observe(metricValue)
+
+    await expect(client.register.metrics()).to.eventually.include(`${metricName}_sum ${metricValue}`)
+
+    metric.reset()
+
+    await expect(client.register.metrics()).to.eventually.not.include(`${metricName}_sum`, 'did not include updated metric')
+  })
+
+  it('should allow use of the same histogram from multiple reporters', async () => {
+    const metricName = randomMetricName()
+    const metricLabel = randomMetricName('label_')
+    const metricValue1 = 5
+    const metricValue2 = 7
+    const metrics = prometheusMetrics()({
+      logger: defaultLogger()
+    })
+    const metric1 = metrics.registerHistogram(metricName, {
+      label: metricLabel
+    })
+    metric1.observe(metricValue1)
+    const metric2 = metrics.registerHistogram(metricName, {
+      label: metricLabel
+    })
+    metric2.observe(metricValue2)
+
+    await expect(client.register.metrics()).to.eventually.include(`${metricName}_sum ${metricValue1 + metricValue2}`)
+  })
+})

--- a/packages/metrics-prometheus/test/summaries.spec.ts
+++ b/packages/metrics-prometheus/test/summaries.spec.ts
@@ -1,0 +1,87 @@
+import { defaultLogger } from '@libp2p/logger'
+import { expect } from 'aegir/chai'
+import client from 'prom-client'
+import { prometheusMetrics } from '../src/index.js'
+import { randomMetricName } from './fixtures/random-metric-name.js'
+
+describe('summaries', () => {
+  it('should set a summary', async () => {
+    const metricName = randomMetricName()
+    const metricValue = 5
+    const metrics = prometheusMetrics()({
+      logger: defaultLogger()
+    })
+    const metric = metrics.registerSummary(metricName)
+    metric.observe(metricValue)
+
+    const report = await client.register.metrics()
+    expect(report).to.include(`# TYPE ${metricName} summary`, 'did not include metric type')
+    expect(report).to.include(`${metricName}_sum ${metricValue}`, 'did not include updated metric')
+  })
+
+  it('should calculate a summary', async () => {
+    const metricName = randomMetricName()
+    const metricValue = 5
+    const metrics = prometheusMetrics()({
+      logger: defaultLogger()
+    })
+    metrics.registerSummary(metricName, {
+      calculate: () => {
+        return metricValue
+      }
+    })
+
+    await expect(client.register.metrics()).to.eventually.include(`${metricName}_sum ${metricValue}`, 'did not include updated metric')
+  })
+
+  it('should promise to calculate a summary', async () => {
+    const metricName = randomMetricName()
+    const metricValue = 5
+    const metrics = prometheusMetrics()({
+      logger: defaultLogger()
+    })
+    metrics.registerSummary(metricName, {
+      calculate: async () => {
+        return metricValue
+      }
+    })
+
+    await expect(client.register.metrics()).to.eventually.include(`${metricName}_sum ${metricValue}`, 'did not include updated metric')
+  })
+
+  it('should reset a summary', async () => {
+    const metricName = randomMetricName()
+    const metricValue = 5
+    const metrics = prometheusMetrics()({
+      logger: defaultLogger()
+    })
+    const metric = metrics.registerSummary(metricName)
+    metric.observe(metricValue)
+
+    await expect(client.register.metrics()).to.eventually.include(`${metricName}_sum ${metricValue}`)
+
+    metric.reset()
+
+    await expect(client.register.metrics()).to.eventually.include(`${metricName}_sum 0`, 'did not include updated metric')
+  })
+
+  it('should allow use of the same summary from multiple reporters', async () => {
+    const metricName = randomMetricName()
+    const metricLabel = randomMetricName('label_')
+    const metricValue1 = 5
+    const metricValue2 = 7
+    const metrics = prometheusMetrics()({
+      logger: defaultLogger()
+    })
+    const metric1 = metrics.registerSummary(metricName, {
+      label: metricLabel
+    })
+    metric1.observe(metricValue1)
+    const metric2 = metrics.registerSummary(metricName, {
+      label: metricLabel
+    })
+    metric2.observe(metricValue2)
+
+    await expect(client.register.metrics()).to.eventually.include(`${metricName}_sum ${metricValue1 + metricValue2}`)
+  })
+})

--- a/packages/metrics-prometheus/test/summary-groups.spec.ts
+++ b/packages/metrics-prometheus/test/summary-groups.spec.ts
@@ -82,7 +82,7 @@ describe('summary groups', () => {
 
     metric.reset()
 
-    await expect(client.register.metrics()).to.eventually.not.include(metricKey, 'still included metric key')
+    await expect(client.register.metrics()).to.eventually.include(`${metricName}_sum{${metricLabel}="${metricKey}"} 0`, 'did not include updated metric')
   })
 
   it('should allow use of the same summary group from multiple reporters', async () => {

--- a/packages/metrics-prometheus/test/summary-groups.spec.ts
+++ b/packages/metrics-prometheus/test/summary-groups.spec.ts
@@ -1,0 +1,116 @@
+import { defaultLogger } from '@libp2p/logger'
+import { expect } from 'aegir/chai'
+import client from 'prom-client'
+import { prometheusMetrics } from '../src/index.js'
+import { randomMetricName } from './fixtures/random-metric-name.js'
+
+describe('summary groups', () => {
+  it('should set a summary group', async () => {
+    const metricName = randomMetricName()
+    const metricKey = randomMetricName('key_')
+    const metricLabel = randomMetricName('label_')
+    const metricValue = 5
+    const metrics = prometheusMetrics()({
+      logger: defaultLogger()
+    })
+    const metric = metrics.registerSummaryGroup(metricName, {
+      label: metricLabel
+    })
+    metric.observe({
+      [metricKey]: metricValue
+    })
+
+    await expect(client.register.metrics()).to.eventually.include(`${metricName}_sum{${metricLabel}="${metricKey}"} ${metricValue}`, 'did not include updated metric')
+  })
+
+  it('should calculate a summary group value', async () => {
+    const metricName = randomMetricName()
+    const metricKey = randomMetricName('key_')
+    const metricLabel = randomMetricName('label_')
+    const metricValue = 5
+    const metrics = prometheusMetrics()({
+      logger: defaultLogger()
+    })
+    metrics.registerSummaryGroup(metricName, {
+      label: metricLabel,
+      calculate: () => {
+        return {
+          [metricKey]: metricValue
+        }
+      }
+    })
+
+    await expect(client.register.metrics()).to.eventually.include(`${metricName}_sum{${metricLabel}="${metricKey}"} ${metricValue}`, 'did not include updated metric')
+  })
+
+  it('should promise to calculate a summary group value', async () => {
+    const metricName = randomMetricName()
+    const metricKey = randomMetricName('key_')
+    const metricLabel = randomMetricName('label_')
+    const metricValue = 5
+    const metrics = prometheusMetrics()({
+      logger: defaultLogger()
+    })
+    metrics.registerSummaryGroup(metricName, {
+      label: metricLabel,
+      calculate: async () => {
+        return {
+          [metricKey]: metricValue
+        }
+      }
+    })
+
+    await expect(client.register.metrics()).to.eventually.include(`${metricName}_sum{${metricLabel}="${metricKey}"} ${metricValue}`, 'did not include updated metric')
+  })
+
+  it('should reset a summary group', async () => {
+    const metricName = randomMetricName()
+    const metricKey = randomMetricName('key_')
+    const metricLabel = randomMetricName('label_')
+    const metricValue = 5
+    const metrics = prometheusMetrics()({
+      logger: defaultLogger()
+    })
+    const metric = metrics.registerSummaryGroup(metricName, {
+      label: metricLabel
+    })
+    metric.observe({
+      [metricKey]: metricValue
+    })
+
+    await expect(client.register.metrics()).to.eventually.include(`${metricName}_sum{${metricLabel}="${metricKey}"} ${metricValue}`, 'did not include updated metric')
+
+    metric.reset()
+
+    await expect(client.register.metrics()).to.eventually.not.include(metricKey, 'still included metric key')
+  })
+
+  it('should allow use of the same summary group from multiple reporters', async () => {
+    const metricName = randomMetricName()
+    const metricKey1 = randomMetricName('key_')
+    const metricKey2 = randomMetricName('key_')
+    const metricLabel = randomMetricName('label_')
+    const metricValue1 = 5
+    const metricValue2 = 7
+    const metrics = prometheusMetrics()({
+      logger: defaultLogger()
+    })
+    const metric1 = metrics.registerSummaryGroup(metricName, {
+      label: metricLabel
+    })
+    metric1.observe({
+      [metricKey1]: metricValue1
+    })
+    const metric2 = metrics.registerSummaryGroup(metricName, {
+      label: metricLabel
+    })
+    metric2.observe({
+      [metricKey2]: metricValue2
+    })
+
+    const reportedMetrics = await client.register.metrics()
+
+    expect(reportedMetrics).to.include(`${metricName}_sum{${metricLabel}="${metricKey1}"} ${metricValue1}`, 'did not include updated metric')
+    expect(reportedMetrics).to.include(`${metricName}_sum{${metricLabel}="${metricKey2}"} ${metricValue2}`, 'did not include updated metric')
+  })
+})

--- a/packages/metrics-simple/package.json
+++ b/packages/metrics-simple/package.json
@@ -53,9 +53,11 @@
     "@libp2p/interface": "^2.0.1",
     "@libp2p/logger": "^5.0.1",
     "it-foreach": "^2.1.0",
-    "it-stream-types": "^2.0.1"
+    "it-stream-types": "^2.0.1",
+    "tdigest": "^0.1.2"
   },
   "devDependencies": {
+    "@types/tdigest": "^0.1.4",
     "aegir": "^44.0.1",
     "p-defer": "^4.0.1"
   }

--- a/packages/metrics-simple/src/index.ts
+++ b/packages/metrics-simple/src/index.ts
@@ -26,7 +26,8 @@
 import { serviceCapabilities } from '@libp2p/interface'
 import { logger } from '@libp2p/logger'
 import each from 'it-foreach'
-import type { Startable, MultiaddrConnection, Stream, Connection, Metric, MetricGroup, StopTimer, Metrics, CalculatedMetricOptions, MetricOptions, Counter, CounterGroup, CalculateMetric } from '@libp2p/interface'
+import { TDigest } from 'tdigest'
+import type { Startable, MultiaddrConnection, Stream, Connection, Metric, MetricGroup, StopTimer, Metrics, CalculatedMetricOptions, MetricOptions, Counter, CounterGroup, CalculateMetric, Histogram, HistogramOptions, HistogramGroup, Summary, SummaryOptions, SummaryGroup, CalculatedHistogramOptions, CalculatedSummaryOptions } from '@libp2p/interface'
 import type { Duplex } from 'it-stream-types'
 
 const log = logger('libp2p:simple-metrics')
@@ -99,6 +100,153 @@ class DefaultGroupMetric implements MetricGroup {
   }
 }
 
+class DefaultHistogram implements Histogram {
+  public bucketValues = new Map<number, number>()
+  public countValue: number = 0
+  public sumValue: number = 0
+
+  constructor (opts: HistogramOptions) {
+    const buckets = [
+      ...(opts.buckets ?? [0.005, 0.01, 0.025, 0.05, 0.1, 0.25, 0.5, 1, 2.5, 5, 10]),
+      Infinity
+    ]
+    for (const bucket of buckets) {
+      this.bucketValues.set(bucket, 0)
+    }
+  }
+
+  observe (value: number): void {
+    this.countValue++
+    this.sumValue += value
+
+    for (const [bucket, count] of this.bucketValues.entries()) {
+      if (value <= bucket) {
+        this.bucketValues.set(bucket, count + 1)
+      }
+    }
+  }
+
+  reset (): void {
+    this.countValue = 0
+    this.sumValue = 0
+    for (const bucket of this.bucketValues.keys()) {
+      this.bucketValues.set(bucket, 0)
+    }
+  }
+
+  timer (): StopTimer {
+    const start = Date.now()
+
+    return () => {
+      this.observe(Date.now() - start)
+    }
+  }
+}
+
+class DefaultHistogramGroup implements HistogramGroup {
+  public histograms: Record<string, DefaultHistogram> = {}
+
+  constructor (opts: HistogramOptions) {
+    this.histograms = {}
+  }
+
+  observe (values: Partial<Record<string, number>>): void {
+    for (const [key, value] of Object.entries(values) as Array<[string, number]>) {
+      if (this.histograms[key] === undefined) {
+        this.histograms[key] = new DefaultHistogram({})
+      }
+
+      this.histograms[key].observe(value)
+    }
+  }
+
+  reset (): void {
+    for (const histogram of Object.values(this.histograms)) {
+      histogram.reset()
+    }
+  }
+
+  timer (key: string): StopTimer {
+    const start = Date.now()
+
+    return () => {
+      this.observe({ [key]: Date.now() - start })
+    }
+  }
+}
+
+class DefaultSummary implements Summary {
+  public sumValue: number = 0
+  public countValue: number = 0
+  public percentiles: number[]
+  public tdigest = new TDigest(0.01)
+  private readonly compressCount: number
+
+  constructor (opts: SummaryOptions) {
+    this.percentiles = opts.percentiles ?? [0.01, 0.05, 0.5, 0.9, 0.95, 0.99, 0.999]
+    this.compressCount = opts.compressCount ?? 1000
+  }
+
+  observe (value: number): void {
+    this.sumValue += value
+    this.countValue++
+
+    this.tdigest.push(value)
+    if (this.tdigest.size() > this.compressCount) {
+      this.tdigest.compress()
+    }
+  }
+
+  reset (): void {
+    this.sumValue = 0
+    this.countValue = 0
+
+    this.tdigest.reset()
+  }
+
+  timer (): StopTimer {
+    const start = Date.now()
+
+    return () => {
+      this.observe(Date.now() - start)
+    }
+  }
+}
+
+class DefaultSummaryGroup implements SummaryGroup {
+  public summaries: Record<string, DefaultSummary> = {}
+  private readonly opts: SummaryOptions
+
+  constructor (opts: SummaryOptions) {
+    this.summaries = {}
+    this.opts = opts
+  }
+
+  observe (values: Record<string, number>): void {
+    for (const [key, value] of Object.entries(values)) {
+      if (this.summaries[key] === undefined) {
+        this.summaries[key] = new DefaultSummary(this.opts)
+      }
+
+      this.summaries[key].observe(value)
+    }
+  }
+
+  reset (): void {
+    for (const summary of Object.values(this.summaries)) {
+      summary.reset()
+    }
+  }
+
+  timer (key: string): StopTimer {
+    const start = Date.now()
+
+    return () => {
+      this.observe({ [key]: Date.now() - start })
+    }
+  }
+}
+
 export interface OnMetrics { (metrics: Record<string, any>): void }
 
 export interface SimpleMetricsInit {
@@ -114,7 +262,7 @@ export interface SimpleMetricsInit {
 }
 
 class SimpleMetrics implements Metrics, Startable {
-  public metrics = new Map<string, DefaultMetric | DefaultGroupMetric | CalculateMetric>()
+  public metrics = new Map<string, DefaultMetric | DefaultGroupMetric | CalculateMetric | DefaultHistogram | DefaultHistogramGroup | DefaultSummary | DefaultSummaryGroup>()
   private readonly transferStats: Map<string, number>
   private started: boolean
   private interval?: ReturnType<typeof setInterval>
@@ -164,6 +312,38 @@ class SimpleMetrics implements Metrics, Startable {
           output[name] = metric.value
         } else if (metric instanceof DefaultGroupMetric) {
           output[name] = metric.values
+        } else if (metric instanceof DefaultHistogram) {
+          output[name] = {
+            count: metric.countValue,
+            sum: metric.sumValue,
+            buckets: { ...metric.bucketValues }
+          }
+        } else if (metric instanceof DefaultHistogramGroup) {
+          output[name] = {
+            ...Object.fromEntries(Object.entries(metric.histograms).map(([key, histogram]) => {
+              return [key, {
+                count: histogram.countValue,
+                sum: histogram.sumValue,
+                buckets: { ...histogram.bucketValues }
+              }]
+            }))
+          }
+        } else if (metric instanceof DefaultSummary) {
+          output[name] = {
+            count: metric.countValue,
+            sum: metric.sumValue,
+            percentiles: Object.fromEntries(metric.percentiles.map(p => [p, metric.tdigest.percentile(p)]))
+          }
+        } else if (metric instanceof DefaultSummaryGroup) {
+          output[name] = {
+            ...Object.fromEntries(Object.entries(metric.summaries).map(([key, summary]) => {
+              return [key, {
+                count: summary.countValue,
+                sum: summary.sumValue,
+                percentiles: Object.fromEntries(summary.percentiles.map(p => [p, summary.tdigest.percentile(p)]))
+              }]
+            }))
+          }
         } else {
           output[name] = await metric()
         }
@@ -291,6 +471,82 @@ class SimpleMetrics implements Metrics, Startable {
     }
 
     const metric = new DefaultGroupMetric()
+    this.metrics.set(name, metric)
+
+    return metric
+  }
+
+  registerHistogram (name: string, opts: CalculatedHistogramOptions): void
+  registerHistogram (name: string, opts?: HistogramOptions): Histogram
+  registerHistogram (name: string, opts: any = {}): any {
+    if (name == null || name.trim() === '') {
+      throw new Error('Metric name is required')
+    }
+
+    if (opts?.calculate != null) {
+      // calculated metric
+      this.metrics.set(name, opts.calculate)
+      return
+    }
+
+    const metric = new DefaultHistogram(opts)
+    this.metrics.set(name, metric)
+
+    return metric
+  }
+
+  registerHistogramGroup (name: string, opts: CalculatedHistogramOptions<Record<string, number>>): void
+  registerHistogramGroup (name: string, opts?: HistogramOptions): HistogramGroup
+  registerHistogramGroup (name: string, opts: any = {}): any {
+    if (name == null || name.trim() === '') {
+      throw new Error('Metric name is required')
+    }
+
+    if (opts?.calculate != null) {
+      // calculated metric
+      this.metrics.set(name, opts.calculate)
+      return
+    }
+
+    const metric = new DefaultHistogramGroup(opts)
+    this.metrics.set(name, metric)
+
+    return metric
+  }
+
+  registerSummary (name: string, opts: CalculatedSummaryOptions): void
+  registerSummary (name: string, opts?: SummaryOptions): Summary
+  registerSummary (name: string, opts: any = {}): any {
+    if (name == null || name.trim() === '') {
+      throw new Error('Metric name is required')
+    }
+
+    if (opts?.calculate != null) {
+      // calculated metric
+      this.metrics.set(name, opts.calculate)
+      return
+    }
+
+    const metric = new DefaultSummary(opts)
+    this.metrics.set(name, metric)
+
+    return metric
+  }
+
+  registerSummaryGroup (name: string, opts: CalculatedSummaryOptions<Record<string, number>>): void
+  registerSummaryGroup (name: string, opts?: SummaryOptions): SummaryGroup
+  registerSummaryGroup (name: string, opts: any = {}): any {
+    if (name == null || name.trim() === '') {
+      throw new Error('Metric name is required')
+    }
+
+    if (opts?.calculate != null) {
+      // calculated metric
+      this.metrics.set(name, opts.calculate)
+      return
+    }
+
+    const metric = new DefaultSummaryGroup(opts)
     this.metrics.set(name, metric)
 
     return metric


### PR DESCRIPTION
## Description

- Add `Histogram`, `HistogramGroup`, `Summary`, `SummaryGroup` metric types
- Add `registerHistogram`, `registerHistogramGroup`, `registerSummary`, `registerSummaryGroup` methods to `Metrics` interface
- Add corresponding implementations to prometheus and simple metrics packages

## Change checklist

- [x] I have performed a self-review of my own code
- [ ] I have made corresponding changes to the documentation if necessary (this includes comments as well)
- [x] I have added tests that prove my fix is effective or that my feature works