### PR TITLE
fix: decrease default routing table size

### DIFF
--- a/packages/kad-dht/src/index.ts
+++ b/packages/kad-dht/src/index.ts
@@ -428,15 +428,36 @@ export interface KadDHTInit {
    * can be stored.
    *
    * Storing more peers means fewer lookups (and network operations) are needed
-   * to locate a certain peer, but also that more memory is consumed.
+   * to locate a certain peer, but also that more memory is consumed and more
+   * CPU while responding to queries (e.g. with more peers in the table sorting
+   * the closest peers becomes more expensive) and CPU/network during table
+   * maintenance (e.g. checking peers are still online).
    *
-   * @default 32
+   * The larger this value, the more prefix bits must be the same for a peer to
+   * be stored in a KAD bucket, so the fewer nodes that bucket is likely to
+   * contain.
+   *
+   * The total number of peers in the table is a factor of `prefixLength` and
+   * `kBucketSize`:
+   *
+   * ```
+   * (2 ^ prefixLength) * kBucketSize
+   * ```
+   *
+   * @default 8
    */
   prefixLength?: number
 
   /**
    * If true, only ever be a DHT client. If false, be a DHT client until told
    * to be a DHT server via `setMode`.
+   *
+   * In general this should be left as the default because server mode will be
+   * selected automatically when libp2p establishes that the current node has
+   * a publicly dialable address.
+   *
+   * The exception to this is LAN-only DHT (e.g. for testing purposes) where it
+   * is safe to assume that the current node is dialable.
    *
    * @default false
    */

--- a/packages/kad-dht/src/index.ts
+++ b/packages/kad-dht/src/index.ts
@@ -444,7 +444,7 @@ export interface KadDHTInit {
    * (2 ^ prefixLength) * kBucketSize
    * ```
    *
-   * @default 8
+   * @default 6
    */
   prefixLength?: number
 

--- a/packages/kad-dht/src/routing-table/index.ts
+++ b/packages/kad-dht/src/routing-table/index.ts
@@ -14,7 +14,7 @@ import type { AbortOptions, ComponentLogger, CounterGroup, Logger, Metric, Metri
 import type { AdaptiveTimeoutInit } from '@libp2p/utils/adaptive-timeout'
 
 export const KBUCKET_SIZE = 20
-export const PREFIX_LENGTH = 8
+export const PREFIX_LENGTH = 6
 export const PING_NEW_CONTACT_TIMEOUT = 2000
 export const PING_NEW_CONTACT_CONCURRENCY = 20
 export const PING_NEW_CONTACT_MAX_QUEUE_SIZE = 100


### PR DESCRIPTION
Reduces the default routing table size to 1280 (down from 5120).

This improves CPU/memory/network usage as we don't need to sort as many peers when finding the closest ones to a given key, nor do we need to contact as many to ensure only live peers are still in the table.

## Change checklist

- [x] I have performed a self-review of my own code
- [x] I have made corresponding changes to the documentation if necessary (this includes comments as well)
- [x] I have added tests that prove my fix is effective or that my feature works