### PR TITLE
fix: constrain ip6 listener to ip6 addresses

### DIFF
--- a/packages/transport-tcp/src/utils.ts
+++ b/packages/transport-tcp/src/utils.ts
@@ -21,8 +21,14 @@ export function multiaddrToNetConfig (addr: Multiaddr, config: NetConfig = {}): 
     }
   }
 
+  const options = addr.toOptions()
+
   // tcp listening
-  return { ...config, ...addr.toOptions() }
+  return {
+    ...config,
+    ...options,
+    ipv6Only: options.family === 6
+  }
 }
 
 export function getMultiaddrs (proto: 'ip4' | 'ip6', ip: string, port: number): Multiaddr[] {


### PR DESCRIPTION
Solves a port conflict if both ip4 and ip6 wildcard ports are listened on.

Only seems to affect some Linuxes.

## Change checklist

- [x] I have performed a self-review of my own code
- [ ] I have made corresponding changes to the documentation if necessary (this includes comments as well)
- [ ] I have added tests that prove my fix is effective or that my feature works