### PR TITLE
fix: use isPrivate to detect private multiaddrs

### DIFF
--- a/packages/protocol-identify/src/identify.ts
+++ b/packages/protocol-identify/src/identify.ts
@@ -4,7 +4,7 @@ import { publicKeyFromProtobuf, publicKeyToProtobuf } from '@libp2p/crypto/keys'
 import { InvalidMessageError, UnsupportedProtocolError, serviceCapabilities, setMaxListeners } from '@libp2p/interface'
 import { peerIdFromCID } from '@libp2p/peer-id'
 import { RecordEnvelope, PeerRecord } from '@libp2p/peer-record'
-import { isPrivateIp } from '@libp2p/utils/private-ip'
+import { isPrivate } from '@libp2p/utils/multiaddr/is-private'
 import { protocols } from '@multiformats/multiaddr'
 import { IP_OR_DOMAIN } from '@multiformats/multiaddr-matcher'
 import { pbStream } from 'it-protobuf-stream'
@@ -112,7 +112,7 @@ export class Identify extends AbstractIdentify implements Startable, IdentifyInt
     if (cleanObservedAddr != null) {
       this.log('our observed address was %a', cleanObservedAddr)
 
-      if (isPrivateIp(cleanObservedAddr?.nodeAddress().address) === true) {
+      if (isPrivate(cleanObservedAddr)) {
         this.log('our observed address was private')
       } else if (this.addressManager.getObservedAddrs().length < (this.maxObservedAddresses ?? Infinity)) {
         this.log('storing our observed address')


### PR DESCRIPTION
To prevent throwing when non-thin waist addresses are encountered, use `isPrivate` instead of converting the multiaddr to a node address.

## Change checklist

- [x] I have performed a self-review of my own code
- [ ] I have made corresponding changes to the documentation if necessary (this includes comments as well)
- [ ] I have added tests that prove my fix is effective or that my feature works