### PR TITLE
feat: add the ability to limit inbound/outbound connections

### DIFF
--- a/doc/CONFIGURATION.md
+++ b/doc/CONFIGURATION.md
@@ -607,7 +607,8 @@ const node = await createLibp2p({
     noise()
   ],
   connectionManager: {
-    maxConnections: Infinity
+    maxInboundConnections: Infinity,
+    maxOutboundConnections: Infinity
   }
 })
 ```

--- a/doc/LIMITS.md
+++ b/doc/LIMITS.md
@@ -35,7 +35,7 @@ const node = await createLibp2p({
     /**
      * The total number of connections allowed to be open at one time
      */
-    maxConnections: 100,
+    maxInboundConnections: 100,
 
     /**
      * How many connections can be open but not yet upgraded
@@ -191,11 +191,12 @@ const node = await createLibp2p({
       outboundSocketInactivityTimeout: 20,
 
       /**
-       * Once this many connections are open on this listener any further connections
-       * will be rejected - this will have no effect if it is larger than the value
-       * configured for the ConnectionManager maxConnections parameter
+       * Once this many inbound connections are open on this listener any further 
+       * connections will be rejected - this will have no effect if it is larger
+       * than the value configured for the ConnectionManager maxInboundConnections
+       * parameter
        */
-      maxConnections: 50,
+      maxInboundConnections: 50,
     }),
   ],
 });
@@ -254,7 +255,7 @@ Important details for ascertaining this are:
 As a result, the max amount of memory buffered by libp2p is approximately:
 
 ```
-connectionManager.maxConnections *
+(connectionManager.maxInboundConnections + connectionManager.maxOutboundConnections) *
   (muxer.maxUnprocessedMessageQueueSize
    + (muxer.maxInboundStreams * muxer.maxStreamBufferSize)
    + (muxer.maxOutboundStreams * muxer.maxStreamBufferSize)

--- a/packages/libp2p/src/connection-manager/constants.browser.ts
+++ b/packages/libp2p/src/connection-manager/constants.browser.ts
@@ -1,9 +1,14 @@
 export * from './constants.defaults.js'
 
 /**
- * @see https://libp2p.github.io/js-libp2p/interfaces/index._internal_.ConnectionManagerConfig.html#maxConnections
+ * @see https://libp2p.github.io/js-libp2p/interfaces/index._internal_.ConnectionManagerConfig.html#maxInboundConnections
  */
-export const MAX_CONNECTIONS = 100
+export const MAX_INBOUND_CONNECTIONS = 100
+
+/**
+ * @see https://libp2p.github.io/js-libp2p/interfaces/index._internal_.ConnectionManagerConfig.html#maxOutboundConnections
+ */
+export const MAX_OUTBOUND_CONNECTIONS = 100
 
 /**
  * @see https://libp2p.github.io/js-libp2p/interfaces/index._internal_.ConnectionManagerConfig.html#maxParallelDials

--- a/packages/libp2p/src/connection-manager/constants.ts
+++ b/packages/libp2p/src/connection-manager/constants.ts
@@ -1,9 +1,14 @@
 export * from './constants.defaults.js'
 
 /**
- * @see https://libp2p.github.io/js-libp2p/interfaces/index._internal_.ConnectionManagerConfig.html#maxConnections
+ * @see https://libp2p.github.io/js-libp2p/interfaces/index._internal_.ConnectionManagerConfig.html#maxInboundConnections
  */
-export const MAX_CONNECTIONS = 300
+export const MAX_INBOUND_CONNECTIONS = 300
+
+/**
+ * @see https://libp2p.github.io/js-libp2p/interfaces/index._internal_.ConnectionManagerConfig.html#maxOutboundConnections
+ */
+export const MAX_OUTBOUND_CONNECTIONS = 300
 
 /**
  * @see https://libp2p.github.io/js-libp2p/interfaces/index._internal_.ConnectionManagerConfig.html#maxParallelDials

--- a/packages/libp2p/test/connection-manager/direct.node.ts
+++ b/packages/libp2p/test/connection-manager/direct.node.ts
@@ -88,7 +88,8 @@ describe('dialing (direct, TCP)', () => {
     })
     localComponents.peerStore = new PersistentPeerStore(localComponents)
     localComponents.connectionManager = new DefaultConnectionManager(localComponents, {
-      maxConnections: 100,
+      maxInboundConnections: 100,
+      maxOutboundConnections: 100,
       inboundUpgradeTimeout: 1000
     })
     localComponents.addressManager = new DefaultAddressManager(localComponents)

--- a/packages/libp2p/test/connection-manager/direct.spec.ts
+++ b/packages/libp2p/test/connection-manager/direct.spec.ts
@@ -54,7 +54,8 @@ describe('dialing (direct, WebSockets)', () => {
       addressFilter: localComponents.connectionGater.filterMultiaddrForPeer
     })
     localComponents.connectionManager = new DefaultConnectionManager(localComponents, {
-      maxConnections: 100,
+      maxInboundConnections: 100,
+      maxOutboundConnections: 100,
       inboundUpgradeTimeout: 1000
     })
 

--- a/packages/libp2p/test/connection-manager/index.node.ts
+++ b/packages/libp2p/test/connection-manager/index.node.ts
@@ -55,7 +55,7 @@ describe('Connection Manager', () => {
       events: new TypedEventEmitter()
     })
     const connectionManager = new DefaultConnectionManager(components, {
-      maxConnections: 1000,
+      maxInboundConnections: 1000,
       inboundUpgradeTimeout: 1000
     })
 
@@ -92,7 +92,7 @@ describe('Connection Manager', () => {
       events: new TypedEventEmitter()
     })
     const connectionManager = new DefaultConnectionManager(components, {
-      maxConnections: 1000,
+      maxInboundConnections: 1000,
       inboundUpgradeTimeout: 1000
     })
 

--- a/packages/libp2p/test/registrar/errors.spec.ts
+++ b/packages/libp2p/test/registrar/errors.spec.ts
@@ -32,7 +32,7 @@ describe('registrar errors', () => {
     })
     components.peerStore = new PersistentPeerStore(components)
     components.connectionManager = new DefaultConnectionManager(components, {
-      maxConnections: 1000,
+      maxInboundConnections: 1000,
       inboundUpgradeTimeout: 1000
     })
     registrar = new DefaultRegistrar(components)


### PR DESCRIPTION
## What's in this PR

This PR introduces `maxInboundConnections` and `maxOutboundConnections` which replace the `maxConnections` variable which is deprecated by this PR.

While working on this PR, I couldn't find `maxConnections` being respected for outbound connections (neither in openConnection or in dial). So I've added the check in openConnection.

## Notes & open questions

<!--
Any notes, remarks or open questions you have to make about the PR which don't need to go into the final commit message.
-->

## Change checklist

- [ ] I have performed a self-review of my own code
- [ ] I have made corresponding changes to the documentation if necessary (this includes comments as well)
- [ ] I have added tests that prove my fix is effective or that my feature works