### PR TITLE
chore: remove todo from auto tls

### DIFF
--- a/packages/auto-tls/src/auto-tls.ts
+++ b/packages/auto-tls/src/auto-tls.ts
@@ -179,8 +179,6 @@ export class AutoTLS implements AutoTLSInterface {
   private async fetchCertificate (multiaddrs: Multiaddr[], options?: AbortOptions): Promise<void> {
     this.log('fetching certificate')
 
-    // TODO: handle rate limit errors like "too many new registrations (10) from this IP address in the last 3h0m0s, retry after 2024-11-01 09:22:38 UTC: see https://letsencrypt.org/docs/rate-limits/#new-registrations-per-ip-address"
-
     const certificatePrivateKey = await loadOrCreateKey(this.keychain, this.certificatePrivateKeyName, this.certificatePrivateKeyBits)
     const { pem, cert } = await this.loadOrCreateCertificate(certificatePrivateKey, multiaddrs, options)
 


### PR DESCRIPTION
The `acme-client` module takes care of retries after 429s so no need to handle it at this level.

## Change checklist

- [x] I have performed a self-review of my own code
- [ ] I have made corresponding changes to the documentation if necessary (this includes comments as well)
- [ ] I have added tests that prove my fix is effective or that my feature works