### PR TITLE
feat: add functions to convert PrivateKey to CryptoKeyPair

### DIFF
--- a/packages/crypto/src/keys/ecdsa/ecdsa.ts
+++ b/packages/crypto/src/keys/ecdsa/ecdsa.ts
@@ -57,9 +57,16 @@ export class ECDSAPrivateKey implements ECDSAPrivateKeyInterface {
   public readonly publicKey: ECDSAPublicKey
   private _raw?: Uint8Array
 
-  constructor (jwk: JsonWebKey, publicKey: JsonWebKey) {
+  constructor (jwk: JsonWebKey) {
     this.jwk = jwk
-    this.publicKey = new ECDSAPublicKey(publicKey)
+    this.publicKey = new ECDSAPublicKey({
+      crv: jwk.crv,
+      ext: jwk.ext,
+      key_ops: ['verify'],
+      kty: 'EC',
+      x: jwk.x,
+      y: jwk.y
+    })
   }
 
   get raw (): Uint8Array {

--- a/packages/crypto/src/keys/ecdsa/utils.ts
+++ b/packages/crypto/src/keys/ecdsa/utils.ts
@@ -61,11 +61,6 @@ export function pkiMessageToECDSAPrivateKey (message: any): ECDSAPrivateKey {
       d,
       x,
       y
-    }, {
-      ...P_256_KEY_JWK,
-      key_ops: ['verify'],
-      x,
-      y
     })
   }
 
@@ -79,11 +74,6 @@ export function pkiMessageToECDSAPrivateKey (message: any): ECDSAPrivateKey {
       d,
       x,
       y
-    }, {
-      ...P_384_KEY_JWK,
-      key_ops: ['verify'],
-      x,
-      y
     })
   }
 
@@ -95,11 +85,6 @@ export function pkiMessageToECDSAPrivateKey (message: any): ECDSAPrivateKey {
       ...P_521_KEY_JWK,
       key_ops: ['sign'],
       d,
-      x,
-      y
-    }, {
-      ...P_521_KEY_JWK,
-      key_ops: ['verify'],
       x,
       y
     })
