### PR TITLE
feat: allow configuring self-key name in config

### DIFF
--- a/packages/config/src/load-private-key.ts
+++ b/packages/config/src/load-private-key.ts
@@ -13,24 +13,31 @@ export interface LoadOrCreateSelfKeyOptions extends KeychainInit {
    * @default 'Ed25519'
    */
   keyType?: KeyType
+
+  /**
+   * Override the default key name if desired
+   *
+   * @default 'self'
+   */
+  selfKey?: string
 }
 
 export async function loadOrCreateSelfKey (datastore: Datastore, init: LoadOrCreateSelfKeyOptions = {}): Promise<PrivateKey> {
+  const selfKey = init.selfKey ?? 'self'
   const chain = keychain(init)({
     datastore,
     logger: defaultLogger()
   })
 
-  const selfKey = new Key('/pkcs8/self')
   let privateKey
 
-  if (await datastore.has(selfKey)) {
-    privateKey = await chain.exportKey('self')
+  if (await datastore.has(new Key(`/pkcs8/${selfKey}`))) {
+    privateKey = await chain.exportKey(selfKey)
   } else {
     privateKey = await generateKeyPair(init.keyType ?? 'Ed25519')
 
     // persist the peer id in the keychain for next time
-    await chain.importKey('self', privateKey)
+    await chain.importKey(selfKey, privateKey)
   }
 
   return privateKey

--- a/packages/config/test/load-private-key.spec.ts
+++ b/packages/config/test/load-private-key.spec.ts
@@ -20,6 +20,25 @@ describe('load-private-key', () => {
     expect(loaded).to.deep.equal(key)
   })
 
+  it('should load a private key with a different name', async () => {
+    const selfKey = 'my-key'
+    const datastore = new MemoryDatastore()
+    const chain = keychain({
+      selfKey
+    })({
+      datastore,
+      logger: defaultLogger()
+    })
+    const key = await generateKeyPair('secp256k1')
+    await chain.importKey(selfKey, key)
+
+    const loaded = await loadOrCreateSelfKey(datastore, {
+      selfKey
+    })
+
+    expect(loaded).to.deep.equal(key)
+  })
+
   it('should create a private key', async () => {
     const datastore = new MemoryDatastore()
     const loaded = await loadOrCreateSelfKey(datastore)


### PR DESCRIPTION
Allows passing a `selfKey` param to use a different name for the self key.

## Change checklist

- [x] I have performed a self-review of my own code
- [x] I have made corresponding changes to the documentation if necessary (this includes comments as well)
- [x] I have added tests that prove my fix is effective or that my feature works