### PR TITLE
fix: include platform in user agent

### DIFF
--- a/packages/auto-tls/src/auto-tls.ts
+++ b/packages/auto-tls/src/auto-tls.ts
@@ -1,4 +1,3 @@
-import process from 'node:process'
 import { ClientAuth } from '@libp2p/http-fetch/auth'
 import { serviceCapabilities, serviceDependencies, setMaxListeners, start, stop } from '@libp2p/interface'
 import { debounce } from '@libp2p/utils/debounce'
@@ -54,7 +53,6 @@ export class AutoTLS implements AutoTLSInterface {
   private readonly domain
   private readonly domainMapper: DomainMapper
   private readonly autoConfirmAddress: boolean
-  private readonly userAgent: string
 
   constructor (components: AutoTLSComponents, init: AutoTLSInit = {}) {
     this.log = components.logger.forComponent('libp2p:auto-tls')
@@ -79,8 +77,7 @@ export class AutoTLS implements AutoTLSInterface {
     const base36EncodedPeer = base36.encode(this.components.peerId.toCID().bytes)
     this.domain = `${base36EncodedPeer}.${this.forgeDomain}`
     this.email = `${base36EncodedPeer}@${this.forgeDomain}`
-    this.userAgent = init.userAgent ?? `${this.components.nodeInfo.name}/${this.components.nodeInfo.version} ${process.release.name}/${process.version.replaceAll('v', '')}`
-    acme.axios.defaults.headers.common['User-Agent'] = this.userAgent
+    acme.axios.defaults.headers.common['User-Agent'] = this.components.nodeInfo.userAgent
 
     this.domainMapper = new DomainMapper(components, {
       ...init,
@@ -345,7 +342,7 @@ export class AutoTLS implements AutoTLSInterface {
       method: 'POST',
       headers: {
         'Content-Type': 'application/json',
-        'User-Agent': this.userAgent
+        'User-Agent': this.components.nodeInfo.userAgent
       },
       body: JSON.stringify({
         Value: keyAuthorization,

--- a/packages/auto-tls/src/index.ts
+++ b/packages/auto-tls/src/index.ts
@@ -182,13 +182,6 @@ export interface AutoTLSInit {
    * @default false
    */
   autoConfirmAddress?: boolean
-
-  /**
-   * The User-Agent header sent during HTTP requests
-   *
-   * @default "js-libp2p/${version} node/${version}"
-   */
-  userAgent?: string
 }
 
 export interface AutoTLS {

--- a/packages/auto-tls/src/index.ts
+++ b/packages/auto-tls/src/index.ts
@@ -182,7 +182,6 @@ export interface AutoTLSInit {
    * @default false
    */
   autoConfirmAddress?: boolean
-  
   /**
    * The User-Agent header sent during HTTP requests
    *

--- a/packages/auto-tls/src/index.ts
+++ b/packages/auto-tls/src/index.ts
@@ -182,6 +182,7 @@ export interface AutoTLSInit {
    * @default false
    */
   autoConfirmAddress?: boolean
+
   /**
    * The User-Agent header sent during HTTP requests
    *

--- a/packages/auto-tls/src/index.ts
+++ b/packages/auto-tls/src/index.ts
@@ -182,6 +182,14 @@ export interface AutoTLSInit {
    * @default false
    */
   autoConfirmAddress?: boolean
+  
+  /**
+   * The User-Agent header sent during HTTP requests
+   *
+   * @default "js-libp2p/${version} node/${version}"
+   * @deprecated Use `nodeInfo.userAgent` in the main libp2p config instead
+   */
+  userAgent?: string
 }
 
 export interface AutoTLS {

--- a/packages/auto-tls/test/index.spec.ts
+++ b/packages/auto-tls/test/index.spec.ts
@@ -50,7 +50,8 @@ describe('auto-tls', () => {
       datastore: new MemoryDatastore(),
       nodeInfo: {
         name: 'name',
-        version: 'version'
+        version: 'version',
+        userAgent: 'userAgent'
       }
     }
 

--- a/packages/interface/src/index.ts
+++ b/packages/interface/src/index.ts
@@ -723,6 +723,11 @@ export interface NodeInfo {
    * The implementation version
    */
   version: string
+
+  /**
+   * A string that contains information about the implementation and runtime
+   */
+  userAgent: string
 }
 
 /**

--- a/packages/libp2p/.aegir.js
+++ b/packages/libp2p/.aegir.js
@@ -2,5 +2,10 @@
 export default {
   build: {
     bundlesizeMax: '95KB'
+  },
+  dependencyCheck: {
+    ignore: [
+      'react-native'
+    ]
   }
 }

--- a/packages/libp2p/package.json
+++ b/packages/libp2p/package.json
@@ -52,6 +52,10 @@
       "types": "./dist/src/index.d.ts",
       "import": "./dist/src/index.js"
     },
+    "./user-agent": {
+      "types": "./dist/src/user-agent.d.ts",
+      "import": "./dist/src/user-agent.js"
+    },
     "./version": {
       "types": "./dist/src/version.d.ts",
       "import": "./dist/src/version.js"
@@ -132,11 +136,13 @@
   },
   "browser": {
     "./dist/src/connection-manager/constants.js": "./dist/src/connection-manager/constants.browser.js",
-    "./dist/src/config/connection-gater.js": "./dist/src/config/connection-gater.browser.js"
+    "./dist/src/config/connection-gater.js": "./dist/src/config/connection-gater.browser.js",
+    "./dist/src/user-agent.js": "./dist/src/user-agent.browser.js"
   },
   "react-native": {
     "./dist/src/connection-manager/constants.js": "./dist/src/connection-manager/constants.browser.js",
-    "./dist/src/config/connection-gater.js": "./dist/src/config/connection-gater.browser.js"
+    "./dist/src/config/connection-gater.js": "./dist/src/config/connection-gater.browser.js",
+    "./dist/src/user-agent.js": "./dist/src/user-agent.react-native.js"
   },
   "sideEffects": false
 }

--- a/packages/libp2p/package.json
+++ b/packages/libp2p/package.json
@@ -132,7 +132,8 @@
     "p-wait-for": "^5.0.2",
     "sinon": "^19.0.2",
     "sinon-ts": "^2.0.0",
-    "uint8arraylist": "^2.4.8"
+    "uint8arraylist": "^2.4.8",
+    "wherearewe": "^2.0.1"
   },
   "browser": {
     "./dist/src/connection-manager/constants.js": "./dist/src/connection-manager/constants.browser.js",

--- a/packages/libp2p/src/index.ts
+++ b/packages/libp2p/src/index.ts
@@ -50,7 +50,7 @@ export interface Libp2pInit<T extends ServiceMap = ServiceMap> {
   /**
    * Metadata about the node - implementation name, version number, etc
    */
-  nodeInfo?: NodeInfo
+  nodeInfo?: Partial<NodeInfo>
 
   /**
    * Addresses for transport listening and to advertise to the network

--- a/packages/libp2p/src/libp2p.ts
+++ b/packages/libp2p/src/libp2p.ts
@@ -19,6 +19,7 @@ import { RandomWalk } from './random-walk.js'
 import { DefaultRegistrar } from './registrar.js'
 import { DefaultTransportManager } from './transport-manager.js'
 import { DefaultUpgrader } from './upgrader.js'
+import { userAgent } from './user-agent.js'
 import * as pkg from './version.js'
 import type { Components } from './components.js'
 import type { Libp2p as Libp2pInterface, Libp2pInit } from './index.js'
@@ -64,13 +65,18 @@ export class Libp2p<T extends ServiceMap = ServiceMap> extends TypedEventEmitter
     this.log = this.logger.forComponent('libp2p')
     // @ts-expect-error {} may not be of type T
     this.services = {}
+
+    const nodeInfoName = init.nodeInfo?.name ?? pkg.name
+    const nodeInfoVersion = init.nodeInfo?.version ?? pkg.name
+
     // @ts-expect-error defaultComponents is missing component types added later
     const components = this.components = defaultComponents({
       peerId: init.peerId,
       privateKey: init.privateKey,
-      nodeInfo: init.nodeInfo ?? {
-        name: pkg.name,
-        version: pkg.version
+      nodeInfo: {
+        name: nodeInfoName,
+        version: nodeInfoVersion,
+        userAgent: init.nodeInfo?.userAgent ?? userAgent(nodeInfoName, nodeInfoVersion)
       },
       logger: this.logger,
       events,

--- a/packages/libp2p/src/user-agent.browser.ts
+++ b/packages/libp2p/src/user-agent.browser.ts
@@ -1,0 +1,5 @@
+import * as pkg from './version.js'
+
+export function userAgent (name?: string, version?: string): string {
+  return `${name ?? pkg.name}/${version ?? pkg.version} browser/${globalThis.navigator.userAgent}`
+}

--- a/packages/libp2p/src/user-agent.react-native.ts
+++ b/packages/libp2p/src/user-agent.react-native.ts
@@ -1,0 +1,6 @@
+import { Platform } from 'react-native'
+import * as pkg from './version.js'
+
+export function userAgent (name?: string, version?: string): string {
+  return `${name ?? pkg.name}/${version ?? pkg.version} react-native/${Platform.OS}-${`${Platform.Version}`.replaceAll('v', '')}`
+}

--- a/packages/libp2p/src/user-agent.ts
+++ b/packages/libp2p/src/user-agent.ts
@@ -1,0 +1,24 @@
+import process from 'node:process'
+import * as pkg from './version.js'
+
+export function userAgent (name?: string, version?: string): string {
+  let platform = 'node'
+  let platformVersion = process.versions.node
+
+  if (process.versions.deno != null) {
+    platform = 'deno'
+    platformVersion = process.versions.deno
+  }
+
+  if (process.versions.bun != null) {
+    platform = 'bun'
+    platformVersion = process.versions.bun
+  }
+
+  if (process.versions.electron != null) {
+    platform = 'electron'
+    platformVersion = process.versions.electron
+  }
+
+  return `${name ?? pkg.name}/${version ?? pkg.version} ${platform}/${platformVersion.replaceAll('v', '')}`
+}

--- a/packages/libp2p/test/core/user-agent.spec.ts
+++ b/packages/libp2p/test/core/user-agent.spec.ts
@@ -1,0 +1,15 @@
+import { expect } from 'aegir/chai'
+import { isNode, isElectronMain, isBrowser, isWebWorker } from 'wherearewe'
+import { userAgent } from '../../src/user-agent.js'
+
+describe('user-agent', () => {
+  it('should include runtime in user agent', () => {
+    if (isNode) {
+      expect(userAgent()).to.include('node/')
+    } else if (isElectronMain) {
+      expect(userAgent()).to.include('electron/')
+    } else if (isBrowser || isWebWorker) {
+      expect(userAgent()).to.include('browser/')
+    }
+  })
+})

--- a/packages/libp2p/typedoc.json
+++ b/packages/libp2p/typedoc.json
@@ -1,6 +1,7 @@
 {
   "entryPoints": [
     "./src/index.ts",
-    "./src/version.ts"
+    "./src/version.ts",
+    "./src/config/user-agent.ts"
   ]
 }

--- a/packages/libp2p/typedoc.json
+++ b/packages/libp2p/typedoc.json
@@ -2,6 +2,6 @@
   "entryPoints": [
     "./src/index.ts",
     "./src/version.ts",
-    "./src/config/user-agent.ts"
+    "./src/user-agent.ts"
   ]
 }

--- a/packages/metrics-opentelemetry/test/index.spec.ts
+++ b/packages/metrics-opentelemetry/test/index.spec.ts
@@ -6,7 +6,8 @@ describe('opentelemetry-metrics', () => {
     const metrics = openTelemetryMetrics()({
       nodeInfo: {
         name: 'test',
-        version: '1.0.0'
+        version: '1.0.0',
+        userAgent: 'test/1.0.0 node/1.0.0'
       }
     })
 

--- a/packages/protocol-identify/package.json
+++ b/packages/protocol-identify/package.json
@@ -65,8 +65,7 @@
     "it-protobuf-stream": "^1.1.5",
     "protons-runtime": "^5.5.0",
     "uint8arraylist": "^2.4.8",
-    "uint8arrays": "^5.1.0",
-    "wherearewe": "^2.0.1"
+    "uint8arrays": "^5.1.0"
   },
   "devDependencies": {
     "@libp2p/logger": "^5.1.7",

--- a/packages/protocol-identify/src/index.ts
+++ b/packages/protocol-identify/src/index.ts
@@ -56,6 +56,8 @@ export interface IdentifyInit {
 
   /**
    * What details we should send as part of an identify message
+   *
+   * @deprecated Use `nodeInfo.userAgent` in the main libp2p config instead
    */
   agentVersion?: string
 

--- a/packages/protocol-identify/src/utils.ts
+++ b/packages/protocol-identify/src/utils.ts
@@ -4,7 +4,6 @@ import { peerIdFromCID, peerIdFromPublicKey } from '@libp2p/peer-id'
 import { RecordEnvelope, PeerRecord } from '@libp2p/peer-record'
 import { type Multiaddr, multiaddr } from '@multiformats/multiaddr'
 import { fromString as uint8ArrayFromString } from 'uint8arrays/from-string'
-import { isNode, isBrowser, isWebWorker, isElectronMain, isElectronRenderer, isReactNative } from 'wherearewe'
 import { IDENTIFY_PROTOCOL_VERSION, MAX_IDENTIFY_MESSAGE_SIZE, MAX_PUSH_CONCURRENCY } from './consts.js'
 import type { IdentifyComponents, IdentifyInit } from './index.js'
 import type { Identify as IdentifyMessage } from './pb/message.js'
@@ -42,15 +41,7 @@ export function getAgentVersion (nodeInfo: NodeInfo, agentVersion?: string): str
     return agentVersion
   }
 
-  agentVersion = `${nodeInfo.name}/${nodeInfo.version}`
-  // Append user agent version to default AGENT_VERSION depending on the environment
-  if (isNode || isElectronMain) {
-    agentVersion += ` UserAgent=${globalThis.process.version}`
-  } else if (isBrowser || isWebWorker || isElectronRenderer || isReactNative) {
-    agentVersion += ` UserAgent=${globalThis.navigator.userAgent}`
-  }
-
-  return agentVersion
+  return nodeInfo.userAgent
 }
 
 export async function consumeIdentifyMessage (peerStore: PeerStore, events: TypedEventTarget<Libp2pEvents>, log: Logger, connection: Connection, message: IdentifyMessage): Promise<IdentifyResult> {

--- a/packages/protocol-identify/test/index.spec.ts
+++ b/packages/protocol-identify/test/index.spec.ts
@@ -39,7 +39,8 @@ describe('identify', () => {
       logger: defaultLogger(),
       nodeInfo: {
         name: 'test',
-        version: '1.0.0'
+        version: '1.0.0',
+        userAgent: 'test'
       }
     }
   })

--- a/packages/protocol-identify/test/push.spec.ts
+++ b/packages/protocol-identify/test/push.spec.ts
@@ -32,7 +32,8 @@ describe('identify (push)', () => {
       logger: defaultLogger(),
       nodeInfo: {
         name: 'test',
-        version: '1.0.0'
+        version: '1.0.0',
+        userAgent: 'test'
       }
     }
   })

--- a/packages/upnp-nat/test/index.spec.ts
+++ b/packages/upnp-nat/test/index.spec.ts
@@ -29,7 +29,7 @@ describe('UPnP NAT (TCP)', () => {
   async function createNatManager (natManagerOptions: UPnPNATInit = {}): Promise<{ natManager: any, components: StubbedUPnPNATComponents }> {
     const components: StubbedUPnPNATComponents = {
       peerId: peerIdFromPrivateKey(await generateKeyPair('Ed25519')),
-      nodeInfo: { name: 'test', version: 'test' },
+      nodeInfo: { name: 'test', version: 'test', userAgent: 'test' },
       logger: defaultLogger(),
       addressManager: stubInterface<AddressManager>(),
       events: new TypedEventEmitter()


### PR DESCRIPTION
Adds a `userAgent` property to `NodeInfo` that includes the platform the node is running on with detection for node, browsers, electron, deno, bun and react-native.

Also allows importing the user agent function for reuse elsewhere.

## Change checklist

- [x] I have performed a self-review of my own code
- [x] I have made corresponding changes to the documentation if necessary (this includes comments as well)
- [x] I have added tests that prove my fix is effective or that my feature worksAdds a `userAgent` property to `NodeInfo` that includes the platform
the node is running on with detection for node, browsers, electron,
deno, bun and react-native.

Also allows importing the user agent function for reuse elsewhere so applications can easily extend the user agent with their own information.