### PR TITLE
fix: check for connection status before storing

### DIFF
--- a/packages/libp2p/src/connection-manager/dial-queue.ts
+++ b/packages/libp2p/src/connection-manager/dial-queue.ts
@@ -153,7 +153,7 @@ export class DialQueue {
       })
     })
 
-    if (existingConnection != null) {
+    if (existingConnection?.status === 'open') {
       this.log('already connected to %a', existingConnection.remoteAddr)
       options.onProgress?.(new CustomProgressEvent('dial-queue:already-connected'))
       return existingConnection

--- a/packages/libp2p/test/connection-manager/index.spec.ts
+++ b/packages/libp2p/test/connection-manager/index.spec.ts
@@ -93,7 +93,7 @@ describe('Connection Manager', () => {
     await libp2p.start()
 
     const connectionManager = getComponent(libp2p, 'connectionManager')
-    const connectionManagerMaybePruneConnectionsSpy = sinon.spy(connectionManager.connectionPruner, 'maybePruneConnections')
+    const connectionManagerMaybePruneConnectionsSpy = sinon.spy(connectionManager.connectionPruner, '_maybePruneConnections')
     const spies = new Map<number, sinon.SinonSpy<[options?: AbortOptions], Promise<void>>>()
 
     // wait for prune event
@@ -151,7 +151,7 @@ describe('Connection Manager', () => {
     await libp2p.start()
 
     const connectionManager = getComponent(libp2p, 'connectionManager')
-    const connectionManagerMaybePruneConnectionsSpy = sinon.spy(connectionManager.connectionPruner, 'maybePruneConnections')
+    const connectionManagerMaybePruneConnectionsSpy = sinon.spy(connectionManager.connectionPruner, '_maybePruneConnections')
     const spies = new Map<string, sinon.SinonSpy<[options?: AbortOptions], Promise<void>>>()
     const eventPromise = pEvent(libp2p, 'connection:prune')
 
@@ -218,7 +218,7 @@ describe('Connection Manager', () => {
     await libp2p.start()
 
     const connectionManager = getComponent(libp2p, 'connectionManager')
-    const connectionManagerMaybePruneConnectionsSpy = sinon.spy(connectionManager.connectionPruner, 'maybePruneConnections')
+    const connectionManagerMaybePruneConnectionsSpy = sinon.spy(connectionManager.connectionPruner, '_maybePruneConnections')
     const spies = new Map<number, sinon.SinonSpy<[options?: AbortOptions], Promise<void>>>()
     const eventPromise = pEvent(libp2p, 'connection:prune')
 
@@ -299,7 +299,7 @@ describe('Connection Manager', () => {
     await libp2p.start()
 
     const connectionManager = getComponent(libp2p, 'connectionManager')
-    const connectionManagerMaybePruneConnectionsSpy = sinon.spy(connectionManager.connectionPruner, 'maybePruneConnections')
+    const connectionManagerMaybePruneConnectionsSpy = sinon.spy(connectionManager.connectionPruner, '_maybePruneConnections')
     const eventPromise = pEvent(libp2p, 'connection:prune')
 
     // Add 1 too many connections
@@ -392,7 +392,8 @@ describe('Connection Manager', () => {
     await connectionManager.start()
 
     sinon.stub(connectionManager.dialQueue, 'dial').resolves(stubInterface<Connection>({
-      remotePeer: peerIdFromPrivateKey(await generateKeyPair('Ed25519'))
+      remotePeer: peerIdFromPrivateKey(await generateKeyPair('Ed25519')),
+      status: 'open'
     }))
 
     // max out the connection limit
@@ -419,7 +420,9 @@ describe('Connection Manager', () => {
     })
     await connectionManager.start()
 
-    sinon.stub(connectionManager.dialQueue, 'dial').resolves(stubInterface<Connection>())
+    sinon.stub(connectionManager.dialQueue, 'dial').resolves(stubInterface<Connection>({
+      status: 'open'
+    }))
 
     // an inbound connection is opened
     const remotePeer = peerIdFromPrivateKey(await generateKeyPair('Ed25519'))
@@ -453,7 +456,8 @@ describe('Connection Manager', () => {
     await connectionManager.start()
 
     sinon.stub(connectionManager.dialQueue, 'dial').resolves(stubInterface<Connection>({
-      remotePeer: peerIdFromPrivateKey(await generateKeyPair('Ed25519'))
+      remotePeer: peerIdFromPrivateKey(await generateKeyPair('Ed25519')),
+      status: 'open'
     }))
 
     // max out the connection limit
@@ -482,7 +486,8 @@ describe('Connection Manager', () => {
     await connectionManager.start()
 
     sinon.stub(connectionManager.dialQueue, 'dial').resolves(stubInterface<Connection>({
-      remotePeer: peerIdFromPrivateKey(await generateKeyPair('Ed25519'))
+      remotePeer: peerIdFromPrivateKey(await generateKeyPair('Ed25519')),
+      status: 'open'
     }))
 
     // start the upgrade
@@ -531,11 +536,13 @@ describe('Connection Manager', () => {
         bytes: 100n
       },
       remotePeer: targetPeer,
-      remoteAddr: multiaddr(`/ip4/123.123.123.123/tcp/123/p2p-circuit/p2p/${targetPeer}`)
+      remoteAddr: multiaddr(`/ip4/123.123.123.123/tcp/123/p2p-circuit/p2p/${targetPeer}`),
+      status: 'open'
     })
     const newConnection = stubInterface<Connection>({
       remotePeer: targetPeer,
-      remoteAddr: addr
+      remoteAddr: addr,
+      status: 'open'
     })
 
     sinon.stub(connectionManager.dialQueue, 'dial')

--- a/packages/libp2p/test/upgrading/upgrader.spec.ts
+++ b/packages/libp2p/test/upgrading/upgrader.spec.ts
@@ -549,6 +549,9 @@ describe('Upgrader', () => {
       remotePeer
     })
 
+    outbound.remoteAddr = multiaddr('/ip4/127.0.0.1/tcp/0').encapsulate(`/p2p/${remotePeer.toString()}`)
+    inbound.remoteAddr = multiaddr('/ip4/127.0.0.1/tcp/0').encapsulate(`/p2p/${localPeer.toString()}`)
+
     const connections = await Promise.all([
       localUpgrader.upgradeOutbound(outbound, {
         skipEncryption: true,


### PR DESCRIPTION
It's possible that the remote can close the connection very shortly after it is opened, so check the connection status before adding it to the list of connections.

Fixes a memory leak whereby the connection is already closed and then is never removed from the connections list.

## Change checklist

- [x] I have performed a self-review of my own code
- [ ] I have made corresponding changes to the documentation if necessary (this includes comments as well)
- [x] I have added tests that prove my fix is effective or that my feature works