### PR TITLE
test(@libp2p/tcp): close listener during upgrade

### DIFF
--- a/packages/transport-tcp/test/listen-dial.spec.ts
+++ b/packages/transport-tcp/test/listen-dial.spec.ts
@@ -315,6 +315,29 @@ describe('dial', () => {
     await listener.close()
   })
 
+  it('dial and close listener during upgrade', async () => {
+    const ma = multiaddr('/ip6/::/tcp/9090')
+
+    const listener = transport.createListener({
+      upgrader: {
+        ...upgrader,
+        async upgradeInbound () {
+          return new Promise(() => {})
+        }
+      }
+    })
+
+    await listener.listen(ma)
+    const addrs = listener.getAddrs()
+    await transport.dial(addrs[0], {
+      // can also be triggered with a upgradeOutbound that does not resolve
+      // if the listeners upgrader is waiting
+      upgrader
+    })
+
+    await listener.close()
+  })
+
   it('dials on IPv4 with IPFS Id', async () => {
     const ma = multiaddr('/ip4/127.0.0.1/tcp/9090/ipfs/Qmb6owHp6eaWArVbcJJbQSyifyJBttMMjYV76N2hMbf5Vw')
     const listener = transport.createListener({


### PR DESCRIPTION
## Title

test(@libp2p/tcp): close listener during upgrade

<!---
The title of the PR will be the commit message of the merge commit, so please make sure it is descriptive enough.
We utilize the Conventional Commits specification for our commit messages. See <https://www.conventionalcommits.org/en/v1.0.0/#specification> for more information.
The commit tag types can be of one of the following: feat, fix, deps, refactor, chore, docs. See <https://github.com/libp2p/js-libp2p/blob/master/.github/workflows/main.yml#L235-L242>
The title must also be fewer than 72 characters long or it will fail the Semantic PR check. See <https://github.com/libp2p/js-libp2p/blob/master/.github/workflows/semantic-pull-request.yml>
--->

## Description

Adds a failing test which shows that the listener is not able to close during a
tcp connection upgrade.

<!--
Please write a summary of your changes and why you made them.
Please include any relevant issues in here, for example:
Related https://github.com/libp2p/js-libp2p/issues/ABCD.
Fixes https://github.com/libp2p/js-libp2p/issues/XYZ.
-->

## Notes & open questions

Fixed by: #2763

<!--
Any notes, remarks or open questions you have to make about the PR which don't need to go into the final commit message.
-->

## Change checklist

- [x] I have performed a self-review of my own code
- [ ] I have made corresponding changes to the documentation if necessary (this includes comments as well)
- [ ] I have added tests that prove my fix is effective or that my feature works
