### PR TITLE
fix: allow overriding mss mode

### DIFF
--- a/packages/integration-tests/test/dcutr.node.ts
+++ b/packages/integration-tests/test/dcutr.node.ts
@@ -120,7 +120,7 @@ describe('dcutr', () => {
     })
   })
 
-  // TODO: how to test this?
+  // TODO: how to test this? We need to simulate a firewall of some sort
   describe.skip('dctur connection upgrade', () => {
     beforeEach(async () => {
       libp2pA = await createLibp2p(createBaseOptions({
@@ -162,7 +162,7 @@ describe('dcutr', () => {
       }
     })
 
-    it('should perform connection upgrade', async () => {
+    it('should perform unilateral connection upgrade', async () => {
       const relayedAddress = multiaddr(`/ip4/127.0.0.1/tcp/${RELAY_PORT}/p2p/${relay.peerId}/p2p-circuit/p2p/${libp2pB.peerId}`)
       const connection = await libp2pA.dial(relayedAddress)
 
@@ -171,6 +171,20 @@ describe('dcutr', () => {
 
       // wait for DCUtR unilateral upgrade
       await waitForOnlyDirectConnections()
+
+      // should have closed the relayed connection
+      expect(libp2pA.getConnections(libp2pB.peerId)).to.have.lengthOf(1, 'had multiple connections to remote peer')
+    })
+
+    it('should perform holepunch using TCP Simultaneous Connect', async () => {
+      const relayedAddress = multiaddr(`/ip4/127.0.0.1/tcp/${RELAY_PORT}/p2p/${relay.peerId}/p2p-circuit/p2p/${libp2pB.peerId}`)
+      const connection = await libp2pA.dial(relayedAddress)
+
+      // connection should be limited
+      expect(connection).to.have.property('limits').that.is.ok()
+
+      // wait for DCUtR TCP Simultaneous Connect upgrade
+      // TODO: implement me
 
       // should have closed the relayed connection
       expect(libp2pA.getConnections(libp2pB.peerId)).to.have.lengthOf(1, 'had multiple connections to remote peer')

--- a/packages/interface-internal/src/connection-manager/index.ts
+++ b/packages/interface-internal/src/connection-manager/index.ts
@@ -20,6 +20,18 @@ export interface OpenConnectionOptions extends AbortOptions, ProgressOptions<Ope
    * @default false
    */
   force?: boolean
+
+  /**
+   * By default a newly opened outgoing connection operates in initiator mode
+   * during negotiation of encryption/muxing protocols using multistream-select.
+   *
+   * In some cases such as when the dialer is trying to achieve TCP Simultaneous
+   * Connect using the DCUtR protocol, it may wish to act in responder mode, if
+   * so pass `false` here.
+   *
+   * @default true
+   */
+  initiator?: boolean
 }
 
 export interface ConnectionManager {

--- a/packages/interface/src/transport/index.ts
+++ b/packages/interface/src/transport/index.ts
@@ -122,6 +122,7 @@ export interface UpgraderOptions<ConnectionUpgradeEvents extends ProgressEvent =
   skipProtection?: boolean
   muxerFactory?: StreamMuxerFactory
   limits?: ConnectionLimits
+  initiator?: boolean
 }
 
 export type InboundConnectionUpgradeEvents =

--- a/packages/libp2p/src/upgrader.ts
+++ b/packages/libp2p/src/upgrader.ts
@@ -228,7 +228,14 @@ export class DefaultUpgrader implements Upgrader {
         await this.shouldBlockConnection('denyOutboundConnection', remotePeerId, maConn)
       }
 
-      return await this._performUpgrade(maConn, 'outbound', opts)
+      let direction: 'inbound' | 'outbound' = 'outbound'
+
+      // act as the multistream-select server if we are not to be the initiator
+      if (opts.initiator === false) {
+        direction = 'inbound'
+      }
+
+      return await this._performUpgrade(maConn, direction, opts)
     } catch (err) {
       this.metrics.errors?.increment({
         outbound: true

--- a/packages/protocol-dcutr/src/dcutr.ts
+++ b/packages/protocol-dcutr/src/dcutr.ts
@@ -192,10 +192,13 @@ export class DefaultDCUtRService implements Startable {
         // https://github.com/libp2p/specs/blob/master/relay/DCUtR.md#the-protocol
 
         this.log('B dialing', multiaddrs)
-        // Upon expiry of the timer, B dials the address to A.
+        // Upon expiry of the timer, B dials the address to A and acts as the
+        // multistream-select server
         const conn = await this.connectionManager.openConnection(multiaddrs, {
           signal: options.signal,
-          priority: DCUTR_DIAL_PRIORITY
+          priority: DCUTR_DIAL_PRIORITY,
+          force: true,
+          initiator: false
         })
 
         this.log('DCUtR to %p succeeded to address %a, closing relayed connection', relayedConnection.remotePeer, conn.remoteAddr)


### PR DESCRIPTION
According to the DCUtR spec to complete a holepunch via TCP Simultaneous Connect, the dialer (B) needs to act as a multistream-select server rather than a client, otherwise both sides will try to initiate mss which will fail.

## Change checklist

- [x] I have performed a self-review of my own code
- [ ] I have made corresponding changes to the documentation if necessary (this includes comments as well)
- [ ] I have added tests that prove my fix is effective or that my feature works