### PR TITLE
fix: override browser override for react-native

### DIFF
--- a/packages/transport-tcp/package.json
+++ b/packages/transport-tcp/package.json
@@ -82,5 +82,8 @@
   "browser": {
     "./dist/src/tcp.js": "./dist/src/tcp.browser.js"
   },
+  "react-native": {
+    "./dist/src/tcp.js": "./dist/src/tcp.js"
+  },
   "sideEffects": false
 }


### PR DESCRIPTION
The browser override for the tcp module throws if the user tries to use it in a browser environment.

React-native can run a tcp polyfill but selects the browser override so add a react-native override that selects the node implementation.

Fixes #2969

## Change checklist

- [x] I have performed a self-review of my own code
- [ ] I have made corresponding changes to the documentation if necessary (this includes comments as well)
- [ ] I have added tests that prove my fix is effective or that my feature works