### PR TITLE
fix: handle more circuit relay refresh failures

### DIFF
--- a/packages/integration-tests/test/circuit-relay.node.ts
+++ b/packages/integration-tests/test/circuit-relay.node.ts
@@ -540,41 +540,9 @@ describe('circuit-relay', () => {
       const ma = getRelayAddress(relay1).encapsulate(`/p2p-circuit/p2p/${remote.peerId.toString()}`)
 
       await expect(local.dial(ma)).to.eventually.be.rejected
-        .with.property('name', 'DialError')
+        .with.property('name', 'NoValidAddressesError')
     })
-    /*
-    it('should fail to open connection over relayed connection', async () => {
-      // relay1 dials relay2
-      await relay1.dial(relay2.getMultiaddrs()[0])
-      await usingAsRelay(relay1, relay2)
 
-      // remote dials relay2
-      await remote.dial(relay2.getMultiaddrs()[0])
-      await usingAsRelay(remote, relay2)
-
-      // local dials relay1 via relay2
-      const ma = getRelayAddress(relay1)
-
-      // open hop stream and try to connect to remote
-      const stream = await local.dialProtocol(ma, RELAY_V2_HOP_CODEC, {
-        runOnLimitedConnection: true
-      })
-
-      const hopStream = pbStream(stream).pb(HopMessage)
-
-      await hopStream.write({
-        type: HopMessage.Type.CONNECT,
-        peer: {
-          id: remote.peerId.toMultihash().bytes,
-          addrs: []
-        }
-      })
-
-      const response = await hopStream.read()
-      expect(response).to.have.property('type', HopMessage.Type.STATUS)
-      expect(response).to.have.property('status', Status.PERMISSION_DENIED)
-    })
-    */
     it('should emit connection:close when relay stops', async () => {
       // discover relay and make reservation
       await remote.dial(relay1.getMultiaddrs()[0])

--- a/packages/transport-circuit-relay-v2/package.json
+++ b/packages/transport-circuit-relay-v2/package.json
@@ -52,14 +52,15 @@
     "doc-check": "aegir doc-check"
   },
   "dependencies": {
+    "@libp2p/crypto": "^5.0.5",
     "@libp2p/interface": "^2.1.3",
     "@libp2p/interface-internal": "^2.0.8",
     "@libp2p/peer-collections": "^6.0.8",
     "@libp2p/peer-id": "^5.0.5",
     "@libp2p/peer-record": "^8.0.8",
     "@libp2p/utils": "^6.1.1",
-    "@multiformats/mafmt": "^12.1.6",
     "@multiformats/multiaddr": "^12.2.3",
+    "@multiformats/multiaddr-matcher": "^1.3.0",
     "any-signal": "^4.1.1",
     "it-protobuf-stream": "^1.1.3",
     "it-stream-types": "^2.0.1",
@@ -67,11 +68,11 @@
     "progress-events": "^1.0.0",
     "protons-runtime": "^5.4.0",
     "race-signal": "^1.0.2",
+    "retimeable-signal": "^0.0.0",
     "uint8arraylist": "^2.4.8",
     "uint8arrays": "^5.1.0"
   },
   "devDependencies": {
-    "@libp2p/crypto": "^5.0.5",
     "@libp2p/interface-compliance-tests": "^6.1.6",
     "@libp2p/logger": "^5.1.1",
     "aegir": "^44.0.1",

--- a/packages/transport-circuit-relay-v2/src/constants.ts
+++ b/packages/transport-circuit-relay-v2/src/constants.ts
@@ -16,11 +16,6 @@ export const DEFAULT_MAX_RESERVATION_STORE_SIZE = 15
 /**
  * How often to check for reservation expiry
  */
-export const DEFAULT_MAX_RESERVATION_CLEAR_INTERVAL = 300 * second
-
-/**
- * How often to check for reservation expiry
- */
 export const DEFAULT_MAX_RESERVATION_TTL = 2 * 60 * minute
 
 /**

--- a/packages/transport-circuit-relay-v2/src/index.ts
+++ b/packages/transport-circuit-relay-v2/src/index.ts
@@ -43,13 +43,31 @@ import type { Limit } from './pb/index.js'
 import type { TypedEventEmitter } from '@libp2p/interface'
 import type { PeerMap } from '@libp2p/peer-collections'
 import type { Multiaddr } from '@multiformats/multiaddr'
+import type { RetimeableAbortSignal } from 'retimeable-signal'
 
 export type { Limit }
 
 export interface RelayReservation {
-  expire: Date
+  /**
+   * When this reservation expires
+   */
+  expiry: Date
+
+  /**
+   * The address of the relay client
+   */
   addr: Multiaddr
+
+  /**
+   * How much data can be transferred over each relayed connection and for how
+   * long before the underlying stream is reset
+   */
   limit?: Limit
+
+  /**
+   * This signal will fire it's "abort" event when the reservation expires
+   */
+  signal: RetimeableAbortSignal
 }
 
 export interface CircuitRelayServiceEvents {

--- a/packages/transport-circuit-relay-v2/src/pb/index.proto
+++ b/packages/transport-circuit-relay-v2/src/pb/index.proto
@@ -40,7 +40,7 @@ message Peer {
 message Reservation {
   uint64 expire = 1; // Unix expiration time (UTC)
   repeated bytes addrs = 2;   // relay addrs for reserving peer
-  optional bytes voucher = 3; // reservation voucher
+  optional Envelope voucher = 3; // reservation voucher
 }
 
 message Limit {
@@ -64,4 +64,23 @@ message ReservationVoucher {
   bytes relay = 1;
   bytes peer = 2;
   uint64 expiration = 3;
+}
+
+// https://github.com/libp2p/specs/blob/master/RFC/0002-signed-envelopes.md
+message Envelope {
+  // public_key is the public key of the keypair the enclosed payload was
+  // signed with.
+  bytes public_key = 1;
+
+  // payload_type encodes the type of payload, so that it can be deserialized
+  // deterministically.
+  bytes payload_type = 2;
+
+  // payload is the actual payload carried inside this envelope.
+  ReservationVoucher payload = 3;
+
+  // signature is the signature produced by the private key corresponding to
+  // the enclosed public key, over the payload, prefixing a domain string for
+  // additional security.
+  bytes signature = 5;
 }

--- a/packages/transport-circuit-relay-v2/src/server/reservation-store.ts
+++ b/packages/transport-circuit-relay-v2/src/server/reservation-store.ts
@@ -1,14 +1,16 @@
 import { trackedPeerMap } from '@libp2p/peer-collections'
-import { DEFAULT_DATA_LIMIT, DEFAULT_DURATION_LIMIT, DEFAULT_MAX_RESERVATION_CLEAR_INTERVAL, DEFAULT_MAX_RESERVATION_STORE_SIZE, DEFAULT_MAX_RESERVATION_TTL } from '../constants.js'
+import { retimeableSignal } from 'retimeable-signal'
+import { DEFAULT_DATA_LIMIT, DEFAULT_DURATION_LIMIT, DEFAULT_MAX_RESERVATION_STORE_SIZE, DEFAULT_MAX_RESERVATION_TTL } from '../constants.js'
 import { type Limit, Status } from '../pb/index.js'
 import type { RelayReservation } from '../index.js'
-import type { Metrics, PeerId, Startable } from '@libp2p/interface'
+import type { ComponentLogger, Logger, Metrics, PeerId } from '@libp2p/interface'
 import type { PeerMap } from '@libp2p/peer-collections'
 import type { Multiaddr } from '@multiformats/multiaddr'
 
 export type ReservationStatus = Status.OK | Status.PERMISSION_DENIED | Status.RESERVATION_REFUSED
 
 export interface ReservationStoreComponents {
+  logger: ComponentLogger
   metrics?: Metrics
 }
 
@@ -52,20 +54,18 @@ export interface ReservationStoreInit {
   defaultDataLimit?: bigint
 }
 
-export class ReservationStore implements Startable {
+export class ReservationStore {
   public readonly reservations: PeerMap<RelayReservation>
-  private _started = false
-  private interval: any
   private readonly maxReservations: number
-  private readonly reservationClearInterval: number
   private readonly applyDefaultLimit: boolean
   private readonly reservationTtl: number
   private readonly defaultDurationLimit: number
   private readonly defaultDataLimit: bigint
+  private readonly log: Logger
 
   constructor (components: ReservationStoreComponents, init: ReservationStoreInit = {}) {
+    this.log = components.logger.forComponent('libp2p:circuit-relay:server:reservation-store')
     this.maxReservations = init.maxReservations ?? DEFAULT_MAX_RESERVATION_STORE_SIZE
-    this.reservationClearInterval = init.reservationClearInterval ?? DEFAULT_MAX_RESERVATION_CLEAR_INTERVAL
     this.applyDefaultLimit = init.applyDefaultLimit !== false
     this.reservationTtl = init.reservationTtl ?? DEFAULT_MAX_RESERVATION_TTL
     this.defaultDurationLimit = init.defaultDurationLimit ?? DEFAULT_DURATION_LIMIT
@@ -77,59 +77,55 @@ export class ReservationStore implements Startable {
     })
   }
 
-  isStarted (): boolean {
-    return this._started
-  }
-
-  start (): void {
-    if (this._started) {
-      return
-    }
-    this._started = true
-    this.interval = setInterval(
-      () => {
-        const now = (new Date()).getTime()
-        this.reservations.forEach((r, k) => {
-          if (r.expire.getTime() < now) {
-            this.reservations.delete(k)
-          }
-        })
-      },
-      this.reservationClearInterval
-    )
-  }
-
-  stop (): void {
-    clearInterval(this.interval)
-  }
-
   reserve (peer: PeerId, addr: Multiaddr, limit?: Limit): { status: ReservationStatus, expire?: number } {
-    if (this.reservations.size >= this.maxReservations && !this.reservations.has(peer)) {
+    let reservation = this.reservations.get(peer)
+
+    if (this.reservations.size >= this.maxReservations && reservation == null) {
       return { status: Status.RESERVATION_REFUSED }
     }
 
-    const expire = new Date(Date.now() + this.reservationTtl)
+    const expiry = new Date(Date.now() + this.reservationTtl)
     let checkedLimit: Limit | undefined
 
     if (this.applyDefaultLimit) {
-      checkedLimit = limit ?? { data: this.defaultDataLimit, duration: this.defaultDurationLimit }
+      checkedLimit = limit ?? {
+        data: this.defaultDataLimit,
+        duration: this.defaultDurationLimit
+      }
     }
 
-    this.reservations.set(peer, { addr, expire, limit: checkedLimit })
+    if (reservation != null) {
+      this.log('refreshing reservation for client %p', peer)
+      reservation.signal.reset(this.reservationTtl)
+    } else {
+      this.log('creating new reservation for client %p', peer)
+      reservation = {
+        addr,
+        expiry,
+        limit: checkedLimit,
+        signal: retimeableSignal(this.reservationTtl)
+      }
+    }
+
+    this.reservations.set(peer, reservation)
+
+    reservation.signal.addEventListener('abort', () => {
+      this.reservations.delete(peer)
+    })
 
     // return expiry time in seconds
-    return { status: Status.OK, expire: Math.round(expire.getTime() / 1000) }
+    return { status: Status.OK, expire: Math.round(expiry.getTime() / 1000) }
   }
 
   removeReservation (peer: PeerId): void {
     this.reservations.delete(peer)
   }
 
-  hasReservation (dst: PeerId): boolean {
-    return this.reservations.has(dst)
-  }
-
   get (peer: PeerId): RelayReservation | undefined {
     return this.reservations.get(peer)
+  }
+
+  clear (): void {
+    this.reservations.clear()
   }
 }

--- a/packages/transport-circuit-relay-v2/src/server/reservation-voucher.ts
+++ b/packages/transport-circuit-relay-v2/src/server/reservation-voucher.ts
@@ -4,7 +4,7 @@ import type { PeerId, Record } from '@libp2p/interface'
 export interface ReservationVoucherOptions {
   relay: PeerId
   peer: PeerId
-  expiration: number
+  expiration: bigint
 }
 
 export class ReservationVoucherRecord implements Record {
@@ -13,7 +13,7 @@ export class ReservationVoucherRecord implements Record {
 
   private readonly relay: PeerId
   private readonly peer: PeerId
-  private readonly expiration: number
+  private readonly expiration: bigint
 
   constructor ({ relay, peer, expiration }: ReservationVoucherOptions) {
     this.relay = relay

--- a/packages/transport-circuit-relay-v2/src/utils.ts
+++ b/packages/transport-circuit-relay-v2/src/utils.ts
@@ -1,7 +1,10 @@
+import { P2P } from '@multiformats/multiaddr-matcher'
+import { fmt, peerId, literal, optional, and } from '@multiformats/multiaddr-matcher/utils'
 import { anySignal } from 'any-signal'
 import { CID } from 'multiformats/cid'
 import { sha256 } from 'multiformats/hashes/sha2'
 import { DurationLimitError, TransferLimitError } from './errors.js'
+import type { RelayReservation } from './index.js'
 import type { Limit } from './pb/index.js'
 import type { ConnectionLimits, LoggerOptions, Stream } from '@libp2p/interface'
 import type { Source } from 'it-stream-types'
@@ -34,16 +37,18 @@ async function * countStreamBytes (source: Source<Uint8Array | Uint8ArrayList>, 
   }
 }
 
-export function createLimitedRelay (src: Stream, dst: Stream, abortSignal: AbortSignal, limit: Limit | undefined, options: LoggerOptions): void {
+export function createLimitedRelay (src: Stream, dst: Stream, abortSignal: AbortSignal, reservation: RelayReservation, options: LoggerOptions): void {
   function abortStreams (err: Error): void {
     src.abort(err)
     dst.abort(err)
   }
 
-  const signals = [abortSignal]
+  // combine shutdown signal and reservation expiry signal
+  const signals = [abortSignal, reservation.signal]
 
-  if (limit?.duration != null) {
-    signals.push(AbortSignal.timeout(limit.duration))
+  if (reservation.limit?.duration != null) {
+    options.log('limiting relayed connection duration to %dms', reservation.limit.duration)
+    signals.push(AbortSignal.timeout(reservation.limit.duration))
   }
 
   const signal = anySignal(signals)
@@ -53,15 +58,16 @@ export function createLimitedRelay (src: Stream, dst: Stream, abortSignal: Abort
 
   let dataLimit: { remaining: bigint } | undefined
 
-  if (limit?.data != null) {
+  if (reservation.limit?.data != null) {
     dataLimit = {
-      remaining: limit.data
+      remaining: reservation.limit.data
     }
   }
 
   queueMicrotask(() => {
     const onAbort = (): void => {
-      dst.abort(new DurationLimitError(`duration limit of ${limit?.duration} ms exceeded`))
+      options.log('relayed connection reached time limit')
+      dst.abort(new DurationLimitError(`duration limit of ${reservation.limit?.duration} ms exceeded`))
     }
 
     signal.addEventListener('abort', onAbort, { once: true })
@@ -83,7 +89,8 @@ export function createLimitedRelay (src: Stream, dst: Stream, abortSignal: Abort
 
   queueMicrotask(() => {
     const onAbort = (): void => {
-      src.abort(new DurationLimitError(`duration limit of ${limit?.duration} ms exceeded`))
+      options.log('relayed connection reached time limit')
+      src.abort(new DurationLimitError(`duration limit of ${reservation.limit?.duration} ms exceeded`))
     }
 
     signal.addEventListener('abort', onAbort, { once: true })
@@ -185,3 +192,9 @@ export class LimitTracker {
     return output
   }
 }
+
+/**
+ * A custom matcher that makes the `/p2p/peer-id` part of circuit relay
+ * addresses optional
+ */
+export const CircuitListen = fmt(and(P2P.matchers[0], literal('p2p-circuit'), optional(peerId())))

--- a/packages/transport-circuit-relay-v2/test/utils.spec.ts
+++ b/packages/transport-circuit-relay-v2/test/utils.spec.ts
@@ -2,20 +2,33 @@
 
 import { type Logger } from '@libp2p/interface'
 import { mockStream } from '@libp2p/interface-compliance-tests/mocks'
+import { defaultLogger } from '@libp2p/logger'
+import { multiaddr } from '@multiformats/multiaddr'
 import { expect } from 'aegir/chai'
 import delay from 'delay'
 import drain from 'it-drain'
 import { pushable } from 'it-pushable'
 import toBuffer from 'it-to-buffer'
 import { raceSignal } from 'race-signal'
+import { retimeableSignal } from 'retimeable-signal'
 import Sinon from 'sinon'
 import { stubInterface } from 'sinon-ts'
 import { Uint8ArrayList } from 'uint8arraylist'
 import { fromString as uint8arrayFromString } from 'uint8arrays/from-string'
 import { createLimitedRelay, getExpirationMilliseconds, LimitTracker, namespaceToCid } from '../src/utils.js'
+import type { Limit, RelayReservation } from '../src/index.js'
 import type { Duplex, Source } from 'it-stream-types'
 
 describe('circuit-relay utils', () => {
+  function createReservation (limit?: Limit): RelayReservation {
+    return {
+      addr: multiaddr('/ip4/123.123.123.123/tcp/443/tls/wss'),
+      expiry: new Date(Date.now() + 60000),
+      signal: retimeableSignal(60000),
+      limit
+    }
+  }
+
   it('should create relay', async () => {
     const received = pushable<Uint8Array>()
 
@@ -52,7 +65,7 @@ describe('circuit-relay utils', () => {
     const localStreamAbortSpy = Sinon.spy(localStream, 'abort')
     const remoteStreamAbortSpy = Sinon.spy(remoteStream, 'abort')
 
-    createLimitedRelay(localStream, remoteStream, controller.signal, undefined, {
+    createLimitedRelay(localStream, remoteStream, controller.signal, createReservation(), {
       log: stubInterface<Logger>()
     })
 
@@ -100,7 +113,7 @@ describe('circuit-relay utils', () => {
     const localStreamAbortSpy = Sinon.spy(localStream, 'abort')
     const remoteStreamAbortSpy = Sinon.spy(remoteStream, 'abort')
 
-    createLimitedRelay(localStream, remoteStream, controller.signal, limit, {
+    createLimitedRelay(localStream, remoteStream, controller.signal, createReservation(limit), {
       log: stubInterface<Logger>()
     })
 
@@ -160,7 +173,7 @@ describe('circuit-relay utils', () => {
     const localStreamAbortSpy = Sinon.spy(localStream, 'abort')
     const remoteStreamAbortSpy = Sinon.spy(remoteStream, 'abort')
 
-    createLimitedRelay(localStream, remoteStream, controller.signal, limit, {
+    createLimitedRelay(localStream, remoteStream, controller.signal, createReservation(limit), {
       log: stubInterface<Logger>()
     })
 
@@ -212,8 +225,8 @@ describe('circuit-relay utils', () => {
     const localStreamAbortSpy = Sinon.spy(localStream, 'abort')
     const remoteStreamAbortSpy = Sinon.spy(remoteStream, 'abort')
 
-    createLimitedRelay(localStream, remoteStream, controller.signal, limit, {
-      log: stubInterface<Logger>()
+    createLimitedRelay(localStream, remoteStream, controller.signal, createReservation(limit), {
+      log: defaultLogger().forComponent('test')
     })
 
     expect(await toBuffer(received)).to.have.property('byteLength', 4)


### PR DESCRIPTION
Handles some more instances where we don't remove old reservations when refreshing them fails.

## Change checklist

- [x] I have performed a self-review of my own code
- [ ] I have made corresponding changes to the documentation if necessary (this includes comments as well)
- [x] I have added tests that prove my fix is effective or that my feature works