### PR TITLE
fix: allow empty error events

### DIFF
--- a/packages/libp2p/src/connection-manager/dial-queue.ts
+++ b/packages/libp2p/src/connection-manager/dial-queue.ts
@@ -104,7 +104,7 @@ export class DialQueue {
     })
     // a started job errored
     this.queue.addEventListener('error', (event) => {
-      if (event.detail.name !== AbortError.name) {
+      if (event.detail?.name !== AbortError.name) {
         this.log.error('error in dial queue - %e', event.detail)
       }
     })


### PR DESCRIPTION
Some `ErrorEvent` implementations don't have a `.detail` field so null-guard on it before accessing properties.

## Change checklist

- [x] I have performed a self-review of my own code
- [ ] I have made corresponding changes to the documentation if necessary (this includes comments as well)
- [ ] I have added tests that prove my fix is effective or that my feature works