### PR TITLE
docs: fix broken link in libp2p index file

### DIFF
--- a/packages/libp2p/src/index.ts
+++ b/packages/libp2p/src/index.ts
@@ -35,7 +35,7 @@ export type ServiceFactoryMap<T extends ServiceMap = ServiceMap> = {
 export type { AddressManagerInit, AddressFilter }
 
 /**
- * For Libp2p configurations and modules details read the [Configuration Document](https://github.com/libp2p/js-libp2p/tree/main/doc/CONFIGURATION.md).
+ * * For Libp2p configurations and modules details read the [Configuration Document](../doc/CONFIGURATION.md).
  */
 export interface Libp2pInit<T extends ServiceMap = ServiceMap> {
   /**


### PR DESCRIPTION


## Description

This pull request fixes the broken link in the libp2p index file to correctly reference the Configuration Document. The incorrect link was updated to point to the correct path in the repository.

## Changes made:

Updated the link in packages/libp2p/src/index.ts to correctly reference ../doc/CONFIGURATION.md.
This fix resolves the issue detailed in [issue #2111](https://github.com/libp2p/js-libp2p/issues/2111).

