### PR TITLE
feat: allow transports to modify announce addresses

### DIFF
--- a/packages/interface/src/transport.ts
+++ b/packages/interface/src/transport.ts
@@ -39,6 +39,11 @@ export interface Listener extends TypedEventTarget<ListenerEvents> {
    * @returns {Promise<void>}
    */
   close(): Promise<void>
+  /**
+   * Allows transports to amend announce addresses - to add certificate hashes
+   * or other metadata that cannot be known before runtime
+   */
+  updateAnnounceAddrs(addrs: Multiaddr[]): void
 }
 
 export const transportSymbol = Symbol.for('@libp2p/transport')

--- a/packages/libp2p/src/address-manager/index.ts
+++ b/packages/libp2p/src/address-manager/index.ts
@@ -382,6 +382,11 @@ export class AddressManager implements AddressManagerInterface {
     const announceMultiaddrs = this.getAnnounceAddrs()
 
     if (announceMultiaddrs.length > 0) {
+      // allow transports to add certhashes and other runtime information
+      this.components.transportManager.getListeners().forEach(listener => {
+        listener.updateAnnounceAddrs(announceMultiaddrs)
+      })
+
       return announceMultiaddrs.map(multiaddr => ({
         multiaddr,
         verified: true,

--- a/packages/transport-circuit-relay-v2/src/transport/listener.ts
+++ b/packages/transport-circuit-relay-v2/src/transport/listener.ts
@@ -113,6 +113,10 @@ class CircuitRelayTransportListener extends TypedEventEmitter<ListenerEvents> im
     return [...this.listeningAddrs.values()].flat()
   }
 
+  updateAnnounceAddrs (): void {
+
+  }
+
   async close (): Promise<void> {
     this.reservationStore.cancelReservations()
     this.listeningAddrs = []

--- a/packages/transport-memory/src/listener.ts
+++ b/packages/transport-memory/src/listener.ts
@@ -134,6 +134,10 @@ export class MemoryTransportListener extends TypedEventEmitter<ListenerEvents> i
     ]
   }
 
+  updateAnnounceAddrs (): void {
+
+  }
+
   async close (): Promise<void> {
     this.connection?.close()
 

--- a/packages/transport-tcp/src/listener.ts
+++ b/packages/transport-tcp/src/listener.ts
@@ -274,6 +274,10 @@ export class TCPListener extends TypedEventEmitter<ListenerEvents> implements Li
     return addrs.map(ma => peerId != null ? ma.encapsulate(`/p2p/${peerId}`) : ma)
   }
 
+  updateAnnounceAddrs (): void {
+
+  }
+
   async listen (ma: Multiaddr): Promise<void> {
     if (this.status.code === TCPListenerStatusCode.ACTIVE || this.status.code === TCPListenerStatusCode.PAUSED) {
       throw new AlreadyStartedError('server is already listening')

--- a/packages/transport-webrtc/package.json
+++ b/packages/transport-webrtc/package.json
@@ -58,7 +58,7 @@
     "@libp2p/interface-internal": "^2.3.1",
     "@libp2p/peer-id": "^5.0.12",
     "@libp2p/utils": "^6.5.1",
-    "@multiformats/multiaddr": "^12.3.3",
+    "@multiformats/multiaddr": "^12.4.0",
     "@multiformats/multiaddr-matcher": "^1.6.0",
     "@peculiar/webcrypto": "^1.5.0",
     "@peculiar/x509": "^1.11.0",

--- a/packages/transport-webrtc/src/private-to-private/listener.ts
+++ b/packages/transport-webrtc/src/private-to-private/listener.ts
@@ -46,6 +46,10 @@ export class WebRTCPeerListener extends TypedEventEmitter<ListenerEvents> implem
       .flat()
   }
 
+  updateAnnounceAddrs (): void {
+
+  }
+
   async close (): Promise<void> {
     this.shutdownController.abort()
     queueMicrotask(() => {

--- a/packages/transport-webrtc/src/private-to-public/listener.browser.ts
+++ b/packages/transport-webrtc/src/private-to-public/listener.browser.ts
@@ -22,6 +22,10 @@ export class WebRTCDirectListener extends TypedEventEmitter<ListenerEvents> impl
     return []
   }
 
+  updateAnnounceAddrs (): void {
+
+  }
+
   async close (): Promise<void> {
 
   }

--- a/packages/transport-webrtc/src/private-to-public/listener.ts
+++ b/packages/transport-webrtc/src/private-to-public/listener.ts
@@ -1,8 +1,8 @@
 import { networkInterfaces } from 'node:os'
 import { isIPv4, isIPv6 } from '@chainsafe/is-ip'
 import { TypedEventEmitter } from '@libp2p/interface'
-import { multiaddr, protocols } from '@multiformats/multiaddr'
-import { IP4 } from '@multiformats/multiaddr-matcher'
+import { multiaddr, protocols, fromStringTuples } from '@multiformats/multiaddr'
+import { IP4, WebRTCDirect } from '@multiformats/multiaddr-matcher'
 import { Crypto } from '@peculiar/webcrypto'
 import getPort from 'get-port'
 import pWaitFor from 'p-wait-for'
@@ -22,6 +22,8 @@ const crypto = new Crypto()
  * The time to wait, in milliseconds, for the data channel handshake to complete
  */
 const HANDSHAKE_TIMEOUT_MS = 10_000
+const CODEC_WEBRTC_DIRECT = 0x0118
+const CODEC_CERTHASH = 0x01d2
 
 export interface WebRTCDirectListenerComponents {
   peerId: PeerId
@@ -194,6 +196,34 @@ export class WebRTCDirectListener extends TypedEventEmitter<ListenerEvents> impl
 
   getAddrs (): Multiaddr[] {
     return this.multiaddrs
+  }
+
+  updateAnnounceAddrs (multiaddrs: Multiaddr[]): void {
+    for (let i = 0; i < multiaddrs.length; i++) {
+      let ma = multiaddrs[i]
+
+      if (!WebRTCDirect.exactMatch(ma)) {
+        continue
+      }
+
+      // add the certhash if it is missing
+      const tuples = ma.stringTuples()
+
+      for (let j = 0; j < tuples.length; j++) {
+        if (tuples[j][0] !== CODEC_WEBRTC_DIRECT) {
+          continue
+        }
+
+        const certhashIndex = j + 1
+
+        if (tuples[certhashIndex] == null || tuples[certhashIndex][0] !== CODEC_CERTHASH) {
+          tuples.splice(certhashIndex, 0, [CODEC_CERTHASH, this.certificate?.certhash])
+
+          ma = fromStringTuples(tuples)
+          multiaddrs[i] = ma
+        }
+      }
+    }
   }
 
   async close (): Promise<void> {

--- a/packages/transport-webrtc/test/transport.spec.ts
+++ b/packages/transport-webrtc/test/transport.spec.ts
@@ -5,13 +5,13 @@ import { transportSymbol, type Upgrader } from '@libp2p/interface'
 import { defaultLogger } from '@libp2p/logger'
 import { peerIdFromPrivateKey } from '@libp2p/peer-id'
 import { multiaddr, type Multiaddr } from '@multiformats/multiaddr'
+import { WebRTCDirect } from '@multiformats/multiaddr-matcher'
 import { expect } from 'aegir/chai'
 import { stubInterface } from 'sinon-ts'
 import { isNode, isElectronMain } from 'wherearewe'
 import { WebRTCDirectTransport, type WebRTCDirectTransportComponents } from '../src/private-to-public/transport.js'
 import { supportsIpV6 } from './util.js'
 import type { TransportManager } from '@libp2p/interface-internal'
-import { WebRTCDirect } from '@multiformats/multiaddr-matcher'
 
 function assertAllMultiaddrsHaveSamePort (addrs: Multiaddr[]): void {
   let port: number | undefined

--- a/packages/transport-webrtc/test/transport.spec.ts
+++ b/packages/transport-webrtc/test/transport.spec.ts
@@ -11,6 +11,7 @@ import { isNode, isElectronMain } from 'wherearewe'
 import { WebRTCDirectTransport, type WebRTCDirectTransportComponents } from '../src/private-to-public/transport.js'
 import { supportsIpV6 } from './util.js'
 import type { TransportManager } from '@libp2p/interface-internal'
+import { WebRTCDirect } from '@multiformats/multiaddr-matcher'
 
 function assertAllMultiaddrsHaveSamePort (addrs: Multiaddr[]): void {
   let port: number | undefined
@@ -159,6 +160,47 @@ describe('WebRTCDirect Transport', () => {
 
     expect(foundIpv4Loopback).to.be.true('did not listen on ipv4 loopback')
     expect(foundIpv6Loopback).to.be.true('did not listen on ipv6 loopback')
+
+    await listener.close()
+  })
+
+  it('should add certificate to announce addresses', async function () {
+    if ((!isNode && !isElectronMain) || !supportsIpV6()) {
+      return this.skip()
+    }
+
+    const announceAddrs = [
+      multiaddr('/ip4/80.123.123.43/tcp/12345'),
+      multiaddr('/dns/example.com/tcp/12345/wss'),
+      multiaddr('/ip4/80.123.123.43/udp/12346/webrtc-direct'),
+      multiaddr('/ip6/2a00:23c6:14b1:7e00:ac57:dafd:a294:f01/tcp/12345'),
+      multiaddr('/ip6/2a00:23c6:14b1:7e00:ac57:dafd:a294:f01/udp/12346/webrtc-direct'),
+      multiaddr('/ip6/2a00:23c6:14b1:7e00:ac57:dafd:a294:f01/udp/12346/webrtc-direct/p2p/QmNnooDu7bfjPFoTZYxMNLWUQJyrVwtbZg5gBMjTezGAJN')
+    ]
+
+    const upgrader = stubInterface<Upgrader>()
+    const transport = new WebRTCDirectTransport(components)
+    const listener = transport.createListener({
+      upgrader
+    })
+
+    const ipv4 = multiaddr('/ip4/0.0.0.0/udp/0')
+    const ipv6 = multiaddr('/ip6/::/udp/0')
+
+    await Promise.all([
+      listener.listen(ipv4),
+      listener.listen(ipv6)
+    ])
+
+    listener.updateAnnounceAddrs(announceAddrs)
+
+    const webRTCDirectAddrs = announceAddrs.filter(ma => WebRTCDirect.exactMatch(ma))
+
+    expect(webRTCDirectAddrs).to.have.lengthOf(3)
+
+    for (const ma of webRTCDirectAddrs) {
+      expect(ma.toString()).to.include('/udp/12346/webrtc-direct/certhash/u', 'did not add certhash to all WebRTC Direct addresses')
+    }
 
     await listener.close()
   })

--- a/packages/transport-websockets/src/listener.ts
+++ b/packages/transport-websockets/src/listener.ts
@@ -420,6 +420,10 @@ export class WebSocketListener extends TypedEventEmitter<ListenerEvents> impleme
     ]
   }
 
+  updateAnnounceAddrs (): void {
+
+  }
+
   private httpRequestHandler (req: http.IncomingMessage, res: http.ServerResponse): void {
     res.writeHead(400)
     res.write('Only WebSocket connections are supported')


### PR DESCRIPTION
In cases where the published multiaddr for a given transport needs to have a component that can only be known at runtime, allow transports to modify configured announce addresses.

This lets WebRTC Direct add `/certhash` tuples to announced addrs.

## Change checklist

- [x] I have performed a self-review of my own code
- [x] I have made corresponding changes to the documentation if necessary (this includes comments as well)
- [x] I have added tests that prove my fix is effective or that my feature works