### PR TITLE
feat: add util to get thin waist addresses

### DIFF
--- a/packages/utils/package.json
+++ b/packages/utils/package.json
@@ -76,6 +76,11 @@
       "types": "./dist/src/filters/index.d.ts",
       "import": "./dist/src/filters/index.js"
     },
+    "./get-thin-waist-addresses": {
+      "types": "./dist/src/get-thin-waist-addresses.d.ts",
+      "browser": "./dist/src/get-thin-waist-addresses.browser.js",
+      "import": "./dist/src/get-thin-waist-addresses.js"
+    },
     "./global-unicast-ip": {
       "types": "./dist/src/global-unicast-ip.d.ts",
       "import": "./dist/src/global-unicast-ip.js"
@@ -219,7 +224,14 @@
     "it-drain": "^3.0.7",
     "it-pair": "^2.0.6",
     "sinon": "^19.0.2",
-    "sinon-ts": "^2.0.0"
+    "sinon-ts": "^2.0.0",
+    "wherearewe": "^2.0.1"
   },
-  "sideEffects": false
+  "sideEffects": false,
+  "browser": {
+    "./dist/src/get-thin-waist-addresses.js": "./dist/src/get-thin-waist-addresses.browser.js"
+  },
+  "react-native": {
+    "./dist/src/get-thin-waist-addresses.js": "./dist/src/get-thin-waist-addresses.js"
+  }
 }

--- a/packages/utils/src/get-thin-waist-addresses.browser.ts
+++ b/packages/utils/src/get-thin-waist-addresses.browser.ts
@@ -1,0 +1,13 @@
+import { multiaddr, type Multiaddr } from '@multiformats/multiaddr'
+
+/**
+ * Get all thin waist addresses that match the passed multiaddr. Wildcard IP4/6
+ * addresses will be expanded into all available interfaces.
+ */
+export function getThinWaistAddresses (ma: Multiaddr): Multiaddr[] {
+  const options = ma.toOptions()
+
+  return [
+    multiaddr(`/ip${options.family}/${options.host}/${options.transport}/${options.port}`)
+  ]
+}

--- a/packages/utils/src/get-thin-waist-addresses.ts
+++ b/packages/utils/src/get-thin-waist-addresses.ts
@@ -1,0 +1,49 @@
+import os from 'node:os'
+import { multiaddr, type Multiaddr } from '@multiformats/multiaddr'
+
+const FAMILIES = { 4: 'IPv4', 6: 'IPv6' }
+
+function isWildcard (ip: string): boolean {
+  return ['0.0.0.0', '::'].includes(ip)
+}
+
+function getNetworkAddrs (family: 4 | 6): string[] {
+  const addresses: string[] = []
+  const networks = os.networkInterfaces()
+
+  for (const [, netAddrs] of Object.entries(networks)) {
+    if (netAddrs != null) {
+      for (const netAddr of netAddrs) {
+        if (netAddr.family === FAMILIES[family]) {
+          addresses.push(netAddr.address)
+        }
+      }
+    }
+  }
+
+  return addresses
+}
+
+/**
+ * Get all thin waist addresses on the current host that match the family of the
+ * passed multiaddr.
+ *
+ * Wildcard IP4/6 addresses will be expanded into all available interfaces.
+ */
+export function getThinWaistAddresses (ma: Multiaddr): Multiaddr[] {
+  const options = ma.toOptions()
+
+  if (isWildcard(options.host)) {
+    const addrs = []
+
+    for (const host of getNetworkAddrs(options.family)) {
+      addrs.push(multiaddr(`/ip${options.family}/${host}/${options.transport}/${options.port}`))
+    }
+
+    return addrs
+  }
+
+  return [
+    multiaddr(`/ip${options.family}/${options.host}/${options.transport}/${options.port}`)
+  ]
+}

--- a/packages/utils/test/get-thin-waist-addresses.spec.ts
+++ b/packages/utils/test/get-thin-waist-addresses.spec.ts
@@ -1,0 +1,58 @@
+import { multiaddr } from '@multiformats/multiaddr'
+import { expect } from 'aegir/chai'
+import { isNode, isElectronMain } from 'wherearewe'
+import { getThinWaistAddresses } from '../src/get-thin-waist-addresses.js'
+
+describe('get-thin-waist-addresses', () => {
+  it('should get thin waist addresses from specific address', () => {
+    const input = multiaddr('/ip4/123.123.123.123/tcp/1234')
+    const addrs = getThinWaistAddresses(input)
+
+    expect(addrs).to.deep.equal([input])
+  })
+
+  it('should ignore non-thin waist tuples from specific address', () => {
+    const input = multiaddr('/ip4/123.123.123.123/udp/1234/webrtc')
+    const addrs = getThinWaistAddresses(input)
+
+    expect(addrs).to.deep.equal([
+      multiaddr('/ip4/123.123.123.123/udp/1234')
+    ])
+  })
+
+  it('should get thin waist addresses from IPv4 wildcard', function () {
+    if (!isNode && !isElectronMain) {
+      return this.skip()
+    }
+
+    const input = multiaddr('/ip4/0.0.0.0/tcp/1234')
+    const addrs = getThinWaistAddresses(input)
+
+    expect(addrs).to.have.property('length').that.is.greaterThan(0)
+
+    for (const addr of addrs) {
+      const options = addr.toOptions()
+
+      expect(options).to.have.property('family', 4)
+      expect(options).to.have.property('host').that.does.not.equal('0.0.0.0')
+    }
+  })
+
+  it('should get thin waist addresses from IPv6 wildcard', function () {
+    if (!isNode && !isElectronMain) {
+      return this.skip()
+    }
+
+    const input = multiaddr('/ip6/::/tcp/1234')
+    const addrs = getThinWaistAddresses(input)
+
+    expect(addrs).to.have.property('length').that.is.greaterThan(0)
+
+    for (const addr of addrs) {
+      const options = addr.toOptions()
+
+      expect(options).to.have.property('family', 6)
+      expect(options).to.have.property('host').that.does.not.equal('::')
+    }
+  })
+})


### PR DESCRIPTION
Adds a utillity to get all thin waist addresses for the current host, expanding ip4/ip6 wildcards as appropriate.

Largely ports the code from `@libp2p/tcp` for use elsewhere.

## Change checklist

- [x] I have performed a self-review of my own code
- [x] I have made corresponding changes to the documentation if necessary (this includes comments as well)
- [x] I have added tests that prove my fix is effective or that my feature works