### PR TITLE
fix: access components via property

### DIFF
--- a/packages/auto-tls/src/index.ts
+++ b/packages/auto-tls/src/index.ts
@@ -2,7 +2,7 @@
  * @packageDocumentation
  *
  * When a publicly dialable address is detected, use the p2p-forge service at
- * https://registration.libp2p.direct to acquire a valid Let's Encrypted-backed
+ * https://registration.libp2p.direct to acquire a valid Let's Encrypt-backed
  * TLS certificate, which the node can then use with the relevant transports.
  *
  * The node must be configured with a listener for at least one of the following


### PR DESCRIPTION
To allow declaring services in any order, access components via a components property after all services are constructed.

## Change checklist

- [x] I have performed a self-review of my own code
- [ ] I have made corresponding changes to the documentation if necessary (this includes comments as well)
- [ ] I have added tests that prove my fix is effective or that my feature works