### PR TITLE
fix: ignore failures to listen on IPv6 addresses when IPv4 succeeds

### DIFF
--- a/packages/libp2p/src/errors.ts
+++ b/packages/libp2p/src/errors.ts
@@ -66,13 +66,6 @@ export class NoValidAddressesError extends Error {
   }
 }
 
-export class NoSupportedAddressesError extends Error {
-  constructor (message = 'No supported addresses') {
-    super(message)
-    this.name = 'NoSupportedAddressesError'
-  }
-}
-
 export class ConnectionInterceptedError extends Error {
   constructor (message = 'Connection intercepted') {
     super(message)

--- a/packages/libp2p/src/transport-manager.ts
+++ b/packages/libp2p/src/transport-manager.ts
@@ -1,5 +1,6 @@
 import { FaultTolerance, InvalidParametersError, NotStartedError } from '@libp2p/interface'
 import { trackedMap } from '@libp2p/utils/tracked-map'
+import { IP4, IP6 } from '@multiformats/multiaddr-matcher'
 import { CustomProgressEvent } from 'progress-events'
 import { NoValidAddressesError, TransportUnavailableError } from './errors.js'
 import type { Libp2pEvents, ComponentLogger, Logger, Connection, TypedEventTarget, Metrics, Startable, Listener, Transport, Upgrader } from '@libp2p/interface'
@@ -16,6 +17,17 @@ export interface DefaultTransportManagerComponents {
   upgrader: Upgrader
   events: TypedEventTarget<Libp2pEvents>
   logger: ComponentLogger
+}
+
+interface IPStats {
+  success: number
+  attempts: number
+}
+
+interface ListenStats {
+  unsupportedAddresses: Set<string>
+  ipv4: IPStats
+  ipv6: IPStats
 }
 
 export class DefaultTransportManager implements TransportManager, Startable {
@@ -192,11 +204,26 @@ export class DefaultTransportManager implements TransportManager, Startable {
       return
     }
 
-    const couldNotListen = []
+    // track IPv4/IPv6 results - if we succeed on IPv4 but all IPv6 attempts
+    // fail then we are probably on a network without IPv6 support
+    const listenStats: ListenStats = {
+      unsupportedAddresses: new Set(
+        addrs.map(ma => ma.toString())
+      ),
+      ipv4: {
+        success: 0,
+        attempts: 0
+      },
+      ipv6: {
+        success: 0,
+        attempts: 0
+      }
+    }
+
+    const tasks: Array<Promise<void>> = []
 
     for (const [key, transport] of this.transports.entries()) {
       const supportedAddrs = transport.listenFilter(addrs)
-      const tasks = []
 
       // For each supported multiaddr, create a listener
       for (const addr of supportedAddrs) {
@@ -231,36 +258,66 @@ export class DefaultTransportManager implements TransportManager, Startable {
           })
         })
 
+        // track IPv4/IPv6 support
+        if (IP4.matches(addr)) {
+          listenStats.ipv4.attempts++
+        } else if (IP6.matches(addr)) {
+          listenStats.ipv6.attempts++
+        }
+
         // We need to attempt to listen on everything
-        tasks.push(listener.listen(addr))
-      }
+        tasks.push(
+          listener.listen(addr)
+            .then(() => {
+              listenStats.unsupportedAddresses.delete(addr.toString())
 
-      // Keep track of transports we had no addresses for
-      if (tasks.length === 0) {
-        couldNotListen.push(key)
-        continue
-      }
+              if (IP4.matches(addr)) {
+                listenStats.ipv4.success++
+              }
 
-      const results = await Promise.allSettled(tasks)
-      // If we are listening on at least 1 address, succeed.
-      // TODO: we should look at adding a retry (`p-retry`) here to better support
-      // listening on remote addresses as they may be offline. We could then potentially
-      // just wait for any (`p-any`) listener to succeed on each transport before returning
-      const isListening = results.find(r => r.status === 'fulfilled')
-      if ((isListening == null) && this.faultTolerance !== FaultTolerance.NO_FATAL) {
-        throw new NoValidAddressesError(`Transport (${key}) could not listen on any available address`)
+              if (IP6.matches(addr)) {
+                listenStats.ipv6.success++
+              }
+            })
+        )
       }
     }
 
