### PR TITLE
fix: partial revert of #3076 - do not close handshake channel

### DIFF
--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -233,8 +233,6 @@ jobs:
       - uses: libp2p/test-plans/.github/actions/run-transport-interop-test@master
         with:
           test-filter: js-libp2p-head
-          # remove after https://github.com/libp2p/rust-libp2p/issues/5986 is fixed
-          test-ignore: rust-v0.53
           extra-versions: ${{ github.workspace }}/interop/node-version.json ${{ github.workspace }}/interop/chromium-version.json ${{ github.workspace }}/interop/firefox-version.json ${{ github.workspace }}/interop/webkit-version.json
           s3-cache-bucket: ${{ vars.S3_LIBP2P_BUILD_CACHE_BUCKET_NAME }}
           s3-access-key-id: ${{ vars.S3_LIBP2P_BUILD_CACHE_AWS_ACCESS_KEY_ID }}

--- a/packages/transport-webrtc/src/private-to-public/utils/connect.ts
+++ b/packages/transport-webrtc/src/private-to-public/utils/connect.ts
@@ -166,9 +166,6 @@ export async function connect (peerConnection: DirectRTCPeerConnection, ufrag: s
         signal: options.signal
       })
 
-      options.log.trace('%s closing handshake datachannel', options.role)
-      handshakeDataChannel.close()
-
       options.log.trace('%s upgrade outbound', options.role)
       return await options.upgrader.upgradeOutbound(maConn, {
         skipProtection: true,

--- a/packages/transport-webrtc/src/stream.ts
+++ b/packages/transport-webrtc/src/stream.ts
@@ -350,7 +350,7 @@ export class WebRTCStream extends AbstractStream {
       // flags can be sent while we or the remote are closing the datachannel so
       // if the channel isn't open, don't try to send it but return false to let
       // the caller know and act if they need to
-      this.log.trace('not sending flag %s because channel is "%s" and not "open"', this.channel.readyState, flag.toString())
+      this.log.trace('not sending flag %s because channel is "%s" and not "open"', flag.toString(), this.channel.readyState)
       return false
     }
 


### PR DESCRIPTION
Removes the closing of the handshake datachannel after the connection has been opened because it breaks compatibility with rust-libp2p 53.

This can be revisited after https://github.com/libp2p/rust-libp2p/issues/5986 is resolved.

## Change checklist

- [x] I have performed a self-review of my own code
- [ ] I have made corresponding changes to the documentation if necessary (this includes comments as well)
- [ ] I have added tests that prove my fix is effective or that my feature works