### PR TITLE
feat(types): Support custom events on PubSub and PeerStreams

### DIFF
--- a/packages/interface/src/pubsub.ts
+++ b/packages/interface/src/pubsub.ts
@@ -66,7 +66,7 @@ export interface PubSubRPC {
   messages: PubSubRPCMessage[]
 }
 
-export interface PeerStreams extends TypedEventTarget<PeerStreamEvents> {
+export interface PeerStreams<PeerEvents extends PeerStreamEvents = PeerStreamEvents> extends TypedEventTarget<PeerEvents> {
   id: PeerId
   protocol: string
   outboundStream?: Pushable<Uint8ArrayList>

--- a/packages/pubsub/src/peer-streams.ts
+++ b/packages/pubsub/src/peer-streams.ts
@@ -24,7 +24,7 @@ export interface DecoderOptions extends LpDecoderOptions {
 /**
  * Thin wrapper around a peer's inbound / outbound pubsub streams
  */
-export class PeerStreams extends TypedEventEmitter<PeerStreamEvents> {
+export class PeerStreams<PeerEvents extends PeerStreamEvents = PeerStreamEvents> extends TypedEventEmitter<PeerEvents> {
   public readonly id: PeerId
   public readonly protocol: string
   /**


### PR DESCRIPTION
## Title
feat(types): Support custom events on PubSub and PeerStreams

## Description

Allow implementations of PubSub and PeerStreams to maintain type safety when using custom events.

## Notes & open questions

Given these changes don't affect functional code paths and that there's no clear direction on how typescript only changes should be tested in js-libp2p, I've not added any tests.

## Change checklist

- [x] I have performed a self-review of my own code
- [x] I have made corresponding changes to the documentation if necessary (this includes comments as well)
- [ ] I have added tests that prove my fix is effective or that my feature works