### PR TITLE
fix: check max connections before reverifying addresses

### DIFF
--- a/packages/protocol-autonat/src/constants.ts
+++ b/packages/protocol-autonat/src/constants.ts
@@ -15,3 +15,4 @@ export const PROTOCOL_VERSION = '1.0.0'
 export const TIMEOUT = 30000
 export const MAX_INBOUND_STREAMS = 1
 export const MAX_OUTBOUND_STREAMS = 1
+export const DEFAULT_CONNECTION_THRESHOLD = 80

--- a/packages/protocol-autonat/src/index.ts
+++ b/packages/protocol-autonat/src/index.ts
@@ -31,7 +31,7 @@
  */
 
 import { AutoNATService } from './autonat.js'
-import type { ComponentLogger, Libp2pEvents, PeerId, TypedEventTarget } from '@libp2p/interface'
+import type { ComponentLogger, Libp2pEvents, PeerId, PeerStore, TypedEventTarget } from '@libp2p/interface'
 import type { AddressManager, ConnectionManager, RandomWalk, Registrar, TransportManager } from '@libp2p/interface-internal'
 
 export interface AutoNATServiceInit {
@@ -64,6 +64,17 @@ export interface AutoNATServiceInit {
    * How many parallel outbound autoNAT streams we allow per-connection
    */
   maxOutboundStreams?: number
+
+  /**
+   * If the number of currently open connections is higher than this value as
+   * a percentage of the maximum number of allowed connections, automatically
+   * reverify previously verified addresses since auto nat peers may find it
+   * hard to dial and will report that the address is not dialable leading this
+   * node to delist it.
+   *
+   * @default 80
+   */
+  connectionThreshold?: number
 }
 
 export interface AutoNATComponents {
@@ -75,6 +86,7 @@ export interface AutoNATComponents {
   logger: ComponentLogger
   randomWalk: RandomWalk
   events: TypedEventTarget<Libp2pEvents>
+  peerStore: PeerStore
 }
 
 export function autoNAT (init: AutoNATServiceInit = {}): (components: AutoNATComponents) => unknown {


### PR DESCRIPTION
If the node is close to it's max connections, skip reverification of previously verified addresses.

This is because the verifying node may find it hard to connect and then report that the address is undialable.

## Change checklist

- [x] I have performed a self-review of my own code
- [x] I have made corresponding changes to the documentation if necessary (this includes comments as well)
- [x] I have added tests that prove my fix is effective or that my feature works