### PR TITLE
feat: allow early muxer selection by connection encrypters

### DIFF
--- a/packages/interface-compliance-tests/src/mocks/upgrader.ts
+++ b/packages/interface-compliance-tests/src/mocks/upgrader.ts
@@ -1,7 +1,7 @@
 import { setMaxListeners } from '@libp2p/interface'
 import { anySignal } from 'any-signal'
 import { mockConnection } from './connection.js'
-import type { Libp2pEvents, Connection, MultiaddrConnection, TypedEventTarget, Upgrader, UpgraderOptions, ClearableSignal } from '@libp2p/interface'
+import type { Libp2pEvents, Connection, MultiaddrConnection, TypedEventTarget, Upgrader, UpgraderOptions, ClearableSignal, ConnectionEncrypter, StreamMuxerFactory } from '@libp2p/interface'
 import type { Registrar } from '@libp2p/interface-internal'
 
 export interface MockUpgraderInit {
@@ -48,6 +48,14 @@ class MockUpgrader implements Upgrader {
     setMaxListeners(Infinity, output)
 
     return output
+  }
+
+  getConnectionEncrypters (): Map<string, ConnectionEncrypter<unknown>> {
+    return new Map()
+  }
+
+  getStreamMuxers (): Map<string, StreamMuxerFactory> {
+    return new Map()
   }
 }
 

--- a/packages/interface/src/connection-encrypter.ts
+++ b/packages/interface/src/connection-encrypter.ts
@@ -1,5 +1,5 @@
 import type { MultiaddrConnection } from './connection.js'
-import type { AbortOptions } from './index.js'
+import type { AbortOptions, StreamMuxerFactory } from './index.js'
 import type { PeerId } from './peer-id.js'
 import type { Duplex } from 'it-stream-types'
 import type { Uint8ArrayList } from 'uint8arraylist'
@@ -39,4 +39,11 @@ export interface SecuredConnection<Stream = any, Extension = unknown> {
   conn: Stream
   remoteExtensions?: Extension
   remotePeer: PeerId
+
+  /**
+   * Some encryption protocols allow negotiating application protocols as part
+   * of the initial handshake. Where we are able to negotiated a stream muxer
+   * for the connection it will be returned here.
+   */
+  streamMuxer?: StreamMuxerFactory
 }

--- a/packages/interface/src/transport.ts
+++ b/packages/interface/src/transport.ts
@@ -1,6 +1,6 @@
 import type { Connection, ConnectionLimits, MultiaddrConnection } from './connection.js'
 import type { TypedEventTarget } from './event-target.js'
-import type { AbortOptions, ClearableSignal } from './index.js'
+import type { AbortOptions, ClearableSignal, ConnectionEncrypter } from './index.js'
 import type { StreamMuxerFactory } from './stream-muxer.js'
 import type { Multiaddr } from '@multiformats/multiaddr'
 import type { ProgressOptions, ProgressEvent } from 'progress-events'

--- a/packages/interface/src/transport.ts
+++ b/packages/interface/src/transport.ts
@@ -159,4 +159,14 @@ export interface Upgrader {
    * controller to `upgradeInbound`.
    */
   createInboundAbortSignal (signal: AbortSignal): ClearableSignal
+
+  /**
+   * Returns configured stream muxers
+   */
+  getStreamMuxers (): Map<string, StreamMuxerFactory>
+
+  /**
+   * Returns configured connection encrypters
+   */
+  getConnectionEncrypters (): Map<string, ConnectionEncrypter>
 }

--- a/packages/libp2p/src/upgrader.ts
+++ b/packages/libp2p/src/upgrader.ts
@@ -100,7 +100,7 @@ function countStreams (protocol: string, direction: 'inbound' | 'outbound', conn
   return streamCount
 }
 
