### PR TITLE
fix: add retries to certificate provisioning

### DIFF
--- a/packages/auto-tls/README.md
+++ b/packages/auto-tls/README.md
@@ -25,7 +25,7 @@ repo and examine the changes made.
 -->
 
 When a publicly dialable address is detected, use the p2p-forge service at
-<https://registration.libp2p.direct> to acquire a valid Let's Encrypted-backed
+<https://registration.libp2p.direct> to acquire a valid Let's Encrypt-backed
 TLS certificate, which the node can then use with the relevant transports.
 
 The node must be configured with a listener for at least one of the following
@@ -82,27 +82,19 @@ console.info(node.getMultiaddrs())
 # Install
 
 ```console
-$ npm i @libp2p/plaintext
-```
-
-## Browser `<script>` tag
-
-Loading this module through a script tag will make it's exports available as `Libp2pPlaintext` in the global namespace.
-
-```html
-<script src="https://unpkg.com/@libp2p/plaintext/dist/index.min.js"></script>
+$ npm i @libp2p/auto-tls
 ```
 
 # API Docs
 
-- <https://libp2p.github.io/js-libp2p/modules/_libp2p_plaintext.html>
+- <https://libp2p.github.io/js-libp2p/modules/_libp2p_auto-tls.html>
 
 # License
 
 Licensed under either of
 
-- Apache 2.0, ([LICENSE-APACHE](https://github.com/libp2p/js-libp2p/blob/main/packages/connection-encrypter-plaintext/LICENSE-APACHE) / <http://www.apache.org/licenses/LICENSE-2.0>)
-- MIT ([LICENSE-MIT](https://github.com/libp2p/js-libp2p/blob/main/packages/connection-encrypter-plaintext/LICENSE-MIT) / <http://opensource.org/licenses/MIT>)
+- Apache 2.0, ([LICENSE-APACHE](https://github.com/libp2p/js-libp2p/blob/main/packages/auto-tls/LICENSE-APACHE) / <http://www.apache.org/licenses/LICENSE-2.0>)
+- MIT ([LICENSE-MIT](https://github.com/libp2p/js-libp2p/blob/main/packages/auto-tls/LICENSE-MIT) / <http://opensource.org/licenses/MIT>)
 
 # Contribution
 

--- a/packages/auto-tls/package.json
+++ b/packages/auto-tls/package.json
@@ -57,6 +57,8 @@
     "@multiformats/multiaddr-matcher": "^1.4.0",
     "@peculiar/x509": "^1.12.3",
     "acme-client": "^5.4.0",
+    "any-signal": "^4.1.1",
+    "delay": "^6.0.0",
     "interface-datastore": "^8.3.1",
     "multiformats": "^13.3.1",
     "uint8arrays": "^5.1.0"
@@ -66,7 +68,6 @@
     "@libp2p/peer-id": "^5.0.7",
     "aegir": "^44.0.1",
     "datastore-core": "^10.0.2",
-    "delay": "^6.0.0",
     "p-event": "^6.0.1",
     "sinon": "^19.0.2",
     "sinon-ts": "^2.0.0"

--- a/packages/auto-tls/src/constants.ts
+++ b/packages/auto-tls/src/constants.ts
@@ -1,7 +1,8 @@
 export const DEFAULT_FORGE_ENDPOINT = 'https://registration.libp2p.direct'
 export const DEFAULT_FORGE_DOMAIN = 'libp2p.direct'
 export const DEFAULT_ACME_DIRECTORY = 'https://acme-v02.api.letsencrypt.org/directory'
-export const DEFAULT_PROVISION_TIMEOUT = 10_000
+export const DEFAULT_PROVISION_TIMEOUT = 120_000
+export const DEFAULT_PROVISION_REQUEST_TIMEOUT = 10_000
 export const DEFAULT_PROVISION_DELAY = 5_000
 export const DEFAULT_RENEWAL_THRESHOLD = 86_400_000
 export const DEFAULT_ACCOUNT_PRIVATE_KEY_NAME = 'auto-tls-acme-account-private-key'

--- a/packages/auto-tls/src/index.ts
+++ b/packages/auto-tls/src/index.ts
@@ -104,9 +104,17 @@ export interface AutoTLSInit {
   /**
    * How long to attempt to acquire a certificate before timing out in ms
    *
-   * @default 10000
+   * @default 120_000
    */
   provisionTimeout?: number
+
+  /**
+   * How long asking the forge endpoint to answer a DNS challenge can take
+   * before we retry
+   *
+   * @default 10_000
+   */
+  provisionRequestTimeout?: number
 
   /**
    * Certificates are acquired when the `self:peer:update` event fires, which


### PR DESCRIPTION
The p2p-forge service at libp2p.direct sometimes rejects requests with 401 errors, the only thing to do is to retry.

This can probably be reverted in future if it becomes clear why some requests are rejected.

## Change checklist

- [x] I have performed a self-review of my own code
- [ ] I have made corresponding changes to the documentation if necessary (this includes comments as well)
- [ ] I have added tests that prove my fix is effective or that my feature works