### PR TITLE
fix: support multiple udp mux listeners on the same port

### DIFF
--- a/packages/transport-webrtc/package.json
+++ b/packages/transport-webrtc/package.json
@@ -100,7 +100,8 @@
     "./dist/src/webrtc/index.js": "./dist/src/webrtc/index.browser.js",
     "./dist/src/private-to-public/listener.js": "./dist/src/private-to-public/listener.browser.js",
     "./dist/src/private-to-public/utils/get-rtcpeerconnection.js": "./dist/src/private-to-public/utils/get-rtcpeerconnection.browser.js",
-    "node:net": false
+    "node:net": false,
+    "node:os": false
   },
   "react-native": {
     "./dist/src/webrtc/index.js": "./dist/src/webrtc/index.react-native.js"

--- a/packages/transport-webrtc/test/transport.spec.ts
+++ b/packages/transport-webrtc/test/transport.spec.ts
@@ -1,14 +1,30 @@
 /* eslint-disable @typescript-eslint/no-floating-promises */
 
 import { generateKeyPair } from '@libp2p/crypto/keys'
-import { transportSymbol } from '@libp2p/interface'
+import { transportSymbol, type Upgrader } from '@libp2p/interface'
 import { defaultLogger } from '@libp2p/logger'
 import { peerIdFromPrivateKey } from '@libp2p/peer-id'
-import { multiaddr } from '@multiformats/multiaddr'
+import { multiaddr, type Multiaddr } from '@multiformats/multiaddr'
 import { expect } from 'aegir/chai'
 import { stubInterface } from 'sinon-ts'
+import { isNode, isElectronMain } from 'wherearewe'
 import { WebRTCDirectTransport, type WebRTCDirectTransportComponents } from '../src/private-to-public/transport.js'
+import { supportsIpV6 } from './util.js'
 import type { TransportManager } from '@libp2p/interface-internal'
+
+function assertAllMultiaddrsHaveSamePort (addrs: Multiaddr[]): void {
+  let port: number | undefined
+
+  for (const addr of addrs) {
+    const options = addr.toOptions()
+
+    if (port == null) {
+      port = options.port
+    } else {
+      expect(options.port).to.equal(port, 'did not listen on the same port')
+    }
+  }
+}
 
 describe('WebRTCDirect Transport', () => {
   let components: WebRTCDirectTransportComponents
@@ -57,5 +73,93 @@ describe('WebRTCDirect Transport', () => {
       ...valid,
       ...invalid
     ])).to.deep.equal(valid)
+  })
+
+  it('can listen on ipv4 and ipv6 on the same port in series', async function () {
+    if ((!isNode && !isElectronMain) || !supportsIpV6()) {
+      return this.skip()
+    }
+
+    const upgrader = stubInterface<Upgrader>()
+    const transport = new WebRTCDirectTransport(components)
+    const listener = transport.createListener({
+      upgrader
+    })
+
+    const ipv4 = multiaddr('/ip4/127.0.0.1/udp/37287')
+    const ipv6 = multiaddr('/ip6/::1/udp/37287')
+
+    await listener.listen(ipv4)
+    await listener.listen(ipv6)
+
+    assertAllMultiaddrsHaveSamePort(listener.getAddrs())
+
+    await listener.close()
+  })
+
+  it('can listen on ipv4 and ipv6 on the same port in parallel', async function () {
+    if ((!isNode && !isElectronMain) || !supportsIpV6()) {
+      return this.skip()
+    }
+
+    const upgrader = stubInterface<Upgrader>()
+    const transport = new WebRTCDirectTransport(components)
+    const listener = transport.createListener({
+      upgrader
+    })
+
+    const ipv4 = multiaddr('/ip4/127.0.0.1/udp/0')
+    const ipv6 = multiaddr('/ip6/::1/udp/0')
+
+    await Promise.all([
+      listener.listen(ipv4),
+      listener.listen(ipv6)
+    ])
+
+    assertAllMultiaddrsHaveSamePort(listener.getAddrs())
+
+    await listener.close()
+  })
+
+  it('can listen wildcard hosts', async function () {
+    if ((!isNode && !isElectronMain) || !supportsIpV6()) {
+      return this.skip()
+    }
+
+    const upgrader = stubInterface<Upgrader>()
+    const transport = new WebRTCDirectTransport(components)
+    const listener = transport.createListener({
+      upgrader
+    })
+
+    const ipv4 = multiaddr('/ip4/0.0.0.0/udp/0')
+    const ipv6 = multiaddr('/ip6/::/udp/0')
+
+    await Promise.all([
+      listener.listen(ipv4),
+      listener.listen(ipv6)
+    ])
+
+    assertAllMultiaddrsHaveSamePort(listener.getAddrs())
+
+    let foundIpv4Loopback = false
+    let foundIpv6Loopback = false
+
+    for (const addr of listener.getAddrs()) {
+      const options = addr.toOptions()
+
+      if (options.host === '127.0.0.1') {
+        foundIpv4Loopback = true
+      }
+
+      if (options.host === '::1') {
+        foundIpv6Loopback = true
+      }
+    }
+
+    expect(foundIpv4Loopback).to.be.true('did not listen on ipv4 loopback')
+    expect(foundIpv6Loopback).to.be.true('did not listen on ipv6 loopback')
+
+    await listener.close()
   })
 })

--- a/packages/transport-webrtc/test/util.ts
+++ b/packages/transport-webrtc/test/util.ts
@@ -1,4 +1,7 @@
+import os from 'node:os'
+import { isIPv6 } from '@chainsafe/is-ip'
 import * as lengthPrefixed from 'it-length-prefixed'
+import { isNode, isElectronMain } from 'wherearewe'
 import { Message } from '../src/private-to-public/pb/message.js'
 import type { RTCDataChannel } from '../src/webrtc/index.js'
 
@@ -25,4 +28,22 @@ export const mockDataChannel = (opts: { send(bytes: Uint8Array): void, bufferedA
   }
 
   return channel
+}
+
+/**
+ * If we don't have any IPv6 network interfaces, the network we are on probably
+ * doesn't support IPv6
+ */
+export function supportsIpV6 (): boolean {
+  if (!isNode && !isElectronMain) {
+    return false
+  }
+
+  return Object.entries(os.networkInterfaces())
+    .flatMap(([_, addresses]) => addresses)
+    .map(address => address?.address)
+    .filter(address => {
+      return address != null && isIPv6(address)
+    })
+    .length > 0
 }


### PR DESCRIPTION
libjuice binds to all available addresses so if we specify, for example `/ip4/.../udp/12345` and `/ip6/.../udp/12345` they will clash because we can't start two udp muxers on the same port.

Instead support multiple udp mux servers but key them on the port number rather than host+port.

## Change checklist

- [x] I have performed a self-review of my own code
- [ ] I have made corresponding changes to the documentation if necessary (this includes comments as well)
- [x] I have added tests that prove my fix is effective or that my feature works