### PR TITLE
fix: always send key type

### DIFF
--- a/packages/connection-encrypter-plaintext/src/pb/proto.proto
+++ b/packages/connection-encrypter-plaintext/src/pb/proto.proto
@@ -13,6 +13,6 @@ enum KeyType {
 }
 
 message PublicKey {
-  KeyType Type = 1;
+  optional KeyType Type = 1;
   bytes Data = 2;
 }

--- a/packages/connection-encrypter-plaintext/src/pb/proto.ts
+++ b/packages/connection-encrypter-plaintext/src/pb/proto.ts
@@ -98,7 +98,7 @@ export namespace KeyType {
   }
 }
 export interface PublicKey {
-  Type: KeyType
+  Type?: KeyType
   Data: Uint8Array
 }
 
@@ -112,7 +112,7 @@ export namespace PublicKey {
           w.fork()
         }
 
-        if (obj.Type != null && __KeyTypeValues[obj.Type] !== 0) {
+        if (obj.Type != null) {
           w.uint32(8)
           KeyType.codec().encode(obj.Type, w)
         }
@@ -127,7 +127,6 @@ export namespace PublicKey {
         }
       }, (reader, length, opts = {}) => {
         const obj: any = {
-          Type: KeyType.RSA,
           Data: uint8ArrayAlloc(0)
         }
 


### PR DESCRIPTION
Mark the field `optional` so we always send it on the wire, otherwise proto2 decoders that have it marked `required` will fail to decode the incoming message.

## Change checklist

- [x] I have performed a self-review of my own code
- [ ] I have made corresponding changes to the documentation if necessary (this includes comments as well)
- [ ] I have added tests that prove my fix is effective or that my feature works