### PR TITLE
fix: add toStringTag for auto-tls

### DIFF
--- a/packages/auto-tls/src/auto-tls.ts
+++ b/packages/auto-tls/src/auto-tls.ts
@@ -84,6 +84,8 @@ export class AutoTLS implements AutoTLSInterface {
     })
   }
 
+  readonly [Symbol.toStringTag] = '@libp2p/auto-tls'
+
   readonly [serviceCapabilities]: string[] = [
     '@libp2p/auto-tls'
   ]


### PR DESCRIPTION
To generate more helpful error messages, add the `toStringTag` symbol.

## Change checklist

- [x] I have performed a self-review of my own code
- [ ] I have made corresponding changes to the documentation if necessary (this includes comments as well)
- [ ] I have added tests that prove my fix is effective or that my feature works