### PR TITLE
fix: use publicKey.x instead of privateKey.x

### DIFF
--- a/packages/crypto/src/keys/ed25519/index.ts
+++ b/packages/crypto/src/keys/ed25519/index.ts
@@ -45,7 +45,7 @@ export function generateKey (): Uint8ArrayKeyPair {
   // @ts-expect-error node types are missing jwk as a format
   const privateKeyRaw = uint8arrayFromString(key.privateKey.d, 'base64url')
   // @ts-expect-error node types are missing jwk as a format
-  const publicKeyRaw = uint8arrayFromString(key.privateKey.x, 'base64url')
+  const publicKeyRaw = uint8arrayFromString(key.publicKey.x, 'base64url')
 
   return {
     privateKey: uint8arrayConcat([privateKeyRaw, publicKeyRaw], privateKeyRaw.byteLength + publicKeyRaw.byteLength),


### PR DESCRIPTION
## fix: ed25519 generateKeyPairSync: use publicKey.x instead of privateKey.x
<!---
The title of the PR will be the commit message of the merge commit, so please make sure it is descriptive enough.
We utilize the Conventional Commits specification for our commit messages. See <https://www.conventionalcommits.org/en/v1.0.0/#specification> for more information.
The commit tag types can be of one of the following: feat, fix, deps, refactor, chore, docs. See <https://github.com/libp2p/js-libp2p/blob/master/.github/workflows/main.yml#L235-L242>
The title must also be fewer than 72 characters long or it will fail the Semantic PR check. See <https://github.com/libp2p/js-libp2p/blob/master/.github/workflows/semantic-pull-request.yml>
--->

## Description

<!--
Please write a summary of your changes and why you made them.
Please include any relevant issues in here, for example:
Related https://github.com/libp2p/js-libp2p/issues/ABCD.
Fixes https://github.com/libp2p/js-libp2p/issues/XYZ.
-->

Although [RFC7518 6.3.2](https://datatracker.ietf.org/doc/html/rfc7518#section-6.3.2) specifies that private key JWKs must include all the fields present in the public key, this is not the case for the implementation of `node:crypto.generateKeyPairSync` in the deno runtime.

While Node returns the (same) `x` property in both, the `privateKey` and the `publicKey`, Deno only returns the `x` property in `publicKey` (i.e. [no x here](https://github.com/denoland/deno/blob/88490d092751288f736855b2418a4da606a31ce7/ext/node/ops/crypto/keys.rs#L1475)).

This change should not affect any Node users, but would enable the use of libp2p on Deno.


## Notes & open questions

<!--
Any notes, remarks or open questions you have to make about the PR which don't need to go into the final commit message.
-->

## Change checklist

- [x] I have performed a self-review of my own code
- [ ] I have made corresponding changes to the documentation if necessary (this includes comments as well)
- [ ] I have added tests that prove my fix is effective or that my feature works