### PR TITLE
fix: do not add peers to routing table during RPC handling

### DIFF
--- a/packages/kad-dht/src/rpc/index.ts
+++ b/packages/kad-dht/src/rpc/index.ts
@@ -95,12 +95,6 @@ export class RPC {
       const { stream, connection } = data
       const peerId = connection.remotePeer
 
-      try {
-        await this.routingTable.add(peerId)
-      } catch (err: any) {
-        this.log.error(err)
-      }
-
       const self = this // eslint-disable-line @typescript-eslint/no-this-alias
 
       await pipe(

--- a/packages/kad-dht/test/rpc/handlers/ping.spec.ts
+++ b/packages/kad-dht/test/rpc/handlers/ping.spec.ts
@@ -2,7 +2,6 @@
 
 import { defaultLogger } from '@libp2p/logger'
 import { expect } from 'aegir/chai'
-import { fromString as uint8ArrayFromString } from 'uint8arrays/from-string'
 import { type Message, MessageType } from '../../../src/message/dht.js'
 import { PingHandler } from '../../../src/rpc/handlers/ping.js'
 import { createPeerId } from '../../utils/create-peer-id.js'
@@ -30,7 +29,6 @@ describe('rpc - handlers - Ping', () => {
   it('replies with the same message', async () => {
     const msg: Message = {
       type: T,
-      key: uint8ArrayFromString('hello'),
       closer: [],
       providers: []
     }


### PR DESCRIPTION
## Description

I was having a issue where 2 docker dht nodes failed to dht ping each other on startup. The streams would abort due to a read timeout. 

Also removed `key` from the ping tests as not required.

## Notes & open questions

I don't think there needs to be a call to `this.routingTable.add` in `onIncomingStream` as it should be handled by the topology register.  Although alternatively maybe it could be moved to after the `pipe`?

Couldn't replicate the issue on localhost between 2 non-dockerised instances although I can provide docker files / test repo / logs if needed

## Change checklist

- [x] I have performed a self-review of my own code
- [ ] I have made corresponding changes to the documentation if necessary (this includes comments as well)
- [ ] I have added tests that prove my fix is effective or that my feature works