### PR TITLE
feat!: ping peers before adding to routing table

### DIFF
--- a/packages/kad-dht/package.json
+++ b/packages/kad-dht/package.json
@@ -109,7 +109,6 @@
     "lodash.random": "^3.2.0",
     "lodash.range": "^3.2.0",
     "p-retry": "^6.2.0",
-    "p-wait-for": "^5.0.2",
     "protons": "^7.5.0",
     "sinon": "^18.0.0",
     "sinon-ts": "^2.0.0",

--- a/packages/kad-dht/src/errors.ts
+++ b/packages/kad-dht/src/errors.ts
@@ -37,3 +37,13 @@ export class MissingSelectorError extends Error {
     this.name = 'MissingSelectorError'
   }
 }
+
+/**
+ * A selector function was missing
+ */
+export class ContactOnlineError extends Error {
+  constructor (message = 'Contact was still online') {
+    super(message)
+    this.name = 'ContactOnlineError'
+  }
+}

--- a/packages/kad-dht/src/errors.ts
+++ b/packages/kad-dht/src/errors.ts
@@ -37,13 +37,3 @@ export class MissingSelectorError extends Error {
     this.name = 'MissingSelectorError'
   }
 }
-
-/**
- * A selector function was missing
- */
-export class ContactOnlineError extends Error {
-  constructor (message = 'Contact was still online') {
-    super(message)
-    this.name = 'ContactOnlineError'
-  }
-}

