### PR TITLE
feat: support parsing base32 and base36 libp2p-key CIDs in peerIdFromString

### DIFF
--- a/packages/peer-id/src/index.ts
+++ b/packages/peer-id/src/index.ts
@@ -37,6 +37,9 @@ export function peerIdFromString (str: string, decoder?: MultibaseDecoder<any>):
     // identity hash ed25519/secp256k1 key or sha2-256 hash of
     // rsa public key - base58btc encoded either way
     multihash = Digest.decode(base58btc.decode(`z${str}`))
+  } else if (str.startsWith('k51qzi5uqu5') || str.startsWith('kzwfwjn5ji4') || str.startsWith('k2k4r8') || str.startsWith('bafz')) {
+    // base36 encoded CIDv1 with libp2p-key and identity hash (for ed25519/secp256k1/rsa) or base32 encoded CIDv1 with libp2p-key and identity hash (for ed25519/secp256k1/rsa)
+    return peerIdFromCID(CID.parse(str))
   } else {
     if (decoder == null) {
       throw new InvalidParametersError('Please pass a multibase decoder for strings that do not start with "1" or "Q"')
@@ -124,20 +127,4 @@ function isIdentityMultihash (multihash: MultihashDigest): multihash is Multihas
 
 function isSha256Multihash (multihash: MultihashDigest): multihash is MultihashDigest<0x12> {
   return multihash.code === sha256.code
-}
-
-/**
- * Get a PeerId from a string
- *
- * @param peerIdString - The string to get the PeerId from, can be a base58btc encoded multihash or a CID
- * @returns PeerId
- */
-export function getPeerId (peerIdString: string): PeerId {
-  // It's either base58btc encoded multihash (identity or sha256)
-  if (peerIdString.charAt(0) === '1' || peerIdString.charAt(0) === 'Q') {
-    return peerIdFromString(peerIdString)
-  }
-
-  // or base36 encoded CID
-  return peerIdFromCID(CID.parse(peerIdString))
 }

--- a/packages/peer-id/src/index.ts
+++ b/packages/peer-id/src/index.ts
@@ -126,14 +126,13 @@ function isSha256Multihash (multihash: MultihashDigest): multihash is MultihashD
   return multihash.code === sha256.code
 }
 
-
 /**
  * Get a PeerId from a string
  *
  * @param peerIdString - The string to get the PeerId from, can be a base58btc encoded multihash or a CID
  * @returns PeerId
  */
-export function getPeerId(peerIdString: string): PeerId {
+export function getPeerId (peerIdString: string): PeerId {
   // It's either base58btc encoded multihash (identity or sha256)
   if (peerIdString.charAt(0) === '1' || peerIdString.charAt(0) === 'Q') {
     return peerIdFromString(peerIdString)

--- a/packages/peer-id/src/index.ts
+++ b/packages/peer-id/src/index.ts
@@ -17,7 +17,7 @@
 import { publicKeyFromMultihash } from '@libp2p/crypto/keys'
 import { InvalidCIDError, InvalidMultihashError, InvalidParametersError, UnsupportedKeyTypeError } from '@libp2p/interface'
 import { base58btc } from 'multiformats/bases/base58'
-import { type CID, type MultibaseDecoder } from 'multiformats/cid'
+import { CID, type MultibaseDecoder } from 'multiformats/cid'
 import * as Digest from 'multiformats/hashes/digest'
 import { identity } from 'multiformats/hashes/identity'
 import { sha256 } from 'multiformats/hashes/sha2'
@@ -124,4 +124,21 @@ function isIdentityMultihash (multihash: MultihashDigest): multihash is Multihas
 
 function isSha256Multihash (multihash: MultihashDigest): multihash is MultihashDigest<0x12> {
   return multihash.code === sha256.code
+}
+
+
+/**
+ * Get a PeerId from a string
+ *
+ * @param peerIdString - The string to get the PeerId from, can be a base58btc encoded multihash or a CID
+ * @returns PeerId
+ */
+export function getPeerId(peerIdString: string): PeerId {
+  // It's either base58btc encoded multihash (identity or sha256)
+  if (peerIdString.charAt(0) === '1' || peerIdString.charAt(0) === 'Q') {
+    return peerIdFromString(peerIdString)
+  }
+
+  // or base36 encoded CID
+  return peerIdFromCID(CID.parse(peerIdString))
 }

--- a/packages/peer-id/test/index.spec.ts
+++ b/packages/peer-id/test/index.spec.ts
@@ -2,11 +2,13 @@
 import { generateKeyPair } from '@libp2p/crypto/keys'
 import { expect } from 'aegir/chai'
 import { base58btc } from 'multiformats/bases/base58'
+import { base36 } from 'multiformats/bases/base36'
+import { base32 } from 'multiformats/bases/base32'
 import { CID } from 'multiformats/cid'
 import { identity } from 'multiformats/hashes/identity'
 import Sinon from 'sinon'
 import { fromString as uint8ArrayFromString } from 'uint8arrays/from-string'
-import { getPeerId, peerIdFromCID, peerIdFromMultihash, peerIdFromPrivateKey, peerIdFromString } from '../src/index.js'
+import { peerIdFromCID, peerIdFromMultihash, peerIdFromPrivateKey, peerIdFromString } from '../src/index.js'
 import type { KeyType, PeerId } from '@libp2p/interface'
 
 // these values are from https://github.com/multiformats/multicodec/blob/master/table.csv
@@ -56,13 +58,12 @@ describe('PeerId', () => {
         expect(id.toCID().toString()).to.equal(peerId.toCID().toString())
       })
 
-      it('should create a peer id from a string that can be either a base58btc encoded multihash or a CID', async () => {
-        let id = getPeerId(peerId.toString())
+      it('should return the correct peer id from cid encoded peer id in base36 and base32', async () => {
+        let id = peerIdFromString(peerId.toCID().toString(base36))
         expect(id.type).to.equal(type)
         expect(id.toString()).to.equal(peerId.toString())
         expect(id.toCID().toString()).to.equal(peerId.toCID().toString())
-
-        id = getPeerId(peerId.toCID().toString())
+        id = peerIdFromString(peerId.toCID().toString(base32))
         expect(id.type).to.equal(type)
         expect(id.toString()).to.equal(peerId.toString())
         expect(id.toCID().toString()).to.equal(peerId.toCID().toString())

--- a/packages/peer-id/test/index.spec.ts
+++ b/packages/peer-id/test/index.spec.ts
@@ -58,12 +58,15 @@ describe('PeerId', () => {
         expect(id.toCID().toString()).to.equal(peerId.toCID().toString())
       })
 
-      it('should return the correct peer id from cid encoded peer id in base36 and base32', async () => {
-        let id = peerIdFromString(peerId.toCID().toString(base36))
+      it('should return the correct peer id from cid encoded peer id in base36', async () => {
+        const id = peerIdFromString(peerId.toCID().toString(base36))
         expect(id.type).to.equal(type)
         expect(id.toString()).to.equal(peerId.toString())
         expect(id.toCID().toString()).to.equal(peerId.toCID().toString())
-        id = peerIdFromString(peerId.toCID().toString(base32))
+      })
+
+      it('should return the correct peer id from cid encoded peer id in base32', async () => {
+        const id = peerIdFromString(peerId.toCID().toString(base32))
         expect(id.type).to.equal(type)
         expect(id.toString()).to.equal(peerId.toString())
         expect(id.toCID().toString()).to.equal(peerId.toCID().toString())

--- a/packages/peer-id/test/index.spec.ts
+++ b/packages/peer-id/test/index.spec.ts
@@ -6,7 +6,7 @@ import { CID } from 'multiformats/cid'
 import { identity } from 'multiformats/hashes/identity'
 import Sinon from 'sinon'
 import { fromString as uint8ArrayFromString } from 'uint8arrays/from-string'
-import { peerIdFromCID, peerIdFromMultihash, peerIdFromPrivateKey, peerIdFromString } from '../src/index.js'
+import { getPeerId, peerIdFromCID, peerIdFromMultihash, peerIdFromPrivateKey, peerIdFromString } from '../src/index.js'
 import type { KeyType, PeerId } from '@libp2p/interface'
 
 // these values are from https://github.com/multiformats/multicodec/blob/master/table.csv
@@ -51,6 +51,18 @@ describe('PeerId', () => {
 
       it('should parse a v1 CID with the libp2p-key codec', async () => {
         const id = peerIdFromCID(peerId.toCID())
+        expect(id.type).to.equal(type)
+        expect(id.toString()).to.equal(peerId.toString())
+        expect(id.toCID().toString()).to.equal(peerId.toCID().toString())
+      })
+
+      it('should create a peer id from a string that can be either a base58btc encoded multihash or a CID', async () => {
+        let id = getPeerId(peerId.toString())
+        expect(id.type).to.equal(type)
+        expect(id.toString()).to.equal(peerId.toString())
+        expect(id.toCID().toString()).to.equal(peerId.toCID().toString())
+
+        id = getPeerId(peerId.toCID().toString())
         expect(id.type).to.equal(type)
         expect(id.toString()).to.equal(peerId.toString())
         expect(id.toCID().toString()).to.equal(peerId.toCID().toString())

--- a/packages/peer-id/test/index.spec.ts
+++ b/packages/peer-id/test/index.spec.ts
@@ -1,9 +1,9 @@
 /* eslint-env mocha */
 import { generateKeyPair } from '@libp2p/crypto/keys'
 import { expect } from 'aegir/chai'
-import { base58btc } from 'multiformats/bases/base58'
-import { base36 } from 'multiformats/bases/base36'
 import { base32 } from 'multiformats/bases/base32'
+import { base36 } from 'multiformats/bases/base36'
+import { base58btc } from 'multiformats/bases/base58'
 import { CID } from 'multiformats/cid'
 import { identity } from 'multiformats/hashes/identity'
 import Sinon from 'sinon'


### PR DESCRIPTION
## Title

Given the prevalence of both CID encoded PeerIDs and base58mh encoded ones, I found myself defining this function in multiple places. 

This PR introduces this as a helper (as was supported in an earlier version of js-libp2p)

## Notes & open questions

<!--
Any notes, remarks or open questions you have to make about the PR which don't need to go into the final commit message.
-->

## Change checklist

- [x] I have performed a self-review of my own code
- [x] I have made corresponding changes to the documentation if necessary (this includes comments as well)
- [x] I have added tests that prove my fix is effective or that my feature works