### PR TITLE
fix: ignore corrupt peerstore data

### DIFF
--- a/packages/peer-store/src/store.ts
+++ b/packages/peer-store/src/store.ts
@@ -9,7 +9,7 @@ import { bytesToPeer } from './utils/bytes-to-peer.js'
 import { NAMESPACE_COMMON, peerIdToDatastoreKey } from './utils/peer-id-to-datastore-key.js'
 import { toPeerPB } from './utils/to-peer-pb.js'
 import type { AddressFilter, PersistentPeerStoreComponents, PersistentPeerStoreInit } from './index.js'
-import type { PeerUpdate as PeerUpdateExternal, PeerId, Peer, PeerData, PeerQuery } from '@libp2p/interface'
+import type { PeerUpdate as PeerUpdateExternal, PeerId, Peer, PeerData, PeerQuery, Logger } from '@libp2p/interface'
 import type { Datastore, Key, Query } from 'interface-datastore'
 
 /**
@@ -49,8 +49,10 @@ export class PersistentStore {
   private readonly datastore: Datastore
   public readonly lock: Mortice
   private readonly addressFilter?: AddressFilter
+  private readonly log: Logger
 
   constructor (components: PersistentPeerStoreComponents, init: PersistentPeerStoreInit = {}) {
+    this.log = components.logger.forComponent('libp2p:peer-store')
     this.peerId = components.peerId
     this.datastore = components.datastore
     this.addressFilter = init.addressFilter
@@ -141,10 +143,8 @@ export class PersistentStore {
         existingBuf,
         existingPeer
       }
-    } catch (err: any) {
-      if (err.name !== 'NotFoundError') {
-        throw err
-      }
+    } catch (err) {
+      this.log.error('invalid peer data found in peer store - %e', err)
     }
 
     return {}

--- a/packages/peer-store/test/merge.spec.ts
+++ b/packages/peer-store/test/merge.spec.ts
@@ -10,7 +10,9 @@ import { expect } from 'aegir/chai'
 import { MemoryDatastore } from 'datastore-core/memory'
 import { pEvent } from 'p-event'
 import { persistentPeerStore } from '../src/index.js'
+import { peerIdToDatastoreKey } from '../src/utils/peer-id-to-datastore-key.js'
 import type { TypedEventTarget, Libp2pEvents, PeerId, PeerStore, PeerData } from '@libp2p/interface'
+import type { Datastore } from 'interface-datastore'
 
 const addr1 = multiaddr('/ip4/127.0.0.1/tcp/8000')
 const addr2 = multiaddr('/ip4/20.0.0.1/tcp/8001')
@@ -21,15 +23,17 @@ describe('merge', () => {
   let otherPeerId: PeerId
   let peerStore: PeerStore
   let events: TypedEventTarget<Libp2pEvents>
+  let datastore: Datastore
 
   beforeEach(async () => {
     peerId = peerIdFromPrivateKey(await generateKeyPair('Ed25519'))
     otherPeerId = peerIdFromPrivateKey(await generateKeyPair('Ed25519'))
     events = new TypedEventEmitter()
+    datastore = new MemoryDatastore()
     peerStore = persistentPeerStore({
       peerId,
       events,
-      datastore: new MemoryDatastore(),
+      datastore,
       logger: defaultLogger()
     })
   })
@@ -248,5 +252,31 @@ describe('merge', () => {
     expect(updated).to.have.property('metadata').that.deep.equals(original.metadata)
     expect(updated).to.have.property('tags').that.deep.equals(original.tags)
     expect(updated).to.have.property('protocols').that.deep.equals(original.protocols)
+  })
+
+  it('should ignore corrupt peer store data', async () => {
+    const badPeer: PeerData = {
+      multiaddrs: [
+        addr1
+      ]
+    }
+    await peerStore.save(otherPeerId, badPeer)
+    const key = peerIdToDatastoreKey(otherPeerId)
+
+    // store unparsable data
+    await datastore.put(key, Uint8Array.from([0, 1, 2, 3, 4, 5]))
+
+    // update the peer
+    const peer: PeerData = {
+      multiaddrs: [
+        addr2
+      ]
+    }
+    const updated = await peerStore.merge(otherPeerId, peer)
+
+    expect(updated).to.have.property('addresses').that.deep.equals([{
+      multiaddr: addr2,
+      isCertified: false
+    }])
   })
 })

--- a/packages/peer-store/test/save.spec.ts
+++ b/packages/peer-store/test/save.spec.ts
@@ -17,6 +17,8 @@ import type { TypedEventTarget, Libp2pEvents, PeerId, PeerStore, PeerData, PeerU
 
 const addr1 = multiaddr('/ip4/127.0.0.1/tcp/8000')
 const addr2 = multiaddr('/ip4/20.0.0.1/tcp/8001')
+const addr3 = multiaddr('/ip6/2a00:23c6:14b1:7e00:440d:76a7:f9f:b53f/tcp/8001')
+const addr4 = multiaddr('/ip6/fdad:bda1:c508:6261:1e:bea5:2ae6:fef0/tcp/8001')
 
 describe('save', () => {
   let peerId: PeerId
@@ -218,7 +220,9 @@ describe('save', () => {
     const peer: PeerData = {
       multiaddrs: [
         addr1,
-        addr2
+        addr2,
+        addr3,
+        addr4
       ],
       metadata: {
         foo: Uint8Array.from([0, 1, 2])
@@ -239,6 +243,12 @@ describe('save', () => {
       isCertified: false
     }, {
       multiaddr: addr2,
+      isCertified: false
+    }, {
+      multiaddr: addr3,
+      isCertified: false
+    }, {
+      multiaddr: addr4,
       isCertified: false
     }])
     expect(saved).to.have.property('metadata').that.deep.equals(


### PR DESCRIPTION
When we can't load or parse peerstore data, ignore it

## Change checklist

- [x] I have performed a self-review of my own code
- [ ] I have made corresponding changes to the documentation if necessary (this includes comments as well)
- [x] I have added tests that prove my fix is effective or that my feature works