### PR TITLE
docs: correct typo in private key type

### DIFF
--- a/packages/interface/src/keys/index.ts
+++ b/packages/interface/src/keys/index.ts
@@ -193,7 +193,7 @@ export interface Ed25519PrivateKey {
   readonly publicKey: Ed25519PublicKey
 
   /**
-   * The raw public key bytes
+   * The raw private key bytes
    */
   readonly raw: Uint8Array
 
@@ -221,7 +221,7 @@ export interface Secp256k1PrivateKey {
   readonly publicKey: Secp256k1PublicKey
 
   /**
-   * The raw public key bytes
+   * The raw private key bytes
    */
   readonly raw: Uint8Array
 


### PR DESCRIPTION
## What's in this PR

- Correct small typo. I'm pretty sure the `raw` field on the private key types is the actual private key

## Change checklist

- [ ] I have performed a self-review of my own code
- [ ] I have made corresponding changes to the documentation if necessary (this includes comments as well)
- [ ] I have added tests that prove my fix is effective or that my feature works