### PR TITLE
fix: gracefully handle remote stream closure during ping

### DIFF
--- a/packages/protocol-ping/src/ping.ts
+++ b/packages/protocol-ping/src/ping.ts
@@ -1,5 +1,5 @@
 import { randomBytes } from '@libp2p/crypto'
-import { ProtocolError, TimeoutError } from '@libp2p/interface'
+import { ProtocolError, TimeoutError, setMaxListeners } from '@libp2p/interface'
 import { byteStream } from 'it-byte-stream'
 import { equals as uint8ArrayEquals } from 'uint8arrays/equals'
 import { PROTOCOL_PREFIX, PROTOCOL_NAME, PING_LENGTH, PROTOCOL_VERSION, TIMEOUT, MAX_INBOUND_STREAMS, MAX_OUTBOUND_STREAMS } from './constants.js'
@@ -60,44 +60,50 @@ export class PingService implements Startable, PingServiceInterface {
     const { stream } = data
     const start = Date.now()
     const bytes = byteStream(stream)
+    let pinged = false
 
     Promise.resolve().then(async () => {
       while (true) {
         const signal = AbortSignal.timeout(this.timeout)
+        setMaxListeners(Infinity, signal)
         signal.addEventListener('abort', () => {
           stream?.abort(new TimeoutError('ping timeout'))
         })
 
         const buf = await bytes.read(PING_LENGTH, {
           signal
-        }).catch((err: Error) => {
-          if (stream.readStatus === 'ready') throw err
-          return null
         })
-
-        if (buf === null) break
-
         await bytes.write(buf, {
           signal
         })
-      }
-      // close the stream
-      if (stream.status === 'open') {
-        const signal = AbortSignal.timeout(this.timeout)
-        signal.addEventListener('abort', () => {
-          stream?.abort(new TimeoutError('close timeout'))
-        })
 
-        await stream.close({ signal })
+        pinged = true
       }
     })
       .catch(err => {
-        this.log.error('incoming ping from %p failed with error', data.connection.remotePeer, err)
+        // ignore the error if we've processed at least one ping, the remote
+        // closed the stream and we handled or are handling the close cleanly
+        if (pinged && err.name === 'UnexpectedEOFError' && stream.readStatus !== 'ready') {
+          return
+        }
+
+        this.log.error('incoming ping from %p failed with error - %e', data.connection.remotePeer, err)
         stream?.abort(err)
       })
       .finally(() => {
         const ms = Date.now() - start
         this.log('incoming ping from %p complete in %dms', data.connection.remotePeer, ms)
+
+        const signal = AbortSignal.timeout(this.timeout)
+        setMaxListeners(Infinity, signal)
+
+        stream.close({
+          signal
+        })
+          .catch(err => {
+            this.log.error('error closing ping stream from %p - %e', data.connection.remotePeer, err)
+            stream?.abort(err)
+          })
       })
   }
 


### PR DESCRIPTION
This PR fixes the [UnexpectedEOFError issue](https://github.com/libp2p/js-libp2p/issues/2770). This issue happens because the ping protocol does not handle the case where the remote peer closes the stream and with the introduction of `connectionMonitor` this became an issue. It opens a stream for the ping protocol, sends a ping, gets the response then closes the stream. The local peer throws an exception and triggers a yamux reset.

## Change checklist

- [x] I have performed a self-review of my own code
- [ ] I have made corresponding changes to the documentation if necessary (this includes comments as well)
- [ ] I have added tests that prove my fix is effective or that my feature works