### PR TITLE
fix!: make circuit relay listen on addresses like other transports

### DIFF
--- a/.github/workflows/examples.yml
+++ b/.github/workflows/examples.yml
@@ -27,15 +27,15 @@ jobs:
     strategy:
       matrix:
         example:
-          - name: js-libp2p-example-browser-pubsub
-            repo: https://github.com/libp2p/js-libp2p-example-browser-pubsub.git
-            deps:
-              - '@libp2p/circuit-relay-v2@$PWD/packages/transport-circuit-relay-v2'
-              - '@libp2p/dcutr@$PWD/packages/protocol-dcutr'
-              - '@libp2p/identify@$PWD/packages/protocol-identify'
-              - '@libp2p/webrtc@$PWD/packages/transport-webrtc'
-              - '@libp2p/websockets@$PWD/packages/transport-websockets'
-              - 'libp2p@$PWD/packages/libp2p'
+          # - name: js-libp2p-example-browser-pubsub
+          #   repo: https://github.com/libp2p/js-libp2p-example-browser-pubsub.git
+          #   deps:
+          #     - '@libp2p/circuit-relay-v2@$PWD/packages/transport-circuit-relay-v2'
+          #     - '@libp2p/dcutr@$PWD/packages/protocol-dcutr'
+          #     - '@libp2p/identify@$PWD/packages/protocol-identify'
+          #     - '@libp2p/webrtc@$PWD/packages/transport-webrtc'
+          #     - '@libp2p/websockets@$PWD/packages/transport-websockets'
+          #     - 'libp2p@$PWD/packages/libp2p'
           - name: js-libp2p-example-chat
             repo: https://github.com/libp2p/js-libp2p-example-chat.git
             deps:
@@ -43,13 +43,13 @@ jobs:
               - '@libp2p/tcp@$PWD/packages/transport-tcp'
               - '@libp2p/websockets@$PWD/packages/transport-websockets'
               - 'libp2p@$PWD/packages/libp2p'
-          - name: js-libp2p-example-circuit-relay
-            repo: https://github.com/libp2p/js-libp2p-example-circuit-relay.git
-            deps:
-              - '@libp2p/circuit-relay-v2@$PWD/packages/transport-circuit-relay-v2'
-              - '@libp2p/identify@$PWD/packages/protocol-identify'
-              - '@libp2p/websockets@$PWD/packages/transport-websockets'
-              - 'libp2p@$PWD/packages/libp2p'
+          # - name: js-libp2p-example-circuit-relay
+          #   repo: https://github.com/libp2p/js-libp2p-example-circuit-relay.git
+          #   deps:
+          #     - '@libp2p/circuit-relay-v2@$PWD/packages/transport-circuit-relay-v2'
+          #     - '@libp2p/identify@$PWD/packages/protocol-identify'
+          #     - '@libp2p/websockets@$PWD/packages/transport-websockets'
+          #     - 'libp2p@$PWD/packages/libp2p'
           - name: js-libp2p-example-connection-encryption
             repo: https://github.com/libp2p/js-libp2p-example-connection-encryption.git
             deps:
@@ -62,10 +62,10 @@ jobs:
               - '@libp2p/tcp@$PWD/packages/transport-tcp'
               - '@libp2p/websockets@$PWD/packages/transport-websockets'
               - 'libp2p@$PWD/packages/libp2p'
-          - name: js-libp2p-example-delegated-routing
-            repo: https://github.com/libp2p/js-libp2p-example-delegated-routing.git
-            deps:
-              - 'libp2p@$PWD/packages/libp2p'
+          # - name: js-libp2p-example-delegated-routing
+          #   repo: https://github.com/libp2p/js-libp2p-example-delegated-routing.git
+          #   deps:
+          #     - 'libp2p@$PWD/packages/libp2p'
           - name: js-libp2p-example-discovery-mechanisms
             repo: https://github.com/libp2p/js-libp2p-example-discovery-mechanisms.git
             deps:
@@ -106,15 +106,15 @@ jobs:
               - '@libp2p/tcp@$PWD/packages/transport-tcp'
               - '@libp2p/websockets@$PWD/packages/transport-websockets'
               - 'libp2p@$PWD/packages/libp2p'
-          - name: js-libp2p-example-webrtc-private-to-private
-            repo: https://github.com/libp2p/js-libp2p-example-webrtc-private-to-private.git
-            deps:
-              - '@libp2p/circuit-relay-v2@$PWD/packages/transport-circuit-relay-v2'
-              - '@libp2p/identify@$PWD/packages/protocol-identify'
-              - '@libp2p/ping@$PWD/packages/protocol-ping'
-              - '@libp2p/webrtc@$PWD/packages/transport-webrtc'
-              - '@libp2p/websockets@$PWD/packages/transport-websockets'
-              - 'libp2p@$PWD/packages/libp2p'
+          # - name: js-libp2p-example-webrtc-private-to-private
+          #   repo: https://github.com/libp2p/js-libp2p-example-webrtc-private-to-private.git
+          #   deps:
+          #     - '@libp2p/circuit-relay-v2@$PWD/packages/transport-circuit-relay-v2'
+          #     - '@libp2p/identify@$PWD/packages/protocol-identify'
+          #     - '@libp2p/ping@$PWD/packages/protocol-ping'
+          #     - '@libp2p/webrtc@$PWD/packages/transport-webrtc'
+          #     - '@libp2p/websockets@$PWD/packages/transport-websockets'
+          #     - 'libp2p@$PWD/packages/libp2p'
     steps:
       - uses: actions/checkout@v4
       - uses: actions/setup-node@v4

