### PR TITLE
docs: update readme with link to weald

### DIFF
--- a/packages/logger/README.md
+++ b/packages/logger/README.md
@@ -24,7 +24,7 @@ repo and examine the changes made.
 
 -->
 
-A logger for libp2p based on the venerable [debug](https://www.npmjs.com/package/debug) module.
+A logger for libp2p based on [weald](https://www.npmjs.com/package/weald), a TypeScript port of the venerable [debug](https://www.npmjs.com/package/debug) module.
 
 ## Example
 

--- a/packages/logger/src/index.ts
+++ b/packages/logger/src/index.ts
@@ -1,7 +1,7 @@
 /**
  * @packageDocumentation
  *
- * A logger for libp2p based on the venerable [debug](https://www.npmjs.com/package/debug) module.
+ * A logger for libp2p based on [weald](https://www.npmjs.com/package/weald), a TypeScript port of the venerable [debug](https://www.npmjs.com/package/debug) module.
  *
  * @example
  *


### PR DESCRIPTION
debug was swapped for weald because it's in TypeScript, update the readme to reflect this.

## Change checklist

- [x] I have performed a self-review of my own code
- [x] I have made corresponding changes to the documentation if necessary (this includes comments as well)
- [ ] I have added tests that prove my fix is effective or that my feature works