### PR TITLE
fix(mock-connection): use muxer to close/abort streams

### DIFF
--- a/packages/interface-compliance-tests/src/mocks/connection.ts
+++ b/packages/interface-compliance-tests/src/mocks/connection.ts
@@ -100,9 +100,7 @@ class MockConnection implements Connection {
 
   async close (options?: AbortOptions): Promise<void> {
     this.status = 'closing'
-    await Promise.all(
-      this.streams.map(async s => s.close(options))
-    )
+    await this.muxer.close()
     await this.maConn.close()
     this.status = 'closed'
     this.timeline.close = Date.now()
@@ -110,9 +108,7 @@ class MockConnection implements Connection {
 
   abort (err: Error): void {
     this.status = 'closing'
-    this.streams.forEach(s => {
-      s.abort(err)
-    })
+    this.muxer.abort(err)
     this.maConn.abort(err)
     this.status = 'closed'
     this.timeline.close = Date.now()


### PR DESCRIPTION
## Title

fix(mock-connection): use muxer to close/abort streams

<!---
The title of the PR will be the commit message of the merge commit, so please make sure it is descriptive enough.
We utilize the Conventional Commits specification for our commit messages. See <https://www.conventionalcommits.org/en/v1.0.0/#specification> for more information.
The commit tag types can be of one of the following: feat, fix, deps, refactor, chore, docs. See <https://github.com/libp2p/js-libp2p/blob/master/.github/workflows/main.yml#L235-L242>
The title must also be fewer than 72 characters long or it will fail the Semantic PR check. See <https://github.com/libp2p/js-libp2p/blob/master/.github/workflows/semantic-pull-request.yml>
--->

## Description

Uses this.muxer.close and this.muxer.abort in MockConnection's close and abort methods.

<!--
Please write a summary of your changes and why you made them.
Please include any relevant issues in here, for example:
Related https://github.com/libp2p/js-libp2p/issues/ABCD.
Fixes https://github.com/libp2p/js-libp2p/issues/XYZ.
-->

## Notes & open questions

Fixes #2675

I looked at https://github.com/libp2p/js-libp2p/commit/a541748c32c5644aa8098c81e96e51940cb25eaa to see if there was a reason this was done but did not see one.

<!--
Any notes, remarks or open questions you have to make about the PR which don't need to go into the final commit message.
-->

## Change checklist

- [x] I have performed a self-review of my own code
- [ ] I have made corresponding changes to the documentation if necessary (this includes comments as well)
- [ ] I have added tests that prove my fix is effective or that my feature works
