### PR TITLE
fix: emit listening event after circuit relays listen

### DIFF
--- a/packages/transport-webrtc/src/private-to-private/listener.ts
+++ b/packages/transport-webrtc/src/private-to-private/listener.ts
@@ -1,7 +1,7 @@
 import { TypedEventEmitter } from '@libp2p/interface'
 import { P2P } from '@multiformats/multiaddr-matcher'
 import { fmt, literal } from '@multiformats/multiaddr-matcher/utils'
-import type { PeerId, ListenerEvents, Listener } from '@libp2p/interface'
+import type { PeerId, ListenerEvents, Listener, Libp2pEvents, TypedEventTarget } from '@libp2p/interface'
 import type { TransportManager } from '@libp2p/interface-internal'
 import type { Multiaddr } from '@multiformats/multiaddr'
 
@@ -10,6 +10,7 @@ const Circuit = fmt(P2P.matchers[0], literal('p2p-circuit'))
 export interface WebRTCPeerListenerComponents {
   peerId: PeerId
   transportManager: TransportManager
+  events: TypedEventTarget<Libp2pEvents>
 }
 
 export interface WebRTCPeerListenerInit {
@@ -19,18 +20,32 @@ export interface WebRTCPeerListenerInit {
 export class WebRTCPeerListener extends TypedEventEmitter<ListenerEvents> implements Listener {
   private readonly transportManager: TransportManager
   private readonly shutdownController: AbortController
+  private readonly events: TypedEventTarget<Libp2pEvents>
 
   constructor (components: WebRTCPeerListenerComponents, init: WebRTCPeerListenerInit) {
     super()
 
     this.transportManager = components.transportManager
+    this.events = components.events
     this.shutdownController = init.shutdownController
+
+    this.onTransportListening = this.onTransportListening.bind(this)
   }
 
   async listen (): Promise<void> {
-    queueMicrotask(() => {
+    this.events.addEventListener('transport:listening', this.onTransportListening)
+  }
+
+  onTransportListening (event: CustomEvent<Listener>): void {
+    const circuitAddresses = event.detail.getAddrs()
+      .filter(ma => Circuit.exactMatch(ma))
+      .map(ma => {
+        return ma.encapsulate('/webrtc')
+      })
+
+    if (circuitAddresses.length > 0) {
       this.safeDispatchEvent('listening')
-    })
+    }
   }
 
   getAddrs (): Multiaddr[] {
@@ -51,6 +66,8 @@ export class WebRTCPeerListener extends TypedEventEmitter<ListenerEvents> implem
   }
 
   async close (): Promise<void> {
+    this.events.removeEventListener('transport:listening', this.onTransportListening)
+
     this.shutdownController.abort()
     queueMicrotask(() => {
       this.safeDispatchEvent('close')

--- a/packages/transport-webrtc/src/private-to-private/transport.ts
+++ b/packages/transport-webrtc/src/private-to-private/transport.ts
@@ -10,7 +10,7 @@ import { initiateConnection } from './initiate-connection.js'
 import { WebRTCPeerListener } from './listener.js'
 import { handleIncomingStream } from './signaling-stream-handler.js'
 import type { DataChannelOptions } from '../index.js'
-import type { OutboundConnectionUpgradeEvents, CreateListenerOptions, DialTransportOptions, Transport, Listener, Upgrader, ComponentLogger, Logger, Connection, PeerId, CounterGroup, Metrics, Startable, OpenConnectionProgressEvents, IncomingStreamData } from '@libp2p/interface'
+import type { OutboundConnectionUpgradeEvents, CreateListenerOptions, DialTransportOptions, Transport, Listener, Upgrader, ComponentLogger, Logger, Connection, PeerId, CounterGroup, Metrics, Startable, OpenConnectionProgressEvents, IncomingStreamData, Libp2pEvents, TypedEventTarget } from '@libp2p/interface'
 import type { Registrar, ConnectionManager, TransportManager } from '@libp2p/interface-internal'
 import type { ProgressEvent } from 'progress-events'
 
@@ -38,6 +38,7 @@ export interface WebRTCTransportComponents {
   connectionManager: ConnectionManager
   metrics?: Metrics
   logger: ComponentLogger
+  events: TypedEventTarget<Libp2pEvents>
 }
 
 export interface WebRTCTransportMetrics {

--- a/packages/transport-webrtc/test/listener.spec.ts
+++ b/packages/transport-webrtc/test/listener.spec.ts
@@ -1,4 +1,5 @@
 import { generateKeyPair } from '@libp2p/crypto/keys'
+import { TypedEventEmitter } from '@libp2p/interface'
 import { peerIdFromPrivateKey } from '@libp2p/peer-id'
 import { multiaddr } from '@multiformats/multiaddr'
 import { expect } from 'aegir/chai'
@@ -17,7 +18,8 @@ describe('webrtc private-to-private listener', () => {
 
     const listener = new WebRTCPeerListener({
       peerId,
-      transportManager
+      transportManager,
+      events: new TypedEventEmitter()
     }, {
       shutdownController: new AbortController()
     })

--- a/packages/transport-webrtc/test/peer.spec.ts
+++ b/packages/transport-webrtc/test/peer.spec.ts
@@ -1,4 +1,5 @@
 import { generateKeyPair } from '@libp2p/crypto/keys'
+import { TypedEventEmitter } from '@libp2p/interface'
 import { streamPair } from '@libp2p/interface-compliance-tests/mocks'
 import { defaultLogger, logger } from '@libp2p/logger'
 import { peerIdFromPrivateKey } from '@libp2p/peer-id'
@@ -252,7 +253,8 @@ describe('webrtc filter', () => {
       peerId: Sinon.stub() as any,
       registrar: stubInterface<Registrar>(),
       upgrader: stubInterface<Upgrader>(),
-      logger: defaultLogger()
+      logger: defaultLogger(),
+      events: new TypedEventEmitter()
     })
 
     const valid = [


### PR DESCRIPTION
Instead of emitting the 'listening' event as soon as the transport is started, emit it after we start listening on a circuit relay address.

## Change checklist

- [x] I have performed a self-review of my own code
- [ ] I have made corresponding changes to the documentation if necessary (this includes comments as well)
- [ ] I have added tests that prove my fix is effective or that my feature works