### PR TITLE
fix: only close stream if it is open

### DIFF
--- a/packages/integration-tests/test/circuit-relay.node.ts
+++ b/packages/integration-tests/test/circuit-relay.node.ts
@@ -519,8 +519,8 @@ describe('circuit-relay', () => {
       await deferred.promise
 
       // should have closed connections to remote and to relay
-      expect(events[0].detail.remotePeer.toString()).to.equal(relay1.peerId.toString())
-      expect(events[1].detail.remotePeer.toString()).to.equal(remote.peerId.toString())
+      expect(events[0].detail.remotePeer.toString()).to.equal(remote.peerId.toString())
+      expect(events[1].detail.remotePeer.toString()).to.equal(relay1.peerId.toString())
     })
 
     it('should mark an outgoing relayed connection as limited', async () => {

--- a/packages/utils/src/abstract-stream.ts
+++ b/packages/utils/src/abstract-stream.ts
@@ -284,6 +284,10 @@ export abstract class AbstractStream implements Stream {
 
   // Close for both Reading and Writing
   async close (options?: AbortOptions): Promise<void> {
+    if (this.status !== 'open') {
+      return
+    }
+
     this.log.trace('closing gracefully')
 
     this.status = 'closing'


### PR DESCRIPTION
Adds a guard to the `.close` operation similar to the one on `.abort` that ensures we only close the stream if it is open.

The individual `.closeRead`/`.closeWrite` operations already guard on the read/write status of the stream so there's no functional change, we just avoid a bit more async work as those methods return promises.

## Change checklist

- [x] I have performed a self-review of my own code
- [ ] I have made corresponding changes to the documentation if necessary (this includes comments as well)
- [ ] I have added tests that prove my fix is effective or that my feature works