### PR TITLE
fix!: use ip/port mapping

### DIFF
--- a/packages/upnp-nat/src/index.ts
+++ b/packages/upnp-nat/src/index.ts
@@ -97,15 +97,6 @@ export interface UPnPNATInit {
   gateway?: string
 
   /**
-   * How long in ms to wait before giving up trying to auto-detect a
-   * `urn:schemas-upnp-org:device:InternetGatewayDevice:1` device on the local
-   * network
-   *
-   * @default 10000
-   */
-  gatewayDetectionTimeout?: number
-
-  /**
    * Ports are mapped when the `self:peer:update` event fires, which happens
    * when the node's addresses change. To avoid starting to map ports while
    * multiple addresses are being added, the mapping function is debounced by
@@ -120,17 +111,6 @@ export interface UPnPNATInit {
    * otherwise one will be created
    */
   client?: NatAPI
-
-  /**
-   * Any mapped addresses are added to the observed address list. These
-   * addresses require additional verification by the `@libp2p/autonat` protocol
-   * or similar before they are trusted.
-   *
-   * To skip this verification and trust them immediately pass `true` here
-   *
-   * @default false
-   */
-  autoConfirmAddress?: boolean
 }
 
 export interface UPnPNATComponents {

--- a/packages/upnp-nat/test/index.spec.ts
+++ b/packages/upnp-nat/test/index.spec.ts
@@ -81,16 +81,14 @@ describe('UPnP NAT (TCP)', () => {
     expect(client.map.getCall(0).args[1]).to.include({
       protocol: 'TCP'
     })
-    expect(components.addressManager.addObservedAddr.called).to.be.true()
+    expect(components.addressManager.addPublicAddressMapping.called).to.be.true()
   })
 
   it('should map TCP connections to external ports and trust them immediately', async () => {
     const {
       natManager,
       components
-    } = await createNatManager({
-      autoConfirmAddress: true
-    })
+    } = await createNatManager()
 
     client.externalIp.resolves('82.3.1.5')
 
@@ -107,7 +105,7 @@ describe('UPnP NAT (TCP)', () => {
     expect(client.map.getCall(0).args[1]).to.include({
       protocol: 'TCP'
     })
-    expect(components.addressManager.confirmObservedAddr.called).to.be.true()
+    expect(components.addressManager.addPublicAddressMapping.called).to.be.true()
   })
 
   it('should not map TCP connections when double-natted', async () => {
@@ -128,7 +126,7 @@ describe('UPnP NAT (TCP)', () => {
       .with.property('name', 'DoubleNATError')
 
     expect(client.map.called).to.be.false()
-    expect(components.addressManager.addObservedAddr.called).to.be.false()
+    expect(components.addressManager.addPublicAddressMapping.called).to.be.false()
   })
 
   it('should not map non-ipv4 connections to external ports', async () => {
@@ -147,7 +145,7 @@ describe('UPnP NAT (TCP)', () => {
     await natManager.mapIpAddresses()
 
     expect(client.map.called).to.be.false()
-    expect(components.addressManager.addObservedAddr.called).to.be.false()
+    expect(components.addressManager.addPublicAddressMapping.called).to.be.false()
   })
 
   it('should not map non-ipv6 loopback connections to external ports', async () => {
@@ -166,7 +164,7 @@ describe('UPnP NAT (TCP)', () => {
     await natManager.mapIpAddresses()
 
     expect(client.map.called).to.be.false()
-    expect(components.addressManager.addObservedAddr.called).to.be.false()
+    expect(components.addressManager.addPublicAddressMapping.called).to.be.false()
   })
 
   it('should not map non-TCP connections to external ports', async () => {
@@ -185,7 +183,7 @@ describe('UPnP NAT (TCP)', () => {
     await natManager.mapIpAddresses()
 
     expect(client.map.called).to.be.false()
-    expect(components.addressManager.addObservedAddr.called).to.be.false()
+    expect(components.addressManager.addPublicAddressMapping.called).to.be.false()
   })
 
   it('should not map loopback connections to external ports', async () => {
@@ -204,7 +202,7 @@ describe('UPnP NAT (TCP)', () => {
     await natManager.mapIpAddresses()
 
     expect(client.map.called).to.be.false()
-    expect(components.addressManager.addObservedAddr.called).to.be.false()
+    expect(components.addressManager.addPublicAddressMapping.called).to.be.false()
   })
 
   it('should not map non-thin-waist connections to external ports', async () => {
@@ -223,7 +221,7 @@ describe('UPnP NAT (TCP)', () => {
     await natManager.mapIpAddresses()
 
     expect(client.map.called).to.be.false()
-    expect(components.addressManager.addObservedAddr.called).to.be.false()
+    expect(components.addressManager.addPublicAddressMapping.called).to.be.false()
   })
 
   it('should specify large enough TTL', async () => {


### PR DESCRIPTION
Switch to the new public address mapping api in the address manager to ensure all host/port pairs are advertised with external ip addresses

BREAKING CHANGE: the `autoConfirmAddress` option has been removed

## Change checklist

- [x] I have performed a self-review of my own code
- [ ] I have made corresponding changes to the documentation if necessary (this includes comments as well)
- [x] I have added tests that prove my fix is effective or that my feature works