### PR TITLE
fix!: use libp2p ping instad of kad ping

### DIFF
--- a/.github/workflows/examples.yml
+++ b/.github/workflows/examples.yml
@@ -74,6 +74,7 @@ jobs:
               - '@libp2p/identify@$PWD/packages/protocol-identify'
               - '@libp2p/kad-dht@$PWD/packages/kad-dht'
               - '@libp2p/mdns@$PWD/packages/peer-discovery-mdns'
+              - '@libp2p/ping@$PWD/packages/protocol-ping'
               - '@libp2p/tcp@$PWD/packages/transport-tcp'
               - 'libp2p@$PWD/packages/libp2p'
           - name: js-libp2p-example-peer-and-content-routing
@@ -81,6 +82,7 @@ jobs:
             deps:
               - '@libp2p/identify@$PWD/packages/protocol-identify'
               - '@libp2p/kad-dht@$PWD/packages/kad-dht'
+              - '@libp2p/ping@$PWD/packages/protocol-ping'
               - '@libp2p/tcp@$PWD/packages/transport-tcp'
               - 'libp2p@$PWD/packages/libp2p'
           - name: js-libp2p-example-pnet

--- a/packages/integration-tests/test/circuit-relay-discovery.node.ts
+++ b/packages/integration-tests/test/circuit-relay-discovery.node.ts
@@ -5,6 +5,7 @@ import { circuitRelayServer, type CircuitRelayService, circuitRelayTransport } f
 import { identify } from '@libp2p/identify'
 import { stop } from '@libp2p/interface'
 import { kadDHT, passthroughMapper } from '@libp2p/kad-dht'
+import { ping } from '@libp2p/ping'
 import { plaintext } from '@libp2p/plaintext'
 import { tcp } from '@libp2p/tcp'
 import { expect } from 'aegir/chai'
@@ -43,6 +44,7 @@ describe('circuit-relay discovery', () => {
           }
         }),
         identify: identify(),
