### PR TITLE
chore: test WebTransport in Firefox interop tests again

### DIFF
--- a/interop/firefox-version.json
+++ b/interop/firefox-version.json
@@ -3,6 +3,10 @@
   "containerImageID": "firefox-js-libp2p-head",
   "transports": [
     {
+      "name": "webtransport",
+      "onlyDial": true
+    },
+    {
       "name": "webrtc-direct",
       "onlyDial": true
     },


### PR DESCRIPTION
Merge when Firefox fixes the breakage in 134

Reverts libp2p/js-libp2p#2930
Closes #2931