### PR TITLE
feat: add skip muxer negotiation

### DIFF
--- a/packages/connection-encrypter-tls/test/index.spec.ts
+++ b/packages/connection-encrypter-tls/test/index.spec.ts
@@ -113,4 +113,26 @@ describe('tls', () => {
     expect(result).to.have.nested.property('[0].streamMuxer.protocol', '/test/muxer')
     expect(result).to.have.nested.property('[1].streamMuxer.protocol', '/test/muxer')
   })
+
+  it('should not select an early muxer when it is skipped', async () => {
+    const [inbound, outbound] = duplexPair<any>()
+
+    const result = await Promise.all([
+      encrypter.secureInbound(stubInterface<MultiaddrConnection>({
+        ...inbound
+      }), {
+        remotePeer: localPeer,
+        skipStreamMuxerNegotiation: true
+      }),
+      encrypter.secureOutbound(stubInterface<MultiaddrConnection>({
+        ...outbound
+      }), {
+        remotePeer: localPeer,
+        skipStreamMuxerNegotiation: true
+      })
+    ])
+
+    expect(result).to.have.nested.property('[0].streamMuxer', undefined)
+    expect(result).to.have.nested.property('[1].streamMuxer', undefined)
+  })
 })

--- a/packages/interface/src/connection-encrypter.ts
+++ b/packages/interface/src/connection-encrypter.ts
@@ -11,6 +11,14 @@ import type { Uint8ArrayList } from 'uint8arraylist'
  */
 export interface SecureConnectionOptions extends AbortOptions {
   remotePeer?: PeerId
+
+  /**
+   * Some encryption protocols allow negotiating application protocols as part
+   * of the initial handshake. The negotiated stream muxer protocol will be
+   * included as part of the from the `secureOutbound`/`secureInbound` methods
+   * unless `false` is passed here.
+   */
+  skipStreamMuxerNegotiation?: boolean
 }
 
 /**


### PR DESCRIPTION
Some transports have their own muxers but use existing encrypers to do a handshake so skip sending muxer lists as it is not necessary.

## Change checklist

- [x] I have performed a self-review of my own code
- [x] I have made corresponding changes to the documentation if necessary (this includes comments as well)
- [x] I have added tests that prove my fix is effective or that my feature works