### PR TITLE
chore: remove reference to removed roadmap

### DIFF
--- a/packages/libp2p/README.md
+++ b/packages/libp2p/README.md
@@ -74,14 +74,6 @@ We are in the process of writing better documentation, blog posts, tutorials and
 
 To sum up, libp2p is a "network stack" -- a protocol suite -- that cleanly separates concerns, and enables sophisticated applications to only use the protocols they absolutely need, without giving up interoperability and upgradeability. libp2p grew out of IPFS, but it is built so that lots of people can use it, for lots of different projects.
 
-# Roadmap
-
-The js-libp2p roadmap can be found here: <https://github.com/libp2p/js-libp2p/blob/main/ROADMAP.md>
-
-It represents current projects the js-libp2p maintainers are focused on and provides an estimation of completion targets.
-
-It is complementary to the overarching libp2p project roadmap: <https://github.com/libp2p/specs/blob/master/ROADMAP.md>
-
 # Usage
 
 ### Configuration


### PR DESCRIPTION
The roadmap was removed in #2689. There are a few links to it still.

This PR removes the link in libp2p/js-libp2p/packages/libp2p

https://github.com/libp2p/js-libp2p/blob/main/packages/libp2p/README.md#roadmap

There is also a link from libp2p/specs.

https://github.com/libp2p/specs/blob/master/ROADMAP.md#implementation-roadmaps

Can open a PR there for it to be removed but #2689 mentions that `can view roadmap in Github issues` but was not able to find something to link to.
