### PR TITLE
fix: make queue job args non-optional

### DIFF
--- a/packages/utils/src/queue/index.ts
+++ b/packages/utils/src/queue/index.ts
@@ -48,8 +48,8 @@ export interface QueueInit<JobReturnType, JobOptions extends AbortOptions = Abor
 
 export type JobStatus = 'queued' | 'running' | 'errored' | 'complete'
 
-export interface RunFunction<Options = AbortOptions, ReturnType = void> {
-  (opts?: Options): Promise<ReturnType>
+export interface RunFunction<Options extends AbortOptions = AbortOptions, ReturnType = void> {
+  (options: Options): Promise<ReturnType>
 }
 
 export interface JobMatcher<JobOptions extends AbortOptions = AbortOptions> {


### PR DESCRIPTION
There will always be an abort signal passed to a queue job so the options arg will always be present.

## Change checklist

- [x] I have performed a self-review of my own code
- [ ] I have made corresponding changes to the documentation if necessary (this includes comments as well)
- [ ] I have added tests that prove my fix is effective or that my feature works