### PR TITLE
feat: allow configuring self key name

### DIFF
--- a/packages/keychain/src/index.ts
+++ b/packages/keychain/src/index.ts
@@ -63,8 +63,29 @@ export interface DEKConfig {
 }
 
 export interface KeychainInit {
+  /**
+   * The password is used to derive a key which encrypts the keychain at rest
+   */
   pass?: string
+
+  /**
+   * This key configures how the keychain encryption key is derived from the
+   * configured password
+   */
   dek?: DEKConfig
+
+  /**
+   * The 'self' key is the private key of the node from which the peer id is
+   * derived.
+   *
+   * It cannot be renamed or removed.
+   *
+   * By default it is stored under the 'self' key, to use a different name, pass
+   * this option.
+   *
+   * @default 'self'
+   */
+  selfKey?: string
 }
 
 export interface KeychainComponents {

--- a/packages/keychain/src/keychain.ts
+++ b/packages/keychain/src/keychain.ts
@@ -93,6 +93,7 @@ export class Keychain implements KeychainInterface {
   private readonly components: KeychainComponents
   private readonly init: KeychainInit
   private readonly log: Logger
+  private readonly self: string
 
   /**
    * Creates a new instance of a key chain
@@ -101,6 +102,7 @@ export class Keychain implements KeychainInterface {
     this.components = components
     this.log = components.logger.forComponent('libp2p:keychain')
     this.init = mergeOptions(defaultOptions, init)
+    this.self = init.selfKey ?? 'self'
 
     // Enforce NIST SP 800-132
     if (this.init.pass != null && this.init.pass?.length < 20) {
@@ -266,7 +268,7 @@ export class Keychain implements KeychainInterface {
   }
 
   async removeKey (name: string): Promise<KeyInfo> {
-    if (!validateKeyName(name) || name === 'self') {
+    if (!validateKeyName(name) || name === this.self) {
       await randomDelay()
       throw new InvalidParametersError(`Invalid key name '${name}'`)
     }
@@ -307,11 +309,11 @@ export class Keychain implements KeychainInterface {
    * @returns {Promise<KeyInfo>}
    */
   async renameKey (oldName: string, newName: string): Promise<KeyInfo> {
-    if (!validateKeyName(oldName) || oldName === 'self') {
+    if (!validateKeyName(oldName) || oldName === this.self) {
       await randomDelay()
       throw new InvalidParametersError(`Invalid old key name '${oldName}'`)
     }
-    if (!validateKeyName(newName) || newName === 'self') {
+    if (!validateKeyName(newName) || newName === this.self) {
       await randomDelay()
       throw new InvalidParametersError(`Invalid new key name '${newName}'`)
     }

--- a/packages/keychain/test/keychain.spec.ts
+++ b/packages/keychain/test/keychain.spec.ts
@@ -41,6 +41,23 @@ describe('keychain', () => {
     }()).to.eventually.be.ok()
   })
 
+  it('can override the self key name', async () => {
+    const selfKey = 'other-key'
+    const kc = new KeychainClass({
+      datastore: new MemoryDatastore(),
+      logger
+    }, {
+      selfKey
+    })
+
+    const privateKey = await generateKeyPair('Ed25519')
+    await kc.importKey(selfKey, privateKey)
+    await expect(kc.removeKey(selfKey)).to.eventually.be.rejected()
+
+    await kc.importKey('self', privateKey)
+    await expect(kc.removeKey('self')).to.eventually.be.ok()
+  })
+
   it('needs a NIST SP 800-132 non-weak pass phrase', async () => {
     await expect(async function () {
       return new KeychainClass({


### PR DESCRIPTION
To allow the node's private key to be stored under a name other than 'self', allow passing the name of the self-key as a config option.

## Change checklist

- [x] I have performed a self-review of my own code
- [x] I have made corresponding changes to the documentation if necessary (this includes comments as well)
- [x] I have added tests that prove my fix is effective or that my feature works