### PR TITLE
fix: fix metric group timers

### DIFF
--- a/packages/metrics-prometheus/src/metric-group.ts
+++ b/packages/metrics-prometheus/src/metric-group.ts
@@ -72,7 +72,7 @@ export class PrometheusMetricGroup implements MetricGroup, CalculatedMetric<Reco
 
   timer (key: string): StopTimer {
     return this.gauge.startTimer({
-      key: 0
+      [this.label]: key
     })
   }
 }

--- a/packages/metrics-prometheus/test/metric-groups.spec.ts
+++ b/packages/metrics-prometheus/test/metric-groups.spec.ts
@@ -183,4 +183,24 @@ describe('metric groups', () => {
     expect(reportedMetrics).to.include(`${metricName}{${metricLabel}="${metricKey1}"} ${metricValue1}`, 'did not include updated metric')
     expect(reportedMetrics).to.include(`${metricName}{${metricLabel}="${metricKey2}"} ${metricValue2}`, 'did not include updated metric')
   })
+
+  it('should allow grouped timers', async () => {
+    const metricName = randomMetricName()
+    const metricLabel = randomMetricName('label_')
+    const metricKey = randomMetricName('key_')
+    const metrics = prometheusMetrics()({
+      logger: defaultLogger()
+    })
+    const metric1 = metrics.registerMetricGroup(metricName, {
+      label: metricLabel
+    })
+
+    const timer = metric1.timer(metricKey)
+
+    timer()
+
+    const reportedMetrics = await client.register.metrics()
+
+    expect(reportedMetrics).to.include(`${metricName}{${metricLabel}="${metricKey}"}`, 'did not include updated metric')
+  })
 })


### PR DESCRIPTION
We need to pass the metric label as the object key, otherwise trying to stop a group timer throws.

## Change checklist

- [x] I have performed a self-review of my own code
- [ ] I have made corresponding changes to the documentation if necessary (this includes comments as well)
- [x] I have added tests that prove my fix is effective or that my feature works