+        ping: ping(),
         kadDht: kadDHT({
           protocol: DHT_PROTOCOL,
           peerInfoMapper: passthroughMapper,
@@ -66,6 +68,7 @@ describe('circuit-relay discovery', () => {
       ],
       services: {
         identify: identify(),
+        ping: ping(),
         kadDht: kadDHT({
           protocol: DHT_PROTOCOL,
           peerInfoMapper: passthroughMapper,
@@ -108,6 +111,7 @@ describe('circuit-relay discovery', () => {
         ],
         services: {
           identify: identify(),
+          ping: ping(),
           kadDht: kadDHT({
             protocol: DHT_PROTOCOL,
             peerInfoMapper: passthroughMapper,
@@ -133,6 +137,7 @@ describe('circuit-relay discovery', () => {
         ],
         services: {
           identify: identify(),
+          ping: ping(),
           kadDht: kadDHT({
             protocol: DHT_PROTOCOL,
             peerInfoMapper: passthroughMapper,

--- a/packages/integration-tests/test/dht.node.ts
+++ b/packages/integration-tests/test/dht.node.ts
@@ -1,8 +1,10 @@
 /* eslint-env mocha */
 
 import { yamux } from '@chainsafe/libp2p-yamux'
+import { identify, type Identify } from '@libp2p/identify'
 import { kadDHT, passthroughMapper } from '@libp2p/kad-dht'
 import { mplex } from '@libp2p/mplex'
+import { ping } from '@libp2p/ping'
 import { plaintext } from '@libp2p/plaintext'
 import { tcp } from '@libp2p/tcp'
 import { multiaddr } from '@multiformats/multiaddr'
@@ -13,6 +15,7 @@ import pWaitFor from 'p-wait-for'
 import { fromString as uint8ArrayFromString } from 'uint8arrays/from-string'
 import type { Libp2p, PeerId } from '@libp2p/interface'
 import type { KadDHT } from '@libp2p/kad-dht'
+import type { PingService } from '@libp2p/ping'
 import type { Multiaddr } from '@multiformats/multiaddr'
 import type { Libp2pOptions } from 'libp2p'
 
@@ -62,7 +65,9 @@ describe('DHT subsystem operates correctly', () => {
             protocol: subsystemMulticodecs[0],
             peerInfoMapper: passthroughMapper,
             allowQueryWithZeroPeers: true
-          })
+          }),
+          ping: ping(),
+          identify: identify()
         }
       })
 
@@ -85,7 +90,9 @@ describe('DHT subsystem operates correctly', () => {
             protocol: subsystemMulticodecs[0],
             peerInfoMapper: passthroughMapper,
             allowQueryWithZeroPeers: true
-          })
+          }),
+          ping: ping(),
+          identify: identify()
         }
       })
 
@@ -145,7 +152,7 @@ describe('DHT subsystem operates correctly', () => {
   it('kad-dht should discover other peers', async () => {
     const deferred = pDefer()
 
-    const getConfig = (): Libp2pOptions<{ dht: KadDHT }> => ({
+    const getConfig = (): Libp2pOptions<{ dht: KadDHT, ping: PingService, identify: Identify }> => ({
       addresses: {
         listen: [
           listenAddr.toString()
@@ -156,7 +163,9 @@ describe('DHT subsystem operates correctly', () => {
           protocol: subsystemMulticodecs[0],
           peerInfoMapper: passthroughMapper,
           allowQueryWithZeroPeers: true
-        })
+        }),
+        ping: ping(),
+        identify: identify()
       }
     })
 

--- a/packages/integration-tests/test/interop.ts
+++ b/packages/integration-tests/test/interop.ts
@@ -7,11 +7,12 @@ import { privateKeyFromProtobuf } from '@libp2p/crypto/keys'
 import { createClient } from '@libp2p/daemon-client'
 import { createServer } from '@libp2p/daemon-server'
 import { floodsub } from '@libp2p/floodsub'
-import { identify } from '@libp2p/identify'
+import { identify, type Identify } from '@libp2p/identify'
 import { UnsupportedError, interopTests } from '@libp2p/interop'
 import { kadDHT, passthroughMapper } from '@libp2p/kad-dht'
 import { logger } from '@libp2p/logger'
 import { mplex } from '@libp2p/mplex'
+import { ping } from '@libp2p/ping'
 import { plaintext } from '@libp2p/plaintext'
 import { tcp } from '@libp2p/tcp'
 import { tls } from '@libp2p/tls'
@@ -23,6 +24,7 @@ import { createLibp2p, type Libp2pOptions, type ServiceFactoryMap } from 'libp2p
 import pDefer from 'p-defer'
 import type { ServiceMap, PrivateKey } from '@libp2p/interface'
 import type { SpawnOptions, Daemon, DaemonFactory } from '@libp2p/interop'
+import type { PingService } from '@libp2p/ping'
 
 /**
  * @packageDocumentation
@@ -155,8 +157,9 @@ async function createJsPeer (options: SpawnOptions): Promise<Daemon> {
     throw new UnsupportedError()
   }
 
-  const services: ServiceFactoryMap = {
-    identify: identify()
+  const services: ServiceFactoryMap<{ identify: Identify, ping: PingService } & Record<string, any>> = {
+    identify: identify(),
+    ping: ping()
   }
 
   if (options.encryption === 'tls') {

--- a/packages/kad-dht/README.md
+++ b/packages/kad-dht/README.md
@@ -34,12 +34,16 @@ The Kademlia DHT allow for several operations such as finding peers, searching f
 import { kadDHT } from '@libp2p/kad-dht'
 import { createLibp2p } from 'libp2p'
 import { peerIdFromString } from '@libp2p/peer-id'
+import { ping } from '@libp2p/ping'
+import { identify } from '@libp2p/identify'
 
 const node = await createLibp2p({
   services: {
     dht: kadDHT({
       // DHT options
-    })
+    }),
+    ping: ping(),
+    identify: identify()
   }
 })
 
@@ -59,13 +63,17 @@ If you are trying to access content on the public internet, this is the implemen
 import { kadDHT, removePrivateAddressesMapper } from '@libp2p/kad-dht'
 import { createLibp2p } from 'libp2p'
 import { peerIdFromString } from '@libp2p/peer-id'
+import { ping } from '@libp2p/ping'
+import { identify } from '@libp2p/identify'
 
 const node = await createLibp2p({
   services: {
     aminoDHT: kadDHT({
       protocol: '/ipfs/kad/1.0.0',
       peerInfoMapper: removePrivateAddressesMapper
-    })
+    }),
+    ping: ping(),
+    identify: identify()
   }
 })
 
@@ -85,6 +93,8 @@ This is for use when peers are on the local area network.
 import { kadDHT, removePublicAddressesMapper } from '@libp2p/kad-dht'
 import { createLibp2p } from 'libp2p'
 import { peerIdFromString } from '@libp2p/peer-id'
+import { ping } from '@libp2p/ping'
+import { identify } from '@libp2p/identify'
 
 const node = await createLibp2p({
   services: {
@@ -92,7 +102,9 @@ const node = await createLibp2p({
       protocol: '/ipfs/lan/kad/1.0.0',
       peerInfoMapper: removePublicAddressesMapper,
       clientMode: false
-    })
+    }),
+    ping: ping(),
+    identify: identify()
   }
 })
 
@@ -111,6 +123,8 @@ log prefixes to ensure that data is kept separate for each instance.
 import { kadDHT, removePublicAddressesMapper, removePrivateAddressesMapper } from '@libp2p/kad-dht'
 import { createLibp2p } from 'libp2p'
 import { peerIdFromString } from '@libp2p/peer-id'
+import { ping } from '@libp2p/ping'
+import { identify } from '@libp2p/identify'
 
 const node = await createLibp2p({
   services: {
@@ -128,7 +142,9 @@ const node = await createLibp2p({
       logPrefix: 'libp2p:dht-amino',
       datastorePrefix: '/dht-amino',
       metricsPrefix: 'libp2p_dht_amino'
-    })
+    }),
+    ping: ping(),
+    identify: identify()
   }
 })
 

--- a/packages/kad-dht/package.json
+++ b/packages/kad-dht/package.json
@@ -62,6 +62,7 @@
     "@libp2p/interface-internal": "^2.3.9",
     "@libp2p/peer-collections": "^6.0.25",
     "@libp2p/peer-id": "^5.1.0",
+    "@libp2p/ping": "^2.0.27",
     "@libp2p/record": "^4.0.5",
     "@libp2p/utils": "^6.6.0",
     "@multiformats/multiaddr": "^12.3.3",

--- a/packages/kad-dht/src/index.ts
+++ b/packages/kad-dht/src/index.ts
@@ -11,12 +11,16 @@
  * import { kadDHT } from '@libp2p/kad-dht'
  * import { createLibp2p } from 'libp2p'
  * import { peerIdFromString } from '@libp2p/peer-id'
+ * import { ping } from '@libp2p/ping'
+ * import { identify } from '@libp2p/identify'
  *
  * const node = await createLibp2p({
  *   services: {
  *     dht: kadDHT({
  *       // DHT options
- *     })
+ *     }),
+ *     ping: ping(),
+ *     identify: identify()
  *   }
  * })
  *
@@ -36,13 +40,17 @@
  * import { kadDHT, removePrivateAddressesMapper } from '@libp2p/kad-dht'
  * import { createLibp2p } from 'libp2p'
  * import { peerIdFromString } from '@libp2p/peer-id'
+ * import { ping } from '@libp2p/ping'
+ * import { identify } from '@libp2p/identify'
  *
  * const node = await createLibp2p({
  *   services: {
  *     aminoDHT: kadDHT({
  *       protocol: '/ipfs/kad/1.0.0',
  *       peerInfoMapper: removePrivateAddressesMapper
- *     })
+ *     }),
+ *     ping: ping(),
+ *     identify: identify()
  *   }
  * })
  *
@@ -62,6 +70,8 @@
  * import { kadDHT, removePublicAddressesMapper } from '@libp2p/kad-dht'
  * import { createLibp2p } from 'libp2p'
  * import { peerIdFromString } from '@libp2p/peer-id'
+ * import { ping } from '@libp2p/ping'
+ * import { identify } from '@libp2p/identify'
  *
  * const node = await createLibp2p({
  *   services: {
@@ -69,7 +79,9 @@
  *       protocol: '/ipfs/lan/kad/1.0.0',
  *       peerInfoMapper: removePublicAddressesMapper,
  *       clientMode: false
- *     })
+ *     }),
+ *     ping: ping(),
+ *     identify: identify()
  *   }
  * })
  *
@@ -88,6 +100,8 @@
  * import { kadDHT, removePublicAddressesMapper, removePrivateAddressesMapper } from '@libp2p/kad-dht'
  * import { createLibp2p } from 'libp2p'
  * import { peerIdFromString } from '@libp2p/peer-id'
+ * import { ping } from '@libp2p/ping'
+ * import { identify } from '@libp2p/identify'
  *
  * const node = await createLibp2p({
  *   services: {
@@ -105,7 +119,9 @@
  *       logPrefix: 'libp2p:dht-amino',
  *       datastorePrefix: '/dht-amino',
  *       metricsPrefix: 'libp2p_dht_amino'
- *     })
+ *     }),
+ *     ping: ping(),
+ *     identify: identify()
  *   }
  * })
  *
@@ -121,6 +137,7 @@ import { MessageType } from './message/dht.js'
 import { removePrivateAddressesMapper, removePublicAddressesMapper, passthroughMapper } from './utils.js'
 import type { Libp2pEvents, ComponentLogger, TypedEventTarget, Metrics, PeerId, PeerInfo, PeerStore, RoutingOptions, PrivateKey } from '@libp2p/interface'
 import type { AddressManager, ConnectionManager, Registrar } from '@libp2p/interface-internal'
+import type { PingService } from '@libp2p/ping'
 import type { AdaptiveTimeoutInit } from '@libp2p/utils/src/adaptive-timeout.js'
 import type { Datastore } from 'interface-datastore'
 import type { CID } from 'multiformats/cid'
@@ -617,6 +634,7 @@ export interface KadDHTComponents {
   datastore: Datastore
   events: TypedEventTarget<Libp2pEvents>
   logger: ComponentLogger
+  ping: PingService
 }
 
 /**

--- a/packages/kad-dht/src/index.ts
+++ b/packages/kad-dht/src/index.ts
@@ -137,7 +137,7 @@ import { MessageType } from './message/dht.js'
 import { removePrivateAddressesMapper, removePublicAddressesMapper, passthroughMapper } from './utils.js'
 import type { Libp2pEvents, ComponentLogger, TypedEventTarget, Metrics, PeerId, PeerInfo, PeerStore, RoutingOptions, PrivateKey } from '@libp2p/interface'
 import type { AddressManager, ConnectionManager, Registrar } from '@libp2p/interface-internal'
-import type { PingService } from '@libp2p/ping'
+import type { Ping } from '@libp2p/ping'
 import type { AdaptiveTimeoutInit } from '@libp2p/utils/src/adaptive-timeout.js'
 import type { Datastore } from 'interface-datastore'
 import type { CID } from 'multiformats/cid'
@@ -634,7 +634,7 @@ export interface KadDHTComponents {
   datastore: Datastore
   events: TypedEventTarget<Libp2pEvents>
   logger: ComponentLogger
-  ping: PingService
+  ping: Ping
 }
 
 /**

--- a/packages/kad-dht/src/kad-dht.ts
+++ b/packages/kad-dht/src/kad-dht.ts
@@ -366,7 +366,8 @@ export class KadDHT extends TypedEventEmitter<PeerDiscoveryEvents> implements Ka
   ]
 
   readonly [serviceDependencies]: string[] = [
-    '@libp2p/identify'
+    '@libp2p/identify',
+    '@libp2p/ping'
   ]
 
   get [contentRoutingSymbol] (): ContentRouting {

--- a/packages/kad-dht/src/routing-table/index.ts
+++ b/packages/kad-dht/src/routing-table/index.ts
@@ -9,7 +9,7 @@ import { KBucket, isLeafBucket } from './k-bucket.js'
 import type { Bucket, LeafBucket, Peer } from './k-bucket.js'
 import type { Network } from '../network.js'
 import type { AbortOptions, ComponentLogger, CounterGroup, Logger, Metric, Metrics, PeerId, PeerStore, Startable, Stream } from '@libp2p/interface'
-import type { PingService } from '@libp2p/ping'
+import type { Ping } from '@libp2p/ping'
 import type { AdaptiveTimeoutInit } from '@libp2p/utils/adaptive-timeout'
 
 export const KBUCKET_SIZE = 20
@@ -58,7 +58,7 @@ export interface RoutingTableComponents {
   peerStore: PeerStore
   metrics?: Metrics
   logger: ComponentLogger
-  ping: PingService
+  ping: Ping
 }
 
 export interface RoutingTableEvents {

--- a/packages/kad-dht/test/generate-peers/generate-peers.node.ts
+++ b/packages/kad-dht/test/generate-peers/generate-peers.node.ts
@@ -17,6 +17,7 @@ import {
 import type { Network } from '../../src/network.js'
 import type { PeerStore } from '@libp2p/interface'
 import type { ConnectionManager } from '@libp2p/interface-internal'
+import type { PingService } from '@libp2p/ping'
 
 const dirname = path.dirname(fileURLToPath(import.meta.url))
 
@@ -60,7 +61,8 @@ describe.skip('generate peers', function () {
       peerId: id,
       connectionManager: stubInterface<ConnectionManager>(),
       peerStore: stubInterface<PeerStore>(),
-      logger: defaultLogger()
+      logger: defaultLogger(),
+      ping: stubInterface<PingService>()
     }
     const table = new RoutingTable(components, {
       kBucketSize: 20,

--- a/packages/kad-dht/test/generate-peers/generate-peers.node.ts
+++ b/packages/kad-dht/test/generate-peers/generate-peers.node.ts
@@ -17,7 +17,7 @@ import {
 import type { Network } from '../../src/network.js'
 import type { PeerStore } from '@libp2p/interface'
 import type { ConnectionManager } from '@libp2p/interface-internal'
-import type { PingService } from '@libp2p/ping'
+import type { Ping } from '@libp2p/ping'
 
 const dirname = path.dirname(fileURLToPath(import.meta.url))
 
@@ -62,7 +62,7 @@ describe.skip('generate peers', function () {
       connectionManager: stubInterface<ConnectionManager>(),
       peerStore: stubInterface<PeerStore>(),
       logger: defaultLogger(),
-      ping: stubInterface<PingService>()
+      ping: stubInterface<Ping>()
     }
     const table = new RoutingTable(components, {
       kBucketSize: 20,

--- a/packages/kad-dht/test/libp2p-routing.spec.ts
+++ b/packages/kad-dht/test/libp2p-routing.spec.ts
@@ -19,6 +19,7 @@ import { sortClosestPeers } from './utils/sort-closest-peers.js'
 import type { PeerIdWithPrivateKey } from './utils/create-peer-id.js'
 import type { ContentRouting, PeerStore, PeerId, TypedEventTarget, ComponentLogger, Connection, Peer, Stream, PeerRouting, PrivateKey } from '@libp2p/interface'
 import type { AddressManager, ConnectionManager, Registrar } from '@libp2p/interface-internal'
+import type { PingService } from '@libp2p/ping'
 import type { Datastore } from 'interface-datastore'
 
 interface StubbedKadDHTComponents {
@@ -31,6 +32,7 @@ interface StubbedKadDHTComponents {
   datastore: Datastore
   events: TypedEventTarget<any>
   logger: ComponentLogger
+  ping: PingService
 }
 
 const PROTOCOL = '/test/dht/1.0.0'
@@ -106,7 +108,8 @@ describe('content routing', () => {
       }),
       datastore: new MemoryDatastore(),
       events: new TypedEventEmitter<any>(),
-      logger: defaultLogger()
+      logger: defaultLogger(),
+      ping: stubInterface<PingService>()
     }
 
     dht = kadDHT({
@@ -239,7 +242,8 @@ describe('peer routing', () => {
       }),
       datastore: new MemoryDatastore(),
       events: new TypedEventEmitter<any>(),
-      logger: defaultLogger()
+      logger: defaultLogger(),
+      ping: stubInterface<PingService>()
     }
 
     dht = kadDHT({

--- a/packages/kad-dht/test/libp2p-routing.spec.ts
+++ b/packages/kad-dht/test/libp2p-routing.spec.ts
@@ -19,7 +19,7 @@ import { sortClosestPeers } from './utils/sort-closest-peers.js'
 import type { PeerIdWithPrivateKey } from './utils/create-peer-id.js'
 import type { ContentRouting, PeerStore, PeerId, TypedEventTarget, ComponentLogger, Connection, Peer, Stream, PeerRouting, PrivateKey } from '@libp2p/interface'
 import type { AddressManager, ConnectionManager, Registrar } from '@libp2p/interface-internal'
-import type { PingService } from '@libp2p/ping'
+import type { Ping } from '@libp2p/ping'
 import type { Datastore } from 'interface-datastore'
 
 interface StubbedKadDHTComponents {
@@ -32,7 +32,7 @@ interface StubbedKadDHTComponents {
   datastore: Datastore
   events: TypedEventTarget<any>
   logger: ComponentLogger
-  ping: PingService
+  ping: Ping
 }
 
 const PROTOCOL = '/test/dht/1.0.0'
@@ -109,7 +109,7 @@ describe('content routing', () => {
       datastore: new MemoryDatastore(),
       events: new TypedEventEmitter<any>(),
       logger: defaultLogger(),
-      ping: stubInterface<PingService>()
+      ping: stubInterface<Ping>()
     }
 
     dht = kadDHT({
@@ -243,7 +243,7 @@ describe('peer routing', () => {
       datastore: new MemoryDatastore(),
       events: new TypedEventEmitter<any>(),
       logger: defaultLogger(),
-      ping: stubInterface<PingService>()
+      ping: stubInterface<Ping>()
     }
 
     dht = kadDHT({

--- a/packages/kad-dht/test/routing-table.spec.ts
+++ b/packages/kad-dht/test/routing-table.spec.ts
@@ -22,13 +22,13 @@ import { createPeerId, createPeerIds } from './utils/create-peer-id.js'
 import type { Network } from '../src/network.js'
 import type { Bucket } from '../src/routing-table/k-bucket.js'
 import type { Libp2pEvents, PeerId, PeerStore, Peer } from '@libp2p/interface'
-import type { PingService } from '@libp2p/ping'
+import type { Ping } from '@libp2p/ping'
 
 describe('Routing Table', () => {
   let table: RoutingTable
   let components: RoutingTableComponents
   let network: StubbedInstance<Network>
-  let ping: StubbedInstance<PingService>
+  let ping: StubbedInstance<Ping>
 
   beforeEach(async function () {
     this.timeout(20 * 1000)

--- a/packages/kad-dht/test/routing-table.spec.ts
+++ b/packages/kad-dht/test/routing-table.spec.ts
@@ -22,22 +22,26 @@ import { createPeerId, createPeerIds } from './utils/create-peer-id.js'
 import type { Network } from '../src/network.js'
 import type { Bucket } from '../src/routing-table/k-bucket.js'
 import type { Libp2pEvents, PeerId, PeerStore, Peer } from '@libp2p/interface'
+import type { PingService } from '@libp2p/ping'
 
 describe('Routing Table', () => {
   let table: RoutingTable
   let components: RoutingTableComponents
   let network: StubbedInstance<Network>
+  let ping: StubbedInstance<PingService>
 
   beforeEach(async function () {
     this.timeout(20 * 1000)
 
     const events = new TypedEventEmitter<Libp2pEvents>()
     network = stubInterface()
+    ping = stubInterface()
 
     components = {
       peerId: await createPeerId(),
       peerStore: stubInterface<PeerStore>(),
-      logger: defaultLogger()
+      logger: defaultLogger(),
+      ping
     }
     components.peerStore = persistentPeerStore({
       ...components,
@@ -340,8 +344,8 @@ describe('Routing Table', () => {
 
     await drain(table.pingOldContacts([oldPeer]))
 
-    expect(network.sendRequest.calledTwice).to.be.true()
-    expect(network.sendRequest.calledWith(oldPeer.peerId)).to.be.true()
+    expect(ping.ping.calledTwice).to.be.true()
+    expect(ping.ping.calledWith(oldPeer.peerId)).to.be.true()
 
     // did not add the new peer
     expect(table.kb.get(newPeer.kadId)).to.be.undefined()
@@ -395,15 +399,7 @@ describe('Routing Table', () => {
     table.network = network = stubInterface()
 
     // libp2p fails to dial the old peer
-    network.sendRequest.withArgs(oldPeer.peerId).rejects(new Error('Could not dial peer'))
-
-    // the new peer answers the ping
-    network.sendRequest.withArgs(newPeer.peerId).callsFake(async function * (from: PeerId) {
-      yield peerResponseEvent({
-        from,
-        messageType: MessageType.PING
-      })
-    })
+    ping.ping.withArgs(oldPeer.peerId).rejects(new Error('Could not dial peer'))
 
     // add the old peer
     await table.kb.add(oldPeer.peerId)
@@ -491,6 +487,7 @@ describe('Routing Table', () => {
       const kBucketSize = 20
       const maxSize = Math.pow(2, prefixLength) * kBucketSize
 
+      await stop(table)
       table = new RoutingTable(components, {
         logPrefix: '',
         metricsPrefix: '',
@@ -500,17 +497,6 @@ describe('Routing Table', () => {
         kBucketSize
       })
       await start(table)
-
-      // reset network stub so we can have specific behavior
-      table.network = network = stubInterface()
-
-      // all old peers answer pings, no peers should be evicted
-      network.sendRequest.callsFake(async function * (from: PeerId) {
-        yield peerResponseEvent({
-          from,
-          messageType: MessageType.PING
-        })
-      })
 
       for (let i = 0; i < 2 * maxSize; i++) {
         const remotePeer = await createPeerId()

--- a/packages/kad-dht/test/utils/test-dht.ts
+++ b/packages/kad-dht/test/utils/test-dht.ts
@@ -14,6 +14,7 @@ import { type KadDHT, type KadDHTComponents, type KadDHTInit } from '../../src/i
 import { KadDHT as KadDHTClass } from '../../src/kad-dht.js'
 import type { Libp2pEvents, PeerId, PeerStore } from '@libp2p/interface'
 import type { AddressManager, ConnectionManager, Registrar } from '@libp2p/interface-internal'
+import type { PingService } from '@libp2p/ping'
 
 export class TestDHT {
   private readonly peers: Map<string, { dht: KadDHT, registrar: Registrar }>
@@ -37,7 +38,8 @@ export class TestDHT {
       peerStore: stubInterface<PeerStore>(),
       connectionManager: stubInterface<ConnectionManager>(),
       events,
-      logger: defaultLogger()
+      logger: defaultLogger(),
+      ping: stubInterface<PingService>()
     }
     components.connectionManager = mockConnectionManager({
       ...components,

--- a/packages/kad-dht/test/utils/test-dht.ts
+++ b/packages/kad-dht/test/utils/test-dht.ts
@@ -14,7 +14,7 @@ import { type KadDHT, type KadDHTComponents, type KadDHTInit } from '../../src/i
 import { KadDHT as KadDHTClass } from '../../src/kad-dht.js'
 import type { Libp2pEvents, PeerId, PeerStore } from '@libp2p/interface'
 import type { AddressManager, ConnectionManager, Registrar } from '@libp2p/interface-internal'
-import type { PingService } from '@libp2p/ping'
+import type { Ping } from '@libp2p/ping'
 
 export class TestDHT {
   private readonly peers: Map<string, { dht: KadDHT, registrar: Registrar }>
@@ -39,7 +39,7 @@ export class TestDHT {
       connectionManager: stubInterface<ConnectionManager>(),
       events,
       logger: defaultLogger(),
-      ping: stubInterface<PingService>()
+      ping: stubInterface<Ping>()
     }
     components.connectionManager = mockConnectionManager({
       ...components,


### PR DESCRIPTION
The [kad-dht spec](s://github.com/libp2p/specs/tree/master/kad-dht) says:

> PING: Deprecated message type replaced by the dedicated ping protocol. Implementations may still handle incoming PING requests for backwards compatibility. Implementations must not actively send PING requests.

Switch to using `@libp2p/ping` instead of KAD-DHT `PING` messages to be compliant with the spec.

Incoming KAD-DHT `PING` messages are still supported.

Refs: https://github.com/libp2p/js-libp2p/discussions/3058
Fixes: https://github.com/libp2p/js-libp2p/issues/3072

BREAKING CHANGE: `@libp2p/kad-dht` now depends on `@libp2p/ping` - please configure this in your service map

## Change checklist

- [x] I have performed a self-review of my own code
- [x] I have made corresponding changes to the documentation if necessary (this includes comments as well)
- [x] I have added tests that prove my fix is effective or that my feature works