### PR TITLE
fix: remove browser dial filter

### DIFF
--- a/packages/transport-websockets/README.md
+++ b/packages/transport-websockets/README.md
@@ -41,42 +41,8 @@ const node = await createLibp2p({
 })
 await node.start()
 
-const ma = multiaddr('/ip4/127.0.0.1/tcp/9090/ws')
+const ma = multiaddr('/dns4/example.com/tcp/9090/tls/ws')
 await node.dial(ma)
-```
-
-## Filters
-
-When run in a browser by default this module will only connect to secure web socket addresses.
-
-To change this you should pass a filter to the factory function.
-
-You can create your own address filters for this transports, or rely in the filters [provided](./src/filters.js).
-
-The available filters are:
-
-- `filters.all`
-  - Returns all TCP and DNS based addresses, both with `ws` or `wss`.
-- `filters.dnsWss`
-  - Returns all DNS based addresses with `wss`.
-- `filters.dnsWsOrWss`
-  - Returns all DNS based addresses, both with `ws` or `wss`.
-
-## Example - Allow dialing insecure WebSockets
-
-```TypeScript
-import { createLibp2p } from 'libp2p'
-import { webSockets } from '@libp2p/websockets'
-import * as filters from '@libp2p/websockets/filters'
-
-const node = await createLibp2p({
-  transports: [
-    webSockets({
-      // connect to all sockets, even insecure ones
-      filter: filters.all
-    })
-  ]
-})
 ```
 
 # Install


### PR DESCRIPTION
The filter functionality here is covered by the connection gater in libp2p itself so there's no need to duplicate it at the transport level.

## Change checklist

- [x] I have performed a self-review of my own code
- [ ] I have made corresponding changes to the documentation if necessary (this includes comments as well)
- [ ] I have added tests that prove my fix is effective or that my feature works