### PR TITLE
fix: isPrivate should handle more types of addresses

### DIFF
--- a/packages/utils/src/multiaddr/is-private.ts
+++ b/packages/utils/src/multiaddr/is-private.ts
@@ -1,15 +1,34 @@
 import { isPrivateIp } from '../private-ip.js'
 import type { Multiaddr } from '@multiformats/multiaddr'
 
+const CODEC_IP4 = 0x04
+const CODEC_IP6 = 0x29
+const CODEC_DNS = 0x35
+const CODEC_DNS4 = 0x36
+const CODEC_DNS6 = 0x37
+const CODEC_DNSADDR = 0x38
+
 /**
- * Check if a given multiaddr has a private address.
+ * Check if a given multiaddr starts with a private address
  */
 export function isPrivate (ma: Multiaddr): boolean {
   try {
-    const { address } = ma.nodeAddress()
+    const [[codec, value]] = ma.stringTuples()
 
-    return Boolean(isPrivateIp(address))
+    if (value == null) {
+      return true
+    }
+
+    if (codec === CODEC_DNS || codec === CODEC_DNS4 || codec === CODEC_DNS6 || codec === CODEC_DNSADDR) {
+      return false
+    }
+
+    if (codec === CODEC_IP4 || codec === CODEC_IP6) {
+      return isPrivateIp(value) ?? false
+    }
   } catch {
-    return true
+
   }
+
+  return true
 }

--- a/packages/utils/test/multiaddr/is-private.spec.ts
+++ b/packages/utils/test/multiaddr/is-private.spec.ts
@@ -4,7 +4,7 @@ import { multiaddr } from '@multiformats/multiaddr'
 import { expect } from 'aegir/chai'
 import { isPrivate } from '../../src/multiaddr/is-private.js'
 
