### PR TITLE
chore: make tests more reliable in ci

### DIFF
--- a/packages/integration-tests/.aegir.js
+++ b/packages/integration-tests/.aegir.js
@@ -20,6 +20,7 @@ export default {
       const { identify } = await import('@libp2p/identify')
       const { echo } = await import('@libp2p/echo')
       const { mockMuxer } = await import('@libp2p/interface-compliance-tests/mocks')
+      const { ping } = await import('@libp2p/ping')
 
       const libp2p = await createLibp2p({
         connectionManager: {
@@ -54,7 +55,8 @@ export default {
           }),
           echo: echo({
             maxInboundStreams: 5
-          })
+          }),
+          ping: ping()
         }
       })
 

--- a/packages/integration-tests/.aegir.js
+++ b/packages/integration-tests/.aegir.js
@@ -57,6 +57,9 @@ export default {
             maxInboundStreams: 5
           }),
           ping: ping()
+        },
+        connectionMonitor: {
+          enabled: false
         }
       })
 

--- a/packages/integration-tests/test/compliance/transport/circuit-relay.spec.ts
+++ b/packages/integration-tests/test/compliance/transport/circuit-relay.spec.ts
@@ -35,6 +35,9 @@ describe('Circuit relay transport interface compliance', () => {
         },
         connectionGater: {
           denyDialMultiaddr: () => false
+        },
+        connectionMonitor: {
+          enabled: false
         }
       }
 

--- a/packages/integration-tests/test/compliance/transport/memory.spec.ts
+++ b/packages/integration-tests/test/compliance/transport/memory.spec.ts
@@ -16,7 +16,10 @@ describe('memory transport interface compliance tests', () => {
         ],
         streamMuxers: [
           yamux()
-        ]
+        ],
+        connectionMonitor: {
+          enabled: false
+        }
       }
 
       return {

--- a/packages/integration-tests/test/compliance/transport/tcp.spec.ts
+++ b/packages/integration-tests/test/compliance/transport/tcp.spec.ts
@@ -21,7 +21,10 @@ describe('tcp transport interface compliance IPv4', () => {
         ],
         streamMuxers: [
           yamux()
-        ]
+        ],
+        connectionMonitor: {
+          enabled: false
+        }
       }
 
       return {

--- a/packages/integration-tests/test/compliance/transport/webrtc.spec.ts
+++ b/packages/integration-tests/test/compliance/transport/webrtc.spec.ts
@@ -5,6 +5,7 @@ import { yamux } from '@chainsafe/libp2p-yamux'
 import { circuitRelayTransport } from '@libp2p/circuit-relay-v2'
 import { identify } from '@libp2p/identify'
 import tests from '@libp2p/interface-compliance-tests/transport'
+import { ping } from '@libp2p/ping'
 import { webRTC } from '@libp2p/webrtc'
 import { webSockets } from '@libp2p/websockets'
 import { all } from '@libp2p/websockets/filters'
@@ -33,10 +34,14 @@ describe('WebRTC transport interface compliance', () => {
           yamux()
         ],
         services: {
-          identify: identify()
+          identify: identify(),
+          ping: ping()
         },
         connectionGater: {
           denyDialMultiaddr: () => false
+        },
+        connectionMonitor: {
+          enabled: false
         }
       }
 

--- a/packages/integration-tests/test/compliance/transport/websockets.spec.ts
+++ b/packages/integration-tests/test/compliance/transport/websockets.spec.ts
@@ -28,6 +28,9 @@ describe('websocket transport interface compliance', () => {
         ],
         connectionGater: {
           denyDialMultiaddr: () => false
+        },
+        connectionMonitor: {
+          enabled: false
         }
       }
 

--- a/packages/interface-compliance-tests/src/transport/index.ts
+++ b/packages/interface-compliance-tests/src/transport/index.ts
@@ -9,7 +9,7 @@ import { isValidTick } from '../is-valid-tick.js'
 import { createPeer, getTransportManager, getUpgrader, slowNetwork } from './utils.js'
 import type { TestSetup } from '../index.js'
 import type { Echo } from '@libp2p/echo'
-import type { Connection, Libp2p, Stream } from '@libp2p/interface'
+import type { Connection, Libp2p } from '@libp2p/interface'
 import type { Multiaddr } from '@multiformats/multiaddr'
 import type { MultiaddrMatcher } from '@multiformats/multiaddr-matcher'
 import type { Libp2pInit } from 'libp2p'
@@ -140,7 +140,7 @@ export default (common: TestSetup<TransportTestFixtures>): void => {
         .with.property('name', 'AbortError')
     })
 
