### PR TITLE
test: add @chainsafe/libp2p-quic to interop suite

### DIFF
--- a/interop/node-version.json
+++ b/interop/node-version.json
@@ -9,7 +9,8 @@
       "onlyDial": true
     },
     "webrtc",
-    "webrtc-direct"
+    "webrtc-direct",
+    "quic"
   ],
   "secureChannels": ["noise", "tls"],
   "muxers": ["yamux", "mplex"]

--- a/interop/node-version.json
+++ b/interop/node-version.json
@@ -10,7 +10,7 @@
     },
     "webrtc",
     "webrtc-direct",
-    "quic"
+    "quic-v1"
   ],
   "secureChannels": ["noise", "tls"],
   "muxers": ["yamux", "mplex"]

--- a/interop/package.json
+++ b/interop/package.json
@@ -19,6 +19,7 @@
   },
   "devDependencies": {
     "@chainsafe/libp2p-noise": "^16.0.0",
+    "@chainsafe/libp2p-quic": "^1.0.4",
     "@chainsafe/libp2p-yamux": "^7.0.1",
     "@libp2p/circuit-relay-v2": "^3.1.3",
     "@libp2p/identify": "^3.0.12",

--- a/interop/package.json
+++ b/interop/package.json
@@ -19,7 +19,7 @@
   },
   "devDependencies": {
     "@chainsafe/libp2p-noise": "^16.0.0",
-    "@chainsafe/libp2p-quic": "^1.0.4",
+    "@chainsafe/libp2p-quic": "^1.0.5",
     "@chainsafe/libp2p-yamux": "^7.0.1",
     "@libp2p/circuit-relay-v2": "^3.1.3",
     "@libp2p/identify": "^3.0.12",

--- a/interop/test/fixtures/get-libp2p.ts
+++ b/interop/test/fixtures/get-libp2p.ts
@@ -1,6 +1,7 @@
 /* eslint-disable complexity */
 
 import { noise } from '@chainsafe/libp2p-noise'
+import { quic } from '@chainsafe/libp2p-quic'
 import { yamux } from '@chainsafe/libp2p-yamux'
 import { circuitRelayTransport } from '@libp2p/circuit-relay-v2'
 import { identify } from '@libp2p/identify'
@@ -82,6 +83,12 @@ export async function getLibp2p (): Promise<Libp2p<{ ping: PingService }>> {
         listen: isDialer ? [] : [`/ip4/${IP}/tcp/0/wss`]
       }
       break
+    case 'quic':
+      options.transports = [quic()]
+      options.addresses = {
+        listen: isDialer ? [] : [`/ip4/${IP}/udp/0/quic-v1`]
+      }
+      break
     default:
       throw new Error(`Unknown transport: ${TRANSPORT ?? '???'}`)
   }
@@ -91,6 +98,7 @@ export async function getLibp2p (): Promise<Libp2p<{ ping: PingService }>> {
   switch (TRANSPORT) {
     case 'webtransport':
     case 'webrtc-direct':
+    case 'quic':
       skipSecureChannel = true
       skipMuxer = true
       break

--- a/interop/test/fixtures/get-libp2p.ts
+++ b/interop/test/fixtures/get-libp2p.ts
@@ -83,7 +83,7 @@ export async function getLibp2p (): Promise<Libp2p<{ ping: PingService }>> {
         listen: isDialer ? [] : [`/ip4/${IP}/tcp/0/wss`]
       }
       break
-    case 'quic':
+    case 'quic-v1':
       options.transports = [quic()]
       options.addresses = {
         listen: isDialer ? [] : [`/ip4/${IP}/udp/0/quic-v1`]
@@ -98,7 +98,7 @@ export async function getLibp2p (): Promise<Libp2p<{ ping: PingService }>> {
   switch (TRANSPORT) {
     case 'webtransport':
     case 'webrtc-direct':
-    case 'quic':
+    case 'quic-v1':
       skipSecureChannel = true
       skipMuxer = true
       break


### PR DESCRIPTION
Tests the experimental quic transport from @chainsafe/libp2p-quic

## Change checklist

- [ ] I have performed a self-review of my own code
- [ ] I have made corresponding changes to the documentation if necessary (this includes comments as well)
- [ ] I have added tests that prove my fix is effective or that my feature works