### PR TITLE
fix: set expires on observed address

### DIFF
--- a/packages/libp2p/src/address-manager/observed-addresses.ts
+++ b/packages/libp2p/src/address-manager/observed-addresses.ts
@@ -84,6 +84,7 @@ export class ObservedAddresses {
     }
     const startingConfidence = metadata.verified
     metadata.verified = true
+    metadata.expires = Date.now() + ttl
     metadata.lastVerified = Date.now()
 
     this.log('marking observed address %a as verified', addrString)


### PR DESCRIPTION
Without this we continually re-validate observed addresses which causes a lot of unecessary network activity.

## Change checklist

- [x] I have performed a self-review of my own code
- [ ] I have made corresponding changes to the documentation if necessary (this includes comments as well)
- [ ] I have added tests that prove my fix is effective or that my feature works