### PR TITLE
chore: update tcp import

### DIFF
--- a/interop/package.json
+++ b/interop/package.json
@@ -34,8 +34,5 @@
     "libp2p": "^2.3.1",
     "p-event": "^6.0.1",
     "redis": "^4.7.0"
-  },
-  "browser": {
-    "@libp2p/tcp": false
   }
 }


### PR DESCRIPTION
`@libp2p/tcp` can be imported by browsers safely to remove the override to silence the log warning about not having any exports.

## Change checklist

- [x] I have performed a self-review of my own code
- [ ] I have made corresponding changes to the documentation if necessary (this includes comments as well)
- [ ] I have added tests that prove my fix is effective or that my feature works