### PR TITLE
fix: allow multiple ping messages

### DIFF
--- a/packages/protocol-ping/package.json
+++ b/packages/protocol-ping/package.json
@@ -54,6 +54,7 @@
     "@libp2p/interface": "^2.0.1",
     "@libp2p/interface-internal": "^2.0.1",
     "@multiformats/multiaddr": "^12.2.3",
+    "it-byte-stream": "^1.1.0",
     "it-first": "^3.0.6",
     "it-pipe": "^3.0.1",
     "uint8arrays": "^5.1.0"
@@ -62,7 +63,6 @@
     "@libp2p/logger": "^5.0.1",
     "@libp2p/peer-id": "^5.0.1",
     "aegir": "^44.0.1",
-    "it-byte-stream": "^1.0.10",
     "it-pair": "^2.0.6",
     "p-defer": "^4.0.1",
     "sinon-ts": "^2.0.0"

--- a/packages/protocol-ping/package.json
+++ b/packages/protocol-ping/package.json
@@ -55,8 +55,6 @@
     "@libp2p/interface-internal": "^2.0.1",
     "@multiformats/multiaddr": "^12.2.3",
     "it-byte-stream": "^1.1.0",
-    "it-first": "^3.0.6",
-    "it-pipe": "^3.0.1",
     "uint8arrays": "^5.1.0"
   },
   "devDependencies": {

--- a/packages/protocol-ping/src/ping.ts
+++ b/packages/protocol-ping/src/ping.ts
@@ -73,7 +73,9 @@ export class PingService implements Startable, PingServiceInterface {
         const buf = await bytes.read(PING_LENGTH, {
           signal
         })
-        await bytes.write(buf)
+        await bytes.write(buf, {
+          signal
+        })
       }
     })
       .catch(err => {

--- a/packages/protocol-ping/test/index.spec.ts
+++ b/packages/protocol-ping/test/index.spec.ts
@@ -107,14 +107,17 @@ describe('ping', () => {
       connection: stubInterface<Connection>()
     })
 
-    const input = new Uint8Array(32)
-
     const b = byteStream(outgoingStream)
+
+    const input = new Uint8Array(32).fill(1)
     void b.write(input)
-
     const output = await b.read()
-
     expect(output).to.equalBytes(input)
+
+    const input2 = new Uint8Array(32).fill(2)
+    void b.write(input2)
+    const output2 = await b.read()
+    expect(output2).to.equalBytes(input2)
   })
 
   it('should abort stream if sending stalls', async () => {


### PR DESCRIPTION
Read incoming ping messges in 32 byte chunks as per the spec and echo them back to the sending peer.

If the remote fails to send us 32 bytes, reset the stream with a `TimeoutError`.

## Change checklist

- [x] I have performed a self-review of my own code
- [ ] I have made corresponding changes to the documentation if necessary (this includes comments as well)
- [x] I have added tests that prove my fix is effective or that my feature works