### PR TITLE
fix: report version correctly

### DIFF
--- a/packages/libp2p/src/libp2p.ts
+++ b/packages/libp2p/src/libp2p.ts
@@ -67,7 +67,7 @@ export class Libp2p<T extends ServiceMap = ServiceMap> extends TypedEventEmitter
     this.services = {}
 
     const nodeInfoName = init.nodeInfo?.name ?? pkg.name
-    const nodeInfoVersion = init.nodeInfo?.version ?? pkg.name
+    const nodeInfoVersion = init.nodeInfo?.version ?? pkg.version
 
     // @ts-expect-error defaultComponents is missing component types added later
     const components = this.components = defaultComponents({


### PR DESCRIPTION
The agent version string had the module name twice.

## Change checklist

- [x] I have performed a self-review of my own code
- [ ] I have made corresponding changes to the documentation if necessary (this includes comments as well)
- [ ] I have added tests that prove my fix is effective or that my feature works