### PR TITLE
feat: add isPubSub method to detect PubSub implementations

### DIFF
--- a/packages/interface-compliance-tests/src/pubsub/api.ts
+++ b/packages/interface-compliance-tests/src/pubsub/api.ts
@@ -1,4 +1,4 @@
-import { isStartable, start, stop } from '@libp2p/interface'
+import { isPubSub, isStartable, start, stop } from '@libp2p/interface'
 import { expect } from 'aegir/chai'
 import delay from 'delay'
 import pDefer from 'p-defer'
@@ -37,6 +37,10 @@ export default (common: TestSetup<PubSub, PubSubArgs>): void => {
       await stop(...Object.values(components))
       await common.teardown()
       mockNetwork.reset()
+    })
+
+    it('is a PubSub implementation', () => {
+      expect(isPubSub(pubsub)).to.be.true()
     })
 
     it('can start correctly', async () => {

--- a/packages/interface/src/pubsub/index.ts
+++ b/packages/interface/src/pubsub/index.ts
@@ -268,3 +268,19 @@ export interface PeerStreamEvents {
   'stream:outbound': CustomEvent<never>
   'close': CustomEvent<never>
 }
+
+export function isPubSub (obj?: any): obj is PubSub {
+  if (obj == null) {
+    return false
+  }
+
+  return obj.globalSignaturePolicy != null &&
+    Array.isArray(obj.multicodecs) &&
+    obj.topicValidators != null &&
+    typeof obj.getPeers === 'function' &&
+    typeof obj.getTopics === 'function' &&
+    typeof obj.subscribe === 'function' &&
+    typeof obj.unsubscribe === 'function' &&
+    typeof obj.getSubscribers === 'function' &&
+    typeof obj.publish === 'function'
+}

--- a/packages/interface/src/pubsub/index.ts
+++ b/packages/interface/src/pubsub/index.ts
@@ -269,18 +269,15 @@ export interface PeerStreamEvents {
   'close': CustomEvent<never>
 }
 
-export function isPubSub (obj?: any): obj is PubSub {
-  if (obj == null) {
-    return false
-  }
+/**
+ * All Pubsub implementations must use this symbol as the name of a property
+ * with a boolean `true` value
+ */
+export const pubSubSymbol = Symbol.for('@libp2p/pubsub')
 
-  return obj.globalSignaturePolicy != null &&
-    Array.isArray(obj.multicodecs) &&
-    obj.topicValidators != null &&
-    typeof obj.getPeers === 'function' &&
-    typeof obj.getTopics === 'function' &&
-    typeof obj.subscribe === 'function' &&
-    typeof obj.unsubscribe === 'function' &&
-    typeof obj.getSubscribers === 'function' &&
-    typeof obj.publish === 'function'
+/**
+ * Returns true if the passed argument is a PubSub implementation
+ */
+export function isPubSub (obj?: any): obj is PubSub {
+  return Boolean(obj?.[pubSubSymbol])
 }

--- a/packages/pubsub-floodsub/src/index.ts
+++ b/packages/pubsub-floodsub/src/index.ts
@@ -32,7 +32,7 @@
  * ```
  */
 
-import { serviceDependencies } from '@libp2p/interface'
+import { pubSubSymbol, serviceDependencies } from '@libp2p/interface'
 import { PubSubBaseProtocol, type PubSubComponents } from '@libp2p/pubsub'
 import { toString } from 'uint8arrays/to-string'
 import { SimpleTimeCache } from './cache.js'
@@ -77,6 +77,8 @@ export class FloodSub extends PubSubBaseProtocol {
       validityMs: init?.seenTTL ?? 30000
     })
   }
+
+  readonly [pubSubSymbol] = true
 
   readonly [Symbol.toStringTag] = '@libp2p/floodsub'
 

--- a/packages/pubsub-floodsub/test/floodsub.spec.ts
+++ b/packages/pubsub-floodsub/test/floodsub.spec.ts
@@ -1,7 +1,7 @@
 /* eslint-env mocha */
 
 import { generateKeyPair } from '@libp2p/crypto/keys'
-import { type Message, type PubSubRPC, StrictNoSign, isPubSub } from '@libp2p/interface'
+import { type Message, type PubSubRPC, StrictNoSign } from '@libp2p/interface'
 import { mockRegistrar } from '@libp2p/interface-compliance-tests/mocks'
 import { defaultLogger } from '@libp2p/logger'
 import { PeerSet } from '@libp2p/peer-collections'

--- a/packages/pubsub-floodsub/test/floodsub.spec.ts
+++ b/packages/pubsub-floodsub/test/floodsub.spec.ts
@@ -47,10 +47,6 @@ describe('floodsub', () => {
     await floodsub.stop()
   })
 
-  it('is a PubSub implementation', () => {
-    expect(isPubSub(floodsub)).to.be.true()
-  })
-
   it('checks cache when processing incoming message', async function () {
     const otherPeer = peerIdFromPrivateKey(await generateKeyPair('Ed25519'))
     const sig = await sha256.encode(message)

--- a/packages/pubsub-floodsub/test/floodsub.spec.ts
+++ b/packages/pubsub-floodsub/test/floodsub.spec.ts
@@ -1,7 +1,7 @@
 /* eslint-env mocha */
 
 import { generateKeyPair } from '@libp2p/crypto/keys'
-import { type Message, type PubSubRPC, StrictNoSign } from '@libp2p/interface'
+import { type Message, type PubSubRPC, StrictNoSign, isPubSub } from '@libp2p/interface'
 import { mockRegistrar } from '@libp2p/interface-compliance-tests/mocks'
 import { defaultLogger } from '@libp2p/logger'
 import { PeerSet } from '@libp2p/peer-collections'
@@ -45,6 +45,10 @@ describe('floodsub', () => {
   afterEach(async () => {
     sinon.restore()
     await floodsub.stop()
+  })
+
+  it('is a PubSub implementation', () => {
+    expect(isPubSub(floodsub)).to.be.true()
   })
 
   it('checks cache when processing incoming message', async function () {


### PR DESCRIPTION
Adds a type disambiguator function to signal to tsc that an object implements the PubSub interface.

## Change checklist

- [x] I have performed a self-review of my own code
- [ ] I have made corresponding changes to the documentation if necessary (this includes comments as well)
- [ ] I have added tests that prove my fix is effective or that my feature works