### PR TITLE
chore: add test to assert peer ids can be passed to stubs

### DIFF
--- a/packages/peer-id/package.json
+++ b/packages/peer-id/package.json
@@ -60,7 +60,8 @@
     "uint8arrays": "^5.1.0"
   },
   "devDependencies": {
-    "aegir": "^44.0.1"
+    "aegir": "^44.0.1",
+    "sinon": "^19.0.2"
   },
   "sideEffects": false
 }

--- a/packages/peer-id/test/index.spec.ts
+++ b/packages/peer-id/test/index.spec.ts
@@ -4,6 +4,7 @@ import { expect } from 'aegir/chai'
 import { base58btc } from 'multiformats/bases/base58'
 import { CID } from 'multiformats/cid'
 import { identity } from 'multiformats/hashes/identity'
+import Sinon from 'sinon'
 import { fromString as uint8ArrayFromString } from 'uint8arrays/from-string'
 import { peerIdFromCID, peerIdFromMultihash, peerIdFromPrivateKey, peerIdFromString } from '../src/index.js'
 import type { KeyType, PeerId } from '@libp2p/interface'
@@ -98,6 +99,13 @@ describe('PeerId', () => {
         peerId1.toString()
 
         expect(peerId1).to.deep.equal(peerId2)
+      })
+
+      it('should be matched by sinon', () => {
+        const stub = Sinon.stub()
+        stub(peerId)
+
+        expect(stub.calledWith(peerId)).to.be.true()
       })
     })
   })


### PR DESCRIPTION
Makes sure we can use peer ids with sinon stubs without custom matchers.

## Change checklist

- [x] I have performed a self-review of my own code
- [ ] I have made corresponding changes to the documentation if necessary (this includes comments as well)
- [x] I have added tests that prove my fix is effective or that my feature works