### PR TITLE
feat: allow changing repeating task interval and timeout

### DIFF
--- a/packages/utils/test/repeating-task.spec.ts
+++ b/packages/utils/test/repeating-task.spec.ts
@@ -67,4 +67,50 @@ describe('repeating-task', () => {
 
     expect(count).to.be.greaterThan(1)
   })
+
+  it('should update the interval of a task', async () => {
+    let count = 0
+
+    const task = repeatingTask(() => {
+      count++
+
+      if (count === 1) {
+        task.setInterval(2000)
+      }
+    }, 100)
+    task.start()
+
+    await delay(1000)
+
+    task.stop()
+
+    expect(count).to.equal(1)
+  })
+
+  it('should update the timeout of a task', async () => {
+    let count = 0
+
+    const task = repeatingTask(async (options) => {
+      // simulate a delay
+      await delay(100)
+
+      if (options?.signal?.aborted !== true) {
+        count++
+      }
+
+      if (count === 1) {
+        // set the task timeout to less than our simulated delay
+        task.setTimeout(10)
+      }
+    }, 100, {
+      timeout: 500
+    })
+    task.start()
+
+    await delay(1000)
+
+    task.stop()
+
+    expect(count).to.equal(1)
+  })
 })


### PR DESCRIPTION
To allow for changing the frequency and timeout of repeating tasks add `setInterval` and `setTimeout` methods to the task.

This lets us repeat a task often to start with, then slow down the repetition once a successful result has occured.

## Change checklist

- [x] I have performed a self-review of my own code
- [x] I have made corresponding changes to the documentation if necessary (this includes comments as well)
- [x] I have added tests that prove my fix is effective or that my feature works