### PR TITLE
fix: tag relay with keep_alive

### DIFF
--- a/packages/transport-circuit-relay-v2/src/transport/reservation-store.ts
+++ b/packages/transport-circuit-relay-v2/src/transport/reservation-store.ts
@@ -1,4 +1,4 @@
-import { TypedEventEmitter, setMaxListeners } from '@libp2p/interface'
+import { KEEP_ALIVE, TypedEventEmitter, setMaxListeners } from '@libp2p/interface'
 import { PeerMap } from '@libp2p/peer-collections'
 import { createBloomFilter } from '@libp2p/utils/filters'
 import { PeerQueue } from '@libp2p/utils/peer-queue'
@@ -247,6 +247,10 @@ export class ReservationStore extends TypedEventEmitter<ReservationStoreEvents> 
         await this.peerStore.merge(peerId, {
           tags: {
             [RELAY_TAG]: {
+              value: 1,
+              ttl: expiration
+            },
+            [KEEP_ALIVE]: {
               value: 1,
               ttl: expiration
             }


### PR DESCRIPTION
Since the auto dialer was removed, we need to tag the relay with `KEEP_ALIVE` to reconnect to it if we disconnect.

## Change checklist

- [x] I have performed a self-review of my own code
- [ ] I have made corresponding changes to the documentation if necessary (this includes comments as well)
- [ ] I have added tests that prove my fix is effective or that my feature works