### PR TITLE
fix: maximum call stack size with duplicate webrtc addresses

### DIFF
--- a/packages/integration-tests/test/webrtc-private-to-private.spec.ts
+++ b/packages/integration-tests/test/webrtc-private-to-private.spec.ts
@@ -1,0 +1,56 @@
+/* eslint-env mocha */
+/* eslint max-nested-callbacks: ['error', 6] */
+
+import { yamux } from '@chainsafe/libp2p-yamux'
+import { circuitRelayTransport } from '@libp2p/circuit-relay-v2'
+import { identify } from '@libp2p/identify'
+import { plaintext } from '@libp2p/plaintext'
+import { webRTC } from '@libp2p/webrtc'
+import { webSockets } from '@libp2p/websockets'
+import { WebRTC } from '@multiformats/multiaddr-matcher'
+import { expect } from 'aegir/chai'
+import { createLibp2p } from 'libp2p'
+import type { Libp2p } from '@libp2p/interface'
+
+describe('webrtc private-to-private', () => {
+  let local: Libp2p
+
+  afterEach(async () => {
+    await local?.stop()
+  })
+
+  it('should listen on two webrtc addresses', async () => {
+    local = await createLibp2p({
+      addresses: {
+        listen: [
+          `${process.env.RELAY_MULTIADDR}/p2p-circuit`,
+          // this is a misconfiguration, it's only necessary to specify this
+          // once as the WebRTC transport is really just a protocol handler so
+          // in effect it will always bind to all addresses
+          '/webrtc',
+          '/webrtc'
+        ]
+      },
+      transports: [
+        circuitRelayTransport(),
+        webSockets(),
+        webRTC()
+      ],
+      streamMuxers: [
+        yamux()
+      ],
+      connectionEncrypters: [
+        plaintext()
+      ],
+      connectionGater: {
+        denyDialMultiaddr: () => false
+      },
+      services: {
+        identify: identify()
+      }
+    })
+
+    // two because the relay listens on two TCP addresses so it binds to both
+    expect(local.getMultiaddrs().filter(WebRTC.exactMatch)).to.have.lengthOf(2)
+  })
+})

--- a/packages/transport-webrtc/src/private-to-private/listener.ts
+++ b/packages/transport-webrtc/src/private-to-private/listener.ts
@@ -36,7 +36,7 @@ export class WebRTCPeerListener extends TypedEventEmitter<ListenerEvents> implem
   getAddrs (): Multiaddr[] {
     return this.transportManager
       .getListeners()
-      .filter(l => l !== this)
+      .filter(l => !(l instanceof WebRTCPeerListener))
       .map(l => l.getAddrs()
         .filter(ma => Circuit.exactMatch(ma))
         .map(ma => {

--- a/packages/transport-webrtc/src/private-to-private/transport.ts
+++ b/packages/transport-webrtc/src/private-to-private/transport.ts
@@ -126,9 +126,12 @@ export class WebRTCTransport implements Transport<WebRTCDialEvents>, Startable {
 
   /**
    * Filter check for all Multiaddrs that this transport can listen on
+   * Returns only unique multiaddrs.
    */
   listenFilter (multiaddrs: Multiaddr[]): Multiaddr[] {
-    return multiaddrs.filter(WebRTC.exactMatch)
+    return multiaddrs
+      .filter(WebRTC.exactMatch)
+      .filter((ma, i, arr) => arr.map(x => x.toString()).indexOf(ma.toString()) === i)
   }
 
   /**

--- a/packages/transport-webrtc/src/private-to-private/transport.ts
+++ b/packages/transport-webrtc/src/private-to-private/transport.ts
@@ -129,9 +129,7 @@ export class WebRTCTransport implements Transport<WebRTCDialEvents>, Startable {
    * Returns only unique multiaddrs.
    */
   listenFilter (multiaddrs: Multiaddr[]): Multiaddr[] {
-    return multiaddrs
-      .filter(WebRTC.exactMatch)
-      .filter((ma, i, arr) => arr.map(x => x.toString()).indexOf(ma.toString()) === i)
+    return multiaddrs.filter(WebRTC.exactMatch)
   }
 
   /**

--- a/packages/transport-webrtc/src/private-to-private/transport.ts
+++ b/packages/transport-webrtc/src/private-to-private/transport.ts
@@ -126,7 +126,6 @@ export class WebRTCTransport implements Transport<WebRTCDialEvents>, Startable {
 
   /**
    * Filter check for all Multiaddrs that this transport can listen on
-   * Returns only unique multiaddrs.
    */
   listenFilter (multiaddrs: Multiaddr[]): Multiaddr[] {
     return multiaddrs.filter(WebRTC.exactMatch)


### PR DESCRIPTION
## Description

Fixes https://github.com/libp2p/js-libp2p/issues/2539

## Change checklist

- [x] I have performed a self-review of my own code
- [x] I have made corresponding changes to the documentation if necessary (this includes comments as well)
- [x] I have added tests that prove my fix is effective or that my feature works