### PR TITLE
fix: .d.ts is in ./dist folder

### DIFF
--- a/packages/crypto/package.json
+++ b/packages/crypto/package.json
@@ -48,7 +48,7 @@
   ],
   "exports": {
     ".": {
-      "types": "./src/index.d.ts",
+      "types": "./dist/src/index.d.ts",
       "import": "./dist/src/index.js"
     },
     "./ciphers": {

--- a/packages/keychain/package.json
+++ b/packages/keychain/package.json
@@ -33,7 +33,7 @@
   ],
   "exports": {
     ".": {
-      "types": "./src/index.d.ts",
+      "types": "./dist/src/index.d.ts",
       "import": "./dist/src/index.js"
     }
   },

--- a/packages/logger/package.json
+++ b/packages/logger/package.json
@@ -28,7 +28,7 @@
   ],
   "exports": {
     ".": {
-      "types": "./src/index.d.ts",
+      "types": "./dist/src/index.d.ts",
       "import": "./dist/src/index.js"
     }
   },

--- a/packages/peer-discovery-bootstrap/package.json
+++ b/packages/peer-discovery-bootstrap/package.json
@@ -28,7 +28,7 @@
   ],
   "exports": {
     ".": {
-      "types": "./src/index.d.ts",
+      "types": "./dist/src/index.d.ts",
       "import": "./dist/src/index.js"
     }
   },

--- a/packages/peer-record/package.json
+++ b/packages/peer-record/package.json
@@ -28,7 +28,7 @@
   ],
   "exports": {
     ".": {
-      "types": "./src/index.d.ts",
+      "types": "./dist/src/index.d.ts",
       "import": "./dist/src/index.js"
     }
   },

--- a/packages/peer-store/package.json
+++ b/packages/peer-store/package.json
@@ -28,7 +28,7 @@
   ],
   "exports": {
     ".": {
-      "types": "./src/index.d.ts",
+      "types": "./dist/src/index.d.ts",
       "import": "./dist/src/index.js"
     }
   },

--- a/packages/pubsub-floodsub/package.json
+++ b/packages/pubsub-floodsub/package.json
@@ -33,7 +33,7 @@
   ],
   "exports": {
     ".": {
-      "types": "./src/index.d.ts",
+      "types": "./dist/src/index.d.ts",
       "import": "./dist/src/index.js"
     }
   },

--- a/packages/transport-webtransport/package.json
+++ b/packages/transport-webtransport/package.json
@@ -28,7 +28,7 @@
   ],
   "exports": {
     ".": {
-      "types": "./src/index.d.ts",
+      "types": "./dist/src/index.d.ts",
       "import": "./dist/src/index.js"
     }
   },

--- a/packages/utils/package.json
+++ b/packages/utils/package.json
@@ -41,7 +41,7 @@
   ],
   "exports": {
     ".": {
-      "types": "./src/index.d.ts",
+      "types": "./dist/src/index.d.ts",
       "import": "./dist/src/index.js"
     },
     "./abort-options": {


### PR DESCRIPTION
## Title
<!---
The title of the PR will be the commit message of the merge commit, so please make sure it is descriptive enough.
We utilize the Conventional Commits specification for our commit messages. See <https://www.conventionalcommits.org/en/v1.0.0/#specification> for more information.
The commit tag types can be of one of the following: feat, fix, deps, refactor, chore, docs. See <https://github.com/libp2p/js-libp2p/blob/master/.github/workflows/main.yml#L235-L242>
The title must also be fewer than 72 characters long or it will fail the Semantic PR check. See <https://github.com/libp2p/js-libp2p/blob/master/.github/workflows/semantic-pull-request.yml>
--->

fix: .d.ts is in ./dist folder

## Description

Since the export is badly done when you try to resolve with esplugin import it will lead to 
1:27  error  Unable to resolve path to module '@libp2p/bootstrap'    import/no-unresolved

<!--
Please write a summary of your changes and why you made them.
Please include any relevant issues in here, for example:
Related https://github.com/libp2p/js-libp2p/issues/ABCD.
Fixes https://github.com/libp2p/js-libp2p/issues/XYZ.
-->

## Notes & open questions

<!--
Any notes, remarks or open questions you have to make about the PR which don't need to go into the final commit message.
-->

## Change checklist

- [x] I have performed a self-review of my own code
- [ ] I have made corresponding changes to the documentation if necessary (this includes comments as well)
- [ ] I have added tests that prove my fix is effective or that my feature works