### PR TITLE
chore: fix ci cache

### DIFF
--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -7,6 +7,12 @@ on:
     branches:
       - '**'
 
+env:
+  CACHE_DIRS: |
+    ./interop/dist
+    ./interop/node_modules
+    ./doc/node_modules
+
 jobs:
 
   build:
@@ -18,10 +24,7 @@ jobs:
         node-version: lts/*
     - uses: ipfs/aegir/actions/cache-node-modules@master
       with:
-        directories: |
-          ./interop/dist
-          ./interop/node_modules
-          ./doc/node_modules
+        directories: ${{ env.CACHE_DIRS }}
 
   check:
     needs: build
@@ -32,6 +35,8 @@ jobs:
       with:
         node-version: lts/*
     - uses: ipfs/aegir/actions/cache-node-modules@master
+      with:
+        directories: ${{ env.CACHE_DIRS }}
     - run: npm run --if-present lint
     - run: npm run --if-present dep-check
     - run: npm run --if-present docs:no-publish
@@ -50,6 +55,8 @@ jobs:
         with:
           node-version: ${{ matrix.node }}
       - uses: ipfs/aegir/actions/cache-node-modules@master
+        with:
+          directories: ${{ env.CACHE_DIRS }}
       - run: npm run --if-present test:node
       - uses: codecov/codecov-action@b9fd7d16f6d7d1b5d2bec1a2887e65ceed900238 # v4.6.0
         with:
@@ -66,6 +73,8 @@ jobs:
         with:
           node-version: lts/*
       - uses: ipfs/aegir/actions/cache-node-modules@master
+        with:
+          directories: ${{ env.CACHE_DIRS }}
       - run: npm run --if-present test:chrome
       - uses: codecov/codecov-action@b9fd7d16f6d7d1b5d2bec1a2887e65ceed900238 # v4.6.0
         with:
@@ -82,6 +91,8 @@ jobs:
         with:
           node-version: lts/*
       - uses: ipfs/aegir/actions/cache-node-modules@master
+        with:
+          directories: ${{ env.CACHE_DIRS }}
       - run: npm run --if-present test:chrome-webworker
       - uses: codecov/codecov-action@b9fd7d16f6d7d1b5d2bec1a2887e65ceed900238 # v4.6.0
         with:
@@ -98,6 +109,8 @@ jobs:
         with:
           node-version: lts/*
       - uses: ipfs/aegir/actions/cache-node-modules@master
+        with:
+          directories: ${{ env.CACHE_DIRS }}
       - run: npm run --if-present test:firefox
       - uses: codecov/codecov-action@b9fd7d16f6d7d1b5d2bec1a2887e65ceed900238 # v4.6.0
         with:
@@ -114,6 +127,8 @@ jobs:
         with:
           node-version: lts/*
       - uses: ipfs/aegir/actions/cache-node-modules@master
+        with:
+          directories: ${{ env.CACHE_DIRS }}
       - run: npm run --if-present test:firefox-webworker
       - uses: codecov/codecov-action@b9fd7d16f6d7d1b5d2bec1a2887e65ceed900238 # v4.6.0
         with:
@@ -130,6 +145,8 @@ jobs:
         with:
           node-version: lts/*
       - uses: ipfs/aegir/actions/cache-node-modules@master
+        with:
+          directories: ${{ env.CACHE_DIRS }}
       # https://github.com/actions/runner-images/issues/9733#issuecomment-2074590278
       - run: |
           sudo rm /etc/apt/sources.list.d/microsoft-prod.list
@@ -151,6 +168,8 @@ jobs:
         with:
           node-version: lts/*
       - uses: ipfs/aegir/actions/cache-node-modules@master
+        with:
+          directories: ${{ env.CACHE_DIRS }}
       - run: npx xvfb-maybe npm run --if-present test:electron-main
       - uses: codecov/codecov-action@b9fd7d16f6d7d1b5d2bec1a2887e65ceed900238 # v4.6.0
         with:
@@ -167,6 +186,8 @@ jobs:
         with:
           node-version: lts/*
       - uses: ipfs/aegir/actions/cache-node-modules@master
+        with:
+          directories: ${{ env.CACHE_DIRS }}
       - run: npx xvfb-maybe npm run --if-present test:electron-renderer
       - uses: codecov/codecov-action@b9fd7d16f6d7d1b5d2bec1a2887e65ceed900238 # v4.6.0
         with:
@@ -183,6 +204,8 @@ jobs:
         with:
           node-version: lts/*
       - uses: ipfs/aegir/actions/cache-node-modules@master
+        with:
+          directories: ${{ env.CACHE_DIRS }}
       - run: npm run test:interop -- --bail
 
   transport-interop:
@@ -195,9 +218,7 @@ jobs:
           node-version: lts/*
       - uses: ipfs/aegir/actions/cache-node-modules@master
         with:
-          directories: |
-            ./interop/dist
-            ./interop/node_modules
+         directories: ${{ env.CACHE_DIRS }}
       - name: Build images
         run: (cd interop && make -j 4)
       - name: Save package-lock.json as artifact
@@ -249,6 +270,8 @@ jobs:
           node-version: lts/*
           registry-url: 'https://registry.npmjs.org'
       - uses: ipfs/aegir/actions/cache-node-modules@master
+        with:
+          directories: ${{ env.CACHE_DIRS }}
       - uses: ipfs/aegir/actions/docker-login@master
         with:
           docker-token: ${{ secrets.DOCKER_TOKEN }}


### PR DESCRIPTION
The `path` arg to `actions/cache` has to be the same every time it is used otherwise it causes cache misses.

## Change checklist

- [x] I have performed a self-review of my own code
- [ ] I have made corresponding changes to the documentation if necessary (this includes comments as well)
- [ ] I have added tests that prove my fix is effective or that my feature works