### PR TITLE
fix: rotate webrtc direct certificates

### DIFF
--- a/packages/transport-webrtc/src/constants.ts
+++ b/packages/transport-webrtc/src/constants.ts
@@ -129,4 +129,9 @@ export const DEFAULT_CERTIFICATE_PRIVATE_KEY_TYPE = 'ECDSA'
 /**
  * How long the certificate is valid for
  */
-export const DEFAULT_CERTIFICATE_LIFESPAN = 365
+export const DEFAULT_CERTIFICATE_LIFESPAN = 1_209_600_000
+
+/**
+ * Renew the certificate this long before it expires
+ */
+export const DEFAULT_CERTIFICATE_RENEWAL_THRESHOLD = 86_400_000

--- a/packages/transport-webrtc/src/private-to-public/listener.ts
+++ b/packages/transport-webrtc/src/private-to-public/listener.ts
@@ -84,6 +84,7 @@ export class WebRTCDirectListener extends TypedEventEmitter<ListenerEvents> impl
 
     // inform the transport manager our addresses have changed
     init.emitter.addEventListener('certificate:renew', evt => {
+      this.log('received new TLS certificate', evt.detail.certhash)
       this.certificate = evt.detail
       this.safeDispatchEvent('listening')
     })

--- a/packages/transport-webrtc/test/certificates.spec.ts
+++ b/packages/transport-webrtc/test/certificates.spec.ts
@@ -1,0 +1,192 @@
+/* eslint-disable @typescript-eslint/no-floating-promises */
+
+import { generateKeyPair } from '@libp2p/crypto/keys'
+import { start, stop } from '@libp2p/interface'
+import { keychain } from '@libp2p/keychain'
+import { defaultLogger } from '@libp2p/logger'
+import { peerIdFromPrivateKey } from '@libp2p/peer-id'
+import { multiaddr, type Multiaddr } from '@multiformats/multiaddr'
+import { expect } from 'aegir/chai'
+import { anySignal } from 'any-signal'
+import { MemoryDatastore } from 'datastore-core'
+import delay from 'delay'
+import { stubInterface } from 'sinon-ts'
+import { isNode, isElectronMain } from 'wherearewe'
+import { CODEC_CERTHASH } from '../src/constants.js'
+import { WebRTCDirectTransport } from '../src/private-to-public/transport.js'
+import type { WebRTCDirectTransportComponents } from '../src/private-to-public/transport.js'
+import type { Upgrader, Listener, Transport } from '@libp2p/interface'
+import type { TransportManager } from '@libp2p/interface-internal'
+
+describe('WebRTCDirect Transport - certificates', () => {
+  let components: WebRTCDirectTransportComponents
+  let listener: Listener
+  let upgrader: Upgrader
+  let transport: Transport
+
+  beforeEach(async () => {
+    const privateKey = await generateKeyPair('Ed25519')
+    const datastore = new MemoryDatastore()
+    const logger = defaultLogger()
+
+    components = {
+      peerId: peerIdFromPrivateKey(privateKey),
+      logger,
+      transportManager: stubInterface<TransportManager>(),
+      privateKey,
+      upgrader: stubInterface<Upgrader>({
+        createInboundAbortSignal: (signal) => {
+          return anySignal([
+            AbortSignal.timeout(5_000),
+            signal
+          ])
+        }
+      }),
+      datastore,
+      keychain: keychain()({
+        datastore,
+        logger
+      })
+    }
+
+    upgrader = stubInterface<Upgrader>()
+  })
+
+  afterEach(async () => {
+    await listener?.close()
+    await stop(transport)
+  })
+
+  it('should reuse the same certificate after a restart', async function () {
+    if (!isNode && !isElectronMain) {
+      return this.skip()
+    }
+
+    const ipv4 = multiaddr('/ip4/127.0.0.1/udp/0')
+
+    transport = new WebRTCDirectTransport(components)
+    await start(transport)
+    listener = transport.createListener({
+      upgrader
+    })
+    await listener.listen(ipv4)
+
+    const certHashes1 = getCerthashes(listener.getAddrs())
+    await listener.close()
+    await stop(transport)
+
+    transport = new WebRTCDirectTransport(components)
+    await start(transport)
+    listener = transport.createListener({
+      upgrader
+    })
+    await listener.listen(ipv4)
+
+    const certHashes2 = getCerthashes(listener.getAddrs())
+    await listener.close()
+    await stop(transport)
+
+    expect(certHashes1).to.have.lengthOf(1)
+    expect(certHashes1).to.have.nested.property('[0]').that.is.a('string')
+    expect(certHashes1).to.deep.equal(certHashes2)
+  })
+
+  it('should renew certificate that expires while stopped', async function () {
+    if (!isNode && !isElectronMain) {
+      return this.skip()
+    }
+
+    const ipv4 = multiaddr('/ip4/127.0.0.1/udp/0')
+
+    transport = new WebRTCDirectTransport(components, {
+      certificateLifespan: 500,
+      certificateRenewalThreshold: 100
+    })
+    await start(transport)
+    listener = transport.createListener({
+      upgrader
+    })
+    await listener.listen(ipv4)
+
+    const certHashes1 = getCerthashes(listener.getAddrs())
+
+    await listener.close()
+    await stop(transport)
+
+    // wait fo the cert to expire
+    await delay(1000)
+
+    await start(transport)
+    listener = transport.createListener({
+      upgrader
+    })
+    await listener.listen(ipv4)
+
+    const certHashes2 = getCerthashes(listener.getAddrs())
+
+    await listener.close()
+    await stop(transport)
+
+    expect(certHashes1).to.have.lengthOf(1)
+    expect(certHashes1).to.have.nested.property('[0]').that.is.a('string')
+    expect(certHashes2).to.have.lengthOf(1)
+    expect(certHashes2).to.have.nested.property('[0]').that.is.a('string')
+    expect(certHashes1).to.not.deep.equal(certHashes2)
+  })
+
+  it('should renew certificate before expiry', async function () {
+    if (!isNode && !isElectronMain) {
+      return this.skip()
+    }
+
+    await stop(transport)
+
+    const ipv4 = multiaddr('/ip4/127.0.0.1/udp/0')
+
+    transport = new WebRTCDirectTransport({
+      ...components,
+      datastore: new MemoryDatastore()
+    }, {
+      certificateLifespan: 2000,
+      certificateRenewalThreshold: 1900
+    })
+    await start(transport)
+    listener = transport.createListener({
+      upgrader
+    })
+    await listener.listen(ipv4)
+
+    const certHashes1 = getCerthashes(listener.getAddrs())
+
+    // wait until the certificate is still valid but we are within the renewal
+    // threshold
+    await delay(1000)
+
+    const certHashes2 = getCerthashes(listener.getAddrs())
+
+    await listener.close()
+    await stop(transport)
+
+    expect(certHashes1).to.have.lengthOf(1)
+    expect(certHashes1).to.have.nested.property('[0]').that.is.a('string')
+    expect(certHashes2).to.have.lengthOf(1)
+    expect(certHashes2).to.have.nested.property('[0]').that.is.a('string')
+    expect(certHashes1).to.not.deep.equal(certHashes2)
+  })
+})
+
+function getCerthashes (addrs: Multiaddr[]): string[] {
+  const output: string[] = []
+
+  addrs
+    .forEach(ma => {
+      ma.stringTuples()
+        .forEach(([key, value]) => {
+          if (key === CODEC_CERTHASH && value != null) {
+            output.push(value)
+          }
+        })
+    })
+
+  return output
+}


### PR DESCRIPTION
Lowers the validity of webrtc direct certs to two weeks similar to webtransport and updates listening multiaddrs after the cert has been renewed.

The validity is lowered because the longest `setTimeout` we can do is just under a month, otherwise we overflow the max value we can pass to `setTimeout`.

## Change checklist

- [x] I have performed a self-review of my own code
- [x] I have made corresponding changes to the documentation if necessary (this includes comments as well)
- [x] I have added tests that prove my fix is effective or that my feature works