### PR TITLE
fix: add abort options to echo

### DIFF
--- a/packages/protocol-echo/src/index.ts
+++ b/packages/protocol-echo/src/index.ts
@@ -43,7 +43,7 @@
  */
 
 import { Echo as EchoClass } from './echo.js'
-import type { ComponentLogger, PeerId } from '@libp2p/interface'
+import type { AbortOptions, ComponentLogger, PeerId } from '@libp2p/interface'
 import type { ConnectionManager, Registrar } from '@libp2p/interface-internal'
 import type { Multiaddr } from '@multiformats/multiaddr'
 
@@ -62,7 +62,7 @@ export interface EchoComponents {
 
 export interface Echo {
   protocol: string
-  echo(peer: PeerId | Multiaddr | Multiaddr[], buf: Uint8Array): Promise<Uint8Array>
+  echo(peer: PeerId | Multiaddr | Multiaddr[], buf: Uint8Array, options?: AbortOptions): Promise<Uint8Array>
 }
 
 export function echo (init: EchoInit = {}): (components: EchoComponents) => Echo {


### PR DESCRIPTION
Adds optional `AbortOptions` to interface, not sure why this wasn't there before.

## Change checklist

- [x] I have performed a self-review of my own code
- [ ] I have made corresponding changes to the documentation if necessary (this includes comments as well)
- [ ] I have added tests that prove my fix is effective or that my feature works