### PR TITLE
fix: remove ws filters

### DIFF
--- a/interop/test/fixtures/get-libp2p.ts
+++ b/interop/test/fixtures/get-libp2p.ts
@@ -9,7 +9,6 @@ import { type PingService, ping } from '@libp2p/ping'
 import { tcp } from '@libp2p/tcp'
 import { webRTC, webRTCDirect } from '@libp2p/webrtc'
 import { webSockets } from '@libp2p/websockets'
-import * as filters from '@libp2p/websockets/filters'
 import { webTransport } from '@libp2p/webtransport'
 import { type Libp2pOptions, createLibp2p } from 'libp2p'
 import type { Libp2p } from '@libp2p/interface'
@@ -59,7 +58,7 @@ export async function getLibp2p (): Promise<Libp2p<{ ping: PingService }>> {
     case 'webrtc':
       options.transports = [
         webRTC(),
-        webSockets({ filter: filters.all }), // ws needed to connect to relay
+        webSockets(), // ws needed to connect to relay
         circuitRelayTransport()
       ]
       options.addresses = {

--- a/interop/test/fixtures/relay.ts
+++ b/interop/test/fixtures/relay.ts
@@ -3,7 +3,6 @@ import { yamux } from '@chainsafe/libp2p-yamux'
 import { circuitRelayServer } from '@libp2p/circuit-relay-v2'
 import { identify } from '@libp2p/identify'
 import { webSockets } from '@libp2p/websockets'
-import * as filters from '@libp2p/websockets/filters'
 import { createLibp2p } from 'libp2p'
 import type { Libp2p } from '@libp2p/interface'
 
@@ -13,10 +12,11 @@ export async function createRelay (): Promise<Libp2p> {
       listen: ['/ip4/0.0.0.0/tcp/0/ws']
     },
     transports: [
-      webSockets({
-        filter: filters.all
-      })
+      webSockets()
     ],
+    connectionGater: {
+      denyDialMultiaddr: () => false
+    },
     connectionEncrypters: [noise()],
     streamMuxers: [yamux()],
     services: {

--- a/packages/integration-tests/test/bootstrap.spec.ts
+++ b/packages/integration-tests/test/bootstrap.spec.ts
@@ -7,7 +7,6 @@ import { mplex } from '@libp2p/mplex'
 import { peerIdFromPrivateKey } from '@libp2p/peer-id'
 import { plaintext } from '@libp2p/plaintext'
 import { webSockets } from '@libp2p/websockets'
-import * as Filter from '@libp2p/websockets/filters'
 import { multiaddr } from '@multiformats/multiaddr'
 import { expect } from 'aegir/chai'
 import { createLibp2p } from 'libp2p'
@@ -118,9 +117,7 @@ describe('bootstrap', () => {
         plaintext()
       ],
       transports: [
-        webSockets({
-          filter: Filter.all
-        })
+        webSockets()
       ],
       streamMuxers: [
         mplex()

--- a/packages/integration-tests/test/circuit-relay-discovery.spec.ts
+++ b/packages/integration-tests/test/circuit-relay-discovery.spec.ts
@@ -9,7 +9,6 @@ import { stop } from '@libp2p/interface'
 import { mplex } from '@libp2p/mplex'
 import { plaintext } from '@libp2p/plaintext'
 import { webSockets } from '@libp2p/websockets'
-import * as filters from '@libp2p/websockets/filters'
 import { webTransport } from '@libp2p/webtransport'
 import { multiaddr } from '@multiformats/multiaddr'
 import { WebSockets, WebTransport } from '@multiformats/multiaddr-matcher'
@@ -28,9 +27,7 @@ describe('circuit-relay discovery', () => {
         ]
       },
       transports: [
-        webSockets({
-          filter: filters.all
-        }),
+        webSockets(),
         circuitRelayTransport(),
         webTransport()
       ],

--- a/packages/integration-tests/test/circuit-relay.spec.ts
+++ b/packages/integration-tests/test/circuit-relay.spec.ts
@@ -7,7 +7,6 @@ import { identify } from '@libp2p/identify'
 import { mplex } from '@libp2p/mplex'
 import { plaintext } from '@libp2p/plaintext'
 import { webSockets } from '@libp2p/websockets'
-import * as filters from '@libp2p/websockets/filters'
 import { Circuit } from '@multiformats/mafmt'
 import { expect } from 'aegir/chai'
 import { createLibp2p } from 'libp2p'
@@ -23,9 +22,7 @@ describe('circuit-relay', () => {
     [local, remote] = await Promise.all([
       createLibp2p({
         transports: [
-          webSockets({
-            filter: filters.all
-          }),
+          webSockets(),
           circuitRelayTransport()
         ],
         streamMuxers: [
@@ -49,9 +46,7 @@ describe('circuit-relay', () => {
           ]
         },
         transports: [
-          webSockets({
-            filter: filters.all
-          }),
+          webSockets(),
           circuitRelayTransport()
         ],
         streamMuxers: [

--- a/packages/integration-tests/test/compliance/transport/circuit-relay.spec.ts
+++ b/packages/integration-tests/test/compliance/transport/circuit-relay.spec.ts
@@ -6,7 +6,6 @@ import { circuitRelayTransport } from '@libp2p/circuit-relay-v2'
 import { identify } from '@libp2p/identify'
 import tests from '@libp2p/interface-compliance-tests/transport'
 import { webSockets } from '@libp2p/websockets'
-import { all } from '@libp2p/websockets/filters'
 import { Circuit, P2P } from '@multiformats/multiaddr-matcher'
 import { and, fmt, literal } from '@multiformats/multiaddr-matcher/utils'
 
@@ -20,9 +19,7 @@ describe('Circuit relay transport interface compliance', () => {
       const dialer = {
         transports: [
           circuitRelayTransport(),
-          webSockets({
-            filter: all
-          })
+          webSockets()
         ],
         connectionEncrypters: [
           noise()

--- a/packages/integration-tests/test/compliance/transport/webrtc.spec.ts
+++ b/packages/integration-tests/test/compliance/transport/webrtc.spec.ts
@@ -8,7 +8,6 @@ import tests from '@libp2p/interface-compliance-tests/transport'
 import { ping } from '@libp2p/ping'
 import { webRTC } from '@libp2p/webrtc'
 import { webSockets } from '@libp2p/websockets'
-import { all } from '@libp2p/websockets/filters'
 import { WebRTC } from '@multiformats/multiaddr-matcher'
 import { isWebWorker } from 'wherearewe'
 
@@ -22,9 +21,7 @@ describe('WebRTC transport interface compliance', () => {
       const dialer = {
         transports: [
           circuitRelayTransport(),
-          webSockets({
-            filter: all
-          }),
+          webSockets(),
           webRTC()
         ],
         connectionEncrypters: [

--- a/packages/integration-tests/test/compliance/transport/websockets.spec.ts
+++ b/packages/integration-tests/test/compliance/transport/websockets.spec.ts
@@ -4,7 +4,6 @@ import { noise } from '@chainsafe/libp2p-noise'
 import { yamux } from '@chainsafe/libp2p-yamux'
 import tests from '@libp2p/interface-compliance-tests/transport'
 import { webSockets } from '@libp2p/websockets'
-import { all } from '@libp2p/websockets/filters'
 import { multiaddr } from '@multiformats/multiaddr'
 import { WebSockets } from '@multiformats/multiaddr-matcher'
 import { isElectronMain, isNode } from 'wherearewe'
@@ -16,9 +15,7 @@ describe('websocket transport interface compliance', () => {
 
       const dialer = {
         transports: [
-          webSockets({
-            filter: all
-          })
+          webSockets()
         ],
         connectionEncrypters: [
           noise()

--- a/packages/integration-tests/test/fixtures/base-options.browser.ts
+++ b/packages/integration-tests/test/fixtures/base-options.browser.ts
@@ -5,7 +5,6 @@ import { mplex } from '@libp2p/mplex'
 import { plaintext } from '@libp2p/plaintext'
 import { webRTC } from '@libp2p/webrtc'
 import { webSockets } from '@libp2p/websockets'
-import * as filters from '@libp2p/websockets/filters'
 import mergeOptions from 'merge-options'
 import { isWebWorker } from 'wherearewe'
 import type { ServiceMap } from '@libp2p/interface'
@@ -19,9 +18,7 @@ export function createBaseOptions <T extends ServiceMap = Record<string, unknown
       ]
     },
     transports: [
-      webSockets({
-        filter: filters.all
-      }),
+      webSockets(),
       circuitRelayTransport()
     ],
     streamMuxers: [

--- a/packages/integration-tests/test/fixtures/base-options.ts
+++ b/packages/integration-tests/test/fixtures/base-options.ts
@@ -6,7 +6,6 @@ import { plaintext } from '@libp2p/plaintext'
 import { tcp } from '@libp2p/tcp'
 import { webRTC } from '@libp2p/webrtc'
 import { webSockets } from '@libp2p/websockets'
-import * as filters from '@libp2p/websockets/filters'
 import mergeOptions from 'merge-options'
 import type { ServiceMap } from '@libp2p/interface'
 import type { Libp2pOptions } from 'libp2p'
@@ -23,9 +22,7 @@ export function createBaseOptions <T extends ServiceMap = Record<string, unknown
     transports: [
       tcp(),
       webRTC(),
-      webSockets({
-        filter: filters.all
-      }),
+      webSockets(),
       circuitRelayTransport()
     ],
     streamMuxers: [

--- a/packages/transport-webrtc/README.md
+++ b/packages/transport-webrtc/README.md
@@ -56,7 +56,6 @@ import { circuitRelayTransport, circuitRelayServer } from '@libp2p/circuit-relay
 import { identify } from '@libp2p/identify'
 import { webRTC } from '@libp2p/webrtc'
 import { webSockets } from '@libp2p/websockets'
-import * as filters from '@libp2p/websockets/filters'
 import { WebRTC } from '@multiformats/multiaddr-matcher'
 import delay from 'delay'
 import { pipe } from 'it-pipe'
@@ -70,10 +69,13 @@ const relay = await createLibp2p({
   listen: ['/ip4/127.0.0.1/tcp/0/ws']
   },
   transports: [
-    webSockets({filter: filters.all})
+    webSockets()
   ],
   connectionEncrypters: [noise()],
   streamMuxers: [yamux()],
+  connectionGater: {
+    denyDialMultiaddr: () => false
+  },
   services: {
     identify: identify(),
     relay: circuitRelayServer()
@@ -91,12 +93,15 @@ const listener = await createLibp2p({
     ]
   },
   transports: [
-    webSockets({filter: filters.all}),
+    webSockets(),
     webRTC(),
     circuitRelayTransport()
   ],
   connectionEncrypters: [noise()],
   streamMuxers: [yamux()],
+  connectionGater: {
+    denyDialMultiaddr: () => false
+  },
   services: {
     identify: identify(),
     echo: echo()
@@ -128,12 +133,15 @@ while (true) {
 // direct WebRTC connection
 const dialer = await createLibp2p({
   transports: [
-    webSockets({filter: filters.all}),
+    webSockets(),
     webRTC(),
     circuitRelayTransport()
   ],
   connectionEncrypters: [noise()],
   streamMuxers: [yamux()],
+  connectionGater: {
+    denyDialMultiaddr: () => false
+  },
   services: {
     identify: identify(),
     echo: echo()

--- a/packages/transport-webrtc/src/index.ts
+++ b/packages/transport-webrtc/src/index.ts
@@ -33,7 +33,6 @@
  * import { identify } from '@libp2p/identify'
  * import { webRTC } from '@libp2p/webrtc'
  * import { webSockets } from '@libp2p/websockets'
- * import * as filters from '@libp2p/websockets/filters'
  * import { WebRTC } from '@multiformats/multiaddr-matcher'
  * import delay from 'delay'
  * import { pipe } from 'it-pipe'
@@ -47,10 +46,13 @@
  *   listen: ['/ip4/127.0.0.1/tcp/0/ws']
  *   },
  *   transports: [
- *     webSockets({filter: filters.all})
+ *     webSockets()
  *   ],
  *   connectionEncrypters: [noise()],
  *   streamMuxers: [yamux()],
+ *   connectionGater: {
+ *     denyDialMultiaddr: () => false
+ *   },
  *   services: {
  *     identify: identify(),
  *     relay: circuitRelayServer()
@@ -68,12 +70,15 @@
  *     ]
  *   },
  *   transports: [
- *     webSockets({filter: filters.all}),
+ *     webSockets(),
  *     webRTC(),
  *     circuitRelayTransport()
  *   ],
  *   connectionEncrypters: [noise()],
  *   streamMuxers: [yamux()],
+ *   connectionGater: {
+ *     denyDialMultiaddr: () => false
+ *   },
  *   services: {
  *     identify: identify(),
  *     echo: echo()
@@ -105,12 +110,15 @@
  * // direct WebRTC connection
  * const dialer = await createLibp2p({
  *   transports: [
- *     webSockets({filter: filters.all}),
+ *     webSockets(),
  *     webRTC(),
  *     circuitRelayTransport()
  *   ],
  *   connectionEncrypters: [noise()],
  *   streamMuxers: [yamux()],
+ *   connectionGater: {
+ *     denyDialMultiaddr: () => false
+ *   },
  *   services: {
  *     identify: identify(),
  *     echo: echo()

--- a/packages/transport-websockets/src/filters.ts
+++ b/packages/transport-websockets/src/filters.ts
@@ -1,24 +1,36 @@
 import { WebSocketsSecure, WebSockets, DNS } from '@multiformats/multiaddr-matcher'
 import type { Multiaddr } from '@multiformats/multiaddr'
 
+/**
+ * @deprecated Configure this globally by passing a `connectionGater` to `createLibp2p` with a `denyDialMultiaddr` method that returns `false`
+ */
 export function all (multiaddrs: Multiaddr[]): Multiaddr[] {
   return multiaddrs.filter((ma) => {
     return WebSocketsSecure.exactMatch(ma) || WebSockets.exactMatch(ma)
   })
 }
 
+/**
+ * @deprecated Configure this globally by passing a `connectionGater` to `createLibp2p`
+ */
 export function wss (multiaddrs: Multiaddr[]): Multiaddr[] {
   return multiaddrs.filter((ma) => {
     return WebSocketsSecure.exactMatch(ma)
   })
 }
 
+/**
+ * @deprecated Configure this globally by passing a `connectionGater` to `createLibp2p`
+ */
 export function dnsWss (multiaddrs: Multiaddr[]): Multiaddr[] {
   return multiaddrs.filter((ma) => {
     return DNS.matches(ma) && WebSocketsSecure.exactMatch(ma)
   })
 }
 
+/**
+ * @deprecated Configure this globally by passing a `connectionGater` to `createLibp2p`
+ */
 export function dnsWsOrWss (multiaddrs: Multiaddr[]): Multiaddr[] {
   return multiaddrs.filter((ma) => {
     return DNS.matches(ma) && (WebSocketsSecure.exactMatch(ma) || WebSockets.exactMatch(ma))


### PR DESCRIPTION
These are deprecated in favour of the connection gater so remove their use in the codebase.

## Change checklist

- [x] I have performed a self-review of my own code
- [ ] I have made corresponding changes to the documentation if necessary (this includes comments as well)
- [ ] I have added tests that prove my fix is effective or that my feature works