### PR TITLE
feat: store x509 certs in the keychain

### DIFF
--- a/packages/keychain/package.json
+++ b/packages/keychain/package.json
@@ -71,6 +71,7 @@
   },
   "devDependencies": {
     "@libp2p/logger": "^5.1.13",
+    "@peculiar/x509": "^1.12.3",
     "aegir": "^45.1.1",
     "datastore-core": "^10.0.2"
   },

--- a/packages/keychain/src/index.ts
+++ b/packages/keychain/src/index.ts
@@ -105,6 +105,13 @@ export interface KeyInfo {
   name: string
 }
 
+export interface X509Info {
+  /**
+   * The local key name
+   */
+  name: string
+}
+
 export interface Keychain {
   /**
    * Find a key by name
@@ -200,6 +207,32 @@ export interface Keychain {
    * ```
    */
   listKeys(): Promise<KeyInfo[]>
+
+  /**
+   * Import an X509 certificate in PEM format
+   */
+  importX509 (name: string, pem: string): Promise<void>
+
+  /**
+   * Export an X509 certificate in PEM format
+   */
+  exportX509 (name: string): Promise<string>
+
+  /**
+   * Removes an X509 certificate from the keychain
+   */
+  removeX509 (name: string): Promise<void>
+
+  /**
+   * List all certificates.
+   *
+   * @example
+   *
+   * ```TypeScript
+   * const certs = await libp2p.keychain.listX509()
+   * ```
+   */
+  listX509(): Promise<X509Info[]>
 
   /**
    * Rotate keychain password and re-encrypt all associated keys

--- a/packages/keychain/test/certificates.spec.ts
+++ b/packages/keychain/test/certificates.spec.ts
@@ -1,0 +1,102 @@
+import { generateKeyPair } from '@libp2p/crypto/keys'
+import { defaultLogger } from '@libp2p/logger'
+import { expect } from 'aegir/chai'
+import { MemoryDatastore } from 'datastore-core/memory'
+import { Keychain as KeychainClass } from '../src/keychain.js'
+import { createSelfSigned } from './fixtures/create-certificate.js'
+import type { Keychain } from '../src/index.js'
+import type { Datastore } from 'interface-datastore'
+
+describe('certificates', () => {
+  const passPhrase = 'this is not a secure phrase'
+  const logger = defaultLogger()
+  let kc: Keychain
+  let datastore: Datastore
+
+  beforeEach(async () => {
+    datastore = new MemoryDatastore()
+
+    kc = new KeychainClass({
+      datastore,
+      logger
+    }, { pass: passPhrase })
+  })
+
+  it('can store a ECDSA certificate', async () => {
+    const keyName = `key-${Math.random()}`
+    const certName = `cert-${Math.random()}`
+
+    const key = await generateKeyPair('ECDSA')
+    await kc.importKey(keyName, key)
+
+    const cert = await createSelfSigned(key)
+
+    const pem = cert.toString('pem')
+    await kc.importX509(certName, pem)
+
+    const stored = await kc.exportX509(certName)
+    expect(stored).to.equal(pem)
+  })
+
+  it('can store a RSA certificate', async () => {
+    const keyName = `key-${Math.random()}`
+    const certName = `cert-${Math.random()}`
+
+    const key = await generateKeyPair('RSA')
+    await kc.importKey(keyName, key)
+
+    const cert = await createSelfSigned(key)
+
+    const pem = cert.toString('pem')
+    await kc.importX509(certName, pem)
+
+    const stored = await kc.exportX509(certName)
+    expect(stored).to.equal(pem)
+  })
+
+  it('can remove a certificate', async () => {
+    const keyName = `key-${Math.random()}`
+    const certName = `cert-${Math.random()}`
+
+    const key = await generateKeyPair('RSA')
+    await kc.importKey(keyName, key)
+
+    const cert = await createSelfSigned(key)
+
+    const pem = cert.toString('pem')
+    await kc.importX509(certName, pem)
+
+    await kc.removeX509(certName)
+
+    await expect(kc.exportX509(certName)).to.eventually.be.rejected
+      .with.property('name', 'NotFoundError')
+  })
+
+  it('can list all certificates', async () => {
+    const keyName = `key-${Math.random()}`
+    const certName1 = `cert-${Math.random()}-1`
+    const certName2 = `cert-${Math.random()}-2`
+    const certName3 = `cert-${Math.random()}-3`
+
+    const key = await generateKeyPair('RSA')
+    await kc.importKey(keyName, key)
+
+    const cert1 = await createSelfSigned(key)
+    const cert2 = await createSelfSigned(key)
+    const cert3 = await createSelfSigned(key)
+
+    await kc.importX509(certName1, cert1.toString('pem'))
+    await kc.importX509(certName2, cert2.toString('pem'))
+    await kc.importX509(certName3, cert3.toString('pem'))
+
+    const certs = await kc.listX509()
+
+    expect(certs).to.deep.equal([{
+      name: certName1
+    }, {
+      name: certName2
+    }, {
+      name: certName3
+    }])
+  })
+})

--- a/packages/keychain/test/fixtures/create-certificate.ts
+++ b/packages/keychain/test/fixtures/create-certificate.ts
@@ -1,0 +1,25 @@
+import { privateKeyToCryptoKeyPair } from '@libp2p/crypto/keys'
+import * as x509 from '@peculiar/x509'
+import type { PrivateKey } from '@libp2p/interface'
+
+export async function createSelfSigned (privateKey: PrivateKey): Promise<x509.X509Certificate> {
+  const keys = await privateKeyToCryptoKeyPair(privateKey)
+
+  return x509.X509CertificateGenerator.createSelfSigned({
+    serialNumber: '01',
+    name: 'CN=Test',
+    notBefore: new Date('2020/01/01'),
+    notAfter: new Date('2020/01/02'),
+    signingAlgorithm: {
+      name: 'RSASSA-PKCS1-v1_5',
+      hash: 'SHA-256'
+    },
+    keys,
+    extensions: [
+      new x509.BasicConstraintsExtension(true, 2, true),
+      new x509.ExtendedKeyUsageExtension(['1.2.3.4.5.6.7', '2.3.4.5.6.7.8'], true),
+      new x509.KeyUsagesExtension(x509.KeyUsageFlags.keyCertSign | x509.KeyUsageFlags.cRLSign, true),
+      await x509.SubjectKeyIdentifierExtension.create(keys.publicKey)
+    ]
+  })
+}


### PR DESCRIPTION
Adds `importX509`/`exportX509`/etc methods to the keychain to enable storing x509 certificates securely.

## Change checklist

- [x] I have performed a self-review of my own code
- [x] I have made corresponding changes to the documentation if necessary (this includes comments as well)
- [x] I have added tests that prove my fix is effective or that my feature works