### PR TITLE
fix: only log when data is invalid

### DIFF
--- a/packages/peer-store/src/store.ts
+++ b/packages/peer-store/src/store.ts
@@ -143,8 +143,10 @@ export class PersistentStore {
         existingBuf,
         existingPeer
       }
-    } catch (err) {
-      this.log.error('invalid peer data found in peer store - %e', err)
+    } catch (err: any) {
+      if (err.name !== 'NotFoundError') {
+        this.log.error('invalid peer data found in peer store - %e', err)
+      }
     }
 
     return {}


### PR DESCRIPTION
Only log an error when parsing peer data fails, not when it is not present.

## Change checklist

- [x] I have performed a self-review of my own code
- [ ] I have made corresponding changes to the documentation if necessary (this includes comments as well)
- [ ] I have added tests that prove my fix is effective or that my feature works