### PR TITLE
fix: abort connection on TLS error

### DIFF
--- a/packages/connection-encrypter-tls/src/tls.ts
+++ b/packages/connection-encrypter-tls/src/tls.ts
@@ -157,6 +157,11 @@ export class TLS implements ConnectionEncrypter {
         }
 
         socket.destroy(err)
+
+        if (isAbortable(conn)) {
+          conn.abort(err)
+        }
+
         reject(err)
       })
       socket.once('secure', () => {
@@ -178,4 +183,12 @@ export class TLS implements ConnectionEncrypter {
       })
     })
   }
+}
+
+interface Abortable {
+  abort (err: Error): void
+}
+
+function isAbortable <T> (obj: T & Partial<Abortable>): obj is T & Abortable {
+  return typeof obj?.abort === 'function'
 }


### PR DESCRIPTION
If the TLS socket emits an error message, abort the connection if it is abortable.

We should probably ammend the interface so `.abort` is relected in the types but this would be a bigger change.

## Change checklist

- [x] I have performed a self-review of my own code
- [ ] I have made corresponding changes to the documentation if necessary (this includes comments as well)
- [ ] I have added tests that prove my fix is effective or that my feature works