### PR TITLE
fix: handle router mappings of mixed IP version

### DIFF
--- a/packages/libp2p/package.json
+++ b/packages/libp2p/package.json
@@ -85,6 +85,7 @@
     "test:webkit": "aegir test -t browser -- --browser webkit"
   },
   "dependencies": {
+    "@chainsafe/is-ip": "^2.0.2",
     "@libp2p/crypto": "^5.0.7",
     "@libp2p/interface": "^2.2.1",
     "@libp2p/interface-internal": "^2.1.1",

--- a/packages/libp2p/src/address-manager.ts
+++ b/packages/libp2p/src/address-manager.ts
@@ -1,3 +1,4 @@
+import { isIPv4 } from '@chainsafe/is-ip'
 import { peerIdFromString } from '@libp2p/peer-id'
 import { debounce } from '@libp2p/utils/debounce'
 import { multiaddr, protocols } from '@multiformats/multiaddr'
@@ -149,7 +150,9 @@ export class AddressManager implements AddressManagerInterface {
     this.components.peerStore.patch(this.components.peerId, {
       multiaddrs: addrs
     })
-      .catch(err => { this.log.error('error updating addresses', err) })
+      .catch(err => {
+        this.log.error('error updating addresses', err)
+      })
   }
 
   /**
@@ -267,6 +270,7 @@ export class AddressManager implements AddressManagerInterface {
       }
 
       mappings.forEach(mapping => {
+        tuples[0][0] = isIPv4(mapping.externalIp) ? CODEC_IP4 : CODEC_IP6
         tuples[0][1] = mapping.externalIp
         tuples[1][1] = `${mapping.externalPort}`
 


### PR DESCRIPTION
Handle the case where the router has an external IPv4 address but the internal network is IPv6 only, and vice versa.

## Change checklist

- [x] I have performed a self-review of my own code
- [ ] I have made corresponding changes to the documentation if necessary (this includes comments as well)
- [x] I have added tests that prove my fix is effective or that my feature works