### PR TITLE
fix: split error/operation metrics

### DIFF
--- a/packages/libp2p/src/connection-manager/dial-queue.ts
+++ b/packages/libp2p/src/connection-manager/dial-queue.ts
@@ -1,5 +1,5 @@
 /* eslint-disable max-depth */
-import { TimeoutError, DialError, setMaxListeners } from '@libp2p/interface'
+import { TimeoutError, DialError, setMaxListeners, AbortError } from '@libp2p/interface'
 import { PeerMap } from '@libp2p/peer-collections'
 import { defaultAddressSort } from '@libp2p/utils/address-sort'
 import { PriorityQueue, type PriorityQueueJobOptions } from '@libp2p/utils/priority-queue'
@@ -103,7 +103,9 @@ export class DialQueue {
     })
     // a started job errored
     this.queue.addEventListener('error', (event) => {
-      this.log.error('error in dial queue', event.detail)
+      if (event.detail.name !== AbortError.name) {
+        this.log.error('error in dial queue - %e', event.detail)
+      }
     })
   }
 

--- a/packages/libp2p/src/connection-manager/index.ts
+++ b/packages/libp2p/src/connection-manager/index.ts
@@ -532,7 +532,7 @@ export class DefaultConnectionManager implements ConnectionManager, Startable {
       }
 
       // make sure we don't already have a connection to this multiaddr
-      if (conn.id !== connection.id && conn.remoteAddr.equals(connection.remoteAddr)) {
+      if (options.force !== true && conn.id !== connection.id && conn.remoteAddr.equals(connection.remoteAddr)) {
         connection.abort(new InvalidMultiaddrError('Duplicate multiaddr connection'))
 
         // return the existing connection

--- a/packages/libp2p/test/connection-manager/direct.spec.ts
+++ b/packages/libp2p/test/connection-manager/direct.spec.ts
@@ -490,7 +490,7 @@ describe('libp2p.dialer (direct, WebSockets)', () => {
 
     await expect(libp2p.dial(multiaddr(`/ip4/127.0.0.1/tcp/1234/ws/p2p/${libp2p.peerId.toString()}`)))
       .to.eventually.be.rejected()
-      .and.to.have.property('name', 'DialError')
+      .and.to.have.property('name', 'InvalidPeerIdError')
   })
 
   it('should limit the maximum dial queue size', async () => {

--- a/packages/libp2p/test/connection-manager/index.spec.ts
+++ b/packages/libp2p/test/connection-manager/index.spec.ts
@@ -529,10 +529,13 @@ describe('Connection Manager', () => {
     const existingConnection = stubInterface<Connection>({
       limits: {
         bytes: 100n
-      }
+      },
+      remotePeer: targetPeer,
+      remoteAddr: multiaddr(`/ip4/123.123.123.123/tcp/123/p2p-circuit/p2p/${targetPeer}`)
     })
     const newConnection = stubInterface<Connection>({
-      remotePeer: targetPeer
+      remotePeer: targetPeer,
+      remoteAddr: addr
     })
 
     sinon.stub(connectionManager.dialQueue, 'dial')

--- a/packages/libp2p/test/connection-manager/index.spec.ts
+++ b/packages/libp2p/test/connection-manager/index.spec.ts
@@ -391,7 +391,9 @@ describe('Connection Manager', () => {
     })
     await connectionManager.start()
 
-    sinon.stub(connectionManager.dialQueue, 'dial').resolves(stubInterface<Connection>())
+    sinon.stub(connectionManager.dialQueue, 'dial').resolves(stubInterface<Connection>({
+      remotePeer: peerIdFromPrivateKey(await generateKeyPair('Ed25519'))
+    }))
 
     // max out the connection limit
     await connectionManager.openConnection(peerIdFromPrivateKey(await generateKeyPair('Ed25519')))
@@ -450,7 +452,9 @@ describe('Connection Manager', () => {
     })
     await connectionManager.start()
 
-    sinon.stub(connectionManager.dialQueue, 'dial').resolves(stubInterface<Connection>())
+    sinon.stub(connectionManager.dialQueue, 'dial').resolves(stubInterface<Connection>({
+      remotePeer: peerIdFromPrivateKey(await generateKeyPair('Ed25519'))
+    }))
 
     // max out the connection limit
     await connectionManager.openConnection(peerIdFromPrivateKey(await generateKeyPair('Ed25519')))
@@ -477,7 +481,9 @@ describe('Connection Manager', () => {
     })
     await connectionManager.start()
 
-    sinon.stub(connectionManager.dialQueue, 'dial').resolves(stubInterface<Connection>())
+    sinon.stub(connectionManager.dialQueue, 'dial').resolves(stubInterface<Connection>({
+      remotePeer: peerIdFromPrivateKey(await generateKeyPair('Ed25519'))
+    }))
 
     // start the upgrade
     const maConn1 = mockMultiaddrConnection({
@@ -525,7 +531,9 @@ describe('Connection Manager', () => {
         bytes: 100n
       }
     })
-    const newConnection = stubInterface<Connection>()
+    const newConnection = stubInterface<Connection>({
+      remotePeer: targetPeer
+    })
 
     sinon.stub(connectionManager.dialQueue, 'dial')
       .withArgs(addr)


### PR DESCRIPTION
Splitting metrics is considered best practice where there are a small number of outcomes.

Refs: https://promlabs.com/blog/2023/09/19/errors-successes-totals-which-metrics-should-i-expose-to-prometheus/

## Change checklist

- [x] I have performed a self-review of my own code
- [ ] I have made corresponding changes to the documentation if necessary (this includes comments as well)
- [ ] I have added tests that prove my fix is effective or that my feature works