### PR TITLE
fix: emit 'listening' when relays change

### DIFF
--- a/packages/integration-tests/test/circuit-relay.node.ts
+++ b/packages/integration-tests/test/circuit-relay.node.ts
@@ -624,15 +624,16 @@ describe('circuit-relay', () => {
         return circuitMultiaddrs.length > 0
       })
 
-      expect(circuitListener[0].relayStore.listenerCount('relay:removed')).to.equal(2)
+      expect(circuitListener[0].reservationStore.listenerCount('relay:removed')).to.equal(2)
 
-      // remove one listener
-      await local.hangUp(relay1.peerId)
+      // stop the listener
+      await circuitListener[0].close()
 
+      // not using the relay any more
       await notUsingAsRelay(local, relay1)
 
       // expect 1 listener
-      expect(circuitListener[0].relayStore.listenerCount('relay:removed')).to.equal(1)
+      expect(circuitListener[0].reservationStore.listenerCount('relay:removed')).to.equal(1)
     })
 
     it('should mark an outgoing relayed connection as limited', async () => {

--- a/packages/interface/src/index.ts
+++ b/packages/interface/src/index.ts
@@ -161,9 +161,10 @@ export interface Libp2pEvents<T extends ServiceMap = ServiceMap> {
   'peer:connect': CustomEvent<PeerId>
 
   /**
-   * This event will be triggered any time we are disconnected from another peer, regardless of
-   * the circumstances of that disconnection. If we happen to have multiple connections to a
-   * peer, this event will **only** be triggered when the last connection is closed.
+   * This event will be triggered any time we are disconnected from another
+   * peer, regardless of the circumstances of that disconnection. If we happen
+   * to have multiple connections to a peer, this event will **only** be
+   * triggered when the last connection is closed.
    *
    * @example
    *
@@ -177,9 +178,26 @@ export interface Libp2pEvents<T extends ServiceMap = ServiceMap> {
   'peer:disconnect': CustomEvent<PeerId>
 
   /**
-   * This event is dispatched after a remote peer has successfully responded to the identify
-   * protocol. Note that for this to be emitted, both peers must have an identify service
-   * configured.
+   * When a peer tagged with `keep-alive` disconnects, we will make multiple
+   * attempts to reconnect to it with a backoff factor (see the connection
+   * manager settings for details). If these all fail, the `keep-alive` tag will
+   * be removed and this event will be emitted.
+   *
+   * @example
+   *
+   * ```TypeScript
+   * libp2p.addEventListener('peer:reconnect-failure', (event) => {
+   *   const peerId = event.detail
+   *   // ...
+   * })
+   * ```
+   */
+  'peer:reconnect-failure': CustomEvent<PeerId>
+
+  /**
+   * This event is dispatched after a remote peer has successfully responded to
+   * the identify protocol. Note that for this to be emitted, both peers must
+   * have an identify service configured.
    *
    * @example
    *

--- a/packages/transport-circuit-relay-v2/package.json
+++ b/packages/transport-circuit-relay-v2/package.json
@@ -64,7 +64,6 @@
     "it-protobuf-stream": "^1.1.3",
     "it-stream-types": "^2.0.1",
     "multiformats": "^13.1.0",
-    "p-defer": "^4.0.1",
     "progress-events": "^1.0.0",
     "protons-runtime": "^5.4.0",
     "race-signal": "^1.0.2",

--- a/packages/transport-circuit-relay-v2/src/constants.ts
+++ b/packages/transport-circuit-relay-v2/src/constants.ts
@@ -29,9 +29,9 @@ export const DEFAULT_MAX_RESERVATION_TTL = 2 * 60 * minute
 export const DEFAULT_RESERVATION_CONCURRENCY = 1
 
 /**
- * How long to wait for a reservation attempt to finsih
+ * How long to wait for a reservation attempt to finish
  */
-export const DEFAULT_RESERVATION_COMPLETION_TIMEOUT = 1000
+export const DEFAULT_RESERVATION_COMPLETION_TIMEOUT = 2000
 
 /**
  * How long to let the reservation attempt queue to grow
@@ -43,6 +43,7 @@ export const RELAY_SOURCE_TAG = 'circuit-relay-source'
 export const RELAY_TAG = 'circuit-relay-relay'
 
 export const KEEP_ALIVE_TAG = `${KEEP_ALIVE}-circuit-relay`
+export const KEEP_ALIVE_SOURCE_TAG = `${KEEP_ALIVE}-circuit-relay-source`
 
 // circuit v2 connection limits
 // https://github.com/libp2p/go-libp2p/blob/master/p2p/protocol/circuitv2/relay/resources.go#L61-L66

--- a/packages/transport-circuit-relay-v2/src/index.ts
+++ b/packages/transport-circuit-relay-v2/src/index.ts
@@ -64,10 +64,10 @@ export interface CircuitRelayService extends TypedEventEmitter<CircuitRelayServi
 
 export { circuitRelayServer } from './server/index.js'
 export type { CircuitRelayServerInit, CircuitRelayServerComponents } from './server/index.js'
-export type { ReservationStoreInit } from './server/reservation-store.js'
+export type { ReservationStoreInit as ServerReservationStoreInit } from './server/reservation-store.js'
 export { circuitRelayTransport } from './transport/index.js'
 export type { RelayDiscoveryComponents } from './transport/discovery.js'
-export type { RelayStoreInit } from './transport/reservation-store.js'
+export type { ReservationStoreInit as TransportReservationStoreInit } from './transport/reservation-store.js'
 export type { CircuitRelayTransportInit, CircuitRelayTransportComponents } from './transport/index.js'
 
 export {

--- a/packages/transport-circuit-relay-v2/src/server/index.ts
+++ b/packages/transport-circuit-relay-v2/src/server/index.ts
@@ -4,10 +4,10 @@ import { RecordEnvelope } from '@libp2p/peer-record'
 import { type Multiaddr, multiaddr } from '@multiformats/multiaddr'
 import { pbStream, type ProtobufStream } from 'it-protobuf-stream'
 import * as Digest from 'multiformats/hashes/digest'
-import pDefer from 'p-defer'
 import {
   CIRCUIT_PROTO_CODE,
   DEFAULT_HOP_TIMEOUT,
+  KEEP_ALIVE_SOURCE_TAG,
   MAX_CONNECTIONS,
   RELAY_SOURCE_TAG,
   RELAY_V2_HOP_CODEC,
@@ -18,7 +18,7 @@ import { createLimitedRelay } from '../utils.js'
 import { ReservationStore, type ReservationStoreInit } from './reservation-store.js'
 import { ReservationVoucherRecord } from './reservation-voucher.js'
 import type { CircuitRelayService, RelayReservation } from '../index.js'
-import type { ComponentLogger, Logger, Connection, Stream, ConnectionGater, PeerId, PeerStore, Startable, PrivateKey, Metrics } from '@libp2p/interface'
+import type { ComponentLogger, Logger, Connection, Stream, ConnectionGater, PeerId, PeerStore, Startable, PrivateKey, Metrics, AbortOptions } from '@libp2p/interface'
 import type { AddressManager, ConnectionManager, IncomingStreamData, Registrar } from '@libp2p/interface-internal'
 import type { PeerMap } from '@libp2p/peer-collections'
 
@@ -175,17 +175,13 @@ class CircuitRelayServer extends TypedEventEmitter<RelayServerEvents> implements
   async onHop ({ connection, stream }: IncomingStreamData): Promise<void> {
     this.log('received circuit v2 hop protocol stream from %p', connection.remotePeer)
 
-    const hopTimeoutPromise = pDefer<HopMessage>()
-    const timeout = setTimeout(() => {
-      hopTimeoutPromise.reject('timed out')
-    }, this.hopTimeout)
+    const options = {
+      signal: AbortSignal.timeout(this.hopTimeout)
+    }
     const pbstr = pbStream(stream)
 
     try {
-      const request: HopMessage = await Promise.race([
-        pbstr.pb(HopMessage).read(),
-        hopTimeoutPromise.promise
-      ])
+      const request: HopMessage = await pbstr.pb(HopMessage).read(options)
 
       if (request?.type == null) {
         throw new Error('request was invalid, could not read from stream')
@@ -193,31 +189,26 @@ class CircuitRelayServer extends TypedEventEmitter<RelayServerEvents> implements
 
       this.log('received', request.type)
 
-      await Promise.race([
-        this.handleHopProtocol({
-          connection,
-          stream: pbstr,
-          request
-        }),
-        hopTimeoutPromise.promise
-      ])
+      await this.handleHopProtocol({
+        connection,
+        stream: pbstr,
+        request
+      }, options)
     } catch (err: any) {
       this.log.error('error while handling hop', err)
       await pbstr.pb(HopMessage).write({
         type: HopMessage.Type.STATUS,
         status: Status.MALFORMED_MESSAGE
-      })
+      }, options)
       stream.abort(err)
-    } finally {
-      clearTimeout(timeout)
     }
   }
 
-  async handleHopProtocol ({ stream, request, connection }: HopProtocolOptions): Promise<void> {
+  async handleHopProtocol ({ stream, request, connection }: HopProtocolOptions, options: AbortOptions): Promise<void> {
     this.log('received hop message')
     switch (request.type) {
-      case HopMessage.Type.RESERVE: await this.handleReserve({ stream, request, connection }); break
-      case HopMessage.Type.CONNECT: await this.handleConnect({ stream, request, connection }); break
+      case HopMessage.Type.RESERVE: await this.handleReserve({ stream, request, connection }, options); break
+      case HopMessage.Type.CONNECT: await this.handleConnect({ stream, request, connection }, options); break
       default: {
         this.log.error('invalid hop request type %s via peer %p', request.type, connection.remotePeer)
         await stream.pb(HopMessage).write({ type: HopMessage.Type.STATUS, status: Status.UNEXPECTED_MESSAGE })
@@ -225,37 +216,38 @@ class CircuitRelayServer extends TypedEventEmitter<RelayServerEvents> implements
     }
   }
 
-  async handleReserve ({ stream, request, connection }: HopProtocolOptions): Promise<void> {
+  async handleReserve ({ stream, connection }: HopProtocolOptions, options: AbortOptions): Promise<void> {
     const hopstr = stream.pb(HopMessage)
     this.log('hop reserve request from %p', connection.remotePeer)
 
     if (isRelayAddr(connection.remoteAddr)) {
       this.log.error('relay reservation over circuit connection denied for peer: %p', connection.remotePeer)
-      await hopstr.write({ type: HopMessage.Type.STATUS, status: Status.PERMISSION_DENIED })
+      await hopstr.write({ type: HopMessage.Type.STATUS, status: Status.PERMISSION_DENIED }, options)
       return
     }
 
     if ((await this.connectionGater.denyInboundRelayReservation?.(connection.remotePeer)) === true) {
       this.log.error('reservation for %p denied by connection gater', connection.remotePeer)
-      await hopstr.write({ type: HopMessage.Type.STATUS, status: Status.PERMISSION_DENIED })
+      await hopstr.write({ type: HopMessage.Type.STATUS, status: Status.PERMISSION_DENIED }, options)
       return
     }
 
     const result = this.reservationStore.reserve(connection.remotePeer, connection.remoteAddr)
 
-    if (result.status !== Status.OK) {
-      await hopstr.write({ type: HopMessage.Type.STATUS, status: result.status })
-      return
-    }
-
     try {
+      if (result.status !== Status.OK) {
+        await hopstr.write({ type: HopMessage.Type.STATUS, status: result.status }, options)
+        return
+      }
+
       // tag relay target peer
       // result.expire is non-null if `ReservationStore.reserve` returns with status == OK
       if (result.expire != null) {
         const ttl = (result.expire * 1000) - Date.now()
         await this.peerStore.merge(connection.remotePeer, {
           tags: {
-            [RELAY_SOURCE_TAG]: { value: 1, ttl }
+            [RELAY_SOURCE_TAG]: { value: 1, ttl },
+            [KEEP_ALIVE_SOURCE_TAG]: { value: 1, ttl }
           }
         })
       }
@@ -265,11 +257,22 @@ class CircuitRelayServer extends TypedEventEmitter<RelayServerEvents> implements
         status: Status.OK,
         reservation: await this.makeReservation(connection.remotePeer, BigInt(result.expire ?? 0)),
         limit: this.reservationStore.get(connection.remotePeer)?.limit
-      })
+      }, options)
       this.log('sent confirmation response to %s', connection.remotePeer)
     } catch (err) {
-      this.log.error('failed to send confirmation response to %p', connection.remotePeer, err)
+      this.log.error('failed to send confirmation response to %p - %e', connection.remotePeer, err)
       this.reservationStore.removeReservation(connection.remotePeer)
+
+      try {
+        await this.peerStore.merge(connection.remotePeer, {
+          tags: {
+            [RELAY_SOURCE_TAG]: undefined,
+            [KEEP_ALIVE_SOURCE_TAG]: undefined
+          }
+        })
+      } catch (err) {
+        this.log.error('failed to untag relay source peer %p - %e', connection.remotePeer, err)
+      }
     }
   }
 
@@ -300,12 +303,12 @@ class CircuitRelayServer extends TypedEventEmitter<RelayServerEvents> implements
     }
   }
 
-  async handleConnect ({ stream, request, connection }: HopProtocolOptions): Promise<void> {
+  async handleConnect ({ stream, request, connection }: HopProtocolOptions, options: AbortOptions): Promise<void> {
     const hopstr = stream.pb(HopMessage)
 
     if (isRelayAddr(connection.remoteAddr)) {
       this.log.error('relay reservation over circuit connection denied for peer: %p', connection.remotePeer)
-      await hopstr.write({ type: HopMessage.Type.STATUS, status: Status.PERMISSION_DENIED })
+      await hopstr.write({ type: HopMessage.Type.STATUS, status: Status.PERMISSION_DENIED }, options)
       return
     }
 
@@ -323,19 +326,19 @@ class CircuitRelayServer extends TypedEventEmitter<RelayServerEvents> implements
       dstPeer = peerIdFromMultihash(Digest.decode(request.peer.id))
     } catch (err) {
       this.log.error('invalid hop connect request via peer %p %s', connection.remotePeer, err)
-      await hopstr.write({ type: HopMessage.Type.STATUS, status: Status.MALFORMED_MESSAGE })
+      await hopstr.write({ type: HopMessage.Type.STATUS, status: Status.MALFORMED_MESSAGE }, options)
       return
     }
 
     if (!this.reservationStore.hasReservation(dstPeer)) {
       this.log.error('hop connect denied for destination peer %p not having a reservation for %p with status %s', dstPeer, connection.remotePeer, Status.NO_RESERVATION)
-      await hopstr.write({ type: HopMessage.Type.STATUS, status: Status.NO_RESERVATION })
+      await hopstr.write({ type: HopMessage.Type.STATUS, status: Status.NO_RESERVATION }, options)
       return
     }
 
     if ((await this.connectionGater.denyOutboundRelayedConnection?.(connection.remotePeer, dstPeer)) === true) {
       this.log.error('hop connect for %p to %p denied by connection gater', connection.remotePeer, dstPeer)
-      await hopstr.write({ type: HopMessage.Type.STATUS, status: Status.PERMISSION_DENIED })
+      await hopstr.write({ type: HopMessage.Type.STATUS, status: Status.PERMISSION_DENIED }, options)
       return
     }
 
@@ -343,7 +346,7 @@ class CircuitRelayServer extends TypedEventEmitter<RelayServerEvents> implements
 
     if (connections.length === 0) {
       this.log('hop connect denied for destination peer %p not having a connection for %p as there is no destination connection', dstPeer, connection.remotePeer)
-      await hopstr.write({ type: HopMessage.Type.STATUS, status: Status.NO_RESERVATION })
+      await hopstr.write({ type: HopMessage.Type.STATUS, status: Status.NO_RESERVATION }, options)
       return
     }
 
@@ -360,11 +363,11 @@ class CircuitRelayServer extends TypedEventEmitter<RelayServerEvents> implements
         },
         limit
       }
-    })
+    }, options)
 
     if (destinationStream == null) {
       this.log.error('failed to open stream to destination peer %p', destinationConnection?.remotePeer)
-      await hopstr.write({ type: HopMessage.Type.STATUS, status: Status.CONNECTION_FAILED })
+      await hopstr.write({ type: HopMessage.Type.STATUS, status: Status.CONNECTION_FAILED }, options)
       return
     }
 
@@ -372,7 +375,7 @@ class CircuitRelayServer extends TypedEventEmitter<RelayServerEvents> implements
       type: HopMessage.Type.STATUS,
       status: Status.OK,
       limit
-    })
+    }, options)
     const sourceStream = stream.unwrap()
 
     this.log('connection from %p to %p established - merging streams', connection.remotePeer, dstPeer)
@@ -385,29 +388,27 @@ class CircuitRelayServer extends TypedEventEmitter<RelayServerEvents> implements
   /**
    * Send a STOP request to the target peer that the dialing peer wants to contact
    */
-  async stopHop ({
-    connection,
-    request
-  }: StopOptions): Promise<Stream | undefined> {
+  async stopHop ({ connection, request }: StopOptions, options: AbortOptions): Promise<Stream | undefined> {
     this.log('starting circuit relay v2 stop request to %s', connection.remotePeer)
     const stream = await connection.newStream([RELAY_V2_STOP_CODEC], {
       maxOutboundStreams: this.maxOutboundStopStreams,
-      runOnLimitedConnection: true
+      runOnLimitedConnection: true,
+      ...options
     })
     const pbstr = pbStream(stream)
     const stopstr = pbstr.pb(StopMessage)
-    await stopstr.write(request)
+    await stopstr.write(request, options)
     let response
 
     try {
-      response = await stopstr.read()
+      response = await stopstr.read(options)
     } catch (err) {
       this.log.error('error parsing stop message response from %p', connection.remotePeer)
     }
 
     if (response == null) {
       this.log.error('could not read response from %p', connection.remotePeer)
-      await stream.close()
+      await stream.close(options)
       return
     }
 
@@ -417,7 +418,7 @@ class CircuitRelayServer extends TypedEventEmitter<RelayServerEvents> implements
     }
 
     this.log('stop request failed with code %d', response.status)
-    await stream.close()
+    await stream.close(options)
   }
 
   get reservations (): PeerMap<RelayReservation> {

--- a/packages/transport-circuit-relay-v2/src/transport/discovery.ts
+++ b/packages/transport-circuit-relay-v2/src/transport/discovery.ts
@@ -66,7 +66,7 @@ export class RelayDiscovery extends TypedEventEmitter<RelayDiscoveryEvents> impl
     this.topologyId = await this.registrar.register(RELAY_V2_HOP_CODEC, {
       filter: this.filter,
       onConnect: (peerId) => {
-        this.log('discovered relay %p', peerId)
+        this.log.trace('discovered relay %p', peerId)
         this.safeDispatchEvent('relay:discover', { detail: peerId })
       }
     })

--- a/packages/transport-circuit-relay-v2/src/transport/index.ts
+++ b/packages/transport-circuit-relay-v2/src/transport/index.ts
@@ -1,6 +1,6 @@
 import { CircuitRelayTransport } from './transport.js'
 import type { RelayDiscoveryComponents } from './discovery.js'
-import type { RelayStoreInit } from './reservation-store.js'
+import type { ReservationStoreInit } from './reservation-store.js'
 import type { Transport, Upgrader, Libp2pEvents, ConnectionGater, TypedEventTarget, PeerId, TopologyFilter } from '@libp2p/interface'
 import type { AddressManager, Registrar } from '@libp2p/interface-internal'
 
@@ -16,7 +16,7 @@ export interface CircuitRelayTransportComponents extends RelayDiscoveryComponent
 /**
  * RelayConfig configures the circuit v2 relay transport.
  */
-export interface CircuitRelayTransportInit extends RelayStoreInit {
+export interface CircuitRelayTransportInit extends ReservationStoreInit {
   /**
    * The number of peers running diable relays to search for and connect to
    *

--- a/packages/transport-circuit-relay-v2/src/transport/listener.ts
+++ b/packages/transport-circuit-relay-v2/src/transport/listener.ts
@@ -14,7 +14,7 @@ export interface CircuitRelayTransportListenerComponents {
 
 class CircuitRelayTransportListener extends TypedEventEmitter<ListenerEvents> implements Listener {
   private readonly connectionManager: ConnectionManager
-  private readonly relayStore: ReservationStore
+  private readonly reservationStore: ReservationStore
   private readonly listeningAddrs: PeerMap<Multiaddr[]>
   private readonly log: Logger
 
@@ -23,15 +23,26 @@ class CircuitRelayTransportListener extends TypedEventEmitter<ListenerEvents> im
 
     this.log = components.logger.forComponent('libp2p:circuit-relay:transport:listener')
     this.connectionManager = components.connectionManager
-    this.relayStore = components.relayStore
+    this.reservationStore = components.relayStore
     this.listeningAddrs = new PeerMap()
 
     // remove listening addrs when a relay is removed
-    this.relayStore.addEventListener('relay:removed', this._onRemoveRelayPeer)
+    this.reservationStore.addEventListener('relay:removed', this._onRemoveRelayPeer)
   }
 
   _onRemoveRelayPeer = (evt: CustomEvent<PeerId>): void => {
-    this.#removeRelayPeer(evt.detail)
+    const had = this.listeningAddrs.has(evt.detail)
+
+    this.log('relay peer removed %p - had reservation', evt.detail, had)
+
+    if (!had) {
+      return
+    }
+
+    this.listeningAddrs.delete(evt.detail)
+
+    // announce listen addresses change
+    this.safeDispatchEvent('listening')
   }
 
   async listen (addr: Multiaddr): Promise<void> {
@@ -41,14 +52,14 @@ class CircuitRelayTransportListener extends TypedEventEmitter<ListenerEvents> im
     const relayAddr = addr.decapsulate('/p2p-circuit')
     const relayConn = await this.connectionManager.openConnection(relayAddr)
 
-    if (!this.relayStore.hasReservation(relayConn.remotePeer)) {
+    if (!this.reservationStore.hasReservation(relayConn.remotePeer)) {
       this.log('making reservation on peer %p', relayConn.remotePeer)
       // addRelay calls transportManager.listen which calls this listen method
-      await this.relayStore.addRelay(relayConn.remotePeer, 'configured')
+      await this.reservationStore.addRelay(relayConn.remotePeer, 'configured')
       return
     }
 
-    const reservation = this.relayStore.getReservation(relayConn.remotePeer)
+    const reservation = this.reservationStore.getReservation(relayConn.remotePeer)
 
     if (reservation == null) {
       throw new ListenError('Did not have reservation after making reservation')
@@ -60,11 +71,11 @@ class CircuitRelayTransportListener extends TypedEventEmitter<ListenerEvents> im
     }
 
     // add all addresses from the relay reservation
-    this.listeningAddrs.set(relayConn.remotePeer, reservation.addrs.map(buf => {
-      return multiaddr(buf).encapsulate('/p2p-circuit')
-    }))
+    this.listeningAddrs.set(relayConn.remotePeer, reservation.addrs
+      .map(buf => multiaddr(buf).encapsulate('/p2p-circuit'))
+    )
 
-    this.safeDispatchEvent('listening', {})
+    this.safeDispatchEvent('listening')
   }
 
   getAddrs (): Multiaddr[] {
@@ -72,22 +83,14 @@ class CircuitRelayTransportListener extends TypedEventEmitter<ListenerEvents> im
   }
 
   async close (): Promise<void> {
+    await this.reservationStore.cancelReservations()
+    this.listeningAddrs.clear()
 
-  }
+    // remove listener
+    this.reservationStore.removeEventListener('relay:removed', this._onRemoveRelayPeer)
 
-  #removeRelayPeer (peerId: PeerId): void {
-    const had = this.listeningAddrs.has(peerId)
-
-    this.log('relay peer removed %p - had reservation', peerId, had)
-
-    this.listeningAddrs.delete(peerId)
-
-    if (had) {
-      this.log.trace('removing relay event listener for peer %p', peerId)
-      this.relayStore.removeEventListener('relay:removed', this._onRemoveRelayPeer)
-      // Announce listen addresses change
-      this.safeDispatchEvent('close', {})
-    }
+    // announce listen addresses change
+    this.safeDispatchEvent('close')
   }
 }
 

--- a/packages/transport-circuit-relay-v2/test/hop.spec.ts
+++ b/packages/transport-circuit-relay-v2/test/hop.spec.ts
@@ -12,7 +12,7 @@ import { expect } from 'aegir/chai'
 import { type MessageStream, pbStream } from 'it-protobuf-stream'
 import Sinon from 'sinon'
 import { type StubbedInstance, stubInterface } from 'sinon-ts'
-import { DEFAULT_MAX_RESERVATION_STORE_SIZE, RELAY_SOURCE_TAG, RELAY_V2_HOP_CODEC } from '../src/constants.js'
+import { DEFAULT_MAX_RESERVATION_STORE_SIZE, KEEP_ALIVE_SOURCE_TAG, RELAY_SOURCE_TAG, RELAY_V2_HOP_CODEC } from '../src/constants.js'
 import { circuitRelayServer, type CircuitRelayService, circuitRelayTransport } from '../src/index.js'
 import { HopMessage, Status } from '../src/pb/index.js'
 import type { CircuitRelayServerInit } from '../src/server/index.js'
@@ -294,6 +294,10 @@ describe('circuit-relay hop protocol', function () {
       expect(relayNode.peerStore.merge.calledWith(matchPeerId(clientNode.peerId), {
         tags: {
           [RELAY_SOURCE_TAG]: {
+            value: 1,
+            ttl: Sinon.match.number as unknown as number
+          },
+          [KEEP_ALIVE_SOURCE_TAG]: {
             value: 1,
             ttl: Sinon.match.number as unknown as number
           }

--- a/packages/transport-circuit-relay-v2/test/transport/reservation-store.spec.ts
+++ b/packages/transport-circuit-relay-v2/test/transport/reservation-store.spec.ts
@@ -1,0 +1,64 @@
+import { generateKeyPair } from '@libp2p/crypto/keys'
+import { TypedEventEmitter, start } from '@libp2p/interface'
+import { defaultLogger } from '@libp2p/logger'
+import { peerIdFromPrivateKey } from '@libp2p/peer-id'
+import { expect } from 'aegir/chai'
+import delay from 'delay'
+import { stubInterface } from 'sinon-ts'
+import { KEEP_ALIVE_TAG, RELAY_TAG } from '../../src/constants.js'
+import { ReservationStore } from '../../src/transport/reservation-store.js'
+import type { ComponentLogger, Libp2pEvents, Peer, PeerId, PeerStore, TypedEventTarget } from '@libp2p/interface'
+import type { ConnectionManager, TransportManager } from '@libp2p/interface-internal'
+import type { StubbedInstance } from 'sinon-ts'
+
+export interface StubbedReservationStoreComponents {
+  peerId: PeerId
+  connectionManager: StubbedInstance<ConnectionManager>
+  transportManager: StubbedInstance<TransportManager>
+  peerStore: StubbedInstance<PeerStore>
+  events: TypedEventTarget<Libp2pEvents>
+  logger: ComponentLogger
+}
+
+describe('transport reservation-store', () => {
+  let store: ReservationStore
+  let components: StubbedReservationStoreComponents
+
+  beforeEach(async () => {
+    const privateKey = await generateKeyPair('Ed25519')
+
+    components = {
+      peerId: peerIdFromPrivateKey(privateKey),
+      connectionManager: stubInterface(),
+      transportManager: stubInterface(),
+      peerStore: stubInterface(),
+      events: new TypedEventEmitter(),
+      logger: defaultLogger()
+    }
+
+    store = new ReservationStore(components)
+  })
+
+  it('should remove relay tags on start', async () => {
+    const peer: Peer = {
+      id: peerIdFromPrivateKey(await generateKeyPair('Ed25519')),
+      addresses: [],
+      metadata: new Map(),
+      tags: new Map([[RELAY_TAG, { value: 1 }]]),
+      protocols: []
+    }
+
+    components.peerStore.all.resolves([peer])
+
+    await start(store)
+
+    await delay(100)
+
+    expect(components.peerStore.merge.calledWith(peer.id, {
+      tags: {
+        [RELAY_TAG]: undefined,
+        [KEEP_ALIVE_TAG]: undefined
+      }
+    })).to.be.true()
+  })
+})


### PR DESCRIPTION
To signal to the rest of libp2p that our addresses are changing, emit the `listening` event when relays go away or our reservation expires.

Also remove the old tags on startup to ensure we don't reconnect to old relays as the spec says the reservation is only valid while we are connected.

## Change checklist

- [x] I have performed a self-review of my own code
- [ ] I have made corresponding changes to the documentation if necessary (this includes comments as well)
- [x] I have added tests that prove my fix is effective or that my feature works