### PR TITLE
fix: run UPnP nat on address change, update nat port mapper

### DIFF
--- a/packages/upnp-nat/package.json
+++ b/packages/upnp-nat/package.json
@@ -50,12 +50,15 @@
     "test:electron-main": "aegir test -t electron-main"
   },
   "dependencies": {
-    "@achingbrain/nat-port-mapper": "^1.0.13",
+    "@achingbrain/nat-port-mapper": "^2.0.1",
+    "@chainsafe/is-ip": "^2.0.2",
     "@libp2p/interface": "^2.2.0",
     "@libp2p/interface-internal": "^2.0.10",
     "@libp2p/utils": "^6.1.3",
     "@multiformats/multiaddr": "^12.2.3",
-    "wherearewe": "^2.0.1"
+    "@multiformats/multiaddr-matcher": "^1.4.0",
+    "p-defer": "^4.0.1",
+    "race-signal": "^1.1.0"
   },
   "devDependencies": {
     "@libp2p/crypto": "^5.0.6",

--- a/packages/upnp-nat/src/check-external-address.ts
+++ b/packages/upnp-nat/src/check-external-address.ts
@@ -1,0 +1,139 @@
+import { NotStartedError, start, stop } from '@libp2p/interface'
+import { repeatingTask } from '@libp2p/utils/repeating-task'
+import { multiaddr } from '@multiformats/multiaddr'
+import pDefer from 'p-defer'
+import { raceSignal } from 'race-signal'
+import type { NatAPI } from '@achingbrain/nat-port-mapper'
+import type { AbortOptions, ComponentLogger, Logger, Startable } from '@libp2p/interface'
+import type { AddressManager } from '@libp2p/interface-internal'
+import type { RepeatingTask } from '@libp2p/utils/repeating-task'
+import type { DeferredPromise } from 'p-defer'
+
+export interface ExternalAddressCheckerComponents {
+  client: NatAPI
+  addressManager: AddressManager
+  logger: ComponentLogger
+}
+
+export interface ExternalAddressCheckerInit {
+  /**
+   * How often to check if our external address has changed in ms
+   *
+   * @default 60000
+   */
+  interval?: number
+
+  /**
+   * How long to try detecting our external address
+   */
+  timeout?: number
+}
+
+export interface ExternalAddress {
+  getPublicIp (options?: AbortOptions): Promise<string> | string
+}
+
+/**
+ * Monitors the external network address and notifies when/if it changes
+ */
+class ExternalAddressChecker implements ExternalAddress, Startable {
+  private readonly log: Logger
+  private readonly client: NatAPI
+  private readonly addressManager: AddressManager
+  private started: boolean
+  private lastPublicIp?: string
+  private readonly lastPublicIpPromise: DeferredPromise<string>
+  private readonly check: RepeatingTask
+
+  constructor (components: ExternalAddressCheckerComponents, init: ExternalAddressCheckerInit = {}) {
+    this.log = components.logger.forComponent('libp2p:upnp-nat:external-address-check')
+    this.client = components.client
+    this.addressManager = components.addressManager
+    this.started = false
+
+    this.checkExternalAddress = this.checkExternalAddress.bind(this)
+
+    this.lastPublicIpPromise = pDefer()
+
+    this.check = repeatingTask(this.checkExternalAddress, init.interval ?? 30000, {
+      timeout: init.timeout,
+      runImmediately: true
+    })
+  }
+
+  async start (): Promise<void> {
+    if (this.started) {
+      return
+    }
+
+    await start(this.check)
+
+    this.check.start()
+    this.started = true
+  }
+
+  async stop (): Promise<void> {
+    await stop(this.check)
+
+    this.started = false
+  }
+
+  /**
+   * Return the last public IP address we found, or wait for it to be found
+   */
+  async getPublicIp (options?: AbortOptions): Promise<string> {
+    if (!this.started) {
+      throw new NotStartedError('Not started yet')
+    }
+
+    return this.lastPublicIp ?? raceSignal(this.lastPublicIpPromise.promise, options?.signal, {
+      errorMessage: 'Requesting the public IP from the network gateway timed out - UPnP may not be enabled'
+    })
+  }
+
+  private async checkExternalAddress (options?: AbortOptions): Promise<void> {
+    try {
+      const externalAddress = await this.client.externalIp(options)
+
+      // check if our public address has changed
+      if (this.lastPublicIp != null && externalAddress !== this.lastPublicIp) {
+        this.log('external address changed from %s to %s', this.lastPublicIp, externalAddress)
+
+        for (const ma of this.addressManager.getAddresses()) {
+          const addrString = ma.toString()
+
+          if (!addrString.includes(this.lastPublicIp)) {
+            continue
+          }
+
+          // create a new version of the multiaddr with the new public IP
+          const newAddress = multiaddr(addrString.replace(this.lastPublicIp, externalAddress))
+
+          // remove the old address and add the new one
+          this.addressManager.removeObservedAddr(ma)
+          this.addressManager.confirmObservedAddr(newAddress)
+        }
+      }
+
+      this.lastPublicIp = externalAddress
+      this.lastPublicIpPromise.resolve(externalAddress)
+    } catch (err: any) {
+      if (this.lastPublicIp != null) {
+        // ignore the error if we've previously run successfully
+        return
+      }
+
+      this.lastPublicIpPromise.reject(err)
+    }
+  }
+}
+
+export function dynamicExternalAddress (components: ExternalAddressCheckerComponents, init: ExternalAddressCheckerInit = {}): ExternalAddress {
+  return new ExternalAddressChecker(components, init)
+}
+
+export function staticExternalAddress (address: string): ExternalAddress {
+  return {
+    getPublicIp: () => address
+  }
+}

--- a/packages/upnp-nat/src/errors.ts
+++ b/packages/upnp-nat/src/errors.ts
@@ -4,3 +4,8 @@ export class DoubleNATError extends Error {
     this.name = 'DoubleNATError'
   }
 }