-describe.only('multiaddr isPrivate', () => {
+describe('multiaddr isPrivate', () => {
   it('identifies private ip4 multiaddrs', () => {
     [
       multiaddr('/ip4/127.0.0.1/tcp/1000'),

--- a/packages/utils/test/multiaddr/is-private.spec.ts
+++ b/packages/utils/test/multiaddr/is-private.spec.ts
@@ -4,15 +4,18 @@ import { multiaddr } from '@multiformats/multiaddr'
 import { expect } from 'aegir/chai'
 import { isPrivate } from '../../src/multiaddr/is-private.js'
 
-describe('multiaddr isPrivate', () => {
+describe.only('multiaddr isPrivate', () => {
   it('identifies private ip4 multiaddrs', () => {
     [
       multiaddr('/ip4/127.0.0.1/tcp/1000'),
       multiaddr('/ip4/10.0.0.1/tcp/1000'),
       multiaddr('/ip4/192.168.0.1/tcp/1000'),
-      multiaddr('/ip4/172.16.0.1/tcp/1000')
+      multiaddr('/ip4/172.16.0.1/tcp/1000'),
+      multiaddr('/ip4/172.16.0.1/tcp/1000/p2p/QmNnooDu7bfjPFoTZYxMNLWUQJyrVwtbZg5gBMjTezGAJN'),
+      multiaddr('/ip4/172.16.0.1/tcp/1000/p2p/QmNnooDu7bfjPFoTZYxMNLWUQJyrVwtbZg5gBMjTezGAJN/p2p-circuit/p2p/12D3KooWNvSZnPi3RrhrTwEY4LuuBeB6K6facKUCJcyWG1aoDd2p'),
+      multiaddr('/ip4/172.16.0.1')
     ].forEach(ma => {
-      expect(isPrivate(ma)).to.eql(true)
+      expect(isPrivate(ma)).to.be.true()
     })
   })
 
@@ -21,9 +24,12 @@ describe('multiaddr isPrivate', () => {
       multiaddr('/ip4/101.0.26.90/tcp/1000'),
       multiaddr('/ip4/40.1.20.9/tcp/1000'),
       multiaddr('/ip4/92.168.0.1/tcp/1000'),
-      multiaddr('/ip4/2.16.0.1/tcp/1000')
+      multiaddr('/ip4/2.16.0.1/tcp/1000'),
+      multiaddr('/ip4/2.16.0.1/tcp/1000/p2p/QmNnooDu7bfjPFoTZYxMNLWUQJyrVwtbZg5gBMjTezGAJN'),
+      multiaddr('/ip4/2.16.0.1/tcp/1000/p2p/QmNnooDu7bfjPFoTZYxMNLWUQJyrVwtbZg5gBMjTezGAJN/p2p-circuit/p2p/12D3KooWNvSZnPi3RrhrTwEY4LuuBeB6K6facKUCJcyWG1aoDd2p'),
+      multiaddr('/ip4/2.16.0.1')
     ].forEach(ma => {
-      expect(isPrivate(ma)).to.eql(false)
+      expect(isPrivate(ma)).to.be.false()
     })
   })
 
@@ -38,10 +44,11 @@ describe('multiaddr isPrivate', () => {
       multiaddr('/ip6/::ffff:10.0.0.1/tcp/1000'),
       multiaddr('/ip6/::ffff:172.16.0.1/tcp/1000'),
       multiaddr('/ip6/::ffff:192.168.0.1/tcp/1000'),
-      multiaddr('/ip6/::ffff:127.0.0.1/tcp/1000')
+      multiaddr('/ip6/::ffff:127.0.0.1/tcp/1000'),
+      multiaddr('/ip6/::ffff:127.0.0.1')
     ].forEach(ma => {
       try {
-        expect(isPrivate(ma)).to.eql(true)
+        expect(isPrivate(ma)).to.be.true()
       } catch (error) {
         throw new Error(`Failed for ${ma.toString()}`)
       }
@@ -67,18 +74,20 @@ describe('multiaddr isPrivate', () => {
       multiaddr('/ip6/::ffff:172.15.0.1/tcp/1000'), // not a private range
       multiaddr('/ip6/::ffff:172.32.0.1/tcp/1000'), // not a private range
       multiaddr('/ip6/::ffff:192.167.0.1/tcp/1000'), // not a private range
-      multiaddr('/ip6/::ffff:192.169.0.1/tcp/1000') // not a private range
+      multiaddr('/ip6/::ffff:192.169.0.1/tcp/1000'), // not a private range
+      multiaddr('/ip6/::ffff:192.169.0.1') // not a private range
     ].forEach(ma => {
-      expect(isPrivate(ma)).to.eql(false)
+      expect(isPrivate(ma)).to.be.false()
     })
   })
 
   it('identifies other multiaddrs as not private addresses', () => {
     [
       multiaddr('/dns4/wss0.bootstrap.libp2p.io/tcp/443'),
-      multiaddr('/dns6/wss0.bootstrap.libp2p.io/tcp/443')
+      multiaddr('/dns6/wss0.bootstrap.libp2p.io/tcp/443'),
+      multiaddr('/dns6/wss0.bootstrap.libp2p.io')
     ].forEach(ma => {
-      expect(isPrivate(ma)).to.eql(false)
+      expect(isPrivate(ma)).to.be.false()
     })
   })
 
@@ -86,9 +95,10 @@ describe('multiaddr isPrivate', () => {
     [
       multiaddr('/ip4/127.0.0.1/tcp/1000/p2p-circuit'),
       multiaddr('/unix/foo/bar/baz.sock'),
-      multiaddr('/ip4/127.0.0.1/sctp/1000')
+      multiaddr('/ip4/127.0.0.1/sctp/1000'),
+      multiaddr('/ip4/127.0.0.1')
     ].forEach(ma => {
-      expect(isPrivate(ma)).to.eql(true)
+      expect(isPrivate(ma)).to.be.true()
     })
   })
 })


### PR DESCRIPTION
Refactors the `isPrivate(multiaddr)` function to not require tcp/udp ports to be part of the address.

## Change checklist

- [x] I have performed a self-review of my own code
- [ ] I have made corresponding changes to the documentation if necessary (this includes comments as well)
- [x] I have added tests that prove my fix is effective or that my feature works