### PR TITLE
fix: refactor connection opening and closing

### DIFF
--- a/packages/integration-tests/test/circuit-relay.node.ts
+++ b/packages/integration-tests/test/circuit-relay.node.ts
@@ -602,8 +602,8 @@ describe('circuit-relay', () => {
       await deferred.promise
 
       // should have closed connections to remote and to relay
-      expect(events[0].detail.remotePeer.toString()).to.equal(remote.peerId.toString())
-      expect(events[1].detail.remotePeer.toString()).to.equal(relay1.peerId.toString())
+      expect(events[0].detail.remotePeer.toString()).to.equal(relay1.peerId.toString())
+      expect(events[1].detail.remotePeer.toString()).to.equal(remote.peerId.toString())
     })
 
     it('should remove the relay event listener when the relay stops', async () => {

--- a/packages/transport-tcp/package.json
+++ b/packages/transport-tcp/package.json
@@ -65,6 +65,7 @@
     "@multiformats/mafmt": "^12.1.6",
     "@multiformats/multiaddr": "^12.2.3",
     "@types/sinon": "^17.0.3",
+    "p-defer": "^4.0.1",
     "progress-events": "^1.0.0",
     "stream-to-it": "^1.0.1"
   },
@@ -74,7 +75,6 @@
     "aegir": "^44.0.1",
     "it-all": "^3.0.6",
     "it-pipe": "^3.0.1",
-    "p-defer": "^4.0.1",
     "sinon": "^18.0.0",
     "uint8arrays": "^5.1.0",
     "wherearewe": "^2.0.1"

--- a/packages/transport-tcp/package.json
+++ b/packages/transport-tcp/package.json
@@ -67,6 +67,7 @@
     "@types/sinon": "^17.0.3",
     "p-defer": "^4.0.1",
     "progress-events": "^1.0.0",
+    "race-event": "^1.3.0",
     "stream-to-it": "^1.0.1"
   },
   "devDependencies": {

--- a/packages/transport-tcp/src/constants.ts
+++ b/packages/transport-tcp/src/constants.ts
@@ -7,4 +7,4 @@ export const CODE_UNIX = 400
 export const CLOSE_TIMEOUT = 500
 
 // Close the socket if there is no activity after this long in ms
-export const SOCKET_TIMEOUT = 5 * 60000 // 5 mins
+export const SOCKET_TIMEOUT = 2 * 60000 // 2 mins

--- a/packages/transport-tcp/src/index.ts
+++ b/packages/transport-tcp/src/index.ts
@@ -123,7 +123,8 @@ export interface TCPComponents {
 }
 
 export interface TCPMetrics {
-  dialerEvents: CounterGroup<'error' | 'timeout' | 'connect' | 'abort'>
+  events: CounterGroup<'error' | 'timeout' | 'connect' | 'abort'>
+  errors: CounterGroup<'outbound_to_connection' | 'outbound_upgrade'>
 }
 
 export function tcp (init: TCPOptions = {}): (components: TCPComponents) => Transport {


### PR DESCRIPTION
Simplifies tcp transport connection opening/closing, catches some instances where we were not destroying sockets for incoming and outgoing connections which caused a file descriptor leak.

Before/after:

<img width="654" alt="image" src="https://github.com/user-attachments/assets/af786b2e-becf-485d-8138-cb7f142f4cdc">

## Change checklist

- [x] I have performed a self-review of my own code
- [ ] I have made corresponding changes to the documentation if necessary (this includes comments as well)
- [x] I have added tests that prove my fix is effective or that my feature works