-    // If no transports were able to listen, throw an error. This likely
-    // means we were given addresses we do not have transports for
-    if (couldNotListen.length === this.transports.size) {
-      const message = `no valid addresses were provided for transports [${couldNotListen.join(', ')}]`
-      if (this.faultTolerance === FaultTolerance.FATAL_ALL) {
-        throw new NoValidAddressesError(message)
-      }
-      this.log(`libp2p in dial mode only: ${message}`)
+    await Promise.allSettled(tasks)
+
+    // listening on all addresses, all good
+    if (listenStats.unsupportedAddresses.size === 0) {
+      return
     }
+
+    // detect lack of IPv6 support on the current network - if we tried to
+    // listen on IPv4 and IPv6 addresses, and all IPv4 addresses succeeded but
+    // all IPv6 addresses fail, then we can assume there's no IPv6 here
+    if (this.ipv6Unsupported(listenStats)) {
+      this.log('all IPv4 addresses succeed but all IPv6 failed')
+      return
+    }
+
+    if (this.faultTolerance === FaultTolerance.NO_FATAL) {
+      // ok to be dial-only
+      return
+    }
+
+    // if a configured address was not able to be listened on, throw an error
+    throw new NoValidAddressesError(`No configured transport could listen on these addresses, please remove them from your config: ${[
+      ...listenStats.unsupportedAddresses
+    ].join(', ')}`)
+  }
+
+  private ipv6Unsupported (listenStats: ListenStats): boolean {
+    if (listenStats.ipv4.attempts === 0 || listenStats.ipv6.attempts === 0) {
+      return false
+    }
+
+    const allIpv4Succeeded = listenStats.ipv4.attempts === listenStats.ipv4.success
+    const allIpv6Failed = listenStats.ipv6.success === 0
+
+    return allIpv4Succeeded && allIpv6Failed
   }
 
   /**

--- a/packages/transport-webrtc/src/private-to-private/listener.ts
+++ b/packages/transport-webrtc/src/private-to-private/listener.ts
@@ -1,7 +1,7 @@
 import { TypedEventEmitter } from '@libp2p/interface'
 import { P2P } from '@multiformats/multiaddr-matcher'
 import { fmt, literal } from '@multiformats/multiaddr-matcher/utils'
-import type { PeerId, ListenerEvents, Listener } from '@libp2p/interface'
+import type { PeerId, ListenerEvents, Listener, Libp2pEvents, TypedEventTarget } from '@libp2p/interface'
 import type { TransportManager } from '@libp2p/interface-internal'
 import type { Multiaddr } from '@multiformats/multiaddr'
 
@@ -10,6 +10,7 @@ const Circuit = fmt(P2P.matchers[0], literal('p2p-circuit'))
 export interface WebRTCPeerListenerComponents {
   peerId: PeerId
   transportManager: TransportManager
+  events: TypedEventTarget<Libp2pEvents>
 }
 
 export interface WebRTCPeerListenerInit {
@@ -19,18 +20,32 @@ export interface WebRTCPeerListenerInit {
 export class WebRTCPeerListener extends TypedEventEmitter<ListenerEvents> implements Listener {
   private readonly transportManager: TransportManager
   private readonly shutdownController: AbortController
+  private readonly events: TypedEventTarget<Libp2pEvents>
 
   constructor (components: WebRTCPeerListenerComponents, init: WebRTCPeerListenerInit) {
     super()
 
     this.transportManager = components.transportManager
+    this.events = components.events
     this.shutdownController = init.shutdownController
+
+    this.onTransportListening = this.onTransportListening.bind(this)
   }
 
   async listen (): Promise<void> {
-    queueMicrotask(() => {
+    this.events.addEventListener('transport:listening', this.onTransportListening)
+  }
+
+  onTransportListening (event: CustomEvent<Listener>): void {
+    const circuitAddresses = event.detail.getAddrs()
+      .filter(ma => Circuit.exactMatch(ma))
+      .map(ma => {
+        return ma.encapsulate('/webrtc')
+      })
+
+    if (circuitAddresses.length > 0) {
       this.safeDispatchEvent('listening')
-    })
+    }
   }
 
   getAddrs (): Multiaddr[] {
@@ -51,6 +66,8 @@ export class WebRTCPeerListener extends TypedEventEmitter<ListenerEvents> implem
   }
 
   async close (): Promise<void> {
+    this.events.removeEventListener('transport:listening', this.onTransportListening)
+
     this.shutdownController.abort()
     queueMicrotask(() => {
       this.safeDispatchEvent('close')

--- a/packages/transport-webrtc/src/private-to-private/transport.ts
+++ b/packages/transport-webrtc/src/private-to-private/transport.ts
@@ -10,7 +10,7 @@ import { initiateConnection } from './initiate-connection.js'
 import { WebRTCPeerListener } from './listener.js'
 import { handleIncomingStream } from './signaling-stream-handler.js'
 import type { DataChannelOptions } from '../index.js'
-import type { OutboundConnectionUpgradeEvents, CreateListenerOptions, DialTransportOptions, Transport, Listener, Upgrader, ComponentLogger, Logger, Connection, PeerId, CounterGroup, Metrics, Startable, OpenConnectionProgressEvents, IncomingStreamData } from '@libp2p/interface'
+import type { OutboundConnectionUpgradeEvents, CreateListenerOptions, DialTransportOptions, Transport, Listener, Upgrader, ComponentLogger, Logger, Connection, PeerId, CounterGroup, Metrics, Startable, OpenConnectionProgressEvents, IncomingStreamData, Libp2pEvents, TypedEventTarget } from '@libp2p/interface'
 import type { Registrar, ConnectionManager, TransportManager } from '@libp2p/interface-internal'
 import type { ProgressEvent } from 'progress-events'
 
@@ -38,6 +38,7 @@ export interface WebRTCTransportComponents {
   connectionManager: ConnectionManager
   metrics?: Metrics
   logger: ComponentLogger
+  events: TypedEventTarget<Libp2pEvents>
 }
 
 export interface WebRTCTransportMetrics {

--- a/packages/transport-webrtc/test/listener.spec.ts
+++ b/packages/transport-webrtc/test/listener.spec.ts
@@ -1,4 +1,5 @@
 import { generateKeyPair } from '@libp2p/crypto/keys'
+import { TypedEventEmitter } from '@libp2p/interface'
 import { peerIdFromPrivateKey } from '@libp2p/peer-id'
 import { multiaddr } from '@multiformats/multiaddr'
 import { expect } from 'aegir/chai'
@@ -17,7 +18,8 @@ describe('webrtc private-to-private listener', () => {
 
     const listener = new WebRTCPeerListener({
       peerId,
-      transportManager
+      transportManager,
+      events: new TypedEventEmitter()
     }, {
       shutdownController: new AbortController()
     })

--- a/packages/transport-webrtc/test/peer.spec.ts
+++ b/packages/transport-webrtc/test/peer.spec.ts
@@ -1,4 +1,5 @@
 import { generateKeyPair } from '@libp2p/crypto/keys'
+import { TypedEventEmitter } from '@libp2p/interface'
 import { streamPair } from '@libp2p/interface-compliance-tests/mocks'
 import { defaultLogger, logger } from '@libp2p/logger'
 import { peerIdFromPrivateKey } from '@libp2p/peer-id'
@@ -252,7 +253,8 @@ describe('webrtc filter', () => {
       peerId: Sinon.stub() as any,
       registrar: stubInterface<Registrar>(),
       upgrader: stubInterface<Upgrader>(),
-      logger: defaultLogger()
+      logger: defaultLogger(),
+      events: new TypedEventEmitter()
     })
 
     const valid = [


### PR DESCRIPTION
If listening on all IPv4 addresses succeeds but listening on all IPv6 addresses fails, we may be on a network that doesn't support IPv6 so ignore the failure.

Fixes #2977

## Change checklist

- [x] I have performed a self-review of my own code
- [ ] I have made corresponding changes to the documentation if necessary (this includes comments as well)
- [x] I have added tests that prove my fix is effective or that my feature works