### PR TITLE
chore: use prefix logger

### DIFF
--- a/packages/integration-tests/.aegir.js
+++ b/packages/integration-tests/.aegir.js
@@ -21,8 +21,10 @@ export default {
       const { echo } = await import('@libp2p/echo')
       const { mockMuxer } = await import('@libp2p/interface-compliance-tests/mocks')
       const { ping } = await import('@libp2p/ping')
+      const { prefixLogger } = await import('@libp2p/logger')
 
       const libp2p = await createLibp2p({
+        logger: prefixLogger('relay'),
         connectionManager: {
           inboundConnectionThreshold: Infinity
         },

--- a/packages/kad-dht/.aegir.js
+++ b/packages/kad-dht/.aegir.js
@@ -1,4 +1,3 @@
-
 /** @type {import('aegir').PartialOptions} */
 export default {
   build: {

--- a/packages/metrics-prometheus/.aegir.js
+++ b/packages/metrics-prometheus/.aegir.js
@@ -1,4 +1,4 @@
-
+/** @type {import('aegir').PartialOptions} */
 export default {
   build: {
     bundle: false

--- a/packages/pubsub-floodsub/.aegir.js
+++ b/packages/pubsub-floodsub/.aegir.js
@@ -1,6 +1,6 @@
 /** @type {import('aegir').PartialOptions} */
 export default {
   build: {
-    bundlesizeMax: '109KB',
+    bundlesizeMax: '109KB'
   }
 }

--- a/packages/stream-multiplexer-mplex/.aegir.js
+++ b/packages/stream-multiplexer-mplex/.aegir.js
@@ -1,4 +1,3 @@
-
 /** @type {import('aegir').PartialOptions} */
 export default {
   build: {


### PR DESCRIPTION
Where a relay server is started, use a prefix logger to prevent DEBUG output clashing with the unit under test

## Change checklist

- [x] I have performed a self-review of my own code
- [ ] I have made corresponding changes to the documentation if necessary (this includes comments as well)
- [ ] I have added tests that prove my fix is effective or that my feature works