### PR TITLE
fix: remove unused fields from browser polyfill

### DIFF
--- a/packages/transport-tcp/src/tcp.browser.ts
+++ b/packages/transport-tcp/src/tcp.browser.ts
@@ -1,14 +1,9 @@
 import { serviceCapabilities, transportSymbol } from '@libp2p/interface'
-import type { TCPComponents, TCPDialEvents, TCPMetrics, TCPOptions } from './index.js'
-import type { Logger, Connection, Transport, Listener } from '@libp2p/interface'
+import type { TCPDialEvents } from './index.js'
+import type { Connection, Transport, Listener } from '@libp2p/interface'
 import type { Multiaddr } from '@multiformats/multiaddr'
 
 export class TCP implements Transport<TCPDialEvents> {
-  private readonly opts: TCPOptions
-  private readonly metrics?: TCPMetrics
-  private readonly components: TCPComponents
-  private readonly log: Logger
-
   constructor () {
     throw new Error('TCP connections are not possible in browsers')
   }


### PR DESCRIPTION
Removes unused imports and properties.

## Change checklist

- [x] I have performed a self-review of my own code
- [ ] I have made corresponding changes to the documentation if necessary (this includes comments as well)
- [ ] I have added tests that prove my fix is effective or that my feature works