### PR TITLE
fix: make tcp closing error throwing consistent

### DIFF
--- a/packages/transport-tcp/src/listener.ts
+++ b/packages/transport-tcp/src/listener.ts
@@ -167,8 +167,10 @@ export class TCPListener extends TypedEventEmitter<ListenerEvents> implements Li
 
   private onSocket (socket: net.Socket): void {
     if (this.status.code !== TCPListenerStatusCode.ACTIVE) {
+      socket.destroy()
       throw new NotStartedError('Server is not listening yet')
     }
+
     // Avoid uncaught errors caused by unstable connections
     socket.on('error', err => {
       this.log('socket error', err)


### PR DESCRIPTION
In the first close attempt we wrap the `closePromise` with a try/catch and call `.abort` if it throws, and we don't propagate the error.

In the second invocation we return the `closePromise` which can reject making the code non-deterministic.

## Change checklist

- [x] I have performed a self-review of my own code
- [ ] I have made corresponding changes to the documentation if necessary (this includes comments as well)
- [ ] I have added tests that prove my fix is effective or that my feature works