### PR TITLE
feat: add getMaxConnections method to connection manager

### DIFF
--- a/packages/interface-compliance-tests/src/mocks/connection-manager.ts
+++ b/packages/interface-compliance-tests/src/mocks/connection-manager.ts
@@ -97,6 +97,10 @@ class MockConnectionManager implements ConnectionManager, Startable {
     return map
   }
 
+  getMaxConnections (): number {
+    return 10_000
+  }
+
   async openConnection (peerId: PeerId | Multiaddr | Multiaddr[]): Promise<Connection> {
     if (isMultiaddr(peerId)) {
       throw new UnsupportedOperationError('Dialing multiaddrs not supported')

--- a/packages/interface-internal/src/connection-manager/index.ts
+++ b/packages/interface-internal/src/connection-manager/index.ts
@@ -47,6 +47,12 @@ export interface ConnectionManager {
   getConnectionsMap(): PeerMap<Connection[]>
 
   /**
+   * Returns the configured maximum number of connections this connection
+   * manager will accept
+   */
+  getMaxConnections(): number
+
+  /**
    * Open a connection to a remote peer
    *
    * @example


### PR DESCRIPTION
Adds a method to expose the max connections config setting.

## Change checklist

- [x] I have performed a self-review of my own code
- [ ] I have made corresponding changes to the documentation if necessary (this includes comments as well)
- [ ] I have added tests that prove my fix is effective or that my feature works