### PR TITLE
fix: increase max autonat streams and limit incoming message size

### DIFF
--- a/packages/protocol-autonat/src/constants.ts
+++ b/packages/protocol-autonat/src/constants.ts
@@ -13,6 +13,7 @@ export const PROTOCOL_NAME = 'autonat'
  */
 export const PROTOCOL_VERSION = '1.0.0'
 export const TIMEOUT = 30000
-export const MAX_INBOUND_STREAMS = 1
-export const MAX_OUTBOUND_STREAMS = 1
+export const MAX_INBOUND_STREAMS = 2
+export const MAX_OUTBOUND_STREAMS = 20
 export const DEFAULT_CONNECTION_THRESHOLD = 80
+export const MAX_MESSAGE_SIZE = 8192

--- a/packages/protocol-autonat/src/index.ts
+++ b/packages/protocol-autonat/src/index.ts
@@ -75,6 +75,14 @@ export interface AutoNATServiceInit {
    * @default 80
    */
   connectionThreshold?: number
+
+  /**
+   * How large incoming autonat messages are allowed to be in bytes. If messages
+   * larger than this are received the stream will be reset.
+   *
+   * @default 8192
+   */
+  maxMessageSize?: number
 }
 
 export interface AutoNATComponents {


### PR DESCRIPTION
Allows more outgoing streams to be open at the same time and limits the allowed incoming message size.

## Change checklist

- [x] I have performed a self-review of my own code
- [ ] I have made corresponding changes to the documentation if necessary (this includes comments as well)
- [ ] I have added tests that prove my fix is effective or that my feature works