### PR TITLE
fix: send user agent during auto tls

### DIFF
--- a/packages/auto-tls/src/auto-tls.ts
+++ b/packages/auto-tls/src/auto-tls.ts
@@ -1,3 +1,4 @@
+import process from 'node:process'
 import { ClientAuth } from '@libp2p/http-fetch/auth'
 import { serviceCapabilities, serviceDependencies, setMaxListeners, start, stop } from '@libp2p/interface'
 import { debounce } from '@libp2p/utils/debounce'
@@ -340,7 +341,8 @@ export class AutoTLS implements AutoTLSInterface {
     const response = await this.clientAuth.authenticatedFetch(endpoint, {
       method: 'POST',
       headers: {
-        'Content-Type': 'application/json'
+        'Content-Type': 'application/json',
+        'User-Agent': `${this.components.nodeInfo.name}/${this.components.nodeInfo.version} ${process.release.name}/${process.version.replaceAll('v', '')}`
       },
       body: JSON.stringify({
         Value: keyAuthorization,

--- a/packages/auto-tls/src/auto-tls.ts
+++ b/packages/auto-tls/src/auto-tls.ts
@@ -54,6 +54,7 @@ export class AutoTLS implements AutoTLSInterface {
   private readonly domain
   private readonly domainMapper: DomainMapper
   private readonly autoConfirmAddress: boolean
+  private readonly userAgent: string
 
   constructor (components: AutoTLSComponents, init: AutoTLSInit = {}) {
     this.log = components.logger.forComponent('libp2p:auto-tls')
@@ -78,6 +79,8 @@ export class AutoTLS implements AutoTLSInterface {
     const base36EncodedPeer = base36.encode(this.components.peerId.toCID().bytes)
     this.domain = `${base36EncodedPeer}.${this.forgeDomain}`
     this.email = `${base36EncodedPeer}@${this.forgeDomain}`
+    this.userAgent = init.userAgent ?? `${this.components.nodeInfo.name}/${this.components.nodeInfo.version} ${process.release.name}/${process.version.replaceAll('v', '')}`
+    acme.axios.defaults.headers.common['User-Agent'] = this.userAgent
 
     this.domainMapper = new DomainMapper(components, {
       ...init,
@@ -342,7 +345,7 @@ export class AutoTLS implements AutoTLSInterface {
       method: 'POST',
       headers: {
         'Content-Type': 'application/json',
-        'User-Agent': `${this.components.nodeInfo.name}/${this.components.nodeInfo.version} ${process.release.name}/${process.version.replaceAll('v', '')}`
+        'User-Agent': this.userAgent
       },
       body: JSON.stringify({
         Value: keyAuthorization,

--- a/packages/auto-tls/src/index.ts
+++ b/packages/auto-tls/src/index.ts
@@ -60,7 +60,7 @@
  */
 
 import { AutoTLS as AutoTLSClass } from './auto-tls.js'
-import type { PeerId, PrivateKey, ComponentLogger, Libp2pEvents, TypedEventTarget, TLSCertificate } from '@libp2p/interface'
+import type { PeerId, PrivateKey, ComponentLogger, Libp2pEvents, TypedEventTarget, TLSCertificate, NodeInfo } from '@libp2p/interface'
 import type { AddressManager } from '@libp2p/interface-internal'
 import type { Keychain } from '@libp2p/keychain'
 import type { Datastore } from 'interface-datastore'
@@ -73,6 +73,7 @@ export interface AutoTLSComponents {
   events: TypedEventTarget<Libp2pEvents>
   keychain: Keychain
   datastore: Datastore
+  nodeInfo: NodeInfo
 }
 
 export interface AutoTLSInit {

--- a/packages/auto-tls/src/index.ts
+++ b/packages/auto-tls/src/index.ts
@@ -182,6 +182,13 @@ export interface AutoTLSInit {
    * @default false
    */
   autoConfirmAddress?: boolean
+
+  /**
+   * The User-Agent header sent during HTTP requests
+   *
+   * @default "js-libp2p/${version} node/${version}"
+   */
+  userAgent?: string
 }
 
 export interface AutoTLS {

--- a/packages/auto-tls/test/index.spec.ts
+++ b/packages/auto-tls/test/index.spec.ts
@@ -15,7 +15,7 @@ import { AutoTLS } from '../src/auto-tls.js'
 import { DEFAULT_CERTIFICATE_DATASTORE_KEY, DEFAULT_CERTIFICATE_PRIVATE_KEY_NAME } from '../src/constants.js'
 import { importFromPem } from '../src/utils.js'
 import { CERT, CERT_FOR_OTHER_KEY, EXPIRED_CERT, INVALID_CERT, PRIVATE_KEY_PEM } from './fixtures/cert.js'
-import type { ComponentLogger, Libp2pEvents, Peer, PeerId, PrivateKey, RSAPrivateKey, TypedEventTarget } from '@libp2p/interface'
+import type { ComponentLogger, Libp2pEvents, NodeInfo, Peer, PeerId, PrivateKey, RSAPrivateKey, TypedEventTarget } from '@libp2p/interface'
 import type { AddressManager, NodeAddress } from '@libp2p/interface-internal'
 import type { Keychain } from '@libp2p/keychain'
 import type { StubbedInstance } from 'sinon-ts'
@@ -28,6 +28,7 @@ interface StubbedAutoTLSComponents {
   events: TypedEventTarget<Libp2pEvents>
   keychain: StubbedInstance<Keychain>
   datastore: Datastore
+  nodeInfo: NodeInfo
 }
 
 describe('auto-tls', () => {
@@ -46,7 +47,11 @@ describe('auto-tls', () => {
       addressManager: stubInterface<AddressManager>(),
       events: new TypedEventEmitter(),
       keychain: stubInterface<Keychain>(),
-      datastore: new MemoryDatastore()
+      datastore: new MemoryDatastore(),
+      nodeInfo: {
+        name: 'name',
+        version: 'version'
+      }
     }
 
     // a mixture of LAN and public addresses


### PR DESCRIPTION
Sends a js-libp2p specific user agent to libp2p.direct while configuring the ACME DNS-01 response.

The user agent can be overridden but the default is something like:

```
js-libp2p/2.5.1 node/20.1.5
```

Refs: https://github.com/ipshipyard/p2p-forge/issues/48

## Change checklist

- [x] I have performed a self-review of my own code
- [ ] I have made corresponding changes to the documentation if necessary (this includes comments as well)
- [ ] I have added tests that prove my fix is effective or that my feature works