### PR TITLE
fix: error logging in firefox

### DIFF
--- a/packages/logger/src/index.ts
+++ b/packages/logger/src/index.ts
@@ -79,7 +79,7 @@ debug.formatters.a = (v?: Multiaddr): string => {
 
 // Add a formatter for stringifying Errors
 debug.formatters.e = (v?: Error): string => {
-  return v == null ? 'undefined' : v.stack ?? v.message
+  return v == null ? 'undefined' : notEmpty(v.stack) ?? notEmpty(v.message) ?? v.toString()
 }
 
 export interface Logger {
@@ -219,4 +219,18 @@ export function enable (namespaces: string): void {
 
 export function enabled (namespaces: string): boolean {
   return debug.enabled(namespaces)
+}
+
+function notEmpty (str?: string): string | undefined {
+  if (str == null) {
+    return
+  }
+
+  str = str.trim()
+
+  if (str.length === 0) {
+    return
+  }
+
+  return str
 }


### PR DESCRIPTION
Firefox has an error type with a `.stack` property that is an empty string, so guard on the various properties being empty before logging them.

## Change checklist

- [x] I have performed a self-review of my own code
- [ ] I have made corresponding changes to the documentation if necessary (this includes comments as well)
- [ ] I have added tests that prove my fix is effective or that my feature works