### PR TITLE
fix: update race-signal

### DIFF
--- a/packages/kad-dht/package.json
+++ b/packages/kad-dht/package.json
@@ -83,7 +83,7 @@
     "p-event": "^6.0.1",
     "progress-events": "^1.0.1",
     "protons-runtime": "^5.5.0",
-    "race-signal": "^1.1.0",
+    "race-signal": "^1.1.2",
     "uint8-varint": "^2.0.4",
     "uint8arraylist": "^2.4.8",
     "uint8arrays": "^5.1.0"

--- a/packages/libp2p/package.json
+++ b/packages/libp2p/package.json
@@ -116,7 +116,7 @@
     "p-retry": "^6.2.1",
     "progress-events": "^1.0.1",
     "race-event": "^1.3.0",
-    "race-signal": "^1.1.0",
+    "race-signal": "^1.1.2",
     "uint8arrays": "^5.1.0"
   },
   "devDependencies": {

--- a/packages/multistream-select/package.json
+++ b/packages/multistream-select/package.json
@@ -63,7 +63,7 @@
     "it-length-prefixed-stream": "^1.2.0",
     "it-stream-types": "^2.0.2",
     "p-defer": "^4.0.1",
-    "race-signal": "^1.1.0",
+    "race-signal": "^1.1.2",
     "uint8-varint": "^2.0.4",
     "uint8arraylist": "^2.4.8",
     "uint8arrays": "^5.1.0"

--- a/packages/transport-circuit-relay-v2/package.json
+++ b/packages/transport-circuit-relay-v2/package.json
@@ -83,7 +83,7 @@
     "it-to-buffer": "^4.0.7",
     "p-wait-for": "^5.0.2",
     "protons": "^7.6.0",
-    "race-signal": "^1.1.0",
+    "race-signal": "^1.1.2",
     "sinon": "^19.0.2",
     "sinon-ts": "^2.0.0"
   },

--- a/packages/transport-webrtc/package.json
+++ b/packages/transport-webrtc/package.json
@@ -76,7 +76,7 @@
     "progress-events": "^1.0.1",
     "protons-runtime": "^5.5.0",
     "race-event": "^1.3.0",
-    "race-signal": "^1.1.0",
+    "race-signal": "^1.1.2",
     "react-native-webrtc": "^124.0.4",
     "uint8-varint": "^2.0.4",
     "uint8arraylist": "^2.4.8",

--- a/packages/transport-websockets/package.json
+++ b/packages/transport-websockets/package.json
@@ -84,7 +84,7 @@
     "p-defer": "^4.0.1",
     "p-event": "^6.0.1",
     "progress-events": "^1.0.1",
-    "race-signal": "^1.1.0",
+    "race-signal": "^1.1.2",
     "ws": "^8.18.0"
   },
   "devDependencies": {

--- a/packages/transport-webtransport/package.json
+++ b/packages/transport-webtransport/package.json
@@ -59,7 +59,7 @@
     "it-stream-types": "^2.0.2",
     "multiformats": "^13.3.1",
     "progress-events": "^1.0.1",
-    "race-signal": "^1.1.0",
+    "race-signal": "^1.1.2",
     "uint8arraylist": "^2.4.8",
     "uint8arrays": "^5.1.0"
   },

--- a/packages/upnp-nat/package.json
+++ b/packages/upnp-nat/package.json
@@ -62,7 +62,7 @@
     "@multiformats/multiaddr": "^12.3.3",
     "@multiformats/multiaddr-matcher": "^1.6.0",
     "p-defer": "^4.0.1",
-    "race-signal": "^1.1.0"
+    "race-signal": "^1.1.2"
   },
   "devDependencies": {
     "@libp2p/crypto": "^5.0.12",

--- a/packages/utils/package.json
+++ b/packages/utils/package.json
@@ -205,7 +205,7 @@
     "netmask": "^2.0.2",
     "p-defer": "^4.0.1",
     "race-event": "^1.3.0",
-    "race-signal": "^1.1.0",
+    "race-signal": "^1.1.2",
     "uint8arraylist": "^2.4.8",
     "uint8arrays": "^5.1.0"
   },


### PR DESCRIPTION
1.1.2 fixes a potential crash so ensure we get the latest version.

Fixes #2702

## Change checklist

- [ ] I have performed a self-review of my own code
- [ ] I have made corresponding changes to the documentation if necessary (this includes comments as well)
- [ ] I have added tests that prove my fix is effective or that my feature works