### PR TITLE
chore: update error message check

### DIFF
--- a/packages/transport-webrtc/test/peer.spec.ts
+++ b/packages/transport-webrtc/test/peer.spec.ts
@@ -155,7 +155,7 @@ describe('webrtc basic', () => {
       }),
       handleIncomingStream(recipient)
     ]))
-      .to.eventually.be.rejected.with.property('message', 'Oh noes!')
+      .to.eventually.be.rejected.with.property('message').that.matches(/Oh noes!/)
   })
 })
 


### PR DESCRIPTION
The latest version of chrome changes the error message thrown from `signal.throwIfAborted`

## Change checklist

- [x] I have performed a self-review of my own code
- [ ] I have made corresponding changes to the documentation if necessary (this includes comments as well)
- [ ] I have added tests that prove my fix is effective or that my feature works