### PR TITLE
fix: simplify connection upgrade

### DIFF
--- a/packages/interface-compliance-tests/src/transport/listen-test.ts
+++ b/packages/interface-compliance-tests/src/transport/listen-test.ts
@@ -106,8 +106,8 @@ export default (common: TestSetup<TransportTestFixtures>): void => {
       expect(upgradeSpy.callCount).to.equal(2)
     })
 
-    it('should not handle connection if upgradeInbound throws', async () => {
-      sinon.stub(upgrader, 'upgradeInbound').throws()
+    it('should not handle connection if upgradeInbound rejects', async () => {
+      sinon.stub(upgrader, 'upgradeInbound').rejects()
 
       const listen = listener.createListener({
         upgrader

--- a/packages/interface-internal/src/connection-manager/index.ts
+++ b/packages/interface-internal/src/connection-manager/index.ts
@@ -71,7 +71,7 @@ export interface ConnectionManager {
   acceptIncomingConnection(maConn: MultiaddrConnection): Promise<boolean>
 
   /**
-   * Invoked after upgrading a multiaddr connection has finished
+   * Invoked after upgrading an inbound multiaddr connection has finished
    */
   afterUpgradeInbound(): void
 

--- a/packages/interface/src/connection/index.ts
+++ b/packages/interface/src/connection/index.ts
@@ -354,7 +354,7 @@ export interface ConnectionProtector {
    * between its two peers from the PSK the Protector instance was
    * created with.
    */
-  protect(connection: MultiaddrConnection): Promise<MultiaddrConnection>
+  protect(connection: MultiaddrConnection, options?: AbortOptions): Promise<MultiaddrConnection>
 }
 
 export interface MultiaddrConnectionTimeline {

--- a/packages/libp2p/src/connection-manager/constants.defaults.ts
+++ b/packages/libp2p/src/connection-manager/constants.defaults.ts
@@ -4,9 +4,14 @@
 export const DIAL_TIMEOUT = 5e3
 
 /**
- * @see https://libp2p.github.io/js-libp2p/interfaces/index._internal_.ConnectionManagerConfig.html#inboundUpgradeTimeout
+ * @see https://libp2p.github.io/js-libp2p/interfaces/index._internal_.ConnectionManagerConfig.html#upgradeTimeout
  */
-export const INBOUND_UPGRADE_TIMEOUT = 2e3
+export const UPGRADE_TIMEOUT = 3e3
+
+/**
+ * @see https://libp2p.github.io/js-libp2p/interfaces/index._internal_.ConnectionManagerConfig.html#protocolNegotiationTimeout
+ */
+export const PROTOCOL_NEGOTIATION_TIMEOUT = 2e3
 
 /**
  * @see https://libp2p.github.io/js-libp2p/interfaces/index._internal_.ConnectionManagerConfig.html#maxPeerAddrsToDial

--- a/packages/libp2p/src/libp2p.ts
+++ b/packages/libp2p/src/libp2p.ts
@@ -110,7 +110,8 @@ export class Libp2p<T extends ServiceMap = ServiceMap> extends TypedEventEmitter
     this.components.upgrader = new DefaultUpgrader(this.components, {
       connectionEncrypters: (init.connectionEncrypters ?? []).map((fn, index) => this.configureComponent(`connection-encryption-${index}`, fn(this.components))),
       streamMuxers: (init.streamMuxers ?? []).map((fn, index) => this.configureComponent(`stream-muxers-${index}`, fn(this.components))),
-      inboundUpgradeTimeout: init.connectionManager?.inboundUpgradeTimeout
+      inboundUpgradeTimeout: init.connectionManager?.inboundUpgradeTimeout,
+      outboundUpgradeTimeout: init.connectionManager?.outboundUpgradeTimeout
     })
 
     // Setup the transport manager


### PR DESCRIPTION
- Unifies inbound/outbound upgrade
- Adds default timeouts for inbound/outbound upgrades and stream protocol negotation
- Ensure tcp listener closes sockets when upgrade times out
- Passes abort signal to connection encrypter
- Uses simple promise rejection to abort tcp connections

Before:

<img width="680" alt="image" src="https://github.com/user-attachments/assets/7d3054e3-5caf-425d-abed-61d8f4cc885e">

After:

<img width="678" alt="image" src="https://github.com/user-attachments/assets/64596927-27e7-4054-97fc-9268988159e0">

Fixes #2537
Fixes #2477


## Change checklist

- [x] I have performed a self-review of my own code
- [x] I have made corresponding changes to the documentation if necessary (this includes comments as well)
- [ ] I have added tests that prove my fix is effective or that my feature works