### PR TITLE
fix: pass abort signal to peer routing query

### DIFF
--- a/packages/libp2p/src/connection-manager/dial-queue.ts
+++ b/packages/libp2p/src/connection-manager/dial-queue.ts
@@ -349,7 +349,7 @@ export class DialQueue {
         this.log('looking up multiaddrs for %p in the peer routing', peerId)
 
         try {
-          const peerInfo = await this.components.peerRouting.findPeer(peerId)
+          const peerInfo = await this.components.peerRouting.findPeer(peerId, options)
 
           this.log('found multiaddrs for %p in the peer routing', peerId, addrs.map(({ multiaddr }) => multiaddr.toString()))
 


### PR DESCRIPTION
Where we fail to find any addresses for a peer id we are dialing, and we perform a routing query to find their addresses, pass the dial abort signal in to the query to ensure it doesn't continue if we are no longer interested in the result.

## Change checklist

- [x] I have performed a self-review of my own code
- [ ] I have made corresponding changes to the documentation if necessary (this includes comments as well)
- [ ] I have added tests that prove my fix is effective or that my feature works