### PR TITLE
chore: fix double browser install

### DIFF
--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -151,7 +151,6 @@ jobs:
       - run: |
           sudo rm /etc/apt/sources.list.d/microsoft-prod.list
           sudo apt-get update
-      - run: npx playwright install-deps
       - run: npm run --if-present test:webkit
       - uses: codecov/codecov-action@13ce06bfc6bbe3ecf90edbbf1bc32fe5978ca1d3 # v5.3.1
         with:

--- a/interop/BrowserDockerfile
+++ b/interop/BrowserDockerfile
@@ -12,11 +12,10 @@ ENV CI=true
 RUN npm i
 RUN npm run build
 
-# We install browsers here instead of the cached version so that we use the latest browsers at run time.
-# Ideally this would also be pinned, but playwright controls this, so there isn't much we can do about it.
-# By installing here, we avoid installing it at test time.
+# We install browsers here instead of the cached version so that we use the
+# latest browsers at run time. Ideally this would also be pinned, but playwright
+# controls this, so there isn't much we can do about it.
 RUN npx playwright install-deps
-RUN npx playwright install
 
 # Options: chromium, firefox, webkit
 ARG BROWSER=chromium


### PR DESCRIPTION
`playwright-test` installs the target browser anyway.

## Change checklist

- [x] I have performed a self-review of my own code
- [ ] I have made corresponding changes to the documentation if necessary (this includes comments as well)
- [ ] I have added tests that prove my fix is effective or that my feature works