@@ -215,7 +200,7 @@ function getOID (curve?: string): Uint8Array {
 export async function generateECDSAKeyPair (curve: Curve = 'P-256'): Promise<ECDSAPrivateKey> {
   const key = await generateECDSAKey(curve)
 
-  return new ECDSAPrivateKeyClass(key.privateKey, key.publicKey)
+  return new ECDSAPrivateKeyClass(key.privateKey)
 }
 
 export function ensureECDSAKey (key: Uint8Array, length: number): Uint8Array {

--- a/packages/crypto/test/keys/ed25519.spec.ts
+++ b/packages/crypto/test/keys/ed25519.spec.ts
@@ -5,7 +5,7 @@ import { Uint8ArrayList } from 'uint8arraylist'
 import { fromString as uint8ArrayFromString } from 'uint8arrays/from-string'
 import { randomBytes } from '../../src/index.js'
 import { unmarshalEd25519PrivateKey, unmarshalEd25519PublicKey } from '../../src/keys/ed25519/utils.js'
-import { generateKeyPair, generateKeyPairFromSeed, privateKeyFromProtobuf, privateKeyFromRaw, publicKeyFromProtobuf, publicKeyFromRaw } from '../../src/keys/index.js'
+import { generateKeyPair, generateKeyPairFromSeed, privateKeyFromProtobuf, privateKeyFromRaw, publicKeyFromProtobuf, publicKeyFromRaw, privateKeyToCryptoKeyPair } from '../../src/keys/index.js'
 import fixtures from '../fixtures/go-key-ed25519.js'
 import { testGarbage } from '../helpers/test-garbage-error-handling.js'
 import type { Ed25519PrivateKey } from '@libp2p/interface'
@@ -169,6 +169,13 @@ describe('ed25519', function () {
 
     expect(isPrivateKey(key.publicKey)).to.be.false()
     expect(isPublicKey(key.publicKey)).to.be.true()
+  })
+
+  it('fails to export to CryptoKeyPair', async () => {
+    const key = await generateKeyPair('Ed25519')
+
+    await expect(privateKeyToCryptoKeyPair(key)).to.eventually.be.rejected
+      .with.property('message', 'Only RSA and ECDSA keys are supported')
   })
 
   describe('go interop', () => {

--- a/packages/crypto/test/keys/rsa.spec.ts
+++ b/packages/crypto/test/keys/rsa.spec.ts
@@ -8,7 +8,7 @@ import { create } from 'multiformats/hashes/digest'
 import { Uint8ArrayList } from 'uint8arraylist'
 import { fromString as uint8ArrayFromString } from 'uint8arrays/from-string'
 import { randomBytes } from '../../src/index.js'
-import { generateKeyPair, privateKeyFromProtobuf, privateKeyFromRaw, privateKeyToProtobuf, publicKeyFromProtobuf, publicKeyFromRaw, publicKeyToProtobuf } from '../../src/keys/index.js'
+import { privateKeyFromCryptoKeyPair, generateKeyPair, privateKeyFromProtobuf, privateKeyFromRaw, privateKeyToProtobuf, publicKeyFromProtobuf, publicKeyFromRaw, publicKeyToProtobuf, privateKeyToCryptoKeyPair } from '../../src/keys/index.js'
 import * as pb from '../../src/keys/keys.js'
 import { RSAPrivateKey as RSAPrivateKeyClass, RSAPublicKey as RSAPublicKeyClass } from '../../src/keys/rsa/rsa.js'
 import { MAX_RSA_KEY_SIZE, jwkToPkcs1, jwkToPkix, jwkToRSAPrivateKey, pkcs1ToJwk, pkcs1ToRSAPrivateKey, pkixToJwk, pkixToRSAPublicKey } from '../../src/keys/rsa/utils.js'
@@ -278,6 +278,14 @@ describe('RSA', function () {
     it('should round trip 8192 bit private key as pkix', () => {
       roundTrip(RSA_KEY_8192_BITS)
     })
+  })
+
+  it('exports to CryptoKeyPair', async () => {
+    const key = await generateKeyPair('RSA')
+    const keyPair = await privateKeyToCryptoKeyPair(key)
+    const key2 = await privateKeyFromCryptoKeyPair(keyPair)
+
+    expect(key.publicKey.toCID()).to.deep.equal(key2.publicKey.toCID())
   })
 })
 

--- a/packages/crypto/test/keys/secp256k1.spec.ts
+++ b/packages/crypto/test/keys/secp256k1.spec.ts
@@ -5,7 +5,7 @@ import { expect } from 'aegir/chai'
 import { Uint8ArrayList } from 'uint8arraylist'
 import { fromString as uint8ArrayFromString } from 'uint8arrays/from-string'
 import { randomBytes } from '../../src/index.js'
-import { generateKeyPair, privateKeyFromRaw, privateKeyToProtobuf, publicKeyFromRaw, publicKeyToProtobuf } from '../../src/keys/index.js'
+import { generateKeyPair, privateKeyFromRaw, privateKeyToProtobuf, publicKeyFromRaw, publicKeyToProtobuf, privateKeyToCryptoKeyPair } from '../../src/keys/index.js'
 import { KeyType, PrivateKey, PublicKey } from '../../src/keys/keys.js'
 import { hashAndSign, hashAndVerify } from '../../src/keys/secp256k1/index.js'
 import { unmarshalSecp256k1PrivateKey, unmarshalSecp256k1PublicKey, compressSecp256k1PublicKey, computeSecp256k1PublicKey, decompressSecp256k1PublicKey, generateSecp256k1PrivateKey, validateSecp256k1PrivateKey, validateSecp256k1PublicKey } from '../../src/keys/secp256k1/utils.js'
@@ -199,6 +199,13 @@ describe('crypto functions', () => {
     expect(decompressed).to.have.lengthOf(65)
     const recompressed = compressSecp256k1PublicKey(decompressed)
     expect(recompressed).to.equalBytes(pubKey)
+  })
+
+  it('fails to export to CryptoKeyPair', async () => {
+    const key = await generateKeyPair('secp256k1')
+
+    await expect(privateKeyToCryptoKeyPair(key)).to.eventually.be.rejected
+      .with.property('message', 'Only RSA and ECDSA keys are supported')
   })
 })
 


### PR DESCRIPTION
Adds `privateKeyToCryptoKeyPair` and `privateKeyFromCryptoKeyPair` functions to convert libp2p ECDSA/RSA private keys to WebCrypto `CryptoKeyPair` objects and back.

## Change checklist

- [x] I have performed a self-review of my own code
- [x] I have made corresponding changes to the documentation if necessary (this includes comments as well)
- [x] I have added tests that prove my fix is effective or that my feature works