### PR TITLE
fix: close handshake datachannel after use

### DIFF
--- a/packages/transport-webrtc/src/private-to-public/transport.ts
+++ b/packages/transport-webrtc/src/private-to-public/transport.ts
@@ -6,7 +6,6 @@ import { BasicConstraintsExtension, X509Certificate, X509CertificateGenerator } 
 import { Key } from 'interface-datastore'
 import { base64url } from 'multiformats/bases/base64'
 import { sha256 } from 'multiformats/hashes/sha2'
-import { raceSignal } from 'race-signal'
 import { equals as uint8ArrayEquals } from 'uint8arrays/equals'
 import { fromString as uint8ArrayFromString } from 'uint8arrays/from-string'
 import { DEFAULT_CERTIFICATE_DATASTORE_KEY, DEFAULT_CERTIFICATE_LIFESPAN, DEFAULT_CERTIFICATE_PRIVATE_KEY_NAME, DEFAULT_CERTIFICATE_RENEWAL_THRESHOLD } from '../constants.js'
@@ -212,7 +211,7 @@ export class WebRTCDirectTransport implements Transport, Startable {
     const peerConnection = await createDialerRTCPeerConnection('client', ufrag, typeof this.init.rtcConfiguration === 'function' ? await this.init.rtcConfiguration() : this.init.rtcConfiguration ?? {})
 
     try {
-      return await raceSignal(connect(peerConnection, ufrag, {
+      return await connect(peerConnection, ufrag, {
         role: 'client',
         log: this.log,
         logger: this.components.logger,
@@ -225,7 +224,7 @@ export class WebRTCDirectTransport implements Transport, Startable {
         peerId: this.components.peerId,
         remotePeerId: theirPeerId,
         privateKey: this.components.privateKey
-      }), options.signal)
+      })
     } catch (err) {
       peerConnection.close()
       throw err

--- a/packages/transport-webrtc/src/private-to-public/utils/connect.ts
+++ b/packages/transport-webrtc/src/private-to-public/utils/connect.ts
@@ -45,157 +45,161 @@ export async function connect (peerConnection: DirectRTCPeerConnection, ufrag: s
   // is used to confirm the identity of the peer.
   const handshakeDataChannel = peerConnection.createDataChannel('', { negotiated: true, id: 0 })
 
-  if (options.role === 'client') {
-    // the client has to set the local offer before the remote answer
+  try {
+    if (options.role === 'client') {
+      // the client has to set the local offer before the remote answer
 
-    // Create offer and munge sdp with ufrag == pwd. This allows the remote to
-    // respond to STUN messages without performing an actual SDP exchange.
-    // This is because it can infer the passwd field by reading the USERNAME
-    // attribute of the STUN message.
-    options.log.trace('client creating local offer')
-    const offerSdp = await peerConnection.createOffer()
-    options.log.trace('client created local offer %s', offerSdp.sdp)
-    const mungedOfferSdp = sdp.munge(offerSdp, ufrag)
-    options.log.trace('client setting local offer %s', mungedOfferSdp.sdp)
-    await peerConnection.setLocalDescription(mungedOfferSdp)
+      // Create offer and munge sdp with ufrag == pwd. This allows the remote to
+      // respond to STUN messages without performing an actual SDP exchange.
+      // This is because it can infer the passwd field by reading the USERNAME
+      // attribute of the STUN message.
+      options.log.trace('client creating local offer')
+      const offerSdp = await peerConnection.createOffer()
+      options.log.trace('client created local offer %s', offerSdp.sdp)
+      const mungedOfferSdp = sdp.munge(offerSdp, ufrag)
+      options.log.trace('client setting local offer %s', mungedOfferSdp.sdp)
+      await peerConnection.setLocalDescription(mungedOfferSdp)
 
-    const answerSdp = sdp.serverAnswerFromMultiaddr(options.remoteAddr, ufrag)
-    options.log.trace('client setting server description %s', answerSdp.sdp)
-    await peerConnection.setRemoteDescription(answerSdp)
-  } else {
-    // the server has to set the remote offer before the local answer
-    const offerSdp = sdp.clientOfferFromMultiAddr(options.remoteAddr, ufrag)
-    options.log.trace('server setting client %s %s', offerSdp.type, offerSdp.sdp)
-    await peerConnection.setRemoteDescription(offerSdp)
+      const answerSdp = sdp.serverAnswerFromMultiaddr(options.remoteAddr, ufrag)
+      options.log.trace('client setting server description %s', answerSdp.sdp)
+      await peerConnection.setRemoteDescription(answerSdp)
+    } else {
+      // the server has to set the remote offer before the local answer
+      const offerSdp = sdp.clientOfferFromMultiAddr(options.remoteAddr, ufrag)
+      options.log.trace('server setting client %s %s', offerSdp.type, offerSdp.sdp)
+      await peerConnection.setRemoteDescription(offerSdp)
 
-    // Create offer and munge sdp with ufrag == pwd. This allows the remote to
-    // respond to STUN messages without performing an actual SDP exchange.
-    // This is because it can infer the passwd field by reading the USERNAME
-    // attribute of the STUN message.
-    options.log.trace('server creating local answer')
-    const answerSdp = await peerConnection.createAnswer()
-    options.log.trace('server created local answer')
-    const mungedAnswerSdp = sdp.munge(answerSdp, ufrag)
-    options.log.trace('server setting local description %s', answerSdp.sdp)
-    await peerConnection.setLocalDescription(mungedAnswerSdp)
-  }
-
-  options.log.trace('%s wait for handshake channel to open', options.role)
-  await raceEvent(handshakeDataChannel, 'open', options.signal)
-
-  options.log.trace('%s handshake channel opened', options.role)
-
-  if (options.role === 'server') {
-    // now that the connection has been opened, add the remote's certhash to
-    // it's multiaddr so we can complete the noise handshake
-    const remoteFingerprint = peerConnection.remoteFingerprint()?.value ?? ''
-    options.remoteAddr = options.remoteAddr.encapsulate(sdp.fingerprint2Ma(remoteFingerprint))
-  }
-
-  // Do noise handshake.
-  // Set the Noise Prologue to libp2p-webrtc-noise:<FINGERPRINTS> before
-  // starting the actual Noise handshake.
-  // <FINGERPRINTS> is the concatenation of the of the two TLS fingerprints
-  // of A (responder) and B (initiator) in their byte representation.
-  const localFingerprint = sdp.getFingerprintFromSdp(peerConnection.localDescription?.sdp)
-
-  if (localFingerprint == null) {
-    throw new WebRTCTransportError('Could not get fingerprint from local description sdp')
-  }
-
-  options.log.trace('%s performing noise handshake', options.role)
-  const noisePrologue = generateNoisePrologue(localFingerprint, options.remoteAddr, options.role)
-
-  // Since we use the default crypto interface and do not use a static key
-  // or early data, we pass in undefined for these parameters.
-  const connectionEncrypter = noise({ prologueBytes: noisePrologue })(options)
-
-  const wrappedChannel = createStream({
-    channel: handshakeDataChannel,
-    direction: 'inbound',
-    logger: options.logger,
-    ...(options.dataChannel ?? {})
-  })
-  const wrappedDuplex = {
-    ...wrappedChannel,
-    sink: wrappedChannel.sink.bind(wrappedChannel),
-    source: (async function * () {
-      for await (const list of wrappedChannel.source) {
-        for (const buf of list) {
-          yield buf
-        }
-      }
-    }())
-  }
-
-  // Creating the connection before completion of the noise
-  // handshake ensures that the stream opening callback is set up
-  const maConn = new WebRTCMultiaddrConnection(options, {
-    peerConnection,
-    remoteAddr: options.remoteAddr,
-    timeline: {
-      open: Date.now()
-    },
-    metrics: options.events
-  })
-
-  peerConnection.addEventListener(CONNECTION_STATE_CHANGE_EVENT, () => {
-    switch (peerConnection.connectionState) {
-      case 'failed':
-      case 'disconnected':
-      case 'closed':
-        maConn.close().catch((err) => {
-          options.log.error('error closing connection', err)
-          maConn.abort(err)
-        })
-        break
-      default:
-        break
+      // Create offer and munge sdp with ufrag == pwd. This allows the remote to
+      // respond to STUN messages without performing an actual SDP exchange.
+      // This is because it can infer the passwd field by reading the USERNAME
+      // attribute of the STUN message.
+      options.log.trace('server creating local answer')
+      const answerSdp = await peerConnection.createAnswer()
+      options.log.trace('server created local answer')
+      const mungedAnswerSdp = sdp.munge(answerSdp, ufrag)
+      options.log.trace('server setting local description %s', answerSdp.sdp)
+      await peerConnection.setLocalDescription(mungedAnswerSdp)
     }
-  })
 
-  // Track opened peer connection
-  options.events?.increment({ peer_connection: true })
+    options.log.trace('%s wait for handshake channel to open', options.role)
+    await raceEvent(handshakeDataChannel, 'open', options.signal)
 
-  const muxerFactory = new DataChannelMuxerFactory(options, {
-    peerConnection,
-    metrics: options.events,
-    dataChannelOptions: options.dataChannel
-  })
+    options.log.trace('%s handshake channel opened', options.role)
 
-  if (options.role === 'client') {
-    // For outbound connections, the remote is expected to start the noise handshake.
-    // Therefore, we need to secure an inbound noise connection from the remote.
-    options.log.trace('%s secure inbound', options.role)
-    await connectionEncrypter.secureInbound(wrappedDuplex, {
+    if (options.role === 'server') {
+      // now that the connection has been opened, add the remote's certhash to
+      // it's multiaddr so we can complete the noise handshake
+      const remoteFingerprint = peerConnection.remoteFingerprint()?.value ?? ''
+      options.remoteAddr = options.remoteAddr.encapsulate(sdp.fingerprint2Ma(remoteFingerprint))
+    }
+
+    // Do noise handshake.
+    // Set the Noise Prologue to libp2p-webrtc-noise:<FINGERPRINTS> before
+    // starting the actual Noise handshake.
+    // <FINGERPRINTS> is the concatenation of the of the two TLS fingerprints
+    // of A (responder) and B (initiator) in their byte representation.
+    const localFingerprint = sdp.getFingerprintFromSdp(peerConnection.localDescription?.sdp)
+
+    if (localFingerprint == null) {
+      throw new WebRTCTransportError('Could not get fingerprint from local description sdp')
+    }
+
+    options.log.trace('%s performing noise handshake', options.role)
+    const noisePrologue = generateNoisePrologue(localFingerprint, options.remoteAddr, options.role)
+
+    // Since we use the default crypto interface and do not use a static key
+    // or early data, we pass in undefined for these parameters.
+    const connectionEncrypter = noise({ prologueBytes: noisePrologue })(options)
+
+    const wrappedChannel = createStream({
+      channel: handshakeDataChannel,
+      direction: 'inbound',
+      logger: options.logger,
+      ...(options.dataChannel ?? {})
+    })
+    const wrappedDuplex = {
+      ...wrappedChannel,
+      sink: wrappedChannel.sink.bind(wrappedChannel),
+      source: (async function * () {
+        for await (const list of wrappedChannel.source) {
+          for (const buf of list) {
+            yield buf
+          }
+        }
+      }())
+    }
+
+    // Creating the connection before completion of the noise
+    // handshake ensures that the stream opening callback is set up
+    const maConn = new WebRTCMultiaddrConnection(options, {
+      peerConnection,
+      remoteAddr: options.remoteAddr,
+      timeline: {
+        open: Date.now()
+      },
+      metrics: options.events
+    })
+
+    peerConnection.addEventListener(CONNECTION_STATE_CHANGE_EVENT, () => {
+      switch (peerConnection.connectionState) {
+        case 'failed':
+        case 'disconnected':
+        case 'closed':
+          maConn.close().catch((err) => {
+            options.log.error('error closing connection', err)
+            maConn.abort(err)
+          })
+          break
+        default:
+          break
+      }
+    })
+
+    // Track opened peer connection
+    options.events?.increment({ peer_connection: true })
+
+    const muxerFactory = new DataChannelMuxerFactory(options, {
+      peerConnection,
+      metrics: options.events,
+      dataChannelOptions: options.dataChannel
+    })
+
+    if (options.role === 'client') {
+      // For outbound connections, the remote is expected to start the noise handshake.
+      // Therefore, we need to secure an inbound noise connection from the remote.
+      options.log.trace('%s secure inbound', options.role)
+      await connectionEncrypter.secureInbound(wrappedDuplex, {
+        remotePeer: options.remotePeerId,
+        signal: options.signal
+      })
+
+      options.log.trace('%s upgrade outbound', options.role)
+      return await options.upgrader.upgradeOutbound(maConn, {
+        skipProtection: true,
+        skipEncryption: true,
+        muxerFactory,
+        signal: options.signal
+      })
+    }
+
+    // For inbound connections, we are expected to start the noise handshake.
+    // Therefore, we need to secure an outbound noise connection from the remote.
+    options.log.trace('%s secure outbound', options.role)
+    const result = await connectionEncrypter.secureOutbound(wrappedDuplex, {
       remotePeer: options.remotePeerId,
       signal: options.signal
     })
+    maConn.remoteAddr = maConn.remoteAddr.encapsulate(`/p2p/${result.remotePeer}`)
 
-    options.log.trace('%s upgrade outbound', options.role)
-    return options.upgrader.upgradeOutbound(maConn, {
+    options.log.trace('%s upgrade inbound', options.role)
+
+    await options.upgrader.upgradeInbound(maConn, {
       skipProtection: true,
       skipEncryption: true,
       muxerFactory,
       signal: options.signal
     })
+  } finally {
+    handshakeDataChannel.close()
   }
-
-  // For inbound connections, we are expected to start the noise handshake.
-  // Therefore, we need to secure an outbound noise connection from the remote.
-  options.log.trace('%s secure outbound', options.role)
-  const result = await connectionEncrypter.secureOutbound(wrappedDuplex, {
-    remotePeer: options.remotePeerId,
-    signal: options.signal
-  })
-  maConn.remoteAddr = maConn.remoteAddr.encapsulate(`/p2p/${result.remotePeer}`)
-
-  options.log.trace('%s upgrade inbound', options.role)
-
-  await options.upgrader.upgradeInbound(maConn, {
-    skipProtection: true,
-    skipEncryption: true,
-    muxerFactory,
-    signal: options.signal
-  })
 }


### PR DESCRIPTION
Some times the handshake datachannel can remain open which causes a memory leak and stops the process from exiting so explicitly close the channel after the noise handshake has completed.

Also removes a redundant `raceSignal` - it's not necessary as we pass the signal in to the `connect` method.

Fixes #2625

## Change checklist

- [x] I have performed a self-review of my own code
- [ ] I have made corresponding changes to the documentation if necessary (this includes comments as well)
- [ ] I have added tests that prove my fix is effective or that my feature works