### PR TITLE
fix: auto-confirm relay addresses

### DIFF
--- a/packages/interface-internal/src/address-manager/index.ts
+++ b/packages/interface-internal/src/address-manager/index.ts
@@ -50,6 +50,11 @@ export interface ConfirmAddressOptions {
    * Override the TTL of the observed address verification
    */
   ttl?: number
+
+  /**
+   * Allows hinting which type of address this is
+   */
+  type?: AddressType
 }
 
 export interface AddressManager {

--- a/packages/libp2p/src/address-manager/index.ts
+++ b/packages/libp2p/src/address-manager/index.ts
@@ -249,19 +249,19 @@ export class AddressManager implements AddressManagerInterface {
     addr = stripPeerId(addr, this.components.peerId)
     let startingConfidence = true
 
-    if (this.observed.has(addr)) {
+    if (options?.type === 'observed' || this.observed.has(addr)) {
       startingConfidence = this.observed.confirm(addr, options?.ttl ?? this.addressVerificationTTL)
     }
 
-    if (this.transportAddresses.has(addr)) {
+    if (options?.type === 'transport' || this.transportAddresses.has(addr)) {
       startingConfidence = this.transportAddresses.confirm(addr, options?.ttl ?? this.addressVerificationTTL)
     }
 
-    if (this.dnsMappings.has(addr)) {
+    if (options?.type === 'dns-mapping' || this.dnsMappings.has(addr)) {
       startingConfidence = this.dnsMappings.confirm(addr, options?.ttl ?? this.addressVerificationTTL)
     }
 
-    if (this.ipMappings.has(addr)) {
+    if (options?.type === 'ip-mapping' || this.ipMappings.has(addr)) {
       startingConfidence = this.ipMappings.confirm(addr, options?.ttl ?? this.addressVerificationTTL)
     }
 

--- a/packages/libp2p/test/addresses/address-manager.spec.ts
+++ b/packages/libp2p/test/addresses/address-manager.spec.ts
@@ -680,4 +680,38 @@ describe('Address Manager', () => {
       multiaddr(`/ip4/${internalIp}/${protocol}/${internalPort}/p2p/${peerId.toString()}`)
     ])
   })
+
+  it('should confirm unknown observed addresses with hints', () => {
+    const transportManager = stubInterface<TransportManager>()
+    const am = new AddressManager({
+      peerId,
+      transportManager,
+      peerStore,
+      events,
+      logger: defaultLogger()
+    })
+
+    const internalIp = '192.168.1.123'
+    const internalPort = 4567
+    const externalIp = '2a00:23c6:14b1:7e00:28b8:30d:944e:27f3'
+    const externalPort = 8910
+    const protocol = 'tcp'
+
+    // confirm address before fetching addresses
+    am.confirmObservedAddr(multiaddr(`/ip6/${externalIp}/${protocol}/${externalPort}`), {
+      type: 'transport'
+    })
+
+    // one loopback, one LAN address
+    transportManager.getAddrs.returns([
+      multiaddr(`/ip4/${internalIp}/${protocol}/${internalPort}`),
+      multiaddr(`/ip6/${externalIp}/${protocol}/${externalPort}`)
+    ])
+
+    // should have changed the address list
+    expect(am.getAddresses()).to.deep.equal([
+      multiaddr(`/ip4/${internalIp}/${protocol}/${internalPort}/p2p/${peerId.toString()}`),
+      multiaddr(`/ip6/${externalIp}/${protocol}/${externalPort}/p2p/${peerId.toString()}`)
+    ])
+  })
 })

--- a/packages/transport-circuit-relay-v2/src/transport/transport.ts
+++ b/packages/transport-circuit-relay-v2/src/transport/transport.ts
@@ -246,8 +246,10 @@ export class CircuitRelayTransport implements Transport<CircuitRelayDialEvents> 
    */
   createListener (options: CreateListenerOptions): Listener {
     return createListener({
+      peerId: this.peerId,
       connectionManager: this.connectionManager,
-      relayStore: this.reservationStore,
+      addressManager: this.addressManager,
+      reservationStore: this.reservationStore,
       logger: this.logger
     })
   }

--- a/packages/transport-circuit-relay-v2/test/listener.spec.ts
+++ b/packages/transport-circuit-relay-v2/test/listener.spec.ts
@@ -1,0 +1,101 @@
+import { generateKeyPair } from '@libp2p/crypto/keys'
+import { defaultLogger } from '@libp2p/logger'
+import { peerIdFromPrivateKey } from '@libp2p/peer-id'
+import { multiaddr } from '@multiformats/multiaddr'
+import { expect } from 'aegir/chai'
+import { stubInterface } from 'sinon-ts'
+import { createListener } from '../src/transport/listener.js'
+import { type ReservationStore } from '../src/transport/reservation-store.js'
+import type { ComponentLogger, Connection, Listener, PeerId } from '@libp2p/interface'
+import type { AddressManager, ConnectionManager } from '@libp2p/interface-internal'
+import type { StubbedInstance } from 'sinon-ts'
+
+export interface CircuitRelayTransportListenerComponents {
+  peerId: PeerId
+  connectionManager: StubbedInstance<ConnectionManager>
+  addressManager: StubbedInstance<AddressManager>
+  reservationStore: StubbedInstance<ReservationStore>
+  logger: ComponentLogger
+}
+
+describe('listener', () => {
+  let listener: Listener
+  let components: CircuitRelayTransportListenerComponents
+
+  beforeEach(async () => {
+    components = {
+      peerId: peerIdFromPrivateKey(await generateKeyPair('Ed25519')),
+      connectionManager: stubInterface(),
+      addressManager: stubInterface(),
+      reservationStore: stubInterface(),
+      logger: defaultLogger()
+    }
+
+    listener = createListener(components)
+  })
+
+  it('should auto-confirm discovered relay addresses', async () => {
+    await listener.listen(multiaddr('/p2p-circuit'))
+
+    expect(components.reservationStore.reserveRelay).to.have.property('called', true, 'did not begin relay search')
+
+    const relayPeer = peerIdFromPrivateKey(await generateKeyPair('Ed25519'))
+    const relayAddr = multiaddr(`/ip4/123.123.123.123/tcp/1234/p2p/${relayPeer}`)
+
+    const createdReservationListener = components.reservationStore.addEventListener.getCall(1).args[1]
+
+    if (typeof createdReservationListener === 'function') {
+      createdReservationListener(
+        new CustomEvent('relay:created-reservation', {
+          detail: {
+            relay: relayPeer,
+            details: {
+              type: 'discovered',
+              reservation: {
+                addrs: [
+                  relayAddr
+                ]
+              }
+            }
+          }
+        })
+      )
+    }
+
+    expect(components.addressManager.confirmObservedAddr.calledWith(
+      relayAddr.encapsulate('/p2p-circuit')
+    )).to.be.true()
+  })
+
+  it('should auto-confirm configured relay addresses', async () => {
+    const relayPeer = peerIdFromPrivateKey(await generateKeyPair('Ed25519'))
+    const relayAddr = multiaddr(`/ip4/123.123.123.123/tcp/1234/p2p/${relayPeer}/p2p-circuit`)
+    const conn = stubInterface<Connection>({
+      id: 'connection-id-1234',
+      remotePeer: relayPeer
+    })
+
+    components.connectionManager.openConnection.withArgs(relayAddr.decapsulate('/p2p-circuit')).resolves(conn)
+
+    components.reservationStore.addRelay.withArgs(relayPeer).resolves({
+      relay: relayPeer,
+      details: {
+        type: 'configured',
+        reservation: {
+          addrs: [
+            relayAddr.bytes
+          ],
+          expire: 100n
+        },
+        timeout: 0 as any,
+        connection: conn.id
+      }
+    })
+
+    await listener.listen(relayAddr)
+
+    expect(components.addressManager.confirmObservedAddr.calledWith(
+      relayAddr.encapsulate('/p2p-circuit')
+    )).to.be.true()
+  })
+})


### PR DESCRIPTION
After we have created a reservation on a relay, automatically confirm that it is publicly dialable.

Fixes #2883

## Change checklist

- [x] I have performed a self-review of my own code
- [ ] I have made corresponding changes to the documentation if necessary (this includes comments as well)
- [x] I have added tests that prove my fix is effective or that my feature works