### PR TITLE
feat: add capability detection to metrics-devtools

### DIFF
--- a/packages/metrics-devtools/package.json
+++ b/packages/metrics-devtools/package.json
@@ -64,7 +64,8 @@
     "doc-check": "aegir doc-check",
     "build": "aegir build",
     "test": "aegir test -t browser",
-    "test:chrome": "aegir test -t browser --cov"
+    "test:chrome": "aegir test -t browser --cov",
+    "test:firefox": "aegir test -t browser --browser firefox"
   },
   "dependencies": {
     "@libp2p/interface": "^2.0.1",

--- a/packages/metrics-devtools/src/utils/find-capability.ts
+++ b/packages/metrics-devtools/src/utils/find-capability.ts
@@ -1,0 +1,9 @@
+import { gatherCapabilities } from './gather-capabilities.js'
+
+export function findCapability (capability: string, components: any): any | undefined {
+  for (const [name, capabilities] of Object.entries(gatherCapabilities(components))) {
+    if (capabilities.includes(capability)) {
+      return components[name]
+    }
+  }
+}

--- a/packages/metrics-devtools/src/utils/gather-capabilities.ts
+++ b/packages/metrics-devtools/src/utils/gather-capabilities.ts
@@ -2,7 +2,7 @@ import { serviceCapabilities } from '@libp2p/interface'
 
 export function gatherCapabilities (components: any): Record<string, string[]> {
   const capabilities: Record<string, string[]> = {}
-  const services: Record<string, any> = components.components
+  const services: Record<string, any> = components.components ?? components
 
   Object.entries(services).forEach(([name, component]) => {
     if (component?.[serviceCapabilities] != null && Array.isArray(component[serviceCapabilities])) {

--- a/packages/metrics-devtools/src/utils/gather-capabilities.ts
+++ b/packages/metrics-devtools/src/utils/gather-capabilities.ts
@@ -1,0 +1,14 @@
+import { serviceCapabilities } from '@libp2p/interface'
+
+export function gatherCapabilities (components: any): Record<string, string[]> {
+  const capabilities: Record<string, string[]> = {}
+  const services: Record<string, any> = components.components
+
+  Object.entries(services).forEach(([name, component]) => {
+    if (component?.[serviceCapabilities] != null && Array.isArray(component[serviceCapabilities])) {
+      capabilities[name] = component[serviceCapabilities]
+    }
+  })
+
+  return capabilities
+}

--- a/packages/metrics-devtools/src/utils/get-pubsub.ts
+++ b/packages/metrics-devtools/src/utils/get-pubsub.ts
@@ -1,0 +1,12 @@
+import { InvalidParametersError, isPubSub } from '@libp2p/interface'
+import type { PubSub } from '@libp2p/interface'
+
+export function getPubSub (component: string, components: any): PubSub {
+  const pubsub = components[component]
+
+  if (!isPubSub(pubsub)) {
+    throw new InvalidParametersError(`Component ${component} did not implement the PubSub interface`)
+  }
+
+  return pubsub
+}


### PR DESCRIPTION
## Description

Adds the ability to find configured services that possess a given capability and interact with that service via rpc.

Starts with a configured PubSub service.

## Change checklist

- [ ] I have performed a self-review of my own code
- [ ] I have made corresponding changes to the documentation if necessary (this includes comments as well)
- [ ] I have added tests that prove my fix is effective or that my feature works