### PR TITLE
fix: pass upgrader to noise

### DIFF
--- a/packages/transport-webtransport/package.json
+++ b/packages/transport-webtransport/package.json
@@ -76,7 +76,8 @@
     "it-to-buffer": "^4.0.7",
     "libp2p": "^2.8.0",
     "p-defer": "^4.0.1",
-    "p-wait-for": "^5.0.2"
+    "p-wait-for": "^5.0.2",
+    "sinon-ts": "^2.0.0"
   },
   "browser": {
     "./dist/src/listener.js": "./dist/src/listener.browser.js",

--- a/packages/transport-webtransport/src/index.ts
+++ b/packages/transport-webtransport/src/index.ts
@@ -41,7 +41,7 @@ import { inertDuplex } from './utils/inert-duplex.js'
 import { isSubset } from './utils/is-subset.js'
 import { parseMultiaddr } from './utils/parse-multiaddr.js'
 import WebTransport from './webtransport.js'
-import type { Transport, CreateListenerOptions, DialTransportOptions, Listener, ComponentLogger, Logger, Connection, MultiaddrConnection, CounterGroup, Metrics, PeerId, OutboundConnectionUpgradeEvents, PrivateKey } from '@libp2p/interface'
+import type { Upgrader, Transport, CreateListenerOptions, DialTransportOptions, Listener, ComponentLogger, Logger, Connection, MultiaddrConnection, CounterGroup, Metrics, PeerId, OutboundConnectionUpgradeEvents, PrivateKey } from '@libp2p/interface'
 import type { Multiaddr } from '@multiformats/multiaddr'
 import type { Source } from 'it-stream-types'
 import type { MultihashDigest } from 'multiformats/hashes/interface'
@@ -72,6 +72,7 @@ export interface WebTransportComponents {
   privateKey: PrivateKey
   metrics?: Metrics
   logger: ComponentLogger
+  upgrader: Upgrader
 }
 
 export interface WebTransportMetrics {

--- a/packages/transport-webtransport/test/transport.spec.ts
+++ b/packages/transport-webtransport/test/transport.spec.ts
@@ -6,7 +6,9 @@ import { defaultLogger } from '@libp2p/logger'
 import { peerIdFromPrivateKey } from '@libp2p/peer-id'
 import { multiaddr } from '@multiformats/multiaddr'
 import { expect } from 'aegir/chai'
+import { stubInterface } from 'sinon-ts'
 import { webTransport, type WebTransportComponents } from '../src/index.js'
+import type { Upgrader } from '@libp2p/interface'
 
 describe('WebTransport Transport', () => {
   let components: WebTransportComponents
@@ -17,7 +19,8 @@ describe('WebTransport Transport', () => {
     components = {
       peerId: peerIdFromPrivateKey(privateKey),
       privateKey,
-      logger: defaultLogger()
+      logger: defaultLogger(),
+      upgrader: stubInterface<Upgrader>()
     }
   })
 


### PR DESCRIPTION
Compatibility fix ahead of https://github.com/ChainSafe/js-libp2p-noise/pull/482

## Change checklist

- [x] I have performed a self-review of my own code
- [ ] I have made corresponding changes to the documentation if necessary (this includes comments as well)
- [ ] I have added tests that prove my fix is effective or that my feature works