-export interface DefaultUpgraderComponents {
+export interface UpgraderComponents {
   peerId: PeerId
   metrics?: Metrics
   connectionManager: ConnectionManager
@@ -115,7 +115,7 @@ export interface DefaultUpgraderComponents {
 type ConnectionDeniedType = keyof Pick<ConnectionGater, 'denyOutboundConnection' | 'denyInboundEncryptedConnection' | 'denyOutboundEncryptedConnection' | 'denyInboundUpgradedConnection' | 'denyOutboundUpgradedConnection'>
 
 export class Upgrader implements UpgraderInterface {
-  private readonly components: DefaultUpgraderComponents
+  private readonly components: UpgraderComponents
   private readonly connectionEncrypters: Map<string, ConnectionEncrypter>
   private readonly streamMuxers: Map<string, StreamMuxerFactory>
   private readonly inboundUpgradeTimeout: number
@@ -127,7 +127,7 @@ export class Upgrader implements UpgraderInterface {
     errors?: CounterGroup<'inbound' | 'outbound'>
   }
 
-  constructor (components: DefaultUpgraderComponents, init: UpgraderInit) {
+  constructor (components: UpgraderComponents, init: UpgraderInit) {
     this.components = components
     this.connectionEncrypters = new Map()
 

--- a/packages/libp2p/src/upgrader.ts
+++ b/packages/libp2p/src/upgrader.ts
@@ -286,7 +286,8 @@ export class Upgrader implements UpgraderInterface {
         ({
           conn: encryptedConn,
           remotePeer,
-          protocol: cryptoProtocol
+          protocol: cryptoProtocol,
+          streamMuxer: muxerFactory
         } = await (direction === 'inbound'
           ? this._encryptInbound(protectedConn, opts)
           : this._encryptOutbound(protectedConn, opts)
@@ -322,7 +323,7 @@ export class Upgrader implements UpgraderInterface {
       upgradedConn = encryptedConn
       if (opts?.muxerFactory != null) {
         muxerFactory = opts.muxerFactory
-      } else if (this.streamMuxers.size > 0) {
+      } else if (muxerFactory == null && this.streamMuxers.size > 0) {
         opts?.onProgress?.(new CustomProgressEvent(`upgrader:multiplex-${direction}-connection`))
 
         // Multiplex the connection
@@ -745,5 +746,13 @@ export class Upgrader implements UpgraderInterface {
       connection.log.error('error multiplexing inbound connection', err)
       throw new MuxerUnavailableError(String(err))
     }
+  }
+
+  getConnectionEncrypters (): Map<string, ConnectionEncrypter<unknown>> {
+    return this.connectionEncrypters
+  }
+
+  getStreamMuxers (): Map<string, StreamMuxerFactory> {
+    return this.streamMuxers
   }
 }

--- a/packages/libp2p/test/upgrading/utils.ts
+++ b/packages/libp2p/test/upgrading/utils.ts
@@ -5,11 +5,11 @@ import { TypedEventEmitter } from '@libp2p/interface'
 import { defaultLogger } from '@libp2p/logger'
 import { peerIdFromPrivateKey } from '@libp2p/peer-id'
 import { stubInterface, type StubbedInstance } from 'sinon-ts'
-import type { DefaultUpgraderComponents } from '../../src/upgrader.js'
+import type { UpgraderComponents } from '../../src/upgrader.js'
 import type { ConnectionGater, PeerId, PeerStore, TypedEventTarget, Libp2pEvents, ComponentLogger, Metrics, ConnectionProtector } from '@libp2p/interface'
 import type { ConnectionManager, Registrar } from '@libp2p/interface-internal'
 
-export interface StubbedDefaultUpgraderComponents {
+export interface StubbedUpgraderComponents {
   peerId: PeerId
   metrics?: StubbedInstance<Metrics>
   connectionManager: StubbedInstance<ConnectionManager>
@@ -21,7 +21,7 @@ export interface StubbedDefaultUpgraderComponents {
   logger: ComponentLogger
 }
 
-export async function createDefaultUpgraderComponents (options?: Partial<DefaultUpgraderComponents>): Promise<StubbedDefaultUpgraderComponents> {
+export async function createDefaultUpgraderComponents (options?: Partial<UpgraderComponents>): Promise<StubbedUpgraderComponents> {
   return {
     peerId: peerIdFromPrivateKey(await generateKeyPair('Ed25519')),
     connectionManager: stubInterface<ConnectionManager>({


### PR DESCRIPTION
Some encrypters allow sending application protocols along with the initial handshake.

We can use these to select muxers and save the round-trips of mss.

## Change checklist

- [x] I have performed a self-review of my own code
- [x] I have made corresponding changes to the documentation if necessary (this includes comments as well)
- [x] I have added tests that prove my fix is effective or that my feature works