### PR TITLE
feat: add .echo method to echo protocol

### DIFF
--- a/packages/protocol-echo/package.json
+++ b/packages/protocol-echo/package.json
@@ -53,6 +53,8 @@
   "dependencies": {
     "@libp2p/interface": "^2.1.3",
     "@libp2p/interface-internal": "^2.0.8",
+    "@multiformats/multiaddr": "^12.3.1",
+    "it-byte-stream": "^1.1.0",
     "it-pipe": "^3.0.1"
   },
   "devDependencies": {

--- a/packages/protocol-echo/src/echo.ts
+++ b/packages/protocol-echo/src/echo.ts
@@ -1,7 +1,9 @@
+import { byteStream } from 'it-byte-stream'
 import { pipe } from 'it-pipe'
 import { PROTOCOL_NAME, PROTOCOL_VERSION } from './constants.js'
 import type { Echo as EchoInterface, EchoComponents, EchoInit } from './index.js'
-import type { Logger, Startable } from '@libp2p/interface'
+import type { AbortOptions, Logger, PeerId, Startable } from '@libp2p/interface'
+import type { Multiaddr } from '@multiformats/multiaddr'
 
 /**
  * A simple echo stream, any data received will be sent back to the sender
@@ -31,7 +33,8 @@ export class Echo implements Startable, EchoInterface {
         })
     }, {
       maxInboundStreams: this.init.maxInboundStreams,
-      maxOutboundStreams: this.init.maxOutboundStreams
+      maxOutboundStreams: this.init.maxOutboundStreams,
+      runOnLimitedConnection: this.init.runOnLimitedConnection
     })
     this.started = true
   }
@@ -43,5 +46,23 @@ export class Echo implements Startable, EchoInterface {
 
   isStarted (): boolean {
     return this.started
+  }
+
+  async echo (peer: PeerId | Multiaddr | Multiaddr[], buf: Uint8Array, options?: AbortOptions): Promise<Uint8Array> {
+    const conn = await this.components.connectionManager.openConnection(peer, options)
+    const stream = await conn.newStream(this.protocol, {
+      ...this.init,
+      ...options
+    })
+    const bytes = byteStream(stream)
+
+    const [, output] = await Promise.all([
+      bytes.write(buf, options),
+      bytes.read(buf.byteLength, options)
+    ])
+
+    await stream.close(options)
+
+    return output.subarray()
   }
 }

--- a/packages/protocol-echo/src/index.ts
+++ b/packages/protocol-echo/src/index.ts
@@ -43,13 +43,15 @@
  */
 
 import { Echo as EchoClass } from './echo.js'
-import type { ComponentLogger } from '@libp2p/interface'
+import type { ComponentLogger, PeerId } from '@libp2p/interface'
 import type { ConnectionManager, Registrar } from '@libp2p/interface-internal'
+import type { Multiaddr } from '@multiformats/multiaddr'
 
 export interface EchoInit {
   protocolPrefix?: string
   maxInboundStreams?: number
   maxOutboundStreams?: number
+  runOnLimitedConnection?: boolean
 }
 
 export interface EchoComponents {
@@ -60,6 +62,7 @@ export interface EchoComponents {
 
 export interface Echo {
   protocol: string
+  echo(peer: PeerId | Multiaddr | Multiaddr[], buf: Uint8Array): Promise<Uint8Array>
 }
 
 export function echo (init: EchoInit = {}): (components: EchoComponents) => Echo {


### PR DESCRIPTION
To make it easier to invoke the echo protocol, add a method to the service.

## Change checklist

- [x] I have performed a self-review of my own code
- [ ] I have made corresponding changes to the documentation if necessary (this includes comments as well)
- [x] I have added tests that prove my fix is effective or that my feature works