### PR TITLE
fix: make start/stop methods optional

### DIFF
--- a/packages/interface/src/index.ts
+++ b/packages/interface/src/index.ts
@@ -23,7 +23,6 @@ import type { Ed25519PeerId, PeerId, RSAPeerId, Secp256k1PeerId, URLPeerId } fro
 import type { PeerInfo } from './peer-info/index.js'
 import type { PeerRouting } from './peer-routing/index.js'
 import type { Address, Peer, PeerStore } from './peer-store/index.js'
-import type { Startable } from './startable.js'
 import type { StreamHandler, StreamHandlerOptions } from './stream-handler/index.js'
 import type { Topology } from './topology/index.js'
 import type { Listener, OutboundConnectionUpgradeEvents } from './transport/index.js'
@@ -379,7 +378,7 @@ export interface DialProtocolOptions extends NewStreamOptions {
 /**
  * Libp2p nodes implement this interface.
  */
-export interface Libp2p<T extends ServiceMap = ServiceMap> extends Startable, TypedEventTarget<Libp2pEvents<T>> {
+export interface Libp2p<T extends ServiceMap = ServiceMap> extends TypedEventTarget<Libp2pEvents<T>> {
   /**
    * The PeerId is a unique identifier for a node on the network.
    *
@@ -680,6 +679,16 @@ export interface Libp2p<T extends ServiceMap = ServiceMap> extends Startable, Ty
    * This may involve resolving DNS addresses so you should pass an AbortSignal.
    */
   isDialable(multiaddr: Multiaddr | Multiaddr[], options?: IsDialableOptions): Promise<boolean>
+
+  /**
+   * Starts the libp2p node and all its subsystems
+   */
+  start(): Promise<void>
+
+  /**
+   * Stop the libp2p node by closing its listeners and open connections
+   */
+  stop(): Promise<void>
 
   /**
    * A set of user defined services

--- a/packages/interface/src/startable.ts
+++ b/packages/interface/src/startable.ts
@@ -45,21 +45,16 @@ export interface Startable {
   afterStop?(): void | Promise<void>
 }
 
+/**
+ * @deprecated Pass the object to `start`/`stop`, no need to use this any more
+ */
 export function isStartable (obj: any): obj is Startable {
-  return obj != null && typeof obj.start === 'function' && typeof obj.stop === 'function'
+  return obj != null
 }
 
 export async function start (...objs: any[]): Promise<void> {
-  const startables: Startable[] = []
-
-  for (const obj of objs) {
-    if (isStartable(obj)) {
-      startables.push(obj)
-    }
-  }
-
   await Promise.all(
-    startables.map(async s => {
+    objs.map(async s => {
       if (s.beforeStart != null) {
         await s.beforeStart()
       }
@@ -67,7 +62,7 @@ export async function start (...objs: any[]): Promise<void> {
   )
 
   await Promise.all(
-    startables.map(async s => {
+    objs.map(async s => {
       if (s.start != null) {
         await s.start()
       }
@@ -75,7 +70,7 @@ export async function start (...objs: any[]): Promise<void> {
   )
 
   await Promise.all(
-    startables.map(async s => {
+    objs.map(async s => {
       if (s.afterStart != null) {
         await s.afterStart()
       }
@@ -84,16 +79,8 @@ export async function start (...objs: any[]): Promise<void> {
 }
 
 export async function stop (...objs: any[]): Promise<void> {
-  const startables: Startable[] = []
-
-  for (const obj of objs) {
-    if (isStartable(obj)) {
-      startables.push(obj)
-    }
-  }
-
   await Promise.all(
-    startables.map(async s => {
+    objs.map(async s => {
       if (s.beforeStop != null) {
         await s.beforeStop()
       }
@@ -101,7 +88,7 @@ export async function stop (...objs: any[]): Promise<void> {
   )
 
   await Promise.all(
-    startables.map(async s => {
+    objs.map(async s => {
       if (s.stop != null) {
         await s.stop()
       }
@@ -109,7 +96,7 @@ export async function stop (...objs: any[]): Promise<void> {
   )
 
   await Promise.all(
-    startables.map(async s => {
+    objs.map(async s => {
       if (s.afterStop != null) {
         await s.afterStop()
       }

--- a/packages/interface/src/startable.ts
+++ b/packages/interface/src/startable.ts
@@ -14,7 +14,7 @@ export interface Startable {
    *
    * It should not assume that any other components have been started.
    */
-  start(): void | Promise<void>
+  start?(): void | Promise<void>
 
   /**
    * If implemented, this method will be invoked after the start method.
@@ -35,7 +35,7 @@ export interface Startable {
    *
    * It should not assume any other components are running when it is called.
    */
-  stop(): void | Promise<void>
+  stop?(): void | Promise<void>
 
   /**
    * If implemented, this method will be invoked after the stop method.
@@ -68,7 +68,9 @@ export async function start (...objs: any[]): Promise<void> {
 
   await Promise.all(
     startables.map(async s => {
-      await s.start()
+      if (s.start != null) {
+        await s.start()
+      }
     })
   )
 
@@ -100,7 +102,9 @@ export async function stop (...objs: any[]): Promise<void> {
 
   await Promise.all(
     startables.map(async s => {
-      await s.stop()
+      if (s.stop != null) {
+        await s.stop()
+      }
     })
   )
 

--- a/packages/libp2p/src/libp2p.ts
+++ b/packages/libp2p/src/libp2p.ts
@@ -1,5 +1,5 @@
 import { publicKeyFromProtobuf } from '@libp2p/crypto/keys'
-import { contentRoutingSymbol, TypedEventEmitter, setMaxListeners, peerDiscoverySymbol, peerRoutingSymbol, InvalidParametersError } from '@libp2p/interface'
+import { contentRoutingSymbol, TypedEventEmitter, setMaxListeners, peerDiscoverySymbol, peerRoutingSymbol, InvalidParametersError, start, stop } from '@libp2p/interface'
 import { defaultLogger } from '@libp2p/logger'
 import { PeerSet } from '@libp2p/peer-collections'
 import { peerIdFromString } from '@libp2p/peer-id'
@@ -221,9 +221,7 @@ export class Libp2p<T extends ServiceMap = ServiceMap> extends TypedEventEmitter
     this.log('libp2p is starting')
 
     try {
-      await this.components.beforeStart?.()
-      await this.components.start()
-      await this.components.afterStart?.()
+      await start(this.components)
 
       this.status = 'started'
       this.safeDispatchEvent('start', { detail: this })
@@ -249,9 +247,7 @@ export class Libp2p<T extends ServiceMap = ServiceMap> extends TypedEventEmitter
 
     this.status = 'stopping'
 
-    await this.components.beforeStop?.()
-    await this.components.stop()
-    await this.components.afterStop?.()
+    await stop(this.components)
 
     this.status = 'stopped'
     this.safeDispatchEvent('stop', { detail: this })

--- a/packages/libp2p/test/peer-discovery/peer-discovery.spec.ts
+++ b/packages/libp2p/test/peer-discovery/peer-discovery.spec.ts
@@ -29,12 +29,12 @@ describe('peer discovery', () => {
     })
 
     await libp2p.start()
-    expect(discovery.start.calledOnce).to.be.true()
-    expect(discovery.stop.called).to.be.false()
+    expect(discovery.start?.calledOnce).to.be.true()
+    expect(discovery.stop?.called).to.be.false()
 
     await libp2p.stop()
-    expect(discovery.start.calledOnce).to.be.true()
-    expect(discovery.stop.calledOnce).to.be.true()
+    expect(discovery.start?.calledOnce).to.be.true()
+    expect(discovery.stop?.calledOnce).to.be.true()
   })
 
   it('should ignore self on discovery', async () => {

--- a/packages/transport-circuit-relay-v2/test/hop.spec.ts
+++ b/packages/transport-circuit-relay-v2/test/hop.spec.ts
@@ -1,7 +1,7 @@
 /* eslint-disable max-nested-callbacks */
 
 import { generateKeyPair } from '@libp2p/crypto/keys'
-import { TypedEventEmitter, isStartable } from '@libp2p/interface'
+import { TypedEventEmitter, start, stop } from '@libp2p/interface'
 import { matchPeerId } from '@libp2p/interface-compliance-tests/matchers'
 import { mockRegistrar, mockUpgrader, mockNetwork, mockConnectionManager, mockConnectionGater } from '@libp2p/interface-compliance-tests/mocks'
 import { defaultLogger } from '@libp2p/logger'
@@ -94,9 +94,7 @@ describe('circuit-relay hop protocol', function () {
       logger: defaultLogger()
     })
 
-    if (isStartable(service)) {
-      await service.start()
-    }
+    await start(service)
 
     const transport = circuitRelayTransport({})({
       addressManager,
@@ -112,9 +110,7 @@ describe('circuit-relay hop protocol', function () {
       logger: defaultLogger()
     })
 
-    if (isStartable(transport)) {
-      await transport.start()
-    }
+    await start(transport)
 
     const node: Node = {
       peerId,
@@ -187,13 +183,7 @@ describe('circuit-relay hop protocol', function () {
 
   afterEach(async () => {
     for (const node of nodes) {
-      if (isStartable(node.circuitRelayService)) {
-        await node.circuitRelayService.stop()
-      }
-
-      if (isStartable(node.circuitRelayTransport)) {
-        await node.circuitRelayTransport.stop()
-      }
+      await stop(node.circuitRelayService, node.circuitRelayTransport)
     }
 
     mockNetwork.reset()


### PR DESCRIPTION
A thing that is stoppable might not need to be startable so make the methods optional.

## Change checklist

- [x] I have performed a self-review of my own code
- [ ] I have made corresponding changes to the documentation if necessary (this includes comments as well)
- [ ] I have added tests that prove my fix is effective or that my feature works