### PR TITLE
feat: add auto-confirm option to auto-tls

### DIFF
--- a/packages/auto-tls/src/auto-tls.ts
+++ b/packages/auto-tls/src/auto-tls.ts
@@ -10,7 +10,7 @@ import { base36 } from 'multiformats/bases/base36'
 import { equals as uint8ArrayEquals } from 'uint8arrays/equals'
 import { fromString as uint8ArrayFromString } from 'uint8arrays/from-string'
 import { toString as uint8ArrayToString } from 'uint8arrays/to-string'
-import { DEFAULT_ACCOUNT_PRIVATE_KEY_BITS, DEFAULT_ACCOUNT_PRIVATE_KEY_NAME, DEFAULT_ACME_DIRECTORY, DEFAULT_CERTIFICATE_DATASTORE_KEY, DEFAULT_CERTIFICATE_PRIVATE_KEY_BITS, DEFAULT_CERTIFICATE_PRIVATE_KEY_NAME, DEFAULT_FORGE_DOMAIN, DEFAULT_FORGE_ENDPOINT, DEFAULT_PROVISION_DELAY, DEFAULT_PROVISION_REQUEST_TIMEOUT, DEFAULT_PROVISION_TIMEOUT, DEFAULT_RENEWAL_THRESHOLD } from './constants.js'
+import { DEFAULT_ACCOUNT_PRIVATE_KEY_BITS, DEFAULT_ACCOUNT_PRIVATE_KEY_NAME, DEFAULT_ACME_DIRECTORY, DEFAULT_AUTO_CONFIRM_ADDRESS, DEFAULT_CERTIFICATE_DATASTORE_KEY, DEFAULT_CERTIFICATE_PRIVATE_KEY_BITS, DEFAULT_CERTIFICATE_PRIVATE_KEY_NAME, DEFAULT_FORGE_DOMAIN, DEFAULT_FORGE_ENDPOINT, DEFAULT_PROVISION_DELAY, DEFAULT_PROVISION_REQUEST_TIMEOUT, DEFAULT_PROVISION_TIMEOUT, DEFAULT_RENEWAL_THRESHOLD } from './constants.js'
 import { DomainMapper } from './domain-mapper.js'
 import { createCsr, importFromPem, loadOrCreateKey, supportedAddressesFilter } from './utils.js'
 import type { AutoTLSComponents, AutoTLSInit, AutoTLS as AutoTLSInterface } from './index.js'
@@ -60,9 +60,10 @@ export class AutoTLS implements AutoTLSInterface {
   private readonly email
   private readonly domain
   private readonly domainMapper: DomainMapper
+  private readonly autoConfirmAddress: boolean
 
   constructor (components: AutoTLSComponents, init: AutoTLSInit = {}) {
-    this.log = components.logger.forComponent('libp2p:certificate-manager')
+    this.log = components.logger.forComponent('libp2p:auto-tls')
     this.addressManager = components.addressManager
     this.privateKey = components.privateKey
     this.peerId = components.peerId
@@ -80,6 +81,7 @@ export class AutoTLS implements AutoTLSInterface {
     this.certificatePrivateKeyName = init.certificatePrivateKeyName ?? DEFAULT_CERTIFICATE_PRIVATE_KEY_NAME
     this.certificatePrivateKeyBits = init.certificatePrivateKeyBits ?? DEFAULT_CERTIFICATE_PRIVATE_KEY_BITS
     this.certificateDatastoreKey = init.certificateDatastoreKey ?? DEFAULT_CERTIFICATE_DATASTORE_KEY
+    this.autoConfirmAddress = init.autoConfirmAddress ?? DEFAULT_AUTO_CONFIRM_ADDRESS
     this.clientAuth = new ClientAuth(this.privateKey)
     this.started = false
     this.fetching = false
@@ -100,10 +102,16 @@ export class AutoTLS implements AutoTLSInterface {
   ]
 
   get [serviceDependencies] (): string[] {
-    return [
+    const dependencies = [
       '@libp2p/identify',
       '@libp2p/keychain'
     ]
+
+    if (!this.autoConfirmAddress) {
+      dependencies.push('@libp2p/autonat')
+    }
+
+    return dependencies
   }
 
   async start (): Promise<void> {

--- a/packages/auto-tls/src/constants.ts
+++ b/packages/auto-tls/src/constants.ts
@@ -10,3 +10,4 @@ export const DEFAULT_ACCOUNT_PRIVATE_KEY_BITS = 2048
 export const DEFAULT_CERTIFICATE_PRIVATE_KEY_NAME = 'auto-tls-certificate-private-key'
 export const DEFAULT_CERTIFICATE_PRIVATE_KEY_BITS = 2048
 export const DEFAULT_CERTIFICATE_DATASTORE_KEY = '/libp2p/auto-tls/certificate'
+export const DEFAULT_AUTO_CONFIRM_ADDRESS = false

--- a/packages/auto-tls/src/index.ts
+++ b/packages/auto-tls/src/index.ts
@@ -168,6 +168,17 @@ export interface AutoTLSInit {
    * @default 2048
    */
   certificatePrivateKeyBits?: number
+
+  /**
+   * Any mapped addresses are added to the observed address list. These
+   * addresses require additional verification by the `@libp2p/autonat` protocol
+   * or similar before they are trusted.
+   *
+   * To skip this verification and trust them immediately pass `true` here
+   *
+   * @default false
+   */
+  autoConfirmAddress?: boolean
 }
 
 export interface AutoTLS {


### PR DESCRIPTION
Adds an `autoConfirmAddress` to trust that the `libp2p.direct` DNS addresses have been configured correctly without waiting for autonat to verify. Defaults to `false`.

## Change checklist

- [x] I have performed a self-review of my own code
- [x] I have made corresponding changes to the documentation if necessary (this includes comments as well)
- [x] I have added tests that prove my fix is effective or that my feature works