### PR TITLE
feat: expose jwk prop on ECDSA and RSA keys

### DIFF
--- a/packages/crypto/src/keys/rsa/rsa.ts
+++ b/packages/crypto/src/keys/rsa/rsa.ts
@@ -8,18 +8,18 @@ import type { Uint8ArrayList } from 'uint8arraylist'
 
 export class RSAPublicKey implements RSAPublicKeyInterface {
   public readonly type = 'RSA'
-  private readonly _key: JsonWebKey
+  public readonly jwk: JsonWebKey
   private _raw?: Uint8Array
   private readonly _multihash: Digest<18, number>
 
-  constructor (key: JsonWebKey, digest: Digest<18, number>) {
-    this._key = key
+  constructor (jwk: JsonWebKey, digest: Digest<18, number>) {
+    this.jwk = jwk
     this._multihash = digest
   }
 
   get raw (): Uint8Array {
     if (this._raw == null) {
-      this._raw = utils.jwkToPkix(this._key)
+      this._raw = utils.jwkToPkix(this.jwk)
     }
 
     return this._raw
@@ -46,24 +46,24 @@ export class RSAPublicKey implements RSAPublicKeyInterface {
   }
 
   verify (data: Uint8Array | Uint8ArrayList, sig: Uint8Array): boolean | Promise<boolean> {
-    return hashAndVerify(this._key, sig, data)
+    return hashAndVerify(this.jwk, sig, data)
   }
 }
 
 export class RSAPrivateKey implements RSAPrivateKeyInterface {
   public readonly type = 'RSA'
-  private readonly _key: JsonWebKey
+  public readonly jwk: JsonWebKey
   private _raw?: Uint8Array
   public readonly publicKey: RSAPublicKey
 
-  constructor (key: JsonWebKey, publicKey: RSAPublicKey) {
-    this._key = key
+  constructor (jwk: JsonWebKey, publicKey: RSAPublicKey) {
+    this.jwk = jwk
     this.publicKey = publicKey
   }
 
   get raw (): Uint8Array {
     if (this._raw == null) {
-      this._raw = utils.jwkToPkcs1(this._key)
+      this._raw = utils.jwkToPkcs1(this.jwk)
     }
 
     return this._raw
@@ -78,6 +78,6 @@ export class RSAPrivateKey implements RSAPrivateKeyInterface {
   }
 
   sign (message: Uint8Array | Uint8ArrayList): Uint8Array | Promise<Uint8Array> {
-    return hashAndSign(this._key, message)
+    return hashAndSign(this.jwk, message)
   }
 }

--- a/packages/crypto/test/keys/ecdsa.spec.ts
+++ b/packages/crypto/test/keys/ecdsa.spec.ts
@@ -61,8 +61,7 @@ describe('ECDSA', function () {
       const keyMarshal = key.raw
       const key2 = unmarshalECDSAPrivateKey(keyMarshal)
 
-      // @ts-expect-error private field
-      expect(key._key.d).to.equal(key2._key.d)
+      expect(key.jwk.d).to.equal(key2.jwk.d)
 
       const keyMarshal2 = key2.raw
       expect(keyMarshal).to.equalBytes(keyMarshal2)
@@ -71,10 +70,8 @@ describe('ECDSA', function () {
       const pkMarshal = pk.raw
       const pk2 = unmarshalECDSAPublicKey(pkMarshal)
 
-      // @ts-expect-error private field
-      expect(pk._key.x).to.deep.equal(pk2._key.x)
-      // @ts-expect-error private field
-      expect(pk._key.y).to.deep.equal(pk2._key.y)
+      expect(pk.jwk.x).to.deep.equal(pk2.jwk.x)
+      expect(pk.jwk.y).to.deep.equal(pk2.jwk.y)
 
       const pkMarshal2 = pk2.raw
       expect(pkMarshal).to.equalBytes(pkMarshal2)

--- a/packages/interface/src/keys.ts
+++ b/packages/interface/src/keys.ts
@@ -16,6 +16,11 @@ export interface RSAPublicKey {
   readonly raw: Uint8Array
 
   /**
+   * The public key as a JSON web key
+   */
+  readonly jwk: JsonWebKey
+
+  /**
    * Returns `true` if the passed object matches this key
    */
   equals(key?: any): boolean
@@ -138,9 +143,14 @@ export interface ECDSAPublicKey {
   readonly type: 'ECDSA'
 
   /**
-   * The raw public key bytes
+   * The public key as a DER-encoded PKIMessage
    */
   readonly raw: Uint8Array
+
+  /**
+   * The public key as a JSON web key
+   */
+  readonly jwk: JsonWebKey
 
   /**
    * Returns `true` if the passed object matches this key
@@ -210,6 +220,11 @@ export interface RSAPrivateKey {
    * PKIX in ASN1 DER format
    */
   readonly raw: Uint8Array
+
+  /**
+   * The private key as a JSON web key
+   */
+  readonly jwk: JsonWebKey
 
   /**
    * Returns `true` if the passed object matches this key
@@ -291,9 +306,14 @@ export interface ECDSAPrivateKey {
   readonly publicKey: ECDSAPublicKey
 
   /**
-   * The raw private key bytes
+   * The private key as a DER-encoded PKIMessage
    */
   readonly raw: Uint8Array
+
+  /**
+   * The private key as a JSON web key
+   */
+  readonly jwk: JsonWebKey
 
   /**
    * Returns `true` if the passed object matches this key


### PR DESCRIPTION
To allow easy use with webcrypto, expose the internally stored JWK representation of the keys.

## Change checklist

- [x] I have performed a self-review of my own code
- [x] I have made corresponding changes to the documentation if necessary (this includes comments as well)
- [ ] I have added tests that prove my fix is effective or that my feature works