### PR TITLE
feat: add isGlobalUnicast function

### DIFF
--- a/packages/utils/package.json
+++ b/packages/utils/package.json
@@ -76,6 +76,10 @@
       "types": "./dist/src/filters/index.d.ts",
       "import": "./dist/src/filters/index.js"
     },
+    "./global-unicast-ip": {
+      "types": "./dist/src/global-unicast-ip.d.ts",
+      "import": "./dist/src/global-unicast-ip.js"
+    },
     "./ip-port-to-multiaddr": {
       "types": "./dist/src/ip-port-to-multiaddr.d.ts",
       "import": "./dist/src/ip-port-to-multiaddr.js"
@@ -91,6 +95,10 @@
     "./moving-average": {
       "types": "./dist/src/moving-average.d.ts",
       "import": "./dist/src/moving-average.js"
+    },
+    "./multiaddr/is-global-unicast": {
+      "types": "./dist/src/multiaddr/is-global-unicast.d.ts",
+      "import": "./dist/src/multiaddr/is-global-unicast.js"
     },
     "./multiaddr/is-link-local": {
       "types": "./dist/src/multiaddr/is-link-local.d.ts",
@@ -164,6 +172,7 @@
   },
   "dependencies": {
     "@chainsafe/is-ip": "^2.0.2",
+    "@chainsafe/netmask": "^2.0.0",
     "@libp2p/crypto": "^5.0.7",
     "@libp2p/interface": "^2.2.1",
     "@libp2p/logger": "^5.1.4",

--- a/packages/utils/src/global-unicast-ip.ts
+++ b/packages/utils/src/global-unicast-ip.ts
@@ -1,0 +1,10 @@
+import { isIPv6 } from '@chainsafe/is-ip'
+import { cidrContains } from '@chainsafe/netmask'
+
+export function isGlobalUnicastIp (ip: string): boolean {
+  if (isIPv6(ip)) {
+    return cidrContains('2000::/3', ip)
+  }
+
+  return false
+}

--- a/packages/utils/src/multiaddr/is-global-unicast.ts
+++ b/packages/utils/src/multiaddr/is-global-unicast.ts
@@ -1,0 +1,25 @@
+import { cidrContains } from '@chainsafe/netmask'
+import type { Multiaddr } from '@multiformats/multiaddr'
+
+const CODEC_IP6 = 0x29
+
+/**
+ * Check if a given multiaddr is an IPv6 global unicast address
+ */
+export function isGlobalUnicast (ma: Multiaddr): boolean {
+  try {
+    const [[codec, value]] = ma.stringTuples()
+
+    if (value == null) {
+      return false
+    }
+
+    if (codec === CODEC_IP6) {
+      return cidrContains('2000::/3', value)
+    }
+  } catch {
+
+  }
+
+  return false
+}

--- a/packages/utils/test/global-unicast-ip.spec.ts
+++ b/packages/utils/test/global-unicast-ip.spec.ts
@@ -1,0 +1,53 @@
+/* eslint-env mocha */
+
+import { expect } from 'aegir/chai'
+import { isGlobalUnicastIp } from '../src/global-unicast-ip.js'
+
+describe('isGlobalUnicastIp', () => {
+  it('identifies ip4 multiaddrs as non-global unicast', () => {
+    [
+      '169.254.35.4',
+      '169.254.35.4',
+      '169.254.0.0',
+      '169.254.255.255',
+      '101.0.26.90',
+      '10.0.0.1',
+      '192.168.0.1',
+      '172.16.0.1'
+    ].forEach(ma => {
+      expect(isGlobalUnicastIp(ma)).to.be.false(`"${ma}" was identified as global unicast`)
+    })
+  })
+
+  it('identifies global unicast ip6 multiaddrs', () => {
+    [
+      '2001:8a0:7ac5:4201:3ac9:86ff:fe31:7095',
+      '2001:8a0:7ac5:4201:3ac9:86ff:fe31:7095%en0'
+    ].forEach(ma => {
+      expect(isGlobalUnicastIp(ma)).to.be.true(`"${ma}" was not identified as global unicast`)
+    })
+  })
+
+  it('identifies non global unicast ip6 multiaddrs', () => {
+    [
+      '::',
+      'fe80::1%lo0',
+      'fe80::1%lo0',
+      'fe80::1893:def4:af04:635a%en',
+      'fe80::1893:def4:af04:635a',
+      'fe80::1893:def4:af04:635a',
+      '::2:0:59c:a24:801'
+    ].forEach(ma => {
+      expect(isGlobalUnicastIp(ma)).to.be.false(`"${ma}" was identified as global unicast`)
+    })
+  })
+
+  it('identifies other multiaddrs as not global unicast addresses', () => {
+    [
+      'wss0.bootstrap.libp2p.io',
+      'wss0.bootstrap.libp2p.io'
+    ].forEach(ma => {
+      expect(isGlobalUnicastIp(ma)).to.be.false(`"${ma}" was identified as global unicast`)
+    })
+  })
+})

--- a/packages/utils/test/link-local-ip.spec.ts
+++ b/packages/utils/test/link-local-ip.spec.ts
@@ -40,7 +40,7 @@ describe('isLinkLocalIp', () => {
 
   it('identifies non link-local ip6 multiaddrs', () => {
     [
-      '2001:8a0:7ac5:4201:3ac9:86ff:fe31',
+      '2001:8a0:7ac5:4201:3ac9:86ff:fe31:7095',
       '::'
     ].forEach(ma => {
       expect(isLinkLocalIp(ma)).to.be.false()

--- a/packages/utils/test/multiaddr/is-global-unicast.spec.ts
+++ b/packages/utils/test/multiaddr/is-global-unicast.spec.ts
@@ -1,0 +1,54 @@
+/* eslint-env mocha */
+
+import { multiaddr } from '@multiformats/multiaddr'
+import { expect } from 'aegir/chai'
+import { isGlobalUnicast } from '../../src/multiaddr/is-global-unicast.js'
+
+describe('multiaddr isGlobalUnicast', () => {
+  it('identifies ip4 multiaddrs as non-global unicast', () => {
+    [
+      multiaddr('/ip4/169.254.35.4'),
+      multiaddr('/ip4/169.254.35.4/tcp/1000'),
+      multiaddr('/ip4/169.254.0.0/tcp/1000'),
+      multiaddr('/ip4/169.254.255.255/tcp/1000'),
+      multiaddr('/ip4/101.0.26.90/tcp/1000'),
+      multiaddr('/ip4/10.0.0.1/tcp/1000'),
+      multiaddr('/ip4/192.168.0.1/tcp/1000'),
+      multiaddr('/ip4/172.16.0.1/tcp/1000')
+    ].forEach(ma => {
+      expect(isGlobalUnicast(ma)).to.be.false(`"${ma}" was identified as global unicast`)
+    })
+  })
+
+  it('identifies global unicast ip6 multiaddrs', () => {
+    [
+      multiaddr('/ip6/2001:8a0:7ac5:4201:3ac9:86ff:fe31:7095/tcp/1000'),
+      multiaddr('/ip6/2001:8a0:7ac5:4201:3ac9:86ff:fe31:7095%en0/tcp/1000')
+    ].forEach(ma => {
+      expect(isGlobalUnicast(ma)).to.be.true(`"${ma}" was not identified as global unicast`)
+    })
+  })
+
+  it('identifies non global unicast ip6 multiaddrs', () => {
+    [
+      multiaddr('/ip6/fe80::1%lo0'),
+      multiaddr('/ip6/fe80::1%lo0/tcp/1000'),
+      multiaddr('/ip6/fe80::1893:def4:af04:635a%en'),
+      multiaddr('/ip6/fe80::1893:def4:af04:635a'),
+      multiaddr('/ip6/fe80::1893:def4:af04:635a/udp/2183'),
+      multiaddr('/ip6/::/tcp/1000'),
+      multiaddr('/ip6/::2:0:59c:a24:801/tcp/64142')
+    ].forEach(ma => {
+      expect(isGlobalUnicast(ma)).to.be.false(`"${ma}" was identified as global unicast`)
+    })
+  })
+
+  it('identifies other multiaddrs as not global unicast addresses', () => {
+    [
+      multiaddr('/dns4/wss0.bootstrap.libp2p.io/tcp/443'),
+      multiaddr('/dns6/wss0.bootstrap.libp2p.io/tcp/443')
+    ].forEach(ma => {
+      expect(isGlobalUnicast(ma)).to.be.false(`"${ma}" was identified as global unicast`)
+    })
+  })
+})


### PR DESCRIPTION
Adds functions for detecting global unicast IPv6 multiaddrs and IP addresses.

## Change checklist

- [x] I have performed a self-review of my own code
- [x] I have made corresponding changes to the documentation if necessary (this includes comments as well)
- [x] I have added tests that prove my fix is effective or that my feature works