### PR TITLE
fix: remove slow network test

### DIFF
--- a/packages/interface-compliance-tests/src/transport/index.ts
+++ b/packages/interface-compliance-tests/src/transport/index.ts
@@ -9,7 +9,7 @@ import pRetry from 'p-retry'
 import pWaitFor from 'p-wait-for'
 import { raceSignal } from 'race-signal'
 import { isValidTick } from '../is-valid-tick.js'
-import { createPeer, getTransportManager, getUpgrader, slowNetwork } from './utils.js'
+import { createPeer, getTransportManager, getUpgrader } from './utils.js'
 import type { TestSetup } from '../index.js'
 import type { Echo } from '@libp2p/echo'
 import type { Connection, Libp2p, Stream, StreamHandler } from '@libp2p/interface'
@@ -123,19 +123,6 @@ export default (common: TestSetup<TransportTestFixtures>): void => {
 
       const controller = new AbortController()
       controller.abort()
-
-      await expect(dialer.dial(dialAddrs[0], {
-        signal: controller.signal
-      })).to.eventually.be.rejected()
-        .with.property('name', 'AbortError')
-    })
-
-    it('abort while dialing throws AbortError', async () => {
-      ({ dialer, listener, dialAddrs } = await getSetup(common))
-      slowNetwork(dialer, 100)
-
-      const controller = new AbortController()
-      setTimeout(() => { controller.abort() }, 50)
 
       await expect(dialer.dial(dialAddrs[0], {
         signal: controller.signal

--- a/packages/interface-compliance-tests/src/transport/utils.ts
+++ b/packages/interface-compliance-tests/src/transport/utils.ts
@@ -3,8 +3,6 @@
 import { echo } from '@libp2p/echo'
 import { memory } from '@libp2p/memory'
 import { plaintext } from '@libp2p/plaintext'
-import delay from 'delay'
-import map from 'it-map'
 import { createLibp2p } from 'libp2p'
 import { mockMuxer } from '../mocks/muxer.js'
 import type { Echo } from '@libp2p/echo'
@@ -34,37 +32,6 @@ export async function createPeer (config: Partial<Libp2pOptions> = {}): Promise<
       })
     }
   })
-}
-
-/**
- * Monkey patch the upgrader in the passed libp2p to add latency to any
- * multiaddr connections upgraded to connections - this is to work with
- * transports that have their own muxers/encrypters and do not support
- * connection protection
- */
-export function slowNetwork (libp2p: any, latency: number): void {
-  const upgrader: Upgrader = getUpgrader(libp2p)
-
-  const originalUpgradeInbound = upgrader.upgradeInbound.bind(upgrader)
-  const originalUpgradeOutbound = upgrader.upgradeOutbound.bind(upgrader)
-
-  upgrader.upgradeInbound = async (maConn, opts) => {
-    maConn.source = map(maConn.source, async (buf) => {
-      await delay(latency)
-      return buf
-    })
-
-    return originalUpgradeInbound(maConn, opts)
-  }
-
-  upgrader.upgradeOutbound = async (maConn, opts) => {
-    maConn.source = map(maConn.source, async (buf) => {
-      await delay(latency)
-      return buf
-    })
-
-    return originalUpgradeOutbound(maConn, opts)
-  }
 }
 
 export function getUpgrader (libp2p: any): Upgrader {


### PR DESCRIPTION
The idea is if async work is done after `.dial` is invoked but before `upgrader.upgradeInbound` is called, and the abort signal aborts, then `.dial` should respect the abort and throw, but there's no reliable cross-transport way to inject the latency that would cause the test to fail so remove the test.

## Change checklist

- [x] I have performed a self-review of my own code
- [ ] I have made corresponding changes to the documentation if necessary (this includes comments as well)
- [ ] I have added tests that prove my fix is effective or that my feature works