### PR TITLE
fix: require confirmation of global unicast addresses

### DIFF
--- a/packages/interface-internal/src/address-manager/index.ts
+++ b/packages/interface-internal/src/address-manager/index.ts
@@ -30,6 +30,11 @@ export interface NodeAddress {
   verified: boolean
 
   /**
+   * The timestamp at which the address was last verified
+   */
+  lastVerified?: number
+
+  /**
    * A millisecond timestamp after which this address should be reverified
    */
   expires: number
@@ -38,6 +43,13 @@ export interface NodeAddress {
    * The source of this address
    */
   type: AddressType
+}
+
+export interface ConfirmAddressOptions {
+  /**
+   * Override the TTL of the observed address verification
+   */
+  ttl?: number
 }
 
 export interface AddressManager {
@@ -61,7 +73,7 @@ export interface AddressManager {
    * Signal that we have confidence an observed multiaddr is publicly dialable -
    * this will make it appear in the output of getAddresses()
    */
-  confirmObservedAddr(addr: Multiaddr): void
+  confirmObservedAddr(addr: Multiaddr, options?: ConfirmAddressOptions): void
 
   /**
    * Signal that we do not have confidence an observed multiaddr is publicly dialable -

--- a/packages/libp2p/src/address-manager/transport-addresses.ts
+++ b/packages/libp2p/src/address-manager/transport-addresses.ts
@@ -1,0 +1,116 @@
+import { isPrivate } from '@libp2p/utils/multiaddr/is-private'
+import type { AddressManagerComponents, AddressManagerInit } from './index.js'
+import type { Logger } from '@libp2p/interface'
+import type { NodeAddress } from '@libp2p/interface-internal'
+import type { Multiaddr } from '@multiformats/multiaddr'
+
+export const defaultValues = {
+  maxObservedAddresses: 10
+}
+
+interface TransportAddressMetadata {
+  verified: boolean
+  expires: number
+  lastVerified?: number
+}
+
+export class TransportAddresses {
+  private readonly log: Logger
+  private readonly addresses: Map<string, TransportAddressMetadata>
+  private readonly maxObservedAddresses: number
+
+  constructor (components: AddressManagerComponents, init: AddressManagerInit = {}) {
+    this.log = components.logger.forComponent('libp2p:address-manager:observed-addresses')
+    this.addresses = new Map()
+    this.maxObservedAddresses = init.maxObservedAddresses ?? defaultValues.maxObservedAddresses
+  }
+
+  get (multiaddr: Multiaddr, ttl: number): NodeAddress {
+    if (isPrivate(multiaddr)) {
+      return {
+        multiaddr,
+        verified: true,
+        type: 'transport',
+        expires: Date.now() + ttl,
+        lastVerified: Date.now()
+      }
+    }
+
+    const key = this.toKey(multiaddr)
+    let metadata = this.addresses.get(key)
+
+    if (metadata == null) {
+      metadata = {
+        verified: false,
+        expires: 0
+      }
+
+      this.addresses.set(key, metadata)
+    }
+
+    return {
+      multiaddr,
+      verified: metadata.verified,
+      type: 'transport',
+      expires: metadata.expires,
+      lastVerified: metadata.lastVerified
+    }
+  }
+
+  has (ma: Multiaddr): boolean {
+    const key = this.toKey(ma)
+    return this.addresses.has(key)
+  }
+
+  remove (ma: Multiaddr): boolean {
+    const key = this.toKey(ma)
+    const startingConfidence = this.addresses.get(key)?.verified ?? false
+
+    this.log('removing observed address %a', ma)
+    this.addresses.delete(key)
+
+    return startingConfidence
+  }
+
+  confirm (ma: Multiaddr, ttl: number): boolean {
+    const key = this.toKey(ma)
+    const metadata = this.addresses.get(key) ?? {
+      verified: false,
+      expires: 0,
+      lastVerified: 0
+    }
+
+    const startingConfidence = metadata.verified
+
+    metadata.verified = true
+    metadata.expires = Date.now() + ttl
+    metadata.lastVerified = Date.now()
+
+    this.addresses.set(key, metadata)
+
+    return startingConfidence
+  }
+
+  unconfirm (ma: Multiaddr, ttl: number): boolean {
+    const key = this.toKey(ma)
+    const metadata = this.addresses.get(key) ?? {
+      verified: false,
+      expires: 0
+    }
+
+    const startingConfidence = metadata.verified
+
+    metadata.verified = false
+    metadata.expires = Date.now() + ttl
+
+    this.addresses.set(key, metadata)
+
+    return startingConfidence
+  }
+
+  private toKey (ma: Multiaddr): string {
+    const options = ma.toOptions()
+
+    return `${options.host}-${options.port}-${options.transport}`
+  }
+}

--- a/packages/libp2p/src/connection-manager/index.ts
+++ b/packages/libp2p/src/connection-manager/index.ts
@@ -395,6 +395,10 @@ export class DefaultConnectionManager implements ConnectionManager, Startable {
     this.log('stopped')
   }
 
+  getMaxConnections (): number {
+    return this.maxConnections
+  }
+
   onConnect (evt: CustomEvent<Connection>): void {
     void this._onConnect(evt).catch(err => {
       this.log.error(err)

--- a/packages/libp2p/test/connection-manager/index.spec.ts
+++ b/packages/libp2p/test/connection-manager/index.spec.ts
@@ -43,6 +43,17 @@ describe('Connection Manager', () => {
     ).to.eventually.rejected('maxConnections must be greater')
   })
 
+  it('should return the max allowed connections', async () => {
+    const maxConnections = 10
+
+    connectionManager = new DefaultConnectionManager(components, {
+      ...defaultOptions,
+      maxConnections
+    })
+
+    expect(connectionManager.getMaxConnections()).to.equal(maxConnections)
+  })
+
   it('should reconnect to important peers on startup', async () => {
     const peerId = peerIdFromPrivateKey(await generateKeyPair('Ed25519'))
 


### PR DESCRIPTION
Some routers will allocate global unicast addresses which peers will treat as publicly routable.  The routers may also firewall any incoming traffic to these addresses so require confirmation that the node is reachable before publishing such addresses.

## Change checklist

- [x] I have performed a self-review of my own code
- [x] I have made corresponding changes to the documentation if necessary (this includes comments as well)
- [x] I have added tests that prove my fix is effective or that my feature works