### PR TITLE
fix: pass abort signal to noise and the upgrader

### DIFF
--- a/packages/transport-webrtc/src/constants.ts
+++ b/packages/transport-webrtc/src/constants.ts
@@ -16,3 +16,10 @@ export const DEFAULT_ICE_SERVERS = [
 export const UFRAG_ALPHABET = Array.from('abcdefghijklmnopqrstuvwxyzABCDEFGHIJKLMNOPQRSTUVWXYZ1234567890')
 
 export const UFRAG_PREFIX = 'libp2p+webrtc+v1/'
+
+/**
+ * The time to wait, in milliseconds, for the data channel handshake to complete
+ */
+export const HANDSHAKE_TIMEOUT_MS = 10_000
+export const CODEC_WEBRTC_DIRECT = 0x0118
+export const CODEC_CERTHASH = 0x01d2

--- a/packages/transport-webrtc/src/private-to-public/listener.ts
+++ b/packages/transport-webrtc/src/private-to-public/listener.ts
@@ -6,6 +6,7 @@ import { IP4, WebRTCDirect } from '@multiformats/multiaddr-matcher'
 import { Crypto } from '@peculiar/webcrypto'
 import getPort from 'get-port'
 import pWaitFor from 'p-wait-for'
+import { CODEC_CERTHASH, CODEC_WEBRTC_DIRECT, HANDSHAKE_TIMEOUT_MS } from '../constants.js'
 import { connect } from './utils/connect.js'
 import { generateTransportCertificate } from './utils/generate-certificates.js'
 import { createDialerRTCPeerConnection } from './utils/get-rtcpeerconnection.js'
@@ -17,13 +18,6 @@ import type { PeerId, ListenerEvents, Listener, Upgrader, ComponentLogger, Logge
 import type { Multiaddr } from '@multiformats/multiaddr'
 
 const crypto = new Crypto()
-
-/**
- * The time to wait, in milliseconds, for the data channel handshake to complete
- */
-const HANDSHAKE_TIMEOUT_MS = 10_000
-const CODEC_WEBRTC_DIRECT = 0x0118
-const CODEC_CERTHASH = 0x01d2
 
 export interface WebRTCDirectListenerComponents {
   peerId: PeerId

--- a/packages/transport-webrtc/src/private-to-public/transport.ts
+++ b/packages/transport-webrtc/src/private-to-public/transport.ts
@@ -1,8 +1,8 @@
 import { serviceCapabilities, transportSymbol } from '@libp2p/interface'
 import { peerIdFromString } from '@libp2p/peer-id'
-import { protocols } from '@multiformats/multiaddr'
 import { WebRTCDirect } from '@multiformats/multiaddr-matcher'
 import { raceSignal } from 'race-signal'
+import { HANDSHAKE_TIMEOUT_MS } from '../constants.js'
 import { genUfrag } from '../util.js'
 import { WebRTCDirectListener } from './listener.js'
 import { connect } from './utils/connect.js'
@@ -12,25 +12,6 @@ import type { WebRTCDialEvents } from '../private-to-private/transport.js'
 import type { CreateListenerOptions, Transport, Listener, ComponentLogger, Logger, Connection, CounterGroup, Metrics, PeerId, DialTransportOptions, PrivateKey } from '@libp2p/interface'
 import type { TransportManager } from '@libp2p/interface-internal'
 import type { Multiaddr } from '@multiformats/multiaddr'
-
-/**
- * The time to wait, in milliseconds, for the data channel handshake to complete
- */
-const HANDSHAKE_TIMEOUT_MS = 10_000
-
-/**
- * Created by converting the hexadecimal protocol code to an integer.
- *
- * {@link https://github.com/multiformats/multiaddr/blob/master/protocols.csv}
- */
-export const WEBRTC_CODE: number = protocols('webrtc-direct').code
-
-/**
- * Created by converting the hexadecimal protocol code to an integer.
- *
- * {@link https://github.com/multiformats/multiaddr/blob/master/protocols.csv}
- */
-export const CERTHASH_CODE: number = protocols('certhash').code
 
 /**
  * The peer for this transport

--- a/packages/transport-webrtc/src/private-to-public/utils/sdp.ts
+++ b/packages/transport-webrtc/src/private-to-public/utils/sdp.ts
@@ -4,9 +4,9 @@ import { base64url } from 'multiformats/bases/base64'
 import { bases, digest } from 'multiformats/basics'
 import * as Digest from 'multiformats/hashes/digest'
 import { sha256 } from 'multiformats/hashes/sha2'
+import { CODEC_CERTHASH } from '../../constants.js'
 import { InvalidFingerprintError, UnsupportedHashAlgorithmError } from '../../error.js'
 import { MAX_MESSAGE_SIZE } from '../../stream.js'
-import { CERTHASH_CODE } from '../transport.js'
 import type { Multiaddr } from '@multiformats/multiaddr'
 import type { MultihashDigest } from 'multiformats/hashes/interface'
 
@@ -29,7 +29,7 @@ export function getFingerprintFromSdp (sdp: string | undefined): string | undefi
 // Extract the certhash from a multiaddr
 export function certhash (ma: Multiaddr): string {
   const tups = ma.stringTuples()
-  const certhash = tups.filter((tup) => tup[0] === CERTHASH_CODE).map((tup) => tup[1])[0]
+  const certhash = tups.filter((tup) => tup[0] === CODEC_CERTHASH).map((tup) => tup[1])[0]
 
   if (certhash === undefined || certhash === '') {
     throw new InvalidParametersError(`Couldn't find a certhash component of multiaddr: ${ma.toString()}`)


### PR DESCRIPTION
To allow the noise handshake to time out, pass the abort signal to the upgrade methods

## Change checklist

- [x] I have performed a self-review of my own code
- [ ] I have made corresponding changes to the documentation if necessary (this includes comments as well)
- [ ] I have added tests that prove my fix is effective or that my feature works