-    it.only('should close all streams when the connection closes', async () => {
+    it('should close all streams when the connection closes', async () => {
       ({ dialer, listener, dialAddrs } = await getSetup(common))
 
       let incomingConnectionPromise: DeferredPromise<Connection> | undefined

--- a/packages/interface-compliance-tests/src/transport/index.ts
+++ b/packages/interface-compliance-tests/src/transport/index.ts
@@ -140,7 +140,7 @@ export default (common: TestSetup<TransportTestFixtures>): void => {
         .with.property('name', 'AbortError')
     })
 
-    it('should close all streams when the connection closes', async () => {
+    it.only('should close all streams when the connection closes', async () => {
       ({ dialer, listener, dialAddrs } = await getSetup(common))
 
       let incomingConnectionPromise: DeferredPromise<Connection> | undefined
@@ -164,13 +164,13 @@ export default (common: TestSetup<TransportTestFixtures>): void => {
         remoteConn = await incomingConnectionPromise.promise
       }
 
-      const streams: Stream[] = []
-
       for (let i = 0; i < 5; i++) {
-        streams.push(await connection.newStream('/echo/1.0.0', {
+        await connection.newStream('/echo/1.0.0', {
           maxOutboundStreams: 5
-        }))
+        })
       }
+
+      const streams = connection.streams
 
       // Close the connection and verify all streams have been closed
       await connection.close()

--- a/packages/transport-webrtc/src/muxer.ts
+++ b/packages/transport-webrtc/src/muxer.ts
@@ -155,12 +155,16 @@ export class DataChannelMuxer implements StreamMuxer {
         return
       }
 
+      // lib-datachannel throws if `.getId` is called on a closed channel so
+      // memoize it
+      const id = channel.id
+
       const stream = createStream({
         channel,
         direction: 'inbound',
         onEnd: () => {
-          this.log('incoming channel %s ended with state %s', channel.id, channel.readyState)
           this.#onStreamEnd(stream, channel)
+          this.log('incoming channel %s ended', id)
         },
         logger: this.logger,
         ...this.dataChannelOptions
@@ -241,15 +245,18 @@ export class DataChannelMuxer implements StreamMuxer {
   newStream (): Stream {
     // The spec says the label SHOULD be an empty string: https://github.com/libp2p/specs/blob/master/webrtc/README.md#rtcdatachannel-label
     const channel = this.peerConnection.createDataChannel('')
+    // lib-datachannel throws if `.getId` is called on a closed channel so
+    // memoize it
+    const id = channel.id
 
-    this.log.trace('opened outgoing datachannel with channel id %s', channel.id)
+    this.log.trace('opened outgoing datachannel with channel id %s', id)
 
     const stream = createStream({
       channel,
       direction: 'outbound',
       onEnd: () => {
-        this.log('outgoing channel %s ended with state %s', channel.id, channel.readyState)
         this.#onStreamEnd(stream, channel)
+        this.log('outgoing channel %s ended', id)
       },
       logger: this.logger,
       ...this.dataChannelOptions

--- a/packages/transport-webrtc/src/stream.ts
+++ b/packages/transport-webrtc/src/stream.ts
@@ -274,7 +274,11 @@ export class WebRTCStream extends AbstractStream {
   }
 
   async sendReset (): Promise<void> {
-    await this._sendFlag(Message.Flag.RESET)
+    try {
+      await this._sendFlag(Message.Flag.RESET)
+    } catch (err) {
+      this.log.error('failed to send reset - %e', err)
+    }
   }
 
   async sendCloseWrite (options: AbortOptions): Promise<void> {
@@ -362,7 +366,7 @@ export class WebRTCStream extends AbstractStream {
 
       return true
     } catch (err: any) {
-      this.log.error('could not send flag %s', flag.toString(), err)
+      this.log.error('could not send flag %s - %e', flag.toString(), err)
     }
 
     return false


### PR DESCRIPTION
CI is underpowered, the "many small writes" test overloads process and means the connection monitor thinks the remote has gone away so disable it during interface tests.

## Change checklist

- [x] I have performed a self-review of my own code
- [ ] I have made corresponding changes to the documentation if necessary (this includes comments as well)
- [ ] I have added tests that prove my fix is effective or that my feature works