+
+export class InvalidIPAddressError extends Error {
+  static name = 'InvalidIPAddressError'
+  name = 'InvalidIPAddressError'
+}

--- a/packages/upnp-nat/src/index.ts
+++ b/packages/upnp-nat/src/index.ts
@@ -36,8 +36,9 @@
  */
 
 import { UPnPNAT as UPnPNATClass, type NatAPI, type MapPortOptions } from './upnp-nat.js'
-import type { ComponentLogger, NodeInfo, PeerId } from '@libp2p/interface'
-import type { AddressManager, TransportManager } from '@libp2p/interface-internal'
+import type { ExternalAddressCheckerInit } from './check-external-address.js'
+import type { ComponentLogger, Libp2pEvents, NodeInfo, PeerId, TypedEventTarget } from '@libp2p/interface'
+import type { AddressManager } from '@libp2p/interface-internal'
 
 export type { NatAPI, MapPortOptions }
 
@@ -50,9 +51,10 @@ export interface PMPOptions {
 
 export interface UPnPNATInit {
   /**
-   * Pass a value to use instead of auto-detection
+   * Pass a string to hard code the external address, otherwise it will be
+   * auto-detected
    */
-  externalAddress?: string
+  externalAddress?: string | ExternalAddressCheckerInit
 
   /**
    * Pass a value to use instead of auto-detection
@@ -78,14 +80,39 @@ export interface UPnPNATInit {
    * Pass a value to use instead of auto-detection
    */
   gateway?: string
+
+  /**
+   * How long in ms to wait before giving up trying to auto-detect a
+   * `urn:schemas-upnp-org:device:InternetGatewayDevice:1` device on the local
+   * network
+   *
+   * @default 10000
+   */
+  gatewayDetectionTimeout?: number
+
+  /**
+   * Ports are mapped when the `self:peer:update` event fires, which happens
+   * when the node's addresses change. To avoid starting to map ports while
+   * multiple addresses are being added, the mapping function is debounced by
+   * this number of ms
+   *
+   * @default 5000
+   */
+  delay?: number
+
+  /**
+   * A preconfigured instance of a NatAPI client can be passed as an option,
+   * otherwise one will be created
+   */
+  client?: NatAPI
 }
 
 export interface UPnPNATComponents {
   peerId: PeerId
   nodeInfo: NodeInfo
   logger: ComponentLogger
-  transportManager: TransportManager
   addressManager: AddressManager
+  events: TypedEventTarget<Libp2pEvents>
 }
 
 export interface UPnPNAT {

--- a/packages/upnp-nat/src/index.ts
+++ b/packages/upnp-nat/src/index.ts
@@ -36,7 +36,6 @@
  */
 
 import { UPnPNAT as UPnPNATClass, type NatAPI, type MapPortOptions } from './upnp-nat.js'
-import type { ExternalAddressCheckerInit } from './check-external-address.js'
 import type { ComponentLogger, Libp2pEvents, NodeInfo, PeerId, TypedEventTarget } from '@libp2p/interface'
 import type { AddressManager } from '@libp2p/interface-internal'
 
@@ -54,7 +53,23 @@ export interface UPnPNATInit {
    * Pass a string to hard code the external address, otherwise it will be
    * auto-detected
    */
-  externalAddress?: string | ExternalAddressCheckerInit
+  externalAddress?: string
+
+  /**
+   * Check if the external address has changed this often in ms. Ignored if an
+   * external address is specified.
+   *
+   * @default 30000
+   */
+  externalAddressCheckInterval?: number
+
+  /**
+   * Do not take longer than this to check if the external address has changed
+   * in ms.  Ignored if an external address is specified.
+   *
+   * @default 10000
+   */
+  externalAddressCheckTimeout?: number
 
   /**
    * Pass a value to use instead of auto-detection
@@ -105,6 +120,17 @@ export interface UPnPNATInit {
    * otherwise one will be created
    */
   client?: NatAPI
+
+  /**
+   * Any mapped addresses are added to the observed address list. These
+   * addresses require additional verification by the `@libp2p/autonat` protocol
+   * or similar before they are trusted.
+   *
+   * To skip this verification and trust them immediately pass `true` here
+   *
+   * @default false
+   */
+  autoConfirmAddress?: boolean
 }
 
 export interface UPnPNATComponents {

--- a/packages/upnp-nat/src/upnp-nat.ts
+++ b/packages/upnp-nat/src/upnp-nat.ts
@@ -1,25 +1,32 @@
-import { upnpNat, type NatAPI, type MapPortOptions } from '@achingbrain/nat-port-mapper'
-import { InvalidParametersError, serviceCapabilities } from '@libp2p/interface'
+import { upnpNat } from '@achingbrain/nat-port-mapper'
+import { isIPv4, isIPv6 } from '@chainsafe/is-ip'
+import { InvalidParametersError, serviceCapabilities, start, stop } from '@libp2p/interface'
+import { debounce } from '@libp2p/utils/debounce'
 import { isLoopback } from '@libp2p/utils/multiaddr/is-loopback'
+import { isPrivate } from '@libp2p/utils/multiaddr/is-private'
 import { isPrivateIp } from '@libp2p/utils/private-ip'
-import { fromNodeAddress } from '@multiformats/multiaddr'
-import { isBrowser } from 'wherearewe'
-import { DoubleNATError } from './errors.js'
+import { multiaddr } from '@multiformats/multiaddr'
+import { QUICV1, TCP, WebSockets, WebSocketsSecure, WebTransport } from '@multiformats/multiaddr-matcher'
+import { raceSignal } from 'race-signal'
+import { dynamicExternalAddress, staticExternalAddress } from './check-external-address.js'
+import { DoubleNATError, InvalidIPAddressError } from './errors.js'
+import type { ExternalAddress } from './check-external-address.js'
 import type { UPnPNATComponents, UPnPNATInit, UPnPNAT as UPnPNATInterface } from './index.js'
-import type { Logger, Startable } from '@libp2p/interface'
+import type { NatAPI, MapPortOptions } from '@achingbrain/nat-port-mapper'
+import type { Libp2pEvents, Logger, Startable, TypedEventTarget } from '@libp2p/interface'
+import type { AddressManager } from '@libp2p/interface-internal'
+import type { DebouncedFunction } from '@libp2p/utils/debounce'
+import type { Multiaddr } from '@multiformats/multiaddr'
 
 const DEFAULT_TTL = 7200
 
 export type { NatAPI, MapPortOptions }
 
-function highPort (min = 1024, max = 65535): number {
-  return Math.floor(Math.random() * (max - min + 1) + min)
-}
-
 export class UPnPNAT implements Startable, UPnPNATInterface {
   public client: NatAPI
-  private readonly components: UPnPNATComponents
-  private readonly externalAddress?: string
+  private readonly addressManager: AddressManager
+  private readonly events: TypedEventTarget<Libp2pEvents>
+  private readonly externalAddress: ExternalAddress
   private readonly localAddress?: string
   private readonly description: string
   private readonly ttl: number
@@ -27,29 +34,45 @@ export class UPnPNAT implements Startable, UPnPNATInterface {
   private readonly gateway?: string
   private started: boolean
   private readonly log: Logger
+  private readonly gatewayDetectionTimeout: number
+  private readonly mappedPorts: Map<number, number>
+  private readonly onSelfPeerUpdate: DebouncedFunction
 
   constructor (components: UPnPNATComponents, init: UPnPNATInit) {
-    this.components = components
-
     this.log = components.logger.forComponent('libp2p:upnp-nat')
+    this.addressManager = components.addressManager
+    this.events = components.events
     this.started = false
-    this.externalAddress = init.externalAddress
     this.localAddress = init.localAddress
-    this.description = init.description ?? `${components.nodeInfo.name}@${components.nodeInfo.version} ${this.components.peerId.toString()}`
+    this.description = init.description ?? `${components.nodeInfo.name}@${components.nodeInfo.version} ${components.peerId.toString()}`
     this.ttl = init.ttl ?? DEFAULT_TTL
     this.keepAlive = init.keepAlive ?? true
     this.gateway = init.gateway
+    this.gatewayDetectionTimeout = init.gatewayDetectionTimeout ?? 10000
+    this.mappedPorts = new Map()
 
     if (this.ttl < DEFAULT_TTL) {
       throw new InvalidParametersError(`NatManager ttl should be at least ${DEFAULT_TTL} seconds`)
     }
 
-    this.client = upnpNat({
+    this.client = init.client ?? upnpNat({
       description: this.description,
       ttl: this.ttl,
       keepAlive: this.keepAlive,
       gateway: this.gateway
     })
+
+    this.onSelfPeerUpdate = debounce(this._onSelfPeerUpdate.bind(this), init.delay ?? 5000)
+
+    if (typeof init.externalAddress === 'string') {
+      this.externalAddress = staticExternalAddress(init.externalAddress)
+    } else {
+      this.externalAddress = dynamicExternalAddress({
+        client: this.client,
+        addressManager: this.addressManager,
+        logger: components.logger
+      }, init.externalAddress)
+    }
   }
 
   readonly [Symbol.toStringTag] = '@libp2p/upnp-nat'
@@ -62,95 +85,160 @@ export class UPnPNAT implements Startable, UPnPNATInterface {
     return this.started
   }
 
-  start (): void {
-    // #TODO: is there a way to remove this? Seems like a hack
-  }
-
-  /**
-   * Attempt to use uPnP to configure port mapping using the current gateway.
-   *
-   * Run after start to ensure the transport manager has all addresses configured.
-   */
-  afterStart (): void {
-    if (isBrowser || this.started) {
+  async start (): Promise<void> {
+    if (this.started) {
       return
     }
 
     this.started = true
-
-    // done async to not slow down startup
-    void this.mapIpAddresses().catch((err) => {
-      // hole punching errors are non-fatal
-      this.log.error(err)
-    })
-  }
-
-  async mapIpAddresses (): Promise<void> {
-    const addrs = this.components.transportManager.getAddrs()
-
-    for (const addr of addrs) {
-      // try to open uPnP ports for each thin waist address
-      const { family, host, port, transport } = addr.toOptions()
-
-      if (!addr.isThinWaistAddress() || transport !== 'tcp') {
-        // only bare tcp addresses
-        // eslint-disable-next-line no-continue
-        continue
-      }
-
-      if (isLoopback(addr)) {
-        // eslint-disable-next-line no-continue
-        continue
-      }
-
-      if (family !== 4) {
-        // ignore ipv6
-        // eslint-disable-next-line no-continue
-        continue
-      }
-
-      const publicIp = this.externalAddress ?? await this.client.externalIp()
-      const isPrivate = isPrivateIp(publicIp)
-
-      if (isPrivate === true) {
-        throw new DoubleNATError(`${publicIp} is private - please set config.nat.externalIp to an externally routable IP or ensure you are not behind a double NAT`)
-      }
-
-      if (isPrivate == null) {
-        throw new InvalidParametersError(`${publicIp} is not an IP address`)
-      }
-
-      const publicPort = highPort()
-
-      this.log(`opening uPnP connection from ${publicIp}:${publicPort} to ${host}:${port}`)
-
-      await this.client.map({
-        publicPort,
-        localPort: port,
-        localAddress: this.localAddress,
-        protocol: transport.toUpperCase() === 'TCP' ? 'TCP' : 'UDP'
-      })
-
-      this.components.addressManager.addObservedAddr(fromNodeAddress({
-        family: 4,
-        address: publicIp,
-        port: publicPort
-      }, transport))
-    }
+    this.events.addEventListener('self:peer:update', this.onSelfPeerUpdate)
+    await start(this.externalAddress, this.onSelfPeerUpdate)
   }
 
   /**
    * Stops the NAT manager
    */
   async stop (): Promise<void> {
-    if (isBrowser || this.client == null) {
+    try {
+      await this.client?.close()
+    } catch (err: any) {
+      this.log.error(err)
+    }
+
+    this.events.removeEventListener('self:peer:update', this.onSelfPeerUpdate)
+    await stop(this.externalAddress, this.onSelfPeerUpdate)
+    this.started = false
+  }
+
+  _onSelfPeerUpdate (): void {
+    this.mapIpAddresses()
+      .catch(err => {
+        this.log.error('error mapping IP addresses - %e', err)
+      })
+  }
+
+  private getUnmappedAddresses (multiaddrs: Multiaddr[], ipType: 4 | 6): Multiaddr[] {
+    const output: Multiaddr[] = []
+
+    for (const ma of multiaddrs) {
+      // ignore public addresses
+      if (!isPrivate(ma)) {
+        continue
+      }
+
+      // ignore loopback
+      if (isLoopback(ma)) {
+        continue
+      }
+
+      // only IP based addresses
+      if (!(
+        TCP.exactMatch(ma) ||
+        WebSockets.exactMatch(ma) ||
+        WebSocketsSecure.exactMatch(ma) ||
+        QUICV1.exactMatch(ma) ||
+        WebTransport.exactMatch(ma)
+      )) {
+        continue
+      }
+
+      const { port, family } = ma.toOptions()
+
+      if (family !== ipType) {
+        continue
+      }
+
+      if (this.mappedPorts.has(port)) {
+        continue
+      }
+
+      output.push(ma)
+    }
+
+    return output
+  }
+
+  async mapIpAddresses (): Promise<void> {
+    if (this.externalAddress == null) {
+      this.log('discovering public address')
+    }
+
+    const publicIp = await this.externalAddress.getPublicIp({
+      signal: AbortSignal.timeout(this.gatewayDetectionTimeout)
+    })
+
+    this.externalAddress ?? await raceSignal(this.client.externalIp(), AbortSignal.timeout(this.gatewayDetectionTimeout), {
+      errorMessage: `Did not discover a "urn:schemas-upnp-org:device:InternetGatewayDevice:1" device on the local network after ${this.gatewayDetectionTimeout}ms - UPnP may not be configured on your router correctly`
+    })
+
+    let ipType: 4 | 6 = 4
+
+    if (isIPv4(publicIp)) {
+      ipType = 4
+    } else if (isIPv6(publicIp)) {
+      ipType = 6
+    } else {
+      throw new InvalidIPAddressError(`Public address ${publicIp} was not an IPv4 address`)
+    }
+
+    // filter addresses to get private, non-relay, IP based addresses that we
+    // haven't mapped yet
+    const addresses = this.getUnmappedAddresses(this.addressManager.getAddresses(), ipType)
+
+    if (addresses.length === 0) {
+      this.log('no private, non-relay, unmapped, IP based addresses found')
       return
     }
 
-    try {
-      await this.client.close()
-    } catch (err: any) {
-      this.log.error(err)
+    this.log('%s public IP %s', this.externalAddress != null ? 'using configured' : 'discovered', publicIp)
+
+    this.assertNotBehindDoubleNAT(publicIp)
+
+    for (const addr of addresses) {
+      // try to open uPnP ports for each thin waist address
+      const { family, host, port, transport } = addr.toOptions()
+
+      if (family === 6) {
+        // only support IPv4 addresses
+        continue
+      }
+
+      if (this.mappedPorts.has(port)) {
+        // already mapped this port
+        continue
+      }
+
+      const protocol = transport.toUpperCase()
+
+      this.log(`creating mapping of ${host}:${port}`)
+
+      const mappedPort = await this.client.map(port, {
+        localAddress: host,
+        protocol: protocol === 'TCP' ? 'TCP' : 'UDP'
+      })
+
+      this.mappedPorts.set(port, mappedPort)
+
+      const ma = multiaddr(addr.toString().replace(`/ip${family}/${host}/${transport}/${port}`, `/ip${family}/${publicIp}/${transport}/${mappedPort}`))
+
+      this.log(`created mapping of ${publicIp}:${mappedPort} to ${host}:${port} as %a`, ma)
+
+      this.addressManager.addObservedAddr(ma)
+    }
+  }
+
+  /**
+   * Some ISPs have double-NATs, there's not much we can do with them
+   */
+  private assertNotBehindDoubleNAT (publicIp: string): void {
+    const isPrivate = isPrivateIp(publicIp)
+
+    if (isPrivate === true) {
+      throw new DoubleNATError(`${publicIp} is private - please set config.nat.externalIp to an externally routable IP or ensure you are not behind a double NAT`)
+    }
+
+    if (isPrivate == null) {
+      throw new InvalidParametersError(`${publicIp} is not an IP address`)
     }
   }
 }


### PR DESCRIPTION
- Updates NAT port mapper to handle unavailable ports
- Runs NAT port mapping on address change rather than once at startup
- Re-maps addresses when the public IP address changes

## Change checklist

- [x] I have performed a self-review of my own code
- [ ] I have made corresponding changes to the documentation if necessary (this includes comments as well)
- [x] I have added tests that prove my fix is effective or that my feature works