### PR TITLE
fix: return empty address list during listen operation

### DIFF
--- a/packages/transport-websockets/src/listener.ts
+++ b/packages/transport-websockets/src/listener.ts
@@ -341,18 +341,18 @@ export class WebSocketListener extends TypedEventEmitter<ListenerEvents> impleme
   }
 
   getAddrs (): Multiaddr[] {
+    if (this.listeningMultiaddr == null) {
+      throw new Error('Listener is not ready yet')
+    }
+
     const address = this.server.address()
 
     if (address == null) {
-      throw new Error('Listener is not ready yet')
+      return []
     }
 
     if (typeof address === 'string') {
       throw new Error('Wrong address type received - expected AddressInfo, got string - are you trying to listen on a unix socket?')
-    }
-
-    if (this.listeningMultiaddr == null) {
-      throw new Error('Listener is not ready yet')
     }
 
     const options = this.listeningMultiaddr.toOptions()

--- a/packages/transport-websockets/test/node.ts
+++ b/packages/transport-websockets/test/node.ts
@@ -73,6 +73,22 @@ describe('listen', () => {
       void listener.listen(ma)
     })
 
+    it('should return an empty address list when `getAddrs` called before listening has finished', async () => {
+      listener = ws.createListener({ upgrader })
+
+      void listener.listen(ma)
+
+      // call getAddrs before sockets have opened
+      expect(listener.getAddrs()).to.be.empty()
+    })
+
+    it('should throw when `.getAddrs` called before `.listen`', async () => {
+      listener = ws.createListener({ upgrader })
+
+      // call getAddrs before sockets have opened
+      expect(() => listener.getAddrs()).to.throw(/not ready/)
+    })
+
     it('should error on starting two listeners on same address', async () => {
       listener = ws.createListener({ upgrader })
       const dumbServer = http.createServer()


### PR DESCRIPTION
If `getAddrs` is called on a WS listener after `.listen` has been called but before any socket(s) have opened, return an empty list instead of throwing.

Fixes #2902

## Change checklist

- [x] I have performed a self-review of my own code
- [ ] I have made corresponding changes to the documentation if necessary (this includes comments as well)
- [x] I have added tests that prove my fix is effective or that my feature works