### PR TITLE
fix: override user agent in exports map

### DIFF
--- a/packages/libp2p/package.json
+++ b/packages/libp2p/package.json
@@ -54,6 +54,7 @@
     },
     "./user-agent": {
       "types": "./dist/src/user-agent.d.ts",
+      "browser": "./dist/src/user-agent.browser.js",
       "import": "./dist/src/user-agent.js"
     },
     "./version": {


### PR DESCRIPTION
Add a browser override in the exports map in case the "browsers" field is not picked up.

## Change checklist

- [x] I have performed a self-review of my own code
- [ ] I have made corresponding changes to the documentation if necessary (this includes comments as well)
- [ ] I have added tests that prove my fix is effective or that my feature works