### PR TITLE
fix: do not expire self multiaddrs

### DIFF
--- a/packages/peer-store/test/index.spec.ts
+++ b/packages/peer-store/test/index.spec.ts
@@ -315,6 +315,26 @@ describe('PersistentPeerStore', () => {
         .with.lengthOf(0, 'did not expire multiaddrs')
     })
 
+    it('should not expire self peer multiaddrs', async () => {
+      const peerStore = persistentPeerStore(components, {
+        maxAddressAge: 100
+      })
+
+      await peerStore.patch(components.peerId, {
+        multiaddrs: [
+          multiaddr('/ip4/123.123.123.123/tcp/1234')
+        ]
+      })
+
+      await expect(peerStore.get(components.peerId)).to.eventually.have.property('addresses')
+        .with.lengthOf(1)
+
+      await delay(500)
+
+      await expect(peerStore.get(components.peerId)).to.eventually.have.property('addresses')
+        .with.lengthOf(1, 'deleted own multiaddrs')
+    })
+
     it('should evict expired peers from .has', async () => {
       const peerStore = persistentPeerStore(components, {
         maxAddressAge: 50,


### PR DESCRIPTION
Do not apply address/record expiry to the peer store entry for the self peer.

Fixes #3051

## Change checklist

- [x] I have performed a self-review of my own code
- [x] I have made corresponding changes to the documentation if necessary (this includes comments as well)
- [x] I have added tests that prove my fix is effective or that my feature works