### PR TITLE
fix: only update pending incoming connections if connection accepted

### DIFF
--- a/packages/libp2p/src/upgrader.ts
+++ b/packages/libp2p/src/upgrader.ts
@@ -182,22 +182,22 @@ export class DefaultUpgrader implements Upgrader {
    * Upgrades an inbound connection
    */
   async upgradeInbound (maConn: MultiaddrConnection, opts: UpgraderOptions = {}): Promise<Connection> {
+    let accepted = false
+
     try {
       this.metrics.dials?.increment({
         inbound: true
       })
 
-      const accept = await this.components.connectionManager.acceptIncomingConnection(maConn)
+      accepted = await this.components.connectionManager.acceptIncomingConnection(maConn)
 
-      if (!accept) {
+      if (!accepted) {
         throw new ConnectionDeniedError('connection denied')
       }
 
       await this.shouldBlockConnection('denyInboundConnection', maConn)
 
-      const conn = await this._performUpgrade(maConn, 'inbound', opts)
-
-      return conn
+      return await this._performUpgrade(maConn, 'inbound', opts)
     } catch (err) {
       this.metrics.errors?.increment({
         inbound: true
@@ -205,7 +205,9 @@ export class DefaultUpgrader implements Upgrader {
 
       throw err
     } finally {
-      this.components.connectionManager.afterUpgradeInbound()
+      if (accepted) {
+        this.components.connectionManager.afterUpgradeInbound()
+      }
     }
   }
 


### PR DESCRIPTION
The `afterUpgradeInbound` function decrements the count of pending (e.g. not upgraded yet) incoming connections, so only invoke that method if we actually accepted the connection, otherwise we decrement a counter that was never incremented.

## Change checklist

- [x] I have performed a self-review of my own code
- [ ] I have made corresponding changes to the documentation if necessary (this includes comments as well)
- [x] I have added tests that prove my fix is effective or that my feature works