### PR TITLE
feat: add relay server reservation store metrics

### DIFF
--- a/packages/transport-circuit-relay-v2/package.json
+++ b/packages/transport-circuit-relay-v2/package.json
@@ -72,10 +72,13 @@
     "uint8arrays": "^5.1.0"
   },
   "devDependencies": {
+    "@libp2p/crypto": "^5.0.4",
     "@libp2p/interface-compliance-tests": "^6.1.2",
+    "@libp2p/logger": "^5.0.4",
     "aegir": "^44.0.1",
     "delay": "^6.0.0",
     "it-drain": "^3.0.7",
+    "it-pair": "^2.0.6",
     "it-pushable": "^3.2.3",
     "it-to-buffer": "^4.0.7",
     "p-wait-for": "^5.0.2",

--- a/packages/transport-circuit-relay-v2/src/server/index.ts
+++ b/packages/transport-circuit-relay-v2/src/server/index.ts
@@ -18,7 +18,7 @@ import { createLimitedRelay } from '../utils.js'
 import { ReservationStore, type ReservationStoreInit } from './reservation-store.js'
 import { ReservationVoucherRecord } from './reservation-voucher.js'
 import type { CircuitRelayService, RelayReservation } from '../index.js'
-import type { ComponentLogger, Logger, Connection, Stream, ConnectionGater, PeerId, PeerStore, Startable, PrivateKey } from '@libp2p/interface'
+import type { ComponentLogger, Logger, Connection, Stream, ConnectionGater, PeerId, PeerStore, Startable, PrivateKey, Metrics } from '@libp2p/interface'
 import type { AddressManager, ConnectionManager, IncomingStreamData, Registrar } from '@libp2p/interface-internal'
 import type { PeerMap } from '@libp2p/peer-collections'
 
@@ -77,6 +77,7 @@ export interface CircuitRelayServerComponents {
   connectionManager: ConnectionManager
   connectionGater: ConnectionGater
   logger: ComponentLogger
+  metrics?: Metrics
 }
 
 export interface RelayServerEvents {
@@ -125,7 +126,7 @@ class CircuitRelayServer extends TypedEventEmitter<RelayServerEvents> implements
     this.maxInboundHopStreams = init.maxInboundHopStreams
     this.maxOutboundHopStreams = init.maxOutboundHopStreams
     this.maxOutboundStopStreams = init.maxOutboundStopStreams ?? defaults.maxOutboundStopStreams
-    this.reservationStore = new ReservationStore(init.reservations)
+    this.reservationStore = new ReservationStore(components, init.reservations)
 
     this.shutdownController = new AbortController()
     setMaxListeners(Infinity, this.shutdownController.signal)

--- a/packages/transport-circuit-relay-v2/test/hop.spec.ts
+++ b/packages/transport-circuit-relay-v2/test/hop.spec.ts
@@ -1,0 +1,357 @@
+/* eslint-disable max-nested-callbacks */
+
+import { generateKeyPair } from '@libp2p/crypto/keys'
+import { TypedEventEmitter, isStartable } from '@libp2p/interface'
+import { matchPeerId } from '@libp2p/interface-compliance-tests/matchers'
+import { mockRegistrar, mockUpgrader, mockNetwork, mockConnectionManager, mockConnectionGater } from '@libp2p/interface-compliance-tests/mocks'
+import { defaultLogger } from '@libp2p/logger'
+import { PeerMap } from '@libp2p/peer-collections'
+import { peerIdFromPrivateKey } from '@libp2p/peer-id'
+import { type Multiaddr, multiaddr } from '@multiformats/multiaddr'
+import { expect } from 'aegir/chai'
+import { type MessageStream, pbStream } from 'it-protobuf-stream'
+import Sinon from 'sinon'
+import { type StubbedInstance, stubInterface } from 'sinon-ts'
+import { DEFAULT_MAX_RESERVATION_STORE_SIZE, RELAY_SOURCE_TAG, RELAY_V2_HOP_CODEC } from '../src/constants.js'
+import { circuitRelayServer, type CircuitRelayService, circuitRelayTransport } from '../src/index.js'
+import { HopMessage, Status } from '../src/pb/index.js'
+import type { CircuitRelayServerInit } from '../src/server/index.js'
+import type { TypedEventTarget, ComponentLogger, Libp2pEvents, Connection, Stream, ConnectionGater, PeerId, PeerStore, Upgrader, Transport, PrivateKey } from '@libp2p/interface'
+import type { RandomWalk, AddressManager, ConnectionManager, Registrar, TransportManager } from '@libp2p/interface-internal'
+
+interface Node {
+  peerId: PeerId
+  privateKey: PrivateKey
+  multiaddr: Multiaddr
+  registrar: Registrar
+  peerStore: StubbedInstance<PeerStore>
+  circuitRelayService: CircuitRelayService
+  upgrader: Upgrader
+  connectionManager: ConnectionManager
+  circuitRelayTransport: Transport
+  connectionGater: ConnectionGater
+  events: TypedEventTarget<Libp2pEvents>
+  logger: ComponentLogger
+}
+
+let peerIndex = 0
+
+describe('circuit-relay hop protocol', function () {
+  let relayNode: Node
+  let clientNode: Node
+  let targetNode: Node
+  let nodes: Node[]
+
+  async function createNode (circuitRelayInit?: CircuitRelayServerInit): Promise<Node> {
+    peerIndex++
+
+    const privateKey = await generateKeyPair('Ed25519')
+    const peerId = peerIdFromPrivateKey(privateKey)
+    const registrar = mockRegistrar()
+    const connections = new PeerMap<Connection>()
+
+    const octet = peerIndex + 100
+    const port = peerIndex + 10000
+    const ma = multiaddr(`/ip4/${octet}.${octet}.${octet}.${octet}/tcp/${port}/p2p/${peerId.toString()}`)
+
+    const addressManager = stubInterface<AddressManager>()
+    addressManager.getAddresses.returns([
+      ma
+    ])
+    const peerStore = stubInterface<PeerStore>()
+
+    const events = new TypedEventEmitter()
+    events.addEventListener('connection:open', (evt) => {
+      const conn = evt.detail
+      connections.set(conn.remotePeer, conn)
+    })
+    events.addEventListener('connection:close', (evt) => {
+      const conn = evt.detail
+      connections.delete(conn.remotePeer)
+    })
+
+    const connectionManager = mockConnectionManager({
+      peerId,
+      registrar,
+      events
+    })
+
+    const upgrader = mockUpgrader({
+      registrar,
+      events
+    })
+
+    const connectionGater = mockConnectionGater()
+
+    const service = circuitRelayServer(circuitRelayInit)({
+      addressManager,
+      connectionManager,
+      peerId,
+      privateKey,
+      peerStore,
+      registrar,
+      connectionGater,
+      logger: defaultLogger()
+    })
+
+    if (isStartable(service)) {
+      await service.start()
+    }
+
+    const transport = circuitRelayTransport({})({
+      addressManager,
+      connectionManager,
+      peerId,
+      peerStore,
+      randomWalk: stubInterface<RandomWalk>(),
+      registrar,
+      transportManager: stubInterface<TransportManager>(),
+      upgrader,
+      connectionGater,
+      events,
+      logger: defaultLogger()
+    })
+
+    if (isStartable(transport)) {
+      await transport.start()
+    }
+
+    const node: Node = {
+      peerId,
+      privateKey,
+      multiaddr: ma,
+      registrar,
+      circuitRelayService: service,
+      peerStore,
+      upgrader,
+      connectionManager,
+      circuitRelayTransport: transport,
+      connectionGater,
+      events,
+      logger: defaultLogger()
+    }
+
+    mockNetwork.addNode(node)
+    nodes.push(node)
+
+    return node
+  }
+
+  async function openStream (client: Node, relay: Node, protocol: string): Promise<MessageStream<HopMessage, Stream>> {
+    const connection = await client.connectionManager.openConnection(relay.peerId)
+    const clientStream = await connection.newStream(protocol)
+    return pbStream(clientStream).pb(HopMessage)
+  }
+
+  async function makeReservation (client: Node, relay: Node): Promise<{ response: HopMessage, clientPbStream: MessageStream<HopMessage> }> {
+    const clientPbStream = await openStream(client, relay, RELAY_V2_HOP_CODEC)
+
+    // send reserve message
+    await clientPbStream.write({
+      type: HopMessage.Type.RESERVE
+    })
+
+    return {
+      response: await clientPbStream.read(),
+      clientPbStream
+    }
+  }
+
+  async function sendConnect (client: Node, target: Node, relay: Node): Promise<{ response: HopMessage, clientPbStream: MessageStream<HopMessage, Stream> }> {
+    const clientPbStream = await openStream(client, relay, RELAY_V2_HOP_CODEC)
+
+    // send reserve message
+    await clientPbStream.write({
+      type: HopMessage.Type.CONNECT,
+      peer: {
+        id: target.peerId.toMultihash().bytes,
+        addrs: [
+          target.multiaddr.bytes
+        ]
+      }
+    })
+
+    return {
+      response: await clientPbStream.read(),
+      clientPbStream
+    }
+  }
+
+  beforeEach(async () => {
+    nodes = []
+
+    relayNode = await createNode()
+    clientNode = await createNode()
+    targetNode = await createNode()
+  })
+
+  afterEach(async () => {
+    for (const node of nodes) {
+      if (isStartable(node.circuitRelayService)) {
+        await node.circuitRelayService.stop()
+      }
+
+      if (isStartable(node.circuitRelayTransport)) {
+        await node.circuitRelayTransport.stop()
+      }
+    }
+
+    mockNetwork.reset()
+  })
+
+  describe('reserve', function () {
+    it('error on unknown message type', async () => {
+      const clientPbStream = await openStream(clientNode, relayNode, RELAY_V2_HOP_CODEC)
+
+      // wrong initial message
+      await clientPbStream.write({
+        type: HopMessage.Type.STATUS,
+        status: Status.MALFORMED_MESSAGE
+      })
+
+      const msg = await clientPbStream.read()
+      expect(msg).to.have.property('type', HopMessage.Type.STATUS)
+      expect(msg).to.have.property('status', Status.UNEXPECTED_MESSAGE)
+    })
+
+    it('should reserve slot', async () => {
+      const { response } = await makeReservation(clientNode, relayNode)
+      expect(response).to.have.property('type', HopMessage.Type.STATUS)
+      expect(response).to.have.property('status', Status.OK)
+      expect(response).to.have.nested.property('reservation.expire').that.is.a('bigint')
+      expect(response).to.have.nested.property('reservation.addrs').that.satisfies((val: Uint8Array[]) => {
+        return val
+          .map(buf => multiaddr(buf))
+          .map(ma => ma.toString())
+          .includes(relayNode.multiaddr.toString())
+      })
+      expect(response.limit).to.have.property('data').that.is.a('bigint')
+      expect(response.limit).to.have.property('duration').that.is.a('number')
+
+      const reservation = relayNode.circuitRelayService.reservations.get(clientNode.peerId)
+      expect(reservation).to.have.nested.property('limit.data', response.limit?.data)
+      expect(reservation).to.have.nested.property('limit.duration', response.limit?.duration)
+    })
+
+    it('should fail to reserve slot - denied by connection gater', async () => {
+      relayNode.connectionGater.denyInboundRelayReservation = Sinon.stub().returns(true)
+
+      const { response } = await makeReservation(clientNode, relayNode)
+      expect(response).to.have.property('type', HopMessage.Type.STATUS)
+      expect(response).to.have.property('status', Status.PERMISSION_DENIED)
+
+      expect(relayNode.circuitRelayService.reservations.get(clientNode.peerId)).to.be.undefined()
+    })
+
+    it('should fail to reserve slot - resource exceeded', async () => {
+      // fill all the available reservation slots
+      for (let i = 0; i < DEFAULT_MAX_RESERVATION_STORE_SIZE; i++) {
+        const peer = await createNode()
+        const { response } = await makeReservation(peer, relayNode)
+        expect(response).to.have.property('type', HopMessage.Type.STATUS)
+        expect(response).to.have.property('status', Status.OK)
+      }
+
+      // next reservation should fail
+      const { response } = await makeReservation(clientNode, relayNode)
+      expect(response).to.have.property('type', HopMessage.Type.STATUS)
+      expect(response).to.have.property('status', Status.RESERVATION_REFUSED)
+
+      expect(relayNode.circuitRelayService.reservations.get(clientNode.peerId)).to.be.undefined()
+    })
+
+    it('should refresh previous reservation when store is full', async () => {
+      const peers: Node[] = []
+
+      // fill all the available reservation slots
+      for (let i = 0; i < DEFAULT_MAX_RESERVATION_STORE_SIZE; i++) {
+        const peer = await createNode()
+        peers.push(peer)
+
+        const { response } = await makeReservation(peer, relayNode)
+        expect(response).to.have.property('type', HopMessage.Type.STATUS)
+        expect(response).to.have.property('status', Status.OK)
+      }
+
+      // next reservation should fail
+      const { response: failureResponse } = await makeReservation(clientNode, relayNode)
+      expect(failureResponse).to.have.property('type', HopMessage.Type.STATUS)
+      expect(failureResponse).to.have.property('status', Status.RESERVATION_REFUSED)
+      expect(relayNode.circuitRelayService.reservations.get(clientNode.peerId)).to.be.undefined()
+
+      // should be able to refresh older reservation
+      const { response: successResponse } = await makeReservation(peers[0], relayNode)
+      expect(successResponse).to.have.property('type', HopMessage.Type.STATUS)
+      expect(successResponse).to.have.property('status', Status.OK)
+      expect(relayNode.circuitRelayService.reservations.get(peers[0].peerId)).to.be.ok()
+    })
+
+    it('should tag peer making reservation', async () => {
+      const { response } = await makeReservation(clientNode, relayNode)
+      expect(response).to.have.property('type', HopMessage.Type.STATUS)
+      expect(response).to.have.property('status', Status.OK)
+
+      expect(relayNode.peerStore.merge.calledWith(matchPeerId(clientNode.peerId), {
+        tags: {
+          [RELAY_SOURCE_TAG]: {
+            value: 1,
+            ttl: Sinon.match.number as unknown as number
+          }
+        }
+      })).to.be.true()
+    })
+  })
+
+  describe('connect', () => {
+    it('should connect successfully', async () => {
+      // both peers make a reservation on the relay
+      await expect(makeReservation(clientNode, relayNode)).to.eventually.have.nested.property('response.status', Status.OK)
+      await expect(makeReservation(targetNode, relayNode)).to.eventually.have.nested.property('response.status', Status.OK)
+
+      // client peer sends CONNECT to target peer
+      const { response } = await sendConnect(clientNode, targetNode, relayNode)
+      expect(response).to.have.property('type', HopMessage.Type.STATUS)
+      expect(response).to.have.property('status', Status.OK)
+    })
+
+    it('should fail to connect - invalid request', async () => {
+      // both peers make a reservation on the relay
+      await expect(makeReservation(clientNode, relayNode)).to.eventually.have.nested.property('response.status', Status.OK)
+      await expect(makeReservation(targetNode, relayNode)).to.eventually.have.nested.property('response.status', Status.OK)
+
+      const clientPbStream = await openStream(clientNode, relayNode, RELAY_V2_HOP_CODEC)
+      await clientPbStream.write({
+        type: HopMessage.Type.CONNECT,
+        // @ts-expect-error {} is missing the following properties from peer: id, addrs
+        peer: {}
+      })
+
+      const response = await clientPbStream.read()
+      expect(response.type).to.be.equal(HopMessage.Type.STATUS)
+      expect(response.status).to.be.equal(Status.MALFORMED_MESSAGE)
+    })
+
+    it('should failed to connect - denied by connection gater', async () => {
+      relayNode.connectionGater.denyOutboundRelayedConnection = Sinon.stub().returns(true)
+
+      // both peers make a reservation on the relay
+      await expect(makeReservation(clientNode, relayNode)).to.eventually.have.nested.property('response.status', Status.OK)
+      await expect(makeReservation(targetNode, relayNode)).to.eventually.have.nested.property('response.status', Status.OK)
+
+      // client peer sends CONNECT to target peer
+      const { response } = await sendConnect(clientNode, targetNode, relayNode)
+      expect(response).to.have.property('type', HopMessage.Type.STATUS)
+      expect(response).to.have.property('status', Status.PERMISSION_DENIED)
+    })
+
+    it('should fail to connect - no connection', async () => {
+      // target peer has no reservation on the relay
+      await expect(makeReservation(clientNode, relayNode)).to.eventually.have.nested.property('response.status', Status.OK)
+
+      // client peer sends CONNECT to target peer
+      const { response } = await sendConnect(clientNode, targetNode, relayNode)
+      expect(response).to.have.property('type', HopMessage.Type.STATUS)
+      expect(response).to.have.property('status', Status.NO_RESERVATION)
+    })
+  })
+})

--- a/packages/transport-circuit-relay-v2/test/reservation-store.spec.ts
+++ b/packages/transport-circuit-relay-v2/test/reservation-store.spec.ts
@@ -1,0 +1,96 @@
+/* eslint-env mocha */
+
+import { generateKeyPair } from '@libp2p/crypto/keys'
+import { peerIdFromPrivateKey } from '@libp2p/peer-id'
+import { multiaddr } from '@multiformats/multiaddr'
+import { expect } from 'aegir/chai'
+import { DEFAULT_DATA_LIMIT, DEFAULT_DURATION_LIMIT } from '../src/constants.js'
+import { Status } from '../src/pb/index.js'
+import { ReservationStore } from '../src/server/reservation-store.js'
+
+describe('circuit-relay server reservation store', function () {
+  it('should add reservation', async function () {
+    const store = new ReservationStore({}, { maxReservations: 2 })
+    const privateKey = await generateKeyPair('Ed25519')
+    const peer = peerIdFromPrivateKey(privateKey)
+    const result = store.reserve(peer, multiaddr())
+    expect(result.status).to.equal(Status.OK)
+    expect(result.expire).to.not.be.undefined()
+    expect(store.hasReservation(peer)).to.be.true()
+  })
+
+  it('should add reservation if peer already has reservation', async function () {
+    const store = new ReservationStore({}, { maxReservations: 1 })
+    const privateKey = await generateKeyPair('Ed25519')
+    const peer = peerIdFromPrivateKey(privateKey)
+    store.reserve(peer, multiaddr())
+    const result = store.reserve(peer, multiaddr())
+    expect(result.status).to.equal(Status.OK)
+    expect(result.expire).to.not.be.undefined()
+    expect(store.hasReservation(peer)).to.be.true()
+  })
+
+  it('should fail to add reservation on exceeding limit', async function () {
+    const store = new ReservationStore({}, { maxReservations: 0 })
+    const privateKey = await generateKeyPair('Ed25519')
+    const peer = peerIdFromPrivateKey(privateKey)
+    const result = store.reserve(peer, multiaddr())
+    expect(result.status).to.equal(Status.RESERVATION_REFUSED)
+  })
+
+  it('should remove reservation', async function () {
+    const store = new ReservationStore({}, { maxReservations: 10 })
+    const privateKey = await generateKeyPair('Ed25519')
+    const peer = peerIdFromPrivateKey(privateKey)
+    const result = store.reserve(peer, multiaddr())
+    expect(result.status).to.equal(Status.OK)
+    expect(store.hasReservation(peer)).to.be.true()
+    store.removeReservation(peer)
+    expect(store.hasReservation(peer)).to.be.false()
+    store.removeReservation(peer)
+  })
+
+  it('should apply configured default connection limits', async function () {
+    const defaultDataLimit = 10n
+    const defaultDurationLimit = 10
+
+    const store = new ReservationStore({}, {
+      defaultDataLimit,
+      defaultDurationLimit
+    })
+    const privateKey = await generateKeyPair('Ed25519')
+    const peer = peerIdFromPrivateKey(privateKey)
+    store.reserve(peer, multiaddr())
+
+    const reservation = store.get(peer)
+
+    expect(reservation).to.have.nested.property('limit.data', defaultDataLimit)
+    expect(reservation).to.have.nested.property('limit.duration', defaultDurationLimit)
+  })
+
+  it('should apply default connection limits', async function () {
+    const store = new ReservationStore({})
+    const privateKey = await generateKeyPair('Ed25519')
+    const peer = peerIdFromPrivateKey(privateKey)
+    store.reserve(peer, multiaddr())
+
+    const reservation = store.get(peer)
+
+    expect(reservation).to.have.nested.property('limit.data', DEFAULT_DATA_LIMIT)
+    expect(reservation).to.have.nested.property('limit.duration', DEFAULT_DURATION_LIMIT)
+  })
+
+  it('should not apply default connection limits when they have been disabled', async function () {
+    const store = new ReservationStore({}, {
+      applyDefaultLimit: false
+    })
+    const privateKey = await generateKeyPair('Ed25519')
+    const peer = peerIdFromPrivateKey(privateKey)
+    store.reserve(peer, multiaddr())
+
+    const reservation = store.get(peer)
+
+    expect(reservation).to.not.have.nested.property('limit.data')
+    expect(reservation).to.not.have.nested.property('limit.duration')
+  })
+})

--- a/packages/transport-circuit-relay-v2/test/stop.spec.ts
+++ b/packages/transport-circuit-relay-v2/test/stop.spec.ts
@@ -1,0 +1,202 @@
+/* eslint-env mocha */
+
+import { generateKeyPair } from '@libp2p/crypto/keys'
+import { TypedEventEmitter, isStartable } from '@libp2p/interface'
+import { mockStream } from '@libp2p/interface-compliance-tests/mocks'
+import { defaultLogger } from '@libp2p/logger'
+import { peerIdFromPrivateKey } from '@libp2p/peer-id'
+import { multiaddr } from '@multiformats/multiaddr'
+import { expect } from 'aegir/chai'
+import delay from 'delay'
+import { duplexPair } from 'it-pair/duplex'
+import { pbStream, type MessageStream } from 'it-protobuf-stream'
+import Sinon from 'sinon'
+import { stubInterface, type StubbedInstance } from 'sinon-ts'
+import { Status, StopMessage } from '../src/pb/index.js'
+import { CircuitRelayTransport } from '../src/transport/transport.js'
+import type { TypedEventTarget, ComponentLogger, Libp2pEvents, Connection, Stream, ConnectionGater, PeerId, PeerStore, Upgrader } from '@libp2p/interface'
+import type { AddressManager, ConnectionManager, RandomWalk, Registrar, StreamHandler, TransportManager } from '@libp2p/interface-internal'
+
+interface StubbedCircuitRelayTransportComponents {
+  peerId: PeerId
+  peerStore: PeerStore
+  registrar: StubbedInstance<Registrar>
+  connectionManager: StubbedInstance<ConnectionManager>
+  transportManager: StubbedInstance<TransportManager>
+  upgrader: StubbedInstance<Upgrader>
+  addressManager: StubbedInstance<AddressManager>
+  randomWalk: StubbedInstance<RandomWalk>
+  connectionGater: StubbedInstance<ConnectionGater>
+  events: TypedEventTarget<Libp2pEvents>
+  logger: ComponentLogger
+}
+
+describe('circuit-relay stop protocol', function () {
+  let transport: CircuitRelayTransport
+  let components: StubbedCircuitRelayTransportComponents
+  let handler: StreamHandler
+  let pbstr: MessageStream<StopMessage>
+  let sourcePeer: PeerId
+  const stopTimeout = 100
+  let localStream: Stream
+  let remoteStream: Stream
+
+  beforeEach(async () => {
+    const privateKey = await generateKeyPair('Ed25519')
+
+    components = {
+      addressManager: stubInterface<AddressManager>(),
+      connectionManager: stubInterface<ConnectionManager>(),
+      peerId: peerIdFromPrivateKey(privateKey),
+      peerStore: stubInterface<PeerStore>(),
+      randomWalk: stubInterface<RandomWalk>(),
+      registrar: stubInterface<Registrar>(),
+      transportManager: stubInterface<TransportManager>(),
+      upgrader: stubInterface<Upgrader>(),
+      connectionGater: stubInterface<ConnectionGater>(),
+      events: new TypedEventEmitter(),
+      logger: defaultLogger()
+    }
+
+    transport = new CircuitRelayTransport(components, {
+      stopTimeout
+    })
+
+    if (isStartable(transport)) {
+      await transport.start()
+    }
+
+    const sourcePrivateKey = await generateKeyPair('Ed25519')
+    sourcePeer = peerIdFromPrivateKey(sourcePrivateKey)
+
+    handler = components.registrar.handle.getCall(0).args[1]
+
+    const [localDuplex, remoteDuplex] = duplexPair<any>()
+
+    localStream = mockStream(localDuplex)
+    remoteStream = mockStream(remoteDuplex)
+
+    handler({
+      stream: remoteStream,
+      connection: stubInterface<Connection>()
+    })
+
+    pbstr = pbStream(localStream).pb(StopMessage)
+  })
+
+  this.afterEach(async function () {
+    if (isStartable(transport)) {
+      await transport.stop()
+    }
+  })
+
+  it('handle stop - success', async function () {
+    await pbstr.write({
+      type: StopMessage.Type.CONNECT,
+      peer: {
+        id: sourcePeer.toMultihash().bytes,
+        addrs: []
+      }
+    })
+
+    const response = await pbstr.read()
+    expect(response.status).to.be.equal(Status.OK)
+  })
+
+  it('handle stop error - invalid request - missing type', async function () {
+    await pbstr.write({})
+
+    const response = await pbstr.read()
+    expect(response.status).to.be.equal(Status.MALFORMED_MESSAGE)
+  })
+
+  it('handle stop error - invalid request - wrong type', async function () {
+    await pbstr.write({
+      type: StopMessage.Type.STATUS,
+      peer: {
+        id: sourcePeer.toMultihash().bytes,
+        addrs: []
+      }
+    })
+
+    const response = await pbstr.read()
+    expect(response.status).to.be.equal(Status.UNEXPECTED_MESSAGE)
+  })
+
+  it('handle stop error - invalid request - missing peer', async function () {
+    await pbstr.write({
+      type: StopMessage.Type.CONNECT
+    })
+
+    const response = await pbstr.read()
+    expect(response.status).to.be.equal(Status.MALFORMED_MESSAGE)
+  })
+
+  it('handle stop error - invalid request - invalid peer addr', async function () {
+    await pbstr.write({
+      type: StopMessage.Type.CONNECT,
+      peer: {
+        id: sourcePeer.toMultihash().bytes,
+        addrs: [
+          new Uint8Array(32)
+        ]
+      }
+    })
+
+    const response = await pbstr.read()
+    expect(response.status).to.be.equal(Status.MALFORMED_MESSAGE)
+  })
+
+  it('handle stop error - timeout', async function () {
+    const abortSpy = Sinon.spy(remoteStream, 'abort')
+
+    await pbstr.write({
+      type: StopMessage.Type.CONNECT,
+      peer: {
+        id: sourcePeer.toMultihash().bytes,
+        addrs: []
+      }
+    })
+
+    // take longer than `stopTimeout` to read the response
+    await delay(stopTimeout * 2)
+
+    // should have aborted remote stream
+    expect(abortSpy).to.have.property('called', true)
+  })
+
+  it('should try to listen on the address of a relay we are dialed via if no reservation exists', async () => {
+    const remotePrivateKey = await generateKeyPair('Ed25519')
+    const remotePeer = peerIdFromPrivateKey(remotePrivateKey)
+    const remoteAddr = multiaddr(`/ip4/127.0.0.1/tcp/4001/p2p/${remotePeer}`)
+    transport.reservationStore.hasReservation = Sinon.stub().returns(false)
+    const connection = stubInterface<Connection>({
+      remotePeer,
+      remoteAddr
+    })
+
+    components.transportManager.listen.returns(Promise.resolve())
+
+    void transport.onStop({
+      connection,
+      stream: remoteStream
+    })
+
+    await pbstr.write({
+      type: StopMessage.Type.CONNECT,
+      peer: {
+        id: sourcePeer.toMultihash().bytes,
+        addrs: []
+      }
+    })
+
+    const response = await pbstr.read()
+    expect(response.status).to.be.equal(Status.OK)
+
+    expect(components.transportManager.listen.called).to.be.true()
+    expect(components.transportManager.listen.getCall(0).args[0][0].toString()).to.equal(
+      remoteAddr.encapsulate('/p2p-circuit').toString(),
+      'did not dial relay we did not have a reservation on'
+    )
+  })
+})


### PR DESCRIPTION
Tracks the reservation store map to observe how many reservation slots are currently occupied.

Also reinstates tests that were accidentally removed by the linter.

## Change checklist

- [x] I have performed a self-review of my own code
- [ ] I have made corresponding changes to the documentation if necessary (this includes comments as well)
- [x] I have added tests that prove my fix is effective or that my feature works