--- a/doc/CONFIGURATION.md
+++ b/doc/CONFIGURATION.md
@@ -445,12 +445,15 @@ import { identify } from '@libp2p/identify'
 
 
 const node = await createLibp2p({
+  addresses: {
+    listen: {
+      // discover a relay using the routing
+      '/p2p-circuit'
+    }
+  },
   transports: [
     tcp(),
-    circuitRelayTransport({ // allows the current node to make and accept relayed connections
-      discoverRelays: 0, // how many network relays to find
-      reservationConcurrency: 1 // how many relays to attempt to reserve slots on at once
-    })
+    circuitRelayTransport()
   ],
   streamMuxers: [
     yamux()
@@ -499,11 +502,14 @@ import { noise } from '@chainsafe/libp2p-noise'
 import { circuitRelayTransport } from '@libp2p/circuit-relay-v2'
 
 const node = await createLibp2p({
+  addresses: {
+    listen: [
+      '/p2p-circuit'
+    ]
+  },
   transports: [
     tcp(),
-    circuitRelayTransport({
-      discoverRelays: 1
-    })
+    circuitRelayTransport()
   ],
   streamMuxers: [
     yamux()

--- a/doc/migrations/v0.42-v0.43.md
+++ b/doc/migrations/v0.42-v0.43.md
@@ -61,13 +61,12 @@ const node = await createLibp2p({
   // ... other options
   addresses: {
     listen: {
+      '/p2p-circuit', // discover a public relay
       '/ip4/123.123.123.123/p2p/QmRelay/p2p-circuit' // optionally configure a static relay
     }
   },
   transports: [
-    circuitRelayClient({ // enable client portion of relay
-      discoverRelays: 1 // find this number of network relays (default: 0)
-    })
+    circuitRelayClient()
   ],
   relay: circuitRelayServer({ // enable server portion of relay
     advertise: {

--- a/interop/test/fixtures/get-libp2p.ts
+++ b/interop/test/fixtures/get-libp2p.ts
@@ -54,11 +54,13 @@ export async function getLibp2p (): Promise<Libp2p<{ ping: PingService }>> {
       }
       break
     case 'webrtc':
-      options.transports = [webRTC(),
+      options.addresses = {
+        listen: isDialer ? [] : ['/p2p-circuit']
+      }
+      options.transports = [
+        webRTC(),
         webSockets({ filter: filters.all }), // ws needed to connect to relay
-        circuitRelayTransport({
-          discoverRelays: 1
-        }) // needed to use the relay
+        circuitRelayTransport()
       ]
       options.addresses = {
         listen: isDialer ? [] : ['/webrtc']

--- a/interop/test/fixtures/get-libp2p.ts
+++ b/interop/test/fixtures/get-libp2p.ts
@@ -54,16 +54,13 @@ export async function getLibp2p (): Promise<Libp2p<{ ping: PingService }>> {
       }
       break
     case 'webrtc':
-      options.addresses = {
-        listen: isDialer ? [] : ['/p2p-circuit']
-      }
       options.transports = [
         webRTC(),
         webSockets({ filter: filters.all }), // ws needed to connect to relay
         circuitRelayTransport()
       ]
       options.addresses = {
-        listen: isDialer ? [] : ['/webrtc']
+        listen: isDialer ? [] : ['/p2p-circuit', '/webrtc']
       }
       break
     case 'ws':

--- a/packages/integration-tests/test/circuit-relay-discovery.node.ts
+++ b/packages/integration-tests/test/circuit-relay-discovery.node.ts
@@ -92,13 +92,13 @@ describe('circuit-relay discovery', () => {
     ;[local, remote] = await Promise.all([
       createLibp2p({
         addresses: {
-          listen: ['/ip4/127.0.0.1/tcp/0']
+          listen: [
+            '/p2p-circuit'
+          ]
         },
         transports: [
           tcp(),
-          circuitRelayTransport({
-            discoverRelays: 1
-          })
+          circuitRelayTransport()
         ],
         streamMuxers: [
           yamux()
@@ -117,13 +117,13 @@ describe('circuit-relay discovery', () => {
       }),
       createLibp2p({
         addresses: {
-          listen: ['/ip4/127.0.0.1/tcp/0']
+          listen: [
+            '/p2p-circuit'
+          ]
         },
         transports: [
           tcp(),
-          circuitRelayTransport({
-            discoverRelays: 1
-          })
+          circuitRelayTransport()
         ],
         streamMuxers: [
           yamux()

--- a/packages/integration-tests/test/circuit-relay-discovery.spec.ts
+++ b/packages/integration-tests/test/circuit-relay-discovery.spec.ts
@@ -22,13 +22,16 @@ describe('circuit-relay discovery', () => {
 
   beforeEach(async () => {
     node = await createLibp2p({
+      addresses: {
+        listen: [
+          '/p2p-circuit'
+        ]
+      },
       transports: [
         webSockets({
           filter: filters.all
         }),
-        circuitRelayTransport({
-          discoverRelays: 1
-        }),
+        circuitRelayTransport(),
         webTransport()
       ],
       streamMuxers: [

--- a/packages/integration-tests/test/circuit-relay.node.ts
+++ b/packages/integration-tests/test/circuit-relay.node.ts
@@ -20,7 +20,7 @@ import pRetry from 'p-retry'
 import pWaitFor from 'p-wait-for'
 import sinon from 'sinon'
 import { Uint8ArrayList } from 'uint8arraylist'
-import { discoveredRelayConfig, doesNotHaveRelay, getRelayAddress, hasRelay, notUsingAsRelay, usingAsRelay, usingAsRelayCount } from './fixtures/utils.js'
+import { discoveredRelayConfig, doesNotHaveRelay, getRelayAddress, hasRelay, usingAsRelay } from './fixtures/utils.js'
 import type { Libp2p, Connection } from '@libp2p/interface'
 import type { Registrar } from '@libp2p/interface-internal'
 
@@ -29,7 +29,9 @@ const DEFAULT_DATA_LIMIT = BigInt(1 << 17)
 async function createClient (options: Libp2pOptions = {}): Promise<Libp2p> {
   return createLibp2p({
     addresses: {
-      listen: ['/ip4/127.0.0.1/tcp/0']
+      listen: [
+        '/p2p-circuit'
+      ]
     },
     transports: [
       tcp(),
@@ -95,7 +97,7 @@ const echoService = (components: EchoServiceComponents): unknown => {
 }
 
 describe('circuit-relay', () => {
-  describe('flows with 1 listener', () => {
+  describe('flows with 1 client', () => {
     let local: Libp2p
     let relay1: Libp2p<{ relay: CircuitRelayService }>
     let relay2: Libp2p<{ relay: CircuitRelayService }>
@@ -104,38 +106,10 @@ describe('circuit-relay', () => {
     beforeEach(async () => {
       // create 1 node and 3 relays
       [local, relay1, relay2, relay3] = await Promise.all([
-        createClient({
-          transports: [
-            tcp(),
-            circuitRelayTransport({
-              discoverRelays: 1
-            })
-          ]
-        }),
-        createRelay({
-          transports: [
-            tcp(),
-            circuitRelayTransport({
-              discoverRelays: 1
-            })
-          ]
-        }),
-        createRelay({
-          transports: [
-            tcp(),
-            circuitRelayTransport({
-              discoverRelays: 1
-            })
-          ]
-        }),
-        createRelay({
-          transports: [
-            tcp(),
-            circuitRelayTransport({
-              discoverRelays: 1
-            })
-          ]
-        })
+        createClient(),
+        createRelay(),
+        createRelay(),
+        createRelay()
       ])
     })
 
@@ -263,33 +237,33 @@ describe('circuit-relay', () => {
       const deferred = defer()
 
       // discover one relay and connect
-      await relay1.dial(relay2.getMultiaddrs()[0])
+      await local.dial(relay1.getMultiaddrs()[0])
 
       // wait for peer to be used as a relay
-      await usingAsRelay(relay1, relay2)
+      await usingAsRelay(local, relay1)
 
       // discover an extra relay and connect to gather its Hop support
-      await relay1.dial(relay3.getMultiaddrs()[0])
+      await local.dial(relay2.getMultiaddrs()[0])
 
       // wait for identify for newly dialled peer
-      await discoveredRelayConfig(relay1, relay3)
+      await discoveredRelayConfig(local, relay2)
 
       // stub dial, make sure we can't reconnect
       // @ts-expect-error private field
-      sinon.stub(relay1.components.connectionManager, 'openConnection').callsFake(async () => {
+      sinon.stub(local.components.connectionManager, 'openConnection').callsFake(async () => {
         deferred.resolve()
         return Promise.reject(new Error('failed to dial'))
       })
 
       await Promise.all([
         // disconnect not used listen relay
-        relay1.hangUp(relay3.peerId),
+        local.hangUp(relay2.peerId),
 
         // disconnect from relay
-        relay1.hangUp(relay2.peerId)
+        local.hangUp(relay1.peerId)
       ])
 
-      expect(relay1.getConnections()).to.be.empty()
+      expect(local.getConnections()).to.be.empty()
 
       // wait for failed dial
       await deferred.promise
@@ -342,7 +316,7 @@ describe('circuit-relay', () => {
     })
   })
 
-  describe('flows with 2 listeners', () => {
+  describe('flows with 2 clients', () => {
     let local: Libp2p
     let remote: Libp2p
     let relay1: Libp2p<{ relay: CircuitRelayService }>
@@ -352,45 +326,32 @@ describe('circuit-relay', () => {
     beforeEach(async () => {
       [local, remote, relay1, relay2, relay3] = await Promise.all([
         createClient({
-          transports: [
-            tcp(),
-            circuitRelayTransport({
-              discoverRelays: 3
-            })
-          ]
+          addresses: {
+            listen: [
+              '/p2p-circuit',
+              '/p2p-circuit',
+              '/p2p-circuit'
+            ]
+          }
         }),
-        createClient({
-          transports: [
-            tcp(),
-            circuitRelayTransport({
-              discoverRelays: 1
-            })
-          ]
+        createClient(),
+        createRelay({
+          addresses: {
+            listen: [
+              '/ip4/127.0.0.1/tcp/0',
+              '/p2p-circuit'
+            ]
+          }
         }),
         createRelay({
-          transports: [
-            tcp(),
-            circuitRelayTransport({
-              discoverRelays: 1
-            })
-          ]
+          addresses: {
+            listen: [
+              '/ip4/127.0.0.1/tcp/0',
+              '/p2p-circuit'
+            ]
+          }
         }),
-        createRelay({
-          transports: [
-            tcp(),
-            circuitRelayTransport({
-              discoverRelays: 1
-            })
-          ]
-        }),
-        createRelay({
-          transports: [
-            tcp(),
-            circuitRelayTransport({
-              discoverRelays: 1
-            })
-          ]
-        })
+        createRelay()
       ])
     })
 
@@ -454,18 +415,6 @@ describe('circuit-relay', () => {
 
       // dial via peer id so we load the address from the address book
       await local.dial(remote.peerId)
-    })
-
-    it('should not stay connected to a relay when not already connected and HOP fails', async () => {
-      // dial the remote through the relay
-      const relayedMultiaddr = relay1.getMultiaddrs()[0].encapsulate(`/p2p-circuit/p2p/${remote.peerId.toString()}`)
-
-      await expect(local.dial(relayedMultiaddr))
-        .to.eventually.be.rejected()
-        .and.to.have.property('message').that.matches(/NO_RESERVATION/)
-
-      // we should not be connected to the relay, because we weren't before the dial
-      expect(local.getConnections(relay1.peerId)).to.be.empty()
     })
 
     it('dialer should stay connected to an already connected relay on hop failure', async () => {
@@ -572,36 +521,6 @@ describe('circuit-relay', () => {
       // should have closed connections to remote and to relay
       expect(events[0].detail.remotePeer.toString()).to.equal(relay1.peerId.toString())
       expect(events[1].detail.remotePeer.toString()).to.equal(remote.peerId.toString())
-    })
-
-    it('should remove the relay event listener when the relay stops', async () => {
-      // discover relay and make reservation
-      await local.dial(relay1.getMultiaddrs()[0])
-      await local.dial(relay2.getMultiaddrs()[0])
-
-      await usingAsRelayCount(local, [relay1, relay2], 2)
-
-      // expect 2 listeners
-      // @ts-expect-error these are private fields
-      const listeners = local.components.transportManager.getListeners()
-
-      // @ts-expect-error as a result these will have any types
-      const circuitListener = listeners.filter(listener => {
-        // @ts-expect-error as a result these will have any types
-        const circuitMultiaddrs = listener.getAddrs().filter(ma => Circuit.matches(ma))
-        return circuitMultiaddrs.length > 0
-      })
-
-      expect(circuitListener[0].reservationStore.listenerCount('relay:removed')).to.equal(2)
-
-      // stop the listener
-      await circuitListener[0].close()
-
-      // not using the relay any more
-      await notUsingAsRelay(local, relay1)
-
-      // expect 1 listener
-      expect(circuitListener[0].reservationStore.listenerCount('relay:removed')).to.equal(1)
     })
 
     it('should mark an outgoing relayed connection as limited', async () => {
@@ -718,28 +637,8 @@ describe('circuit-relay', () => {
 
     beforeEach(async () => {
       [local, remote, relay] = await Promise.all([
-        createClient({
-          transports: [
-            tcp(),
-            circuitRelayTransport({
-              discoverRelays: 1
-            })
-          ],
-          services: {
-            identify: identify()
-          }
-        }),
-        createClient({
-          transports: [
-            tcp(),
-            circuitRelayTransport({
-              discoverRelays: 1
-            })
-          ],
-          services: {
-            identify: identify()
-          }
-        }),
+        createClient(),
+        createClient(),
         createRelay({
           services: {
             relay: circuitRelayServer({
@@ -812,28 +711,8 @@ describe('circuit-relay', () => {
 
     beforeEach(async () => {
       [local, remote, relay] = await Promise.all([
-        createClient({
-          transports: [
-            tcp(),
-            circuitRelayTransport({
-              discoverRelays: 1
-            })
-          ],
-          services: {
-            identify: identify()
-          }
-        }),
-        createClient({
-          transports: [
-            tcp(),
-            circuitRelayTransport({
-              discoverRelays: 1
-            })
-          ],
-          services: {
-            identify: identify()
-          }
-        }),
+        createClient(),
+        createClient(),
         createRelay({
           services: {
             relay: circuitRelayServer({
@@ -968,6 +847,8 @@ describe('circuit-relay', () => {
     })
 
     it('should be able to dial remote on preconfigured relay address', async () => {
+      await usingAsRelay(remote, relay)
+
       const ma = getRelayAddress(remote)
 
       await expect(local.dial(ma)).to.eventually.be.ok()

--- a/packages/logger/src/index.ts
+++ b/packages/logger/src/index.ts
@@ -79,7 +79,7 @@ debug.formatters.a = (v?: Multiaddr): string => {
 
 // Add a formatter for stringifying Errors
 debug.formatters.e = (v?: Error): string => {
-  return v == null ? 'undefined' : v.stack ?? v.message
+  return v == null ? 'undefined' : notEmpty(v.stack) ?? notEmpty(v.message) ?? v.toString()
 }
 
 export interface Logger {
@@ -219,4 +219,18 @@ export function enable (namespaces: string): void {
 
 export function enabled (namespaces: string): boolean {
   return debug.enabled(namespaces)
+}
+
+function notEmpty (str?: string): string | undefined {
+  if (str == null) {
+    return
+  }
+
+  str = str.trim()
+
+  if (str.length === 0) {
+    return
+  }
+
+  return str
 }

--- a/packages/transport-circuit-relay-v2/package.json
+++ b/packages/transport-circuit-relay-v2/package.json
@@ -65,9 +65,9 @@
     "it-protobuf-stream": "^1.1.3",
     "it-stream-types": "^2.0.1",
     "multiformats": "^13.1.0",
+    "nanoid": "^5.0.7",
     "progress-events": "^1.0.0",
     "protons-runtime": "^5.4.0",
-    "race-signal": "^1.0.2",
     "retimeable-signal": "^0.0.0",
     "uint8arraylist": "^2.4.8",
     "uint8arrays": "^5.1.0"
@@ -83,6 +83,7 @@
     "it-to-buffer": "^4.0.7",
     "p-wait-for": "^5.0.2",
     "protons": "^7.5.0",
+    "race-signal": "^1.0.2",
     "sinon": "^18.0.0",
     "sinon-ts": "^2.0.0"
   },

--- a/packages/transport-circuit-relay-v2/src/constants.ts
+++ b/packages/transport-circuit-relay-v2/src/constants.ts
@@ -35,8 +35,6 @@ export const DEFAULT_MAX_RESERVATION_QUEUE_LENGTH = 100
 
 export const RELAY_SOURCE_TAG = 'circuit-relay-source'
 
-export const RELAY_TAG = 'circuit-relay-relay'
-
 export const KEEP_ALIVE_TAG = `${KEEP_ALIVE}-circuit-relay`
 export const KEEP_ALIVE_SOURCE_TAG = `${KEEP_ALIVE}-circuit-relay-source`
 

--- a/packages/transport-circuit-relay-v2/src/errors.ts
+++ b/packages/transport-circuit-relay-v2/src/errors.ts
@@ -17,3 +17,27 @@ export class DurationLimitError extends Error {
     this.name = 'DurationLimitError'
   }
 }
+
+/**
+ * There were enough relay reservations already
+ */
+export class HadEnoughRelaysError extends Error {
+  static name: string = 'HadEnoughRelaysError'
+  name: string = 'HadEnoughRelaysError'
+}
+
+/**
+ * An attempt to open a relayed connection over a relayed connection was made
+ */
+export class DoubleRelayError extends Error {
+  static name: string = 'DoubleRelayError'
+  name: string = 'DoubleRelayError'
+}
+
+/**
+ * An attempt to open a relayed connection over a relayed connection was made
+ */
+export class RelayQueueFullError extends Error {
+  static name: string = 'RelayQueueFullError'
+  name: string = 'RelayQueueFullError'
+}

--- a/packages/transport-circuit-relay-v2/src/errors.ts
+++ b/packages/transport-circuit-relay-v2/src/errors.ts
@@ -35,7 +35,8 @@ export class DoubleRelayError extends Error {
 }
 
 /**
- * An attempt to open a relayed connection over a relayed connection was made
+ * An attempt to make a reservation on a relay was made while the reservation
+ * queue was full
  */
 export class RelayQueueFullError extends Error {
   static name: string = 'RelayQueueFullError'

--- a/packages/transport-circuit-relay-v2/src/transport/discovery.ts
+++ b/packages/transport-circuit-relay-v2/src/transport/discovery.ts
@@ -1,11 +1,11 @@
 import { TypedEventEmitter, setMaxListeners } from '@libp2p/interface'
 import { PeerQueue } from '@libp2p/utils/peer-queue'
 import { anySignal } from 'any-signal'
-import { raceSignal } from 'race-signal'
+import { toString as uint8ArrayToString } from 'uint8arrays/to-string'
 import {
   RELAY_V2_HOP_CODEC
 } from '../constants.js'
-import type { ComponentLogger, Logger, PeerId, PeerStore, Startable, TopologyFilter } from '@libp2p/interface'
+import type { ComponentLogger, Logger, Peer, PeerId, PeerStore, Startable, TopologyFilter } from '@libp2p/interface'
 import type { ConnectionManager, RandomWalk, Registrar, TransportManager } from '@libp2p/interface-internal'
 
 export interface RelayDiscoveryEvents {
@@ -40,6 +40,7 @@ export class RelayDiscovery extends TypedEventEmitter<RelayDiscoveryEvents> impl
   private readonly log: Logger
   private discoveryController: AbortController
   private readonly filter?: TopologyFilter
+  private queue?: PeerQueue
 
   constructor (components: RelayDiscoveryComponents, init: RelayDiscoveryInit = {}) {
     super()
@@ -66,7 +67,7 @@ export class RelayDiscovery extends TypedEventEmitter<RelayDiscoveryEvents> impl
     this.topologyId = await this.registrar.register(RELAY_V2_HOP_CODEC, {
       filter: this.filter,
       onConnect: (peerId) => {
-        this.log.trace('discovered relay %p', peerId)
+        this.log.trace('discovered relay %p queue (length: %d, active %d)', peerId, this.queue?.size, this.queue?.running)
         this.safeDispatchEvent('relay:discover', { detail: peerId })
       }
     })
@@ -113,7 +114,23 @@ export class RelayDiscovery extends TypedEventEmitter<RelayDiscoveryEvents> impl
             }
           ],
           orders: [
-            () => Math.random() < 0.5 ? 1 : -1
+            // randomise
+            () => Math.random() < 0.5 ? 1 : -1,
+            // prefer peers we've connected to in the past
+            (a, b) => {
+              const lastDialA = getLastDial(a)
+              const lastDialB = getLastDial(b)
+
+              if (lastDialA > lastDialB) {
+                return -1
+              }
+
+              if (lastDialB > lastDialA) {
+                return 1
+              }
+
+              return 0
+            }
           ]
         }))
 
@@ -126,11 +143,12 @@ export class RelayDiscovery extends TypedEventEmitter<RelayDiscoveryEvents> impl
 
         // perform random walk and dial peers - after identify has run, the network
         // topology will be notified of new relays
-        const queue = new PeerQueue({
+        const queue = this.queue = new PeerQueue({
           concurrency: 5
         })
 
         this.log('start random walk')
+
         for await (const peer of this.randomWalk.walk({ signal: this.discoveryController.signal })) {
           this.log.trace('found random peer %p', peer.id)
 
@@ -155,12 +173,16 @@ export class RelayDiscovery extends TypedEventEmitter<RelayDiscoveryEvents> impl
             continue
           }
 
-          this.log.trace('wait for space in queue for %p', peer.id)
+          if (queue.queued > 10) {
+            this.log.trace('wait for space in queue for %p', peer.id)
 
-          // pause the random walk until there is space in the queue
-          await raceSignal(queue.onSizeLessThan(10), this.discoveryController.signal)
+            // pause the random walk until there is space in the queue
+            await queue.onSizeLessThan(10, {
+              signal: this.discoveryController.signal
+            })
+          }
 
-          this.log('adding random peer %p to dial queue (length: %d)', peer.id, queue.size)
+          this.log('adding random peer %p to dial queue (length: %d, active %d)', peer.id, queue.size, queue.running)
 
           // dial the peer - this will cause identify to run and our topology to
           // be notified and we'll attempt to create reservations
@@ -182,6 +204,8 @@ export class RelayDiscovery extends TypedEventEmitter<RelayDiscoveryEvents> impl
             })
         }
 
+        this.log('stop random walk')
+
         await queue.onIdle()
       })
       .catch(err => {
@@ -196,4 +220,18 @@ export class RelayDiscovery extends TypedEventEmitter<RelayDiscoveryEvents> impl
     this.running = false
     this.discoveryController?.abort()
   }
+}
+
+/**
+ * Returns the timestamp of the last time we connected to this peer, if we've
+ * not connected to them before return 0
+ */
+function getLastDial (peer: Peer): number {
+  const lastDial = peer.metadata.get('last-dial-success')
+
+  if (lastDial == null) {
+    return 0
+  }
+
+  return new Date(uint8ArrayToString(lastDial)).getTime()
 }

--- a/packages/transport-circuit-relay-v2/src/transport/index.ts
+++ b/packages/transport-circuit-relay-v2/src/transport/index.ts
@@ -18,13 +18,6 @@ export interface CircuitRelayTransportComponents extends RelayDiscoveryComponent
  */
 export interface CircuitRelayTransportInit extends ReservationStoreInit {
   /**
-   * The number of peers running diable relays to search for and connect to
-   *
-   * @default 0
-   */
-  discoverRelays?: number
-
-  /**
    * An optional filter used to prevent duplicate attempts to reserve relay
    * slots on the same peer
    */

--- a/packages/transport-circuit-relay-v2/src/transport/reservation-store.ts
+++ b/packages/transport-circuit-relay-v2/src/transport/reservation-store.ts
@@ -1,15 +1,18 @@
-import { TypedEventEmitter, setMaxListeners } from '@libp2p/interface'
+import { ListenError, TypedEventEmitter, setMaxListeners } from '@libp2p/interface'
 import { PeerMap } from '@libp2p/peer-collections'
-import { createBloomFilter } from '@libp2p/utils/filters'
+import { createScalableCuckooFilter } from '@libp2p/utils/filters'
 import { PeerQueue } from '@libp2p/utils/peer-queue'
 import { multiaddr } from '@multiformats/multiaddr'
+import { Circuit } from '@multiformats/multiaddr-matcher'
 import { pbStream } from 'it-protobuf-stream'
-import { DEFAULT_MAX_RESERVATION_QUEUE_LENGTH, DEFAULT_RESERVATION_COMPLETION_TIMEOUT, DEFAULT_RESERVATION_CONCURRENCY, KEEP_ALIVE_TAG, RELAY_TAG, RELAY_V2_HOP_CODEC } from '../constants.js'
+import { nanoid } from 'nanoid'
+import { DEFAULT_MAX_RESERVATION_QUEUE_LENGTH, DEFAULT_RESERVATION_COMPLETION_TIMEOUT, DEFAULT_RESERVATION_CONCURRENCY, KEEP_ALIVE_TAG, RELAY_V2_HOP_CODEC } from '../constants.js'
+import { DoubleRelayError, HadEnoughRelaysError, RelayQueueFullError } from '../errors.js'
 import { HopMessage, Status } from '../pb/index.js'
 import { getExpirationMilliseconds } from '../utils.js'
 import type { Reservation } from '../pb/index.js'
-import type { TypedEventTarget, Libp2pEvents, AbortOptions, ComponentLogger, Logger, Connection, PeerId, PeerStore, Startable, Metrics, Peer } from '@libp2p/interface'
-import type { ConnectionManager, TransportManager } from '@libp2p/interface-internal'
+import type { AbortOptions, TypedEventTarget, Libp2pEvents, ComponentLogger, Logger, PeerId, PeerStore, Startable, Metrics, Peer, Connection } from '@libp2p/interface'
+import type { ConnectionManager } from '@libp2p/interface-internal'
 import type { Filter } from '@libp2p/utils/filters'
 
 // allow refreshing a relay reservation if it will expire in the next 10 minutes
@@ -24,7 +27,6 @@ const REFRESH_TIMEOUT_MIN = 30 * 1000
 export interface ReservationStoreComponents {
   peerId: PeerId
   connectionManager: ConnectionManager
-  transportManager: TransportManager
   peerStore: PeerStore
   events: TypedEventTarget<Libp2pEvents>
   logger: ComponentLogger
@@ -45,11 +47,6 @@ export interface ReservationStoreInit {
   reservationConcurrency?: number
 
   /**
-   * How many discovered relays to allow in the reservation store
-   */
-  discoverRelays?: number
-
-  /**
    * Limit the number of potential relays we will dial
    *
    * @default 100
@@ -66,9 +63,25 @@ export interface ReservationStoreInit {
 
 export type RelayType = 'discovered' | 'configured'
 
-interface RelayEntry {
+export interface DiscoveredRelayEntry {
   timeout: ReturnType<typeof setTimeout>
-  type: RelayType
+  type: 'discovered'
+  reservation: Reservation
+
+  /**
+   * Stores the id of the connection we have to the relay
+   */
+  connection: string
+
+  /**
+   * Stores the identifier returned when the reservation was requested
+   */
+  id: string
+}
+
+export interface ConfiguredRelayEntry {
+  timeout: ReturnType<typeof setTimeout>
+  type: 'configured'
   reservation: Reservation
 
   /**
@@ -77,26 +90,33 @@ interface RelayEntry {
   connection: string
 }
 
+export type RelayEntry = DiscoveredRelayEntry | ConfiguredRelayEntry
+
+export interface RelayReservation {
+  relay: PeerId
+  details: RelayEntry
+}
+
 export interface ReservationStoreEvents {
   'relay:not-enough-relays': CustomEvent
-  'relay:removed': CustomEvent<PeerId>
-  'relay:created-reservation': CustomEvent<PeerId>
+  'relay:found-enough-relays': CustomEvent
+  'relay:removed': CustomEvent<RelayReservation>
+  'relay:created-reservation': CustomEvent<RelayReservation>
 }
 
 export class ReservationStore extends TypedEventEmitter<ReservationStoreEvents> implements Startable {
   private readonly peerId: PeerId
   private readonly connectionManager: ConnectionManager
-  private readonly transportManager: TransportManager
   private readonly peerStore: PeerStore
   private readonly events: TypedEventTarget<Libp2pEvents>
-  private readonly reserveQueue: PeerQueue
+  private readonly reserveQueue: PeerQueue<RelayReservation>
   private readonly reservations: PeerMap<RelayEntry>
-  private readonly maxDiscoveredRelays: number
+  private readonly pendingReservations: string[]
   private readonly maxReservationQueueLength: number
   private readonly reservationCompletionTimeout: number
   private started: boolean
   private readonly log: Logger
-  private readonly relayFilter: Filter
+  private relayFilter: Filter
 
   constructor (components: ReservationStoreComponents, init?: ReservationStoreInit) {
     super()
@@ -104,15 +124,14 @@ export class ReservationStore extends TypedEventEmitter<ReservationStoreEvents> 
     this.log = components.logger.forComponent('libp2p:circuit-relay:transport:reservation-store')
     this.peerId = components.peerId
     this.connectionManager = components.connectionManager
-    this.transportManager = components.transportManager
     this.peerStore = components.peerStore
     this.events = components.events
     this.reservations = new PeerMap()
-    this.maxDiscoveredRelays = init?.discoverRelays ?? 0
+    this.pendingReservations = []
     this.maxReservationQueueLength = init?.maxReservationQueueLength ?? DEFAULT_MAX_RESERVATION_QUEUE_LENGTH
     this.reservationCompletionTimeout = init?.reservationCompletionTimeout ?? DEFAULT_RESERVATION_COMPLETION_TIMEOUT
     this.started = false
-    this.relayFilter = createBloomFilter(100)
+    this.relayFilter = createScalableCuckooFilter(100)
 
     // ensure we don't listen on multiple relays simultaneously
     this.reserveQueue = new PeerQueue({
@@ -132,7 +151,7 @@ export class ReservationStore extends TypedEventEmitter<ReservationStoreEvents> 
         return
       }
 
-      this.#removeReservation(evt.detail.remotePeer, reservation)
+      this.#removeReservation(evt.detail.remotePeer)
         .catch(err => {
           this.log('could not remove relay %p - %e', evt.detail, err)
         })
@@ -153,7 +172,7 @@ export class ReservationStore extends TypedEventEmitter<ReservationStoreEvents> 
       .then(async () => {
         const relayPeers: Peer[] = await this.peerStore.all({
           filters: [(peer) => {
-            return peer.tags.has(RELAY_TAG)
+            return peer.tags.has(KEEP_ALIVE_TAG)
           }]
         })
 
@@ -164,17 +183,18 @@ export class ReservationStore extends TypedEventEmitter<ReservationStoreEvents> 
           relayPeers.map(async peer => {
             await this.peerStore.merge(peer.id, {
               tags: {
-                [RELAY_TAG]: undefined,
                 [KEEP_ALIVE_TAG]: undefined
               }
             })
           })
         )
 
-        if (this.reservations.size < this.maxDiscoveredRelays) {
-          this.log('not enough relays %d/%d', this.reservations.size, this.maxDiscoveredRelays)
-          this.safeDispatchEvent('relay:not-enough-relays', {})
-        }
+        this.log('redialing %d old relays', relayPeers.length)
+        await Promise.all(
+          relayPeers.map(async peer => this.addRelay(peer.id, 'discovered'))
+        )
+
+        this.#checkReservationCount()
       })
       .catch(err => {
         this.log.error(err)
@@ -190,36 +210,46 @@ export class ReservationStore extends TypedEventEmitter<ReservationStoreEvents> 
     this.started = false
   }
 
+  reserveRelay (): string {
+    const id = nanoid()
+
+    this.pendingReservations.push(id)
+
+    this.#checkReservationCount()
+
+    return id
+  }
+
   /**
    * If the number of current relays is beneath the configured `maxReservations`
    * value, and the passed peer id is not our own, and we have a non-relayed
    * connection to the remote, and the remote peer speaks the hop protocol, try
    * to reserve a slot on the remote peer
    */
-  async addRelay (peerId: PeerId, type: RelayType): Promise<void> {
+  async addRelay (peerId: PeerId, type: RelayType): Promise<RelayReservation> {
     if (this.peerId.equals(peerId)) {
       this.log.trace('not trying to use self as relay')
-      return
+      throw new ListenError('Cannot use self as relay')
     }
 
     if (this.reserveQueue.size > this.maxReservationQueueLength) {
-      this.log.trace('not adding potential relay peer %p as the queue is full', peerId)
-      return
+      throw new RelayQueueFullError('The reservation queue is full')
     }
 
-    if (this.reserveQueue.has(peerId)) {
+    const existingJob = this.reserveQueue.find(peerId)
+
+    if (existingJob != null) {
       this.log.trace('potential relay peer %p is already in the reservation queue', peerId)
-      return
+      return existingJob.join()
     }
 
     if (this.relayFilter.has(peerId.toMultihash().bytes)) {
-      this.log.trace('potential relay peer %p has failed previously, not trying again', peerId)
-      return
+      throw new ListenError('The relay was previously invalid')
     }
 
     this.log.trace('try to reserve relay slot with %p', peerId)
 
-    await this.reserveQueue.add(async () => {
+    return this.reserveQueue.add(async () => {
       const start = Date.now()
 
       try {
@@ -241,21 +271,17 @@ export class ReservationStore extends TypedEventEmitter<ReservationStoreEvents> 
 
           if (connected && getExpirationMilliseconds(existingReservation.reservation.expire) > REFRESH_WINDOW) {
             this.log('already have relay reservation with %p but we are still connected and it does not expire soon', peerId)
-            return
+            return {
+              relay: peerId,
+              details: existingReservation
+            } satisfies RelayReservation
           }
 
-          await this.#removeReservation(peerId, existingReservation)
+          await this.#removeReservation(peerId)
         }
 
-        if (type === 'discovered' && [...this.reservations.values()].reduce((acc, curr) => {
-          if (curr.type === 'discovered') {
-            acc++
-          }
-
-          return acc
-        }, 0) >= this.maxDiscoveredRelays) {
-          this.log.trace('already have enough discovered relays')
-          return
+        if (type === 'discovered' && this.pendingReservations.length === 0) {
+          throw new HadEnoughRelaysError('Not making reservation on discovered relay because we do not need any more relays')
         }
 
         const signal = AbortSignal.timeout(this.reservationCompletionTimeout)
@@ -265,9 +291,8 @@ export class ReservationStore extends TypedEventEmitter<ReservationStoreEvents> 
           signal
         })
 
-        if (connection.remoteAddr.protoNames().includes('p2p-circuit')) {
-          this.log('not creating reservation over relayed connection')
-          return
+        if (Circuit.matches(connection.remoteAddr)) {
+          throw new DoubleRelayError('not creating reservation over relayed connection')
         }
 
         const reservation = await this.#createReservation(connection, {
@@ -288,36 +313,45 @@ export class ReservationStore extends TypedEventEmitter<ReservationStoreEvents> 
           this.addRelay(peerId, type)
             .catch(async err => {
               this.log.error('could not refresh reservation to relay %p - %e', peerId, err)
-
-              const reservation = this.reservations.get(peerId)
-
-              if (reservation == null) {
-                this.log.error('did not have reservation after refreshing reservation failed %p', peerId)
-                return
-              }
-
-              await this.#removeReservation(peerId, reservation)
+              await this.#removeReservation(peerId)
             })
             .catch(err => {
               this.log.error('could not remove expired reservation to relay %p - %e', peerId, err)
             })
         }, timeoutDuration)
 
+        let res: RelayEntry
+
+        // assign a reservation id if one was requested
+        if (type === 'discovered') {
+          const id = this.pendingReservations.pop()
+
+          if (id == null) {
+            throw new HadEnoughRelaysError('Made reservation on relay but did not need any more discovered relays')
+          }
+
+          res = {
+            timeout,
+            reservation,
+            type,
+            connection: connection.id,
+            id
+          }
+        } else {
+          res = {
+            timeout,
+            reservation,
+            type,
+            connection: connection.id
+          }
+        }
+
         // we've managed to create a reservation successfully
-        this.reservations.set(peerId, {
-          timeout,
-          reservation,
-          type,
-          connection: connection.id
-        })
+        this.reservations.set(peerId, res)
 
         // ensure we don't close the connection to the relay
         await this.peerStore.merge(peerId, {
           tags: {
-            [RELAY_TAG]: {
-              value: 1,
-              ttl: expiration
-            },
             [KEEP_ALIVE_TAG]: {
               value: 1,
               ttl: expiration
@@ -325,28 +359,37 @@ export class ReservationStore extends TypedEventEmitter<ReservationStoreEvents> 
           }
         })
 
-        // listen on multiaddr that only the circuit transport is listening for
-        await this.transportManager.listen([multiaddr(`/p2p/${peerId.toString()}/p2p-circuit/p2p/${this.peerId.toString()}`)])
+        // check to see if we have discovered enough relays
+        this.#checkReservationCount()
+
+        const result: RelayReservation = {
+          relay: peerId,
+          details: res
+        }
 
         this.safeDispatchEvent('relay:created-reservation', {
-          detail: peerId
+          detail: result
         })
-      } catch (err) {
-        this.log.error('could not reserve slot on %p after %dms', peerId, Date.now() - start, err)
 
-        // don't try this peer again
-        this.relayFilter.add(peerId.toMultihash().bytes)
+        return result
+      } catch (err: any) {
+        if (!(type === 'discovered' && err.name === 'HadEnoughRelaysError')) {
+          this.log.error('could not reserve slot on %p after %dms - %e', peerId, Date.now() - start, err)
+        }
 
-        // cancel the renewal timeout if it's been set
-        const reservation = this.reservations.get(peerId)
+        // don't try this peer again if dialing failed or they do not support
+        // the hop protocol
+        if (err.name === 'DialError' || err.name === 'UnsupportedProtocolError') {
+          this.relayFilter.add(peerId.toMultihash().bytes)
+        }
 
         // if listening failed, remove the reservation
-        if (reservation != null) {
-          this.#removeReservation(peerId, reservation)
-            .catch(err => {
-              this.log.error('could not remove reservation on %p after reserving slot failed - %e', peerId, err)
-            })
-        }
+        this.#removeReservation(peerId)
+          .catch(err => {
+            this.log.error('could not remove reservation on %p after reserving slot failed - %e', peerId, err)
+          })
+
+        throw err
       }
     }, {
       peerId
@@ -361,16 +404,26 @@ export class ReservationStore extends TypedEventEmitter<ReservationStoreEvents> 
     return this.reservations.get(peerId)?.reservation
   }
 
-  reservationCount (): number {
-    return this.reservations.size
+  reservationCount (type?: RelayType): number {
+    if (type == null) {
+      return this.reservations.size
+    }
+
+    return [...this.reservations.values()].reduce((acc, curr) => {
+      if (curr.type === type) {
+        acc++
+      }
+
+      return acc
+    }, 0)
   }
 
-  async cancelReservations (): Promise<void> {
-    await Promise.all(
-      [...this.reservations.entries()].map(async ([peerId, reservation]) => {
-        await this.#removeReservation(peerId, reservation)
-      })
-    )
+  cancelReservations (): void {
+    [...this.reservations.values()].forEach(reservation => {
+      clearTimeout(reservation.timeout)
+    })
+
+    this.reservations.clear()
   }
 
   async #createReservation (connection: Connection, options: AbortOptions): Promise<Reservation> {
@@ -380,11 +433,14 @@ export class ReservationStore extends TypedEventEmitter<ReservationStoreEvents> 
     const stream = await connection.newStream(RELAY_V2_HOP_CODEC, options)
     const pbstr = pbStream(stream)
     const hopstr = pbstr.pb(HopMessage)
+
+    this.log.trace('send RESERVE to %p', connection.remotePeer)
     await hopstr.write({ type: HopMessage.Type.RESERVE }, options)
 
     let response: HopMessage
 
     try {
+      this.log.trace('read response from %p', connection.remotePeer)
       response = await hopstr.read(options)
     } catch (err: any) {
       stream.abort(err)
@@ -394,6 +450,8 @@ export class ReservationStore extends TypedEventEmitter<ReservationStoreEvents> 
         await stream.close(options)
       }
     }
+
+    this.log.trace('read response from %p', response)
 
     if (response.status === Status.OK && response.reservation != null) {
       // check that the returned relay has the relay address - this can be
@@ -432,9 +490,10 @@ export class ReservationStore extends TypedEventEmitter<ReservationStoreEvents> 
   /**
    * Remove listen relay
    */
-  async #removeReservation (peerId: PeerId, reservation: RelayEntry): Promise<void> {
-    if (!this.reservations.has(peerId)) {
-      this.log('not removing relay reservation with %p from local store as we do not have a reservation with this peer', peerId)
+  async #removeReservation (peerId: PeerId): Promise<void> {
+    const reservation = this.reservations.get(peerId)
+
+    if (reservation == null) {
       return
     }
 
@@ -442,19 +501,42 @@ export class ReservationStore extends TypedEventEmitter<ReservationStoreEvents> 
     clearTimeout(reservation.timeout)
     this.reservations.delete(peerId)
 
+    // discover a new relay for this discovery request
+    if (reservation.type === 'discovered') {
+      this.pendingReservations.push(
+        reservation.id
+      )
+    }
+
     // untag the relay
     await this.peerStore.merge(peerId, {
       tags: {
-        [RELAY_TAG]: undefined,
         [KEEP_ALIVE_TAG]: undefined
       }
     })
 
-    this.safeDispatchEvent('relay:removed', { detail: peerId })
+    this.safeDispatchEvent('relay:removed', {
+      detail: {
+        relay: peerId,
+        details: reservation
+      }
+    })
 
-    if (this.reservations.size < this.maxDiscoveredRelays) {
-      this.log('not enough relays %d/%d', this.reservations.size, this.maxDiscoveredRelays)
-      this.safeDispatchEvent('relay:not-enough-relays', {})
+    // maybe trigger discovery of new relays
+    this.#checkReservationCount()
+  }
+
+  #checkReservationCount (): void {
+    if (this.pendingReservations.length === 0) {
+      this.log.trace('have discovered enough relays')
+      this.reserveQueue.clear()
+      this.safeDispatchEvent('relay:found-enough-relays')
+
+      return
     }
+
+    this.relayFilter = createScalableCuckooFilter(100)
+    this.log('not discovered enough relays %d/%d', this.reservations.size, this.pendingReservations.length)
+    this.safeDispatchEvent('relay:not-enough-relays')
   }
 }

--- a/packages/transport-circuit-relay-v2/src/transport/transport.ts
+++ b/packages/transport-circuit-relay-v2/src/transport/transport.ts
@@ -9,7 +9,7 @@ import * as Digest from 'multiformats/hashes/digest'
 import { CustomProgressEvent } from 'progress-events'
 import { CIRCUIT_PROTO_CODE, DEFAULT_DISCOVERY_FILTER_ERROR_RATE, DEFAULT_DISCOVERY_FILTER_SIZE, MAX_CONNECTIONS, RELAY_V2_HOP_CODEC, RELAY_V2_STOP_CODEC } from '../constants.js'
 import { StopMessage, HopMessage, Status } from '../pb/index.js'
-import { CircuitListen, LimitTracker } from '../utils.js'
+import { CircuitListen, CircuitSearch, LimitTracker } from '../utils.js'
 import { RelayDiscovery } from './discovery.js'
 import { createListener } from './listener.js'
 import { ReservationStore } from './reservation-store.js'
@@ -17,7 +17,7 @@ import type { CircuitRelayTransportComponents, CircuitRelayTransportInit } from 
 import type { Transport, CreateListenerOptions, Listener, Upgrader, ComponentLogger, Logger, Connection, Stream, ConnectionGater, PeerId, PeerStore, OutboundConnectionUpgradeEvents, DialTransportOptions, OpenConnectionProgressEvents } from '@libp2p/interface'
 import type { AddressManager, ConnectionManager, IncomingStreamData, Registrar, TransportManager } from '@libp2p/interface-internal'
 import type { Multiaddr } from '@multiformats/multiaddr'
-import type { ProgressEvent, ProgressOptions } from 'progress-events'
+import type { ProgressEvent } from 'progress-events'
 
 const isValidStop = (request: StopMessage): request is Required<StopMessage> => {
   if (request.peer == null) {
@@ -31,16 +31,6 @@ const isValidStop = (request: StopMessage): request is Required<StopMessage> => 
   }
 
   return true
-}
-
-interface ConnectOptions extends ProgressOptions<CircuitRelayDialEvents> {
-  stream: Stream
-  connection: Connection
-  destinationPeer: PeerId
-  destinationAddr: Multiaddr
-  relayAddr: Multiaddr
-  ma: Multiaddr
-  disconnectOnFailure: boolean
 }
 
 const defaults = {
@@ -91,28 +81,23 @@ export class CircuitRelayTransport implements Transport<CircuitRelayDialEvents> 
     this.maxOutboundStopStreams = init.maxOutboundStopStreams ?? defaults.maxOutboundStopStreams
     this.stopTimeout = init.stopTimeout ?? defaults.stopTimeout
 
-    const discoverRelays = init.discoverRelays ?? 0
-
-    if (discoverRelays > 0) {
-      this.discovery = new RelayDiscovery(components, {
-        filter: init.discoveryFilter ?? peerFilter(DEFAULT_DISCOVERY_FILTER_SIZE, DEFAULT_DISCOVERY_FILTER_ERROR_RATE)
-      })
-      this.discovery.addEventListener('relay:discover', (evt) => {
-        this.reservationStore.addRelay(evt.detail, 'discovered')
-          .catch(err => {
+    this.discovery = new RelayDiscovery(components, {
+      filter: init.discoveryFilter ?? peerFilter(DEFAULT_DISCOVERY_FILTER_SIZE, DEFAULT_DISCOVERY_FILTER_ERROR_RATE)
+    })
+    this.discovery.addEventListener('relay:discover', (evt) => {
+      this.reservationStore.addRelay(evt.detail, 'discovered')
+        .catch(err => {
+          if (err.name !== 'HadEnoughRelaysError' && err.name !== 'RelayQueueFullError') {
             this.log.error('could not add discovered relay %p', evt.detail, err)
-          })
-      })
-    }
-
+          }
+        })
+    })
     this.reservationStore = new ReservationStore(components, init)
     this.reservationStore.addEventListener('relay:not-enough-relays', () => {
       this.discovery?.startDiscovery()
     })
-    this.reservationStore.addEventListener('relay:created-reservation', () => {
-      if (this.reservationStore.reservationCount() >= discoverRelays) {
-        this.discovery?.stopDiscovery()
-      }
+    this.reservationStore.addEventListener('relay:found-enough-relays', () => {
+      this.discovery?.stopDiscovery()
     })
 
     this.started = false
@@ -192,7 +177,6 @@ export class CircuitRelayTransport implements Transport<CircuitRelayDialEvents> 
     const relayPeer = peerIdFromString(relayId)
     const destinationPeer = peerIdFromString(destinationId)
 
-    let disconnectOnFailure = false
     const relayConnections = this.connectionManager.getConnections(relayPeer)
     let relayConnection = relayConnections[0]
 
@@ -203,7 +187,6 @@ export class CircuitRelayTransport implements Transport<CircuitRelayDialEvents> 
 
       options.onProgress?.(new CustomProgressEvent('circuit-relay:open-connection'))
       relayConnection = await this.connectionManager.openConnection(relayPeer, options)
-      disconnectOnFailure = true
     } else {
       options.onProgress?.(new CustomProgressEvent('circuit-relay:reuse-connection'))
     }
@@ -212,52 +195,22 @@ export class CircuitRelayTransport implements Transport<CircuitRelayDialEvents> 
 
     try {
       options.onProgress?.(new CustomProgressEvent('circuit-relay:open-hop-stream'))
-      stream = await relayConnection.newStream(RELAY_V2_HOP_CODEC)
+      stream = await relayConnection.newStream(RELAY_V2_HOP_CODEC, options)
 
-      return await this.connectV2({
-        stream,
-        connection: relayConnection,
-        destinationPeer,
-        destinationAddr,
-        relayAddr,
-        ma,
-        disconnectOnFailure,
-        onProgress: options.onProgress
-      })
-    } catch (err: any) {
-      this.log.error('circuit relay dial to destination %p via relay %p failed', destinationPeer, relayPeer, err)
-
-      if (stream != null) {
-        stream.abort(err)
-      }
-      disconnectOnFailure && await relayConnection.close()
-      throw err
-    }
-  }
-
-  async connectV2 (
-    {
-      stream, connection, destinationPeer,
-      destinationAddr, relayAddr, ma,
-      disconnectOnFailure,
-      onProgress
-    }: ConnectOptions
-  ): Promise<Connection> {
-    try {
       const pbstr = pbStream(stream)
       const hopstr = pbstr.pb(HopMessage)
 
-      onProgress?.(new CustomProgressEvent('circuit-relay:write-connect-message'))
+      options.onProgress?.(new CustomProgressEvent('circuit-relay:write-connect-message'))
       await hopstr.write({
         type: HopMessage.Type.CONNECT,
         peer: {
           id: destinationPeer.toMultihash().bytes,
           addrs: [multiaddr(destinationAddr).bytes]
         }
-      })
+      }, options)
 
-      onProgress?.(new CustomProgressEvent('circuit-relay:read-connect-response'))
-      const status = await hopstr.read()
+      options.onProgress?.(new CustomProgressEvent('circuit-relay:read-connect-response'))
+      const status = await hopstr.read(options)
 
       if (status.status !== Status.OK) {
         throw new InvalidMessageError(`failed to connect via relay with status ${status?.status?.toString() ?? 'undefined'}`)
@@ -277,12 +230,13 @@ export class CircuitRelayTransport implements Transport<CircuitRelayDialEvents> 
       this.log('new outbound relayed connection %a', maConn.remoteAddr)
 
       return await this.upgrader.upgradeOutbound(maConn, {
-        limits: limits.getLimits(),
-        onProgress
+        ...options,
+        limits: limits.getLimits()
       })
     } catch (err: any) {
-      this.log.error(`circuit relay dial to destination ${destinationPeer.toString()} via relay ${connection.remotePeer.toString()} failed`, err)
-      disconnectOnFailure && await connection.close()
+      this.log.error('circuit relay dial to destination %p via relay %p failed', destinationPeer, relayPeer, err)
+      stream?.abort(err)
+
       throw err
     }
   }
@@ -305,7 +259,7 @@ export class CircuitRelayTransport implements Transport<CircuitRelayDialEvents> 
     multiaddrs = Array.isArray(multiaddrs) ? multiaddrs : [multiaddrs]
 
     return multiaddrs.filter((ma) => {
-      return CircuitListen.exactMatch(ma)
+      return CircuitListen.exactMatch(ma) || CircuitSearch.exactMatch(ma)
     })
   }
 

--- a/packages/transport-circuit-relay-v2/src/utils.ts
+++ b/packages/transport-circuit-relay-v2/src/utils.ts
@@ -1,5 +1,5 @@
 import { P2P } from '@multiformats/multiaddr-matcher'
-import { fmt, peerId, literal, optional, and } from '@multiformats/multiaddr-matcher/utils'
+import { fmt, literal, and } from '@multiformats/multiaddr-matcher/utils'
 import { anySignal } from 'any-signal'
 import { CID } from 'multiformats/cid'
 import { sha256 } from 'multiformats/hashes/sha2'
@@ -194,7 +194,15 @@ export class LimitTracker {
 }
 
 /**
- * A custom matcher that makes the `/p2p/peer-id` part of circuit relay
- * addresses optional
+ * A custom matcher that tells us to listen on a particular relay
  */
-export const CircuitListen = fmt(and(P2P.matchers[0], literal('p2p-circuit'), optional(peerId())))
+export const CircuitListen = fmt(
+  and(P2P.matchers[0], literal('p2p-circuit'))
+)
+
+/**
+ * A custom matcher that tells us to discover available relays
+ */
+export const CircuitSearch = fmt(
+  literal('p2p-circuit')
+)

--- a/packages/transport-circuit-relay-v2/test/transport/reservation-store.spec.ts
+++ b/packages/transport-circuit-relay-v2/test/transport/reservation-store.spec.ts
@@ -5,7 +5,7 @@ import { peerIdFromPrivateKey } from '@libp2p/peer-id'
 import { expect } from 'aegir/chai'
 import delay from 'delay'
 import { stubInterface } from 'sinon-ts'
-import { KEEP_ALIVE_TAG, RELAY_TAG } from '../../src/constants.js'
+import { KEEP_ALIVE_TAG } from '../../src/constants.js'
 import { ReservationStore } from '../../src/transport/reservation-store.js'
 import type { ComponentLogger, Libp2pEvents, Peer, PeerId, PeerStore, TypedEventTarget } from '@libp2p/interface'
 import type { ConnectionManager, TransportManager } from '@libp2p/interface-internal'
@@ -44,7 +44,7 @@ describe('transport reservation-store', () => {
       id: peerIdFromPrivateKey(await generateKeyPair('Ed25519')),
       addresses: [],
       metadata: new Map(),
-      tags: new Map([[RELAY_TAG, { value: 1 }]]),
+      tags: new Map([[KEEP_ALIVE_TAG, { value: 1 }]]),
       protocols: []
     }
 
@@ -56,7 +56,6 @@ describe('transport reservation-store', () => {
 
     expect(components.peerStore.merge.calledWith(peer.id, {
       tags: {
-        [RELAY_TAG]: undefined,
         [KEEP_ALIVE_TAG]: undefined
       }
     })).to.be.true()


### PR DESCRIPTION
Refactors the circuit relay transport to behave like other transports

1. Specify the addresses to listen on in the `addresses.listen` config
2. Remove the `discoverRelays` option
3. Remove the transport manager listen call to just listen on configured addresses
4. Emit the `listen` event when listen addresses change like other transports

This fixes the instances where we miss relay address updates and the corresponding `self:peer:update` event never fires.

BREAKING CHANGE: The `discoverRelays` option has been removed, instead add one or more instances of `"/p2p-circuit"` to the libp2p config under the `addresses.listen` key

## Change checklist

- [x] I have performed a self-review of my own code
- [x] I have made corresponding changes to the documentation if necessary (this includes comments as well)
- [x] I have added tests that prove my fix is effective or that my feature works