### PR TITLE
fix: constrain ip6 ws listener to ip6 stack

### DIFF
--- a/packages/transport-websockets/src/listener.ts
+++ b/packages/transport-websockets/src/listener.ts
@@ -249,10 +249,13 @@ export class WebSocketListener extends TypedEventEmitter<ListenerEvents> impleme
     }
 
     this.listeningMultiaddr = ma
-    const { host, port } = ma.toOptions()
-    this.addr = `${host}:${port}`
+    const options = ma.toOptions()
+    this.addr = `${options.host}:${options.port}`
 
-    this.server.listen(port, host)
+    this.server.listen({
+      ...options,
+      ipv6Only: options.family === 6
+    })
 
     await new Promise<void>((resolve, reject) => {
       const onListening = (): void => {


### PR DESCRIPTION
Applies fix from #3010 to ws listener

## Change checklist

- [x] I have performed a self-review of my own code
- [ ] I have made corresponding changes to the documentation if necessary (this includes comments as well)
- [ ] I have added tests that prove my fix is effective or that my feature works