### PR TITLE
fix: drain timeout is 30s no 301s

### DIFF
--- a/packages/transport-webrtc/src/constants.ts
+++ b/packages/transport-webrtc/src/constants.ts
@@ -99,7 +99,7 @@ export const OPEN_TIMEOUT = 5_000
  * When closing a stream, we wait for `bufferedAmount` to become 0 before
  * closing the underlying RTCDataChannel - this controls how long we wait in ms
  */
-export const DATA_CHANNEL_DRAIN_TIMEOUT = 30_1000
+export const DATA_CHANNEL_DRAIN_TIMEOUT = 30_000
 
 /**
  * Set as the 'negotiated' muxer protocol name


### PR DESCRIPTION
## Title

fix: drain timeout is 30s no 301s
<!---
The title of the PR will be the commit message of the merge commit, so please make sure it is descriptive enough.
We utilize the Conventional Commits specification for our commit messages. See <https://www.conventionalcommits.org/en/v1.0.0/#specification> for more information.
The commit tag types can be of one of the following: feat, fix, deps, refactor, chore, docs. See <https://github.com/libp2p/js-libp2p/blob/master/.github/workflows/main.yml#L235-L242>
The title must also be fewer than 72 characters long or it will fail the Semantic PR check. See <https://github.com/libp2p/js-libp2p/blob/master/.github/workflows/semantic-pull-request.yml>
--->

## Description
Before it was 30s https://github.com/libp2p/js-libp2p/pull/3005/files#diff-622f25d2f456a8282d3c1a3fe645b8a63044e11f384fabdad6ac7fc78eafa090L16 so I think it is just a typo 
<!--
Please write a summary of your changes and why you made them.
Please include any relevant issues in here, for example:
Related https://github.com/libp2p/js-libp2p/issues/ABCD.
Fixes https://github.com/libp2p/js-libp2p/issues/XYZ.
-->

## Notes & open questions

<!--
Any notes, remarks or open questions you have to make about the PR which don't need to go into the final commit message.
-->

## Change checklist

- [x] I have performed a self-review of my own code
- [x] I have made corresponding changes to the documentation if necessary (this includes comments as well)
- [ ] I have added tests that prove my fix is effective or that my feature works