### PR TITLE
chore: disable Firefox WebTransport interop tests

### DIFF
--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -231,9 +231,7 @@ jobs:
       - uses: libp2p/test-plans/.github/actions/run-interop-ping-test@master
         with:
           test-filter: js-libp2p-head
-          # disable firefox interop (revert once playwright runs ff 136.0)
-          # extra-versions: ${{ github.workspace }}/interop/node-version.json ${{ github.workspace }}/interop/chromium-version.json ${{ github.workspace }}/interop/firefox-version.json
-          extra-versions: ${{ github.workspace }}/interop/node-version.json ${{ github.workspace }}/interop/chromium-version.json
+          extra-versions: ${{ github.workspace }}/interop/node-version.json ${{ github.workspace }}/interop/chromium-version.json ${{ github.workspace }}/interop/firefox-version.json
           s3-cache-bucket: ${{ vars.S3_LIBP2P_BUILD_CACHE_BUCKET_NAME }}
           s3-access-key-id: ${{ vars.S3_LIBP2P_BUILD_CACHE_AWS_ACCESS_KEY_ID }}
           s3-secret-access-key: ${{ secrets.S3_LIBP2P_BUILD_CACHE_AWS_SECRET_ACCESS_KEY }}

--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -231,7 +231,9 @@ jobs:
       - uses: libp2p/test-plans/.github/actions/run-interop-ping-test@master
         with:
           test-filter: js-libp2p-head
-          extra-versions: ${{ github.workspace }}/interop/node-version.json ${{ github.workspace }}/interop/chromium-version.json ${{ github.workspace }}/interop/firefox-version.json
+          # disable firefox interop (revert once playwright runs ff 136.0)
+          # extra-versions: ${{ github.workspace }}/interop/node-version.json ${{ github.workspace }}/interop/chromium-version.json ${{ github.workspace }}/interop/firefox-version.json
+          extra-versions: ${{ github.workspace }}/interop/node-version.json ${{ github.workspace }}/interop/chromium-version.json
           s3-cache-bucket: ${{ vars.S3_LIBP2P_BUILD_CACHE_BUCKET_NAME }}
           s3-access-key-id: ${{ vars.S3_LIBP2P_BUILD_CACHE_AWS_ACCESS_KEY_ID }}
           s3-secret-access-key: ${{ secrets.S3_LIBP2P_BUILD_CACHE_AWS_SECRET_ACCESS_KEY }}

--- a/interop/firefox-version.json
+++ b/interop/firefox-version.json
@@ -3,10 +3,6 @@
   "containerImageID": "firefox-js-libp2p-head",
   "transports": [
     {
-      "name": "webtransport",
-      "onlyDial": true
-    },
-    {
       "name": "webrtc-direct",
       "onlyDial": true
     },


### PR DESCRIPTION
Firefox 134.0 has broken interop as it can no longer dial go-libp2p via WebTransport.

The regression is fixed in Firefox Nightly (136.0) so disable Firefox WebTransport interop testing until that has been released and Playwright has upgraded the version it supports (likely some time in March) or until go-libp2p ships a fix that allows dialling it again.

## Change checklist

- [ ] I have performed a self-review of my own code
- [ ] I have made corresponding changes to the documentation if necessary (this includes comments as well)
- [ ] I have added tests that prove my fix is effective or that my feature works