--- a/packages/kad-dht/src/index.ts
+++ b/packages/kad-dht/src/index.ts
@@ -400,7 +400,7 @@ export interface KadDHTInit {
    * Settings for how long to wait in ms when pinging DHT peers to decide if
    * they should be evicted from the routing table or not.
    */
-  pingTimeout?: Omit<AdaptiveTimeoutInit, 'metricsName' | 'metrics'>
+  pingOldContactTimeout?: Omit<AdaptiveTimeoutInit, 'metricsName' | 'metrics'>
 
   /**
    * How many peers to ping in parallel when deciding if they should
@@ -408,7 +408,35 @@ export interface KadDHTInit {
    *
    * @default 10
    */
-  pingConcurrency?: number
+  pingOldContactConcurrency?: number
+
+  /**
+   * How long the queue to ping peers is allowed to grow
+   *
+   * @default 100
+   */
+  pingOldContactMaxQueueSize?: number
+
+  /**
+   * Settings for how long to wait in ms when pinging DHT peers to decide if
+   * they should be added to the routing table or not.
+   */
+  pingNewContactTimeout?: Omit<AdaptiveTimeoutInit, 'metricsName' | 'metrics'>
+
+  /**
+   * How many peers to ping in parallel when deciding if they should be added to
+   * the routing table or not
+   *
+   * @default 10
+   */
+  pingNewContactConcurrency?: number
+
+  /**
+   * How long the queue to ping peers is allowed to grow
+   *
+   * @default 100
+   */
+  pingNewContactMaxQueueSize?: number
 
   /**
    * How many parallel incoming streams to allow on the DHT protocol per

--- a/packages/kad-dht/src/network.ts
+++ b/packages/kad-dht/src/network.ts
@@ -85,7 +85,7 @@ export class Network extends TypedEventEmitter<NetworkEvents> implements Startab
   }
 
   /**
-   * Send a request and record RTT for latency measurements
+   * Send a request and read a response
    */
   async * sendRequest (to: PeerId, msg: Partial<Message>, options: RoutingOptions = {}): AsyncGenerator<QueryEvent> {
     if (!this.running) {
@@ -204,7 +204,6 @@ export class Network extends TypedEventEmitter<NetworkEvents> implements Startab
   async _writeMessage (stream: Stream, msg: Partial<Message>, options: AbortOptions): Promise<void> {
     const pb = pbStream(stream)
     await pb.write(msg, Message, options)
-    await pb.unwrap().close(options)
   }
 
   /**
@@ -218,8 +217,6 @@ export class Network extends TypedEventEmitter<NetworkEvents> implements Startab
     await pb.write(msg, Message, options)
 
     const message = await pb.read(Message, options)
-
-    await pb.unwrap().close(options)
 
     // tell any listeners about new peers we've seen
     message.closer.forEach(peerData => {

--- a/packages/kad-dht/src/routing-table/index.ts
+++ b/packages/kad-dht/src/routing-table/index.ts
@@ -15,7 +15,7 @@ import type { AdaptiveTimeoutInit } from '@libp2p/utils/adaptive-timeout'
 export const KAD_CLOSE_TAG_NAME = 'kad-close'
 export const KAD_CLOSE_TAG_VALUE = 50
 export const KBUCKET_SIZE = 20
-export const PREFIX_LENGTH = 32
+export const PREFIX_LENGTH = 7
 export const PING_NEW_CONTACT_TIMEOUT = 2000
 export const PING_NEW_CONTACT_CONCURRENCY = 20
 export const PING_NEW_CONTACT_MAX_QUEUE_SIZE = 100
@@ -122,9 +122,6 @@ export class RoutingTable extends TypedEventEmitter<RoutingTableEvents> implemen
       metrics: this.components.metrics,
       maxSize: init.pingOldContactMaxQueueSize ?? PING_OLD_CONTACT_MAX_QUEUE_SIZE
     })
-    this.pingOldContactQueue.addEventListener('error', evt => {
-      this.log.error('error pinging old contact', evt.detail)
-    })
     this.pingOldContactTimeout = new AdaptiveTimeout({
       ...(init.pingOldContactTimeout ?? {}),
       metrics: this.components.metrics,
@@ -136,9 +133,6 @@ export class RoutingTable extends TypedEventEmitter<RoutingTableEvents> implemen
       metricName: `${init.logPrefix.replaceAll(':', '_')}_ping_new_contact_queue`,
       metrics: this.components.metrics,
       maxSize: init.pingNewContactMaxQueueSize ?? PING_NEW_CONTACT_MAX_QUEUE_SIZE
-    })
-    this.pingNewContactQueue.addEventListener('error', evt => {
-      this.log.error('error pinging new contact', evt.detail)
     })
     this.pingNewContactTimeout = new AdaptiveTimeout({
       ...(init.pingNewContactTimeout ?? {}),

--- a/packages/kad-dht/src/routing-table/k-bucket.ts
+++ b/packages/kad-dht/src/routing-table/k-bucket.ts
@@ -1,45 +1,48 @@
-import { TypedEventEmitter } from '@libp2p/interface'
 import map from 'it-map'
+import { equals as uint8ArrayEquals } from 'uint8arrays/equals'
 import { toString as uint8ArrayToString } from 'uint8arrays/to-string'
 import { xor as uint8ArrayXor } from 'uint8arrays/xor'
 import { PeerDistanceList } from '../peer-list/peer-distance-list.js'
-import { KBUCKET_SIZE } from './index.js'
+import { convertPeerId } from '../utils.js'
+import { KBUCKET_SIZE, LAST_PING_THRESHOLD, PING_OLD_CONTACT_COUNT, PREFIX_LENGTH } from './index.js'
 import type { PeerId } from '@libp2p/interface'
+import type { AbortOptions } from 'it-protobuf-stream'
 
-function arrayEquals (array1: Uint8Array, array2: Uint8Array): boolean {
-  if (array1 === array2) {
-    return true
-  }
-  if (array1.length !== array2.length) {
-    return false
-  }
-  for (let i = 0, length = array1.length; i < length; ++i) {
-    if (array1[i] !== array2[i]) {
-      return false
-    }
-  }
-  return true
+export interface PingFunction {
+  /**
+   * Return either none or at least one contact that does not respond to a ping
+   * message
+   */
+  (oldContacts: Peer[], options?: AbortOptions): AsyncGenerator<Peer>
 }
 
-function ensureInt8 (name: string, val?: Uint8Array): void {
-  if (!(val instanceof Uint8Array)) {
-    throw new TypeError(name + ' is not a Uint8Array')
-  }
-
-  if (val.byteLength !== 32) {
-    throw new TypeError(name + ' had incorrect length')
-  }
+/**
+ * Before a peer can be added to the table, verify that it is online and working
+ * correctly
+ */
+export interface VerifyFunction {
+  (contact: Peer, options?: AbortOptions): Promise<boolean>
 }
 
-export interface PingEventDetails {
-  oldContacts: Peer[]
-  newContact: Peer
+export interface OnAddCallback {
+  /**
+   * Invoked when a new peer is added to the routing tables
+   */
+  (peer: Peer, bucket: LeafBucket): Promise<void>
 }
 
-export interface KBucketEvents {
-  'ping': CustomEvent<PingEventDetails>
-  'added': CustomEvent<Peer>
-  'removed': CustomEvent<Peer>
+export interface OnRemoveCallback {
+  /**
+   * Invoked when a peer is evicted from the routing tables
+   */
+  (peer: Peer, bucket: LeafBucket): Promise<void>
+}
+
+export interface OnMoveCallback {
+  /**
+   * Invoked when a peer is moved between buckets in the routing tables
+   */
+  (peer: Peer, oldBucket: LeafBucket, newBucket: LeafBucket): Promise<void>
 }
 
 export interface KBucketOptions {
@@ -47,14 +50,16 @@ export interface KBucketOptions {
    * The current peer. All subsequently added peers must have a KadID that is
    * the same length as this peer.
    */
-  localPeer: Peer
+  // localPeer: Peer
 
   /**
    * How many bits of the key to use when forming the bucket trie. The larger
    * this value, the deeper the tree will grow and the slower the lookups will
    * be but the peers returned will be more specific to the key.
+   *
+   * @default 32
    */
-  prefixLength: number
+  prefixLength?: number
 
   /**
    * The number of nodes that a max-depth k-bucket can contain before being
@@ -74,20 +79,37 @@ export interface KBucketOptions {
 
   /**
    * The number of nodes to ping when a bucket that should not be split becomes
-   * full. KBucket will emit a `ping` event that contains `numberOfNodesToPing`
-   * nodes that have not been contacted the longest.
+   * full. KBucket will emit a `ping` event that contains
+   * `numberOfOldContactsToPing` nodes that have not been contacted the longest.
+   *
+   * @default 3
    */
-  numberOfNodesToPing?: number
+  numberOfOldContactsToPing?: number
+
+  /**
+   * Do not re-ping a peer during this time window in ms
+   *
+   * @default 600000
+   */
+  lastPingThreshold?: number
+
+  ping: PingFunction
+  verify: VerifyFunction
+  onAdd?: OnAddCallback
+  onRemove?: OnRemoveCallback
+  onMove?: OnMoveCallback
 }
 
 export interface Peer {
   kadId: Uint8Array
   peerId: PeerId
+  lastPing: number
 }
 
 export interface LeafBucket {
   prefix: string
   depth: number
+  containsSelf?: boolean
   peers: Peer[]
 }
 
@@ -108,24 +130,31 @@ export function isLeafBucket (obj: any): obj is LeafBucket {
  * Implementation of a Kademlia DHT routing table as a prefix binary trie with
  * configurable prefix length, bucket split threshold and size.
  */
-export class KBucket extends TypedEventEmitter<KBucketEvents> {
+export class KBucket {
   public root: Bucket
-  public localPeer: Peer
+  public localPeer?: Peer
   private readonly prefixLength: number
   private readonly splitThreshold: number
   private readonly kBucketSize: number
   private readonly numberOfNodesToPing: number
+  private readonly lastPingThreshold: number
+  public ping: PingFunction
+  public verify: VerifyFunction
+  private readonly onAdd?: OnAddCallback
+  private readonly onRemove?: OnRemoveCallback
+  private readonly onMove?: OnMoveCallback
 
   constructor (options: KBucketOptions) {
-    super()
-
-    this.localPeer = options.localPeer
-    this.prefixLength = options.prefixLength
+    this.prefixLength = options.prefixLength ?? PREFIX_LENGTH
     this.kBucketSize = options.kBucketSize ?? KBUCKET_SIZE
     this.splitThreshold = options.splitThreshold ?? this.kBucketSize
-    this.numberOfNodesToPing = options.numberOfNodesToPing ?? 3
-
-    ensureInt8('options.localPeer.kadId', options.localPeer.kadId)
+    this.numberOfNodesToPing = options.numberOfOldContactsToPing ?? PING_OLD_CONTACT_COUNT
+    this.lastPingThreshold = options.lastPingThreshold ?? LAST_PING_THRESHOLD
+    this.ping = options.ping
+    this.verify = options.verify
+    this.onAdd = options.onAdd
+    this.onRemove = options.onRemove
+    this.onMove = options.onMove
 
     this.root = {
       prefix: '',
@@ -134,14 +163,31 @@ export class KBucket extends TypedEventEmitter<KBucketEvents> {
     }
   }
 
-  /**
-   * Adds a contact to the k-bucket.
-   *
-   * @param {Peer} peer - the contact object to add
-   */
-  add (peer: Peer): void {
-    ensureInt8('peer.kadId', peer?.kadId)
+  async addSelfPeer (peerId: PeerId): Promise<void> {
+    this.localPeer = {
+      peerId,
+      kadId: await convertPeerId(peerId),
+      lastPing: Date.now()
+    }
 
+    const bucket = this._determineBucket(this.localPeer.kadId)
+    bucket.containsSelf = true
+  }
+
+  /**
+   * Adds a contact to the trie
+   */
+  async add (peerId: PeerId, options?: AbortOptions): Promise<void> {
+    const peer = {
+      peerId,
+      kadId: await convertPeerId(peerId),
+      lastPing: 0
+    }
+
+    return this._add(peer, options)
+  }
+
+  private async _add (peer: Peer, options?: AbortOptions): Promise<void> {
     const bucket = this._determineBucket(peer.kadId)
 
     // check if the contact already exists
@@ -152,18 +198,32 @@ export class KBucket extends TypedEventEmitter<KBucketEvents> {
     // are there too many peers in the bucket and can we make the trie deeper?
     if (bucket.peers.length === this.splitThreshold && bucket.depth < this.prefixLength) {
       // split the bucket
-      this._split(bucket)
+      await this._split(bucket)
 
       // try again
-      this.add(peer)
+      await this._add(peer, options)
 
       return
     }
 
     // is there space in the bucket?
     if (bucket.peers.length < this.kBucketSize) {
-      bucket.peers.push(peer)
-      this.safeDispatchEvent('added', { detail: peer })
+      // we've ping this peer previously, just add them to the bucket
+      if (!needsPing(peer, this.lastPingThreshold)) {
+        bucket.peers.push(peer)
+        await this.onAdd?.(peer, bucket)
+        return
+      }
+
+      const result = await this.verify(peer, options)
+
+      // only add if peer is online and functioning correctly
+      if (result) {
+        peer.lastPing = Date.now()
+
+        // try again - buckets may have changed during ping
+        await this._add(peer, options)
+      }
 
       return
     }
@@ -171,17 +231,51 @@ export class KBucket extends TypedEventEmitter<KBucketEvents> {
     // we are at the bottom of the trie and the bucket is full so we can't add
     // any more peers.
     //
-    // instead ping the first this.numberOfNodesToPing in order to determine
+    // instead ping the first `this.numberOfNodesToPing` in order to determine
     // if they are still online.
     //
     // only add the new peer if one of the pinged nodes does not respond, this
     // prevents DoS flooding with new invalid contacts.
-    this.safeDispatchEvent('ping', {
-      detail: {
-        oldContacts: bucket.peers.slice(0, this.numberOfNodesToPing),
-        newContact: peer
-      }
-    })
+    const toPing = bucket.peers
+      .filter(peer => {
+        if (peer.peerId.equals(this.localPeer?.peerId)) {
+          return false
+        }
+
+        if (peer.lastPing > (Date.now() - this.lastPingThreshold)) {
+          return false
+        }
+
+        return true
+      })
+      .sort((a, b) => {
+        // sort oldest ping -> newest
+        if (a.lastPing < b.lastPing) {
+          return -1
+        }
+
+        if (a.lastPing > b.lastPing) {
+          return 1
+        }
+
+        return 0
+      })
+      .slice(0, this.numberOfNodesToPing)
+
+    let evicted = false
+
+    for await (const toEvict of this.ping(toPing, options)) {
+      evicted = true
+      await this.remove(toEvict.kadId)
+    }
+
+    // did not evict any peers, cannot add new contact
+    if (!evicted) {
+      return
+    }
+
+    // try again - buckets may have changed during ping
+    await this._add(peer, options)
   }
 
   /**
@@ -235,7 +329,7 @@ export class KBucket extends TypedEventEmitter<KBucketEvents> {
    * which branch of the tree to traverse and repeat.
    *
    * @param {Uint8Array} kadId - The ID of the contact to fetch.
-   * @returns {object | undefined} The contact if available, otherwise null
+   * @returns {Peer | undefined} The contact if available, otherwise null
    */
   get (kadId: Uint8Array): Peer | undefined {
     const bucket = this._determineBucket(kadId)
@@ -249,15 +343,14 @@ export class KBucket extends TypedEventEmitter<KBucketEvents> {
    *
    * @param {Uint8Array} kadId - The ID of the contact to remove
    */
-  remove (kadId: Uint8Array): void {
+  async remove (kadId: Uint8Array): Promise<void> {
     const bucket = this._determineBucket(kadId)
     const index = this._indexOf(bucket, kadId)
 
     if (index > -1) {
       const peer = bucket.peers.splice(index, 1)[0]
-      this.safeDispatchEvent('removed', {
-        detail: peer
-      })
+
+      await this.onRemove?.(peer, bucket)
     }
   }
 
@@ -331,7 +424,7 @@ export class KBucket extends TypedEventEmitter<KBucketEvents> {
    * @returns {number} Integer Index of contact with provided id if it exists, -1 otherwise.
    */
   private _indexOf (bucket: LeafBucket, kadId: Uint8Array): number {
-    return bucket.peers.findIndex(peer => arrayEquals(peer.kadId, kadId))
+    return bucket.peers.findIndex(peer => uint8ArrayEquals(peer.kadId, kadId))
   }
 
   /**
@@ -339,8 +432,8 @@ export class KBucket extends TypedEventEmitter<KBucketEvents> {
    *
    * @param {any} bucket - bucket for splitting
    */
-  private _split (bucket: LeafBucket): void {
-    const depth = bucket.depth + 1
+  private async _split (bucket: LeafBucket): Promise<void> {
+    const depth = bucket.prefix === '' ? bucket.depth : bucket.depth + 1
 
     // create child buckets
     const left: LeafBucket = {
@@ -354,23 +447,44 @@ export class KBucket extends TypedEventEmitter<KBucketEvents> {
       peers: []
     }
 
+    if (bucket.containsSelf === true && this.localPeer != null) {
+      delete bucket.containsSelf
+      const selfNodeBitString = uint8ArrayToString(this.localPeer.kadId, 'base2')
+
+      if (selfNodeBitString[depth] === '0') {
+        left.containsSelf = true
+      } else {
+        right.containsSelf = true
+      }
+    }
+
     // redistribute peers
     for (const peer of bucket.peers) {
       const bitString = uint8ArrayToString(peer.kadId, 'base2')
 
       if (bitString[depth] === '0') {
         left.peers.push(peer)
+        await this.onMove?.(peer, bucket, left)
       } else {
         right.peers.push(peer)
+        await this.onMove?.(peer, bucket, right)
       }
     }
 
-    // convert leaf bucket to internal bucket
-    // @ts-expect-error peers is not a property of LeafBucket
-    delete bucket.peers
-    // @ts-expect-error left is not a property of LeafBucket
-    bucket.left = left
-    // @ts-expect-error right is not a property of LeafBucket
-    bucket.right = right
+    // convert old leaf bucket to internal bucket
+    convertToInternalBucket(bucket, left, right)
   }
+}
+
+function convertToInternalBucket (bucket: any, left: any, right: any): bucket is InternalBucket {
+  delete bucket.peers
+  delete bucket.containsSelf
+  bucket.left = left
+  bucket.right = right
+
+  return true
+}
+
+function needsPing (peer: Peer, threshold: number): boolean {
+  return peer.lastPing < (Date.now() - threshold)
 }

--- a/packages/kad-dht/src/routing-table/refresh.ts
+++ b/packages/kad-dht/src/routing-table/refresh.ts
@@ -169,6 +169,10 @@ export class RoutingTableRefresh {
       throw new Error('Routing table not started')
     }
 
+    if (this.routingTable.kb.localPeer == null) {
+      throw new Error('Local peer not set')
+    }
+
     const randomData = randomBytes(2)
     const randomUint16 = (randomData[1] << 8) + randomData[0]
 
@@ -245,7 +249,7 @@ export class RoutingTableRefresh {
    * Yields the common prefix length of every peer in the table
    */
   * _prefixLengths (): Generator<number> {
-    if (this.routingTable.kb == null) {
+    if (this.routingTable.kb?.localPeer == null) {
       return
     }
 

--- a/packages/kad-dht/test/generate-peers/generate-peers.node.ts
+++ b/packages/kad-dht/test/generate-peers/generate-peers.node.ts
@@ -14,6 +14,7 @@ import { RoutingTableRefresh } from '../../src/routing-table/refresh.js'
 import {
   convertPeerId
 } from '../../src/utils.js'
+import type { Network } from '../../src/network.js'
 import type { PeerStore } from '@libp2p/interface'
 import type { ConnectionManager } from '@libp2p/interface-internal'
 
@@ -64,7 +65,8 @@ describe.skip('generate peers', function () {
     const table = new RoutingTable(components, {
       kBucketSize: 20,
       logPrefix: '',
-      protocol: '/ipfs/kad/1.0.0'
+      protocol: '/ipfs/kad/1.0.0',
+      network: stubInterface<Network>()
     })
     refresh = new RoutingTableRefresh({
       logger: defaultLogger()

--- a/packages/kad-dht/test/kad-dht.spec.ts
+++ b/packages/kad-dht/test/kad-dht.spec.ts
@@ -779,8 +779,8 @@ describe('KadDHT', () => {
       // The expected closest kValue peers to the key
       const exp = actualClosest.slice(0, c.K)
 
-      // Expect the kValue peers found to include the kValue closest connected peers
-      // to the key
+      // Expect the kValue peers found to include the kValue closest connected
+      // peers to the key
       expect(countDiffPeers(out, exp)).to.equal(0)
     })
 
@@ -838,7 +838,7 @@ describe('KadDHT', () => {
   })
 
   describe('errors', () => {
-    it('get should handle correctly an unexpected error', async function () {
+    it('get should correctly handle an unexpected error', async function () {
       this.timeout(240 * 1000)
 
       const error = new Error('fake error')

--- a/packages/kad-dht/test/libp2p-routing.spec.ts
+++ b/packages/kad-dht/test/libp2p-routing.spec.ts
@@ -115,6 +115,9 @@ describe('content routing', () => {
       allowQueryWithZeroPeers: true
     })(components)
 
+    // @ts-expect-error not part of public api
+    dht.routingTable.kb.verify = async () => true
+
     await start(dht)
 
     // @ts-expect-error cannot use symbol to index KadDHT type
@@ -246,6 +249,9 @@ describe('peer routing', () => {
     })(components)
 
     await start(dht)
+
+    // @ts-expect-error not part of public api
+    dht.routingTable.kb.verify = async () => true
 
     // @ts-expect-error cannot use symbol to index KadDHT type
     peerRouting = dht[peerRoutingSymbol]

--- a/packages/kad-dht/test/utils/test-dht.ts
+++ b/packages/kad-dht/test/utils/test-dht.ts
@@ -86,6 +86,9 @@ export class TestDHT {
 
     const dht = new KadDHTClass(components, opts)
 
+    // skip peer validation
+    dht.routingTable.kb.verify = async () => true
+
     // simulate libp2p._onDiscoveryPeer
     dht.addEventListener('peer', (evt) => {
       const peerData = evt.detail


### PR DESCRIPTION
Implements the [check-before-add](https://github.com/libp2p/go-libp2p-kad-dht/blob/master/optimizations.md#checking-before-adding) client optimisation to ping a peer before adding it to the routing table.

Adds a "new peer ping queue" to apply a concurrency limit to these pings, because it would be expected for old contacts to be less likely to be online so don't block adding new contacts to unrelated buckets if the connection to an old contact is timing out while being pinged before eviction.

BREAKING CHANGE: the routing ping options have been split into "old contact" and "new contact" and renamed according

## Change checklist

- [x] I have performed a self-review of my own code
- [ ] I have made corresponding changes to the documentation if necessary (this includes comments as well)
- [x] I have added tests that prove my fix is effective or that my feature works