### PR TITLE
fix: use getThinWaistAddresss function

### DIFF
--- a/packages/transport-tcp/package.json
+++ b/packages/transport-tcp/package.json
@@ -62,8 +62,8 @@
   "dependencies": {
     "@libp2p/interface": "^2.7.0",
     "@libp2p/utils": "^6.5.8",
-    "@multiformats/mafmt": "^12.1.6",
     "@multiformats/multiaddr": "^12.3.3",
+    "@multiformats/multiaddr-matcher": "^1.6.0",
     "@types/sinon": "^17.0.3",
     "p-defer": "^4.0.1",
     "p-event": "^6.0.1",

--- a/packages/transport-tcp/src/constants.ts
+++ b/packages/transport-tcp/src/constants.ts
@@ -1,10 +1,5 @@
-// p2p multi-address code
-export const CODE_P2P = 421
-export const CODE_CIRCUIT = 290
-export const CODE_UNIX = 400
-
 // Time to wait for a connection to close gracefully before destroying it manually
 export const CLOSE_TIMEOUT = 500
 
 // Close the socket if there is no activity after this long in ms
-export const SOCKET_TIMEOUT = 2 * 60000 // 2 mins
+export const SOCKET_TIMEOUT = 2 * 60_000 // 2 mins

--- a/packages/transport-tcp/src/tcp.ts
+++ b/packages/transport-tcp/src/tcp.ts
@@ -29,9 +29,8 @@
 
 import net from 'net'
 import { AbortError, TimeoutError, serviceCapabilities, transportSymbol } from '@libp2p/interface'
-import * as mafmt from '@multiformats/mafmt'
+import { TCP as TCPMatcher } from '@multiformats/multiaddr-matcher'
 import { CustomProgressEvent } from 'progress-events'
-import { CODE_CIRCUIT, CODE_P2P, CODE_UNIX } from './constants.js'
 import { TCPListener } from './listener.js'
 import { toMultiaddrConnection } from './socket-to-conn.js'
 import { multiaddrToNetConfig } from './utils.js'
@@ -204,19 +203,7 @@ export class TCP implements Transport<TCPDialEvents> {
    * Takes a list of `Multiaddr`s and returns only valid TCP addresses
    */
   listenFilter (multiaddrs: Multiaddr[]): Multiaddr[] {
-    multiaddrs = Array.isArray(multiaddrs) ? multiaddrs : [multiaddrs]
-
-    return multiaddrs.filter(ma => {
-      if (ma.protoCodes().includes(CODE_CIRCUIT)) {
-        return false
-      }
-
-      if (ma.protoCodes().includes(CODE_UNIX)) {
-        return true
-      }
-
-      return mafmt.TCP.matches(ma.decapsulateCode(CODE_P2P))
-    })
+    return multiaddrs.filter(ma => TCPMatcher.exactMatch(ma) || ma.toString().startsWith('/unix/'))
   }
 
   /**

--- a/packages/transport-tcp/src/utils.ts
+++ b/packages/transport-tcp/src/utils.ts
@@ -1,10 +1,7 @@
 import os from 'os'
 import path from 'path'
-import { multiaddr } from '@multiformats/multiaddr'
 import type { Multiaddr } from '@multiformats/multiaddr'
 import type { ListenOptions, IpcSocketConnectOpts, TcpSocketConnectOpts } from 'net'
-
-const ProtoFamily = { ip4: 'IPv4', ip6: 'IPv6' }
 
 export type NetConfig = ListenOptions | (IpcSocketConnectOpts & TcpSocketConnectOpts)
 
@@ -29,31 +26,4 @@ export function multiaddrToNetConfig (addr: Multiaddr, config: NetConfig = {}): 
     ...options,
     ipv6Only: options.family === 6
   }
-}
-
-export function getMultiaddrs (proto: 'ip4' | 'ip6', ip: string, port: number): Multiaddr[] {
-  const toMa = (ip: string): Multiaddr => multiaddr(`/${proto}/${ip}/tcp/${port}`)
-  return (isAnyAddr(ip) ? getNetworkAddrs(ProtoFamily[proto]) : [ip]).map(toMa)
-}
-
-export function isAnyAddr (ip: string): boolean {
-  return ['0.0.0.0', '::'].includes(ip)
-}
-
-const networks = os.networkInterfaces()
-
-function getNetworkAddrs (family: string): string[] {
-  const addresses: string[] = []
-
-  for (const [, netAddrs] of Object.entries(networks)) {
-    if (netAddrs != null) {
-      for (const netAddr of netAddrs) {
-        if (netAddr.family === family) {
-          addresses.push(netAddr.address)
-        }
-      }
-    }
-  }
-
-  return addresses
 }

--- a/packages/transport-tcp/test/filter.spec.ts
+++ b/packages/transport-tcp/test/filter.spec.ts
@@ -32,6 +32,8 @@ describe('filter addrs', () => {
     expect(valid.length).to.equal(5)
     expect(valid[0]).to.deep.equal(ma1)
     expect(valid[1]).to.deep.equal(ma4)
+    expect(valid[2]).to.deep.equal(ma7)
+    expect(valid[3]).to.deep.equal(ma8)
     expect(valid[4]).to.deep.equal(ma9)
   })
 

--- a/packages/transport-tcp/test/listen-dial.spec.ts
+++ b/packages/transport-tcp/test/listen-dial.spec.ts
@@ -150,18 +150,6 @@ describe('listen', () => {
     expect(multiaddrs.length > 0).to.equal(true)
     expect(multiaddrs[0].toOptions().host).to.not.equal('::')
   })
-
-  it('getAddrs preserves IPFS Id', async () => {
-    const mh = multiaddr('/ip4/127.0.0.1/tcp/9090/ipfs/Qmb6owHp6eaWArVbcJJbQSyifyJBttMMjYV76N2hMbf5Vw')
-    listener = transport.createListener({
-      upgrader
-    })
-    await listener.listen(mh)
-
-    const multiaddrs = listener.getAddrs()
-    expect(multiaddrs.length).to.equal(1)
-    expect(multiaddrs[0]).to.deep.equal(mh)
-  })
 })
 
 describe('dial', () => {

--- a/packages/transport-webrtc/test/transport.spec.ts
+++ b/packages/transport-webrtc/test/transport.spec.ts
@@ -127,23 +127,17 @@ describe('WebRTCDirect Transport', () => {
     await listener.close()
   })
 
-  it('can listen on wildcard hosts', async function () {
+  it('can listen on wildcard IPv4 hosts', async function () {
     if ((!isNode && !isElectronMain) || !supportsIpV6()) {
       return this.skip()
     }
 
     const ipv4 = multiaddr('/ip4/0.0.0.0/udp/0')
-    const ipv6 = multiaddr('/ip6/::/udp/0')
-
-    await Promise.all([
-      listener.listen(ipv4),
-      listener.listen(ipv6)
-    ])
+    await listener.listen(ipv4)
 
     assertAllMultiaddrsHaveSamePort(listener.getAddrs())
 
     let foundIpv4Loopback = false
-    let foundIpv6Loopback = false
 
     for (const addr of listener.getAddrs()) {
       const options = addr.toOptions()
@@ -151,34 +145,36 @@ describe('WebRTCDirect Transport', () => {
       if (options.host === '127.0.0.1') {
         foundIpv4Loopback = true
       }
+    }
+
+    expect(foundIpv4Loopback).to.be.true('did not listen on ipv4 loopback')
+
+    await listener.close()
+  })
+
+  it('can listen on wildcard IPv6 hosts', async function () {
+    if ((!isNode && !isElectronMain) || !supportsIpV6()) {
+      return this.skip()
+    }
+
+    const ipv6 = multiaddr('/ip6/::/udp/0')
+    await listener.listen(ipv6)
+
+    assertAllMultiaddrsHaveSamePort(listener.getAddrs())
+
+    let foundIpv6Loopback = false
+
+    for (const addr of listener.getAddrs()) {
+      const options = addr.toOptions()
 
       if (options.host === '::1') {
         foundIpv6Loopback = true
       }
     }
 
-    expect(foundIpv4Loopback).to.be.true('did not listen on ipv4 loopback')
     expect(foundIpv6Loopback).to.be.true('did not listen on ipv6 loopback')
 
     await listener.close()
-  })
-
-  it('can listen on multiple wildcard ports', async function () {
-    if ((!isNode && !isElectronMain) || !supportsIpV6()) {
-      return this.skip()
-    }
-
-    const ipv4a = multiaddr('/ip4/127.0.0.1/udp/0')
-    const ipv4b = multiaddr('/ip4/127.0.0.1/udp/0')
-
-    await Promise.all([
-      listener.listen(ipv4a),
-      listener.listen(ipv4b)
-    ])
-
-    const addrs = listener.getAddrs()
-    expect(addrs).to.have.lengthOf(2)
-    expect(addrs[0].toOptions().port).to.not.equal(addrs[1].toOptions().port, 'wildcard port listeners with the same ip family should not share ports')
   })
 
   it('should add certificate to announce addresses', async function () {

--- a/packages/transport-websockets/test/node.ts
+++ b/packages/transport-websockets/test/node.ts
@@ -82,13 +82,6 @@ describe('listen', () => {
       expect(listener.getAddrs()).to.be.empty()
     })
 
-    it('should throw when `.getAddrs` called before `.listen`', async () => {
-      listener = ws.createListener({ upgrader })
-
-      // call getAddrs before sockets have opened
-      expect(() => listener.getAddrs()).to.throw(/not ready/)
-    })
-
     it('should error on starting two listeners on same address', async () => {
       listener = ws.createListener({ upgrader })
       const dumbServer = http.createServer()

--- a/packages/utils/src/get-thin-waist-addresses.browser.ts
+++ b/packages/utils/src/get-thin-waist-addresses.browser.ts
@@ -1,13 +1,20 @@
-import { multiaddr, type Multiaddr } from '@multiformats/multiaddr'
+import { multiaddr } from '@multiformats/multiaddr'
+import type { Multiaddr } from '@multiformats/multiaddr'
 
 /**
- * Get all thin waist addresses that match the passed multiaddr. Wildcard IP4/6
- * addresses will be expanded into all available interfaces.
+ * Get all thin waist addresses on the current host that match the family of the
+ * passed multiaddr and optionally override the port.
+ *
+ * Wildcard IP4/6 addresses will be expanded into all available interfaces.
  */
-export function getThinWaistAddresses (ma: Multiaddr): Multiaddr[] {
+export function getThinWaistAddresses (ma?: Multiaddr, port?: number): Multiaddr[] {
+  if (ma == null) {
+    return []
+  }
+
   const options = ma.toOptions()
 
   return [
-    multiaddr(`/ip${options.family}/${options.host}/${options.transport}/${options.port}`)
+    multiaddr(`/ip${options.family}/${options.host}/${options.transport}/${port ?? options.port}`)
   ]
 }

--- a/packages/utils/src/get-thin-waist-addresses.ts
+++ b/packages/utils/src/get-thin-waist-addresses.ts
@@ -1,5 +1,7 @@
 import os from 'node:os'
-import { multiaddr, type Multiaddr } from '@multiformats/multiaddr'
+import { multiaddr } from '@multiformats/multiaddr'
+import { isLinkLocalIp } from './link-local-ip.js'
+import type { Multiaddr } from '@multiformats/multiaddr'
 
 const FAMILIES = { 4: 'IPv4', 6: 'IPv6' }
 
@@ -14,6 +16,10 @@ function getNetworkAddrs (family: 4 | 6): string[] {
   for (const [, netAddrs] of Object.entries(networks)) {
     if (netAddrs != null) {
       for (const netAddr of netAddrs) {
+        if (isLinkLocalIp(netAddr.address)) {
+          continue
+        }
+
         if (netAddr.family === FAMILIES[family]) {
           addresses.push(netAddr.address)
         }
@@ -26,24 +32,28 @@ function getNetworkAddrs (family: 4 | 6): string[] {
 
 /**
  * Get all thin waist addresses on the current host that match the family of the
- * passed multiaddr.
+ * passed multiaddr and optionally override the port.
  *
  * Wildcard IP4/6 addresses will be expanded into all available interfaces.
  */
-export function getThinWaistAddresses (ma: Multiaddr): Multiaddr[] {
+export function getThinWaistAddresses (ma?: Multiaddr, port?: number): Multiaddr[] {
+  if (ma == null) {
+    return []
+  }
+
   const options = ma.toOptions()
 
   if (isWildcard(options.host)) {
     const addrs = []
 
     for (const host of getNetworkAddrs(options.family)) {
-      addrs.push(multiaddr(`/ip${options.family}/${host}/${options.transport}/${options.port}`))
+      addrs.push(multiaddr(`/ip${options.family}/${host}/${options.transport}/${port ?? options.port}`))
     }
 
     return addrs
   }
 
   return [
-    multiaddr(`/ip${options.family}/${options.host}/${options.transport}/${options.port}`)
+    multiaddr(`/ip${options.family}/${options.host}/${options.transport}/${port ?? options.port}`)
   ]
 }

--- a/packages/utils/src/link-local-ip.ts
+++ b/packages/utils/src/link-local-ip.ts
@@ -1,12 +1,10 @@
-import { isIPv4, isIPv6 } from '@chainsafe/is-ip'
-
 export function isLinkLocalIp (ip: string): boolean {
-  if (isIPv4(ip)) {
-    return ip.startsWith('169.254.')
+  if (ip.startsWith('169.254.')) {
+    return true
   }
 
-  if (isIPv6(ip)) {
-    return ip.toLowerCase().startsWith('fe80')
+  if (ip.toLowerCase().startsWith('fe80')) {
+    return true
   }
 
   return false

--- a/packages/utils/test/get-thin-waist-addresses.spec.ts
+++ b/packages/utils/test/get-thin-waist-addresses.spec.ts
@@ -4,11 +4,23 @@ import { isNode, isElectronMain } from 'wherearewe'
 import { getThinWaistAddresses } from '../src/get-thin-waist-addresses.js'
 
 describe('get-thin-waist-addresses', () => {
+  it('should not return addresses when not passed anything', () => {
+    expect(getThinWaistAddresses()).to.have.lengthOf(0)
+    expect(getThinWaistAddresses(undefined)).to.have.lengthOf(0)
+  })
+
   it('should get thin waist addresses from specific address', () => {
     const input = multiaddr('/ip4/123.123.123.123/tcp/1234')
     const addrs = getThinWaistAddresses(input)
 
     expect(addrs).to.deep.equal([input])
+  })
+
+  it('should get thin waist addresses from specific address and override the port', () => {
+    const input = multiaddr('/ip4/123.123.123.123/tcp/1234')
+    const addrs = getThinWaistAddresses(input, 100)
+
+    expect(addrs).to.deep.equal([multiaddr('/ip4/123.123.123.123/tcp/100')])
   })
 
   it('should ignore non-thin waist tuples from specific address', () => {
@@ -38,6 +50,25 @@ describe('get-thin-waist-addresses', () => {
     }
   })
 
+  it('should get thin waist addresses from IPv4 wildcard and override the port', function () {
+    if (!isNode && !isElectronMain) {
+      return this.skip()
+    }
+
+    const input = multiaddr('/ip4/0.0.0.0/tcp/1234')
+    const addrs = getThinWaistAddresses(input, 100)
+
+    expect(addrs).to.have.property('length').that.is.greaterThan(0)
+
+    for (const addr of addrs) {
+      const options = addr.toOptions()
+
+      expect(options).to.have.property('family', 4)
+      expect(options).to.have.property('host').that.does.not.equal('0.0.0.0')
+      expect(options).to.have.property('port', 100)
+    }
+  })
+
   it('should get thin waist addresses from IPv6 wildcard', function () {
     if (!isNode && !isElectronMain) {
       return this.skip()
@@ -53,6 +84,25 @@ describe('get-thin-waist-addresses', () => {
 
       expect(options).to.have.property('family', 6)
       expect(options).to.have.property('host').that.does.not.equal('::')
+    }
+  })
+
+  it('should get thin waist addresses from IPv6 wildcard and override the port', function () {
+    if (!isNode && !isElectronMain) {
+      return this.skip()
+    }
+
+    const input = multiaddr('/ip6/::/tcp/1234')
+    const addrs = getThinWaistAddresses(input, 100)
+
+    expect(addrs).to.have.property('length').that.is.greaterThan(0)
+
+    for (const addr of addrs) {
+      const options = addr.toOptions()
+
+      expect(options).to.have.property('family', 6)
+      expect(options).to.have.property('host').that.does.not.equal('::')
+      expect(options).to.have.property('port', 100)
     }
   })
 })

--- a/packages/utils/typedoc.json
+++ b/packages/utils/typedoc.json
@@ -9,6 +9,7 @@
     "./src/close-source.ts",
     "./src/debounce.ts",
     "./src/filters/index.ts",
+    "./src/get-thin-waist-addresses.ts",
     "./src/global-unicast-ip.ts",
     "./src/ip-port-to-multiaddr.ts",
     "./src/is-async-generator.ts",


### PR DESCRIPTION
Instead of every tcp/udp transport calculating thin waist addresses, use the function in `@libp2p/utils` instead.

## Change checklist

- [x] I have performed a self-review of my own code
- [ ] I have made corresponding changes to the documentation if necessary (this includes comments as well)
- [x] I have added tests that prove my fix is effective or that my feature works