### PR TITLE
fix: limit observed addresses in address manager

### DIFF
--- a/packages/libp2p/test/addresses/address-manager.spec.ts
+++ b/packages/libp2p/test/addresses/address-manager.spec.ts
@@ -130,6 +130,26 @@ describe('Address Manager', () => {
     expect(am.getObservedAddrs()).to.have.lengthOf(1)
   })
 
+  it('should limit observed addresses', () => {
+    const am = new AddressManager({
+      peerId,
+      transportManager: stubInterface<TransportManager>(),
+      peerStore,
+      events,
+      logger: defaultLogger()
+    }, {
+      announceFilter: stubInterface<AddressFilter>()
+    })
+
+    expect(am.getObservedAddrs()).to.be.empty()
+
+    for (let i = 0; i < 100; i++) {
+      am.addObservedAddr(multiaddr(`/ip4/123.123.123.123/tcp/392${i}`))
+    }
+
+    expect(am.getObservedAddrs()).to.have.lengthOf(10)
+  })
+
   it('should allow duplicate listen addresses', () => {
     const ma = multiaddr('/ip4/0.0.0.0/tcp/0')
     const am = new AddressManager({


### PR DESCRIPTION
This is done in the identify protocol but the address manager should guard itself against misuse.

## Notes & open questions

<!--
Any notes, remarks or open questions you have to make about the PR which don't need to go into the final commit message.
-->

## Change checklist

- [x] I have performed a self-review of my own code
- [ ] I have made corresponding changes to the documentation if necessary (this includes comments as well)
- [x] I have added tests that prove my fix is effective or that my feature works