### PR TITLE
fix: skip muxer negotiation

### DIFF
--- a/packages/transport-webrtc/src/private-to-public/utils/connect.ts
+++ b/packages/transport-webrtc/src/private-to-public/utils/connect.ts
@@ -163,7 +163,8 @@ export async function connect (peerConnection: DirectRTCPeerConnection, ufrag: s
       options.log.trace('%s secure inbound', options.role)
       await connectionEncrypter.secureInbound(handshakeStream, {
         remotePeer: options.remotePeerId,
-        signal: options.signal
+        signal: options.signal,
+        skipStreamMuxerNegotiation: true
       })
 
       options.log.trace('%s upgrade outbound', options.role)
@@ -181,7 +182,8 @@ export async function connect (peerConnection: DirectRTCPeerConnection, ufrag: s
     options.log.trace('%s secure outbound', options.role)
     const result = await connectionEncrypter.secureOutbound(handshakeStream, {
       remotePeer: options.remotePeerId,
-      signal: options.signal
+      signal: options.signal,
+      skipStreamMuxerNegotiation: true
     })
 
     maConn.remoteAddr = maConn.remoteAddr.encapsulate(`/p2p/${result.remotePeer}`)

--- a/packages/transport-webtransport/src/index.ts
+++ b/packages/transport-webtransport/src/index.ts
@@ -293,7 +293,8 @@ class WebTransportTransport implements Transport<WebTransportDialEvents> {
     onProgress?.(new CustomProgressEvent('webtransport:secure-outbound-connection'))
     const { remoteExtensions } = await n.secureOutbound(duplex, {
       signal,
-      remotePeer
+      remotePeer,
+      skipStreamMuxerNegotiation: true
     })
 
     onProgress?.(new CustomProgressEvent('webtransport:close-authentication-stream'))


### PR DESCRIPTION
Skips early muxer negotiation during noise handshake since WebRTC incorporates it's own muxer.

Fixes an edge case where a node is only configured with the WebRTC-Direct transport and no additional muxers.

Refs: https://github.com/ChainSafe/js-libp2p-noise/pull/519
Refs: https://github.com/ipshipyard/roadmaps/issues/22

## Change checklist

- [x] I have performed a self-review of my own code
- [ ] I have made corresponding changes to the documentation if necessary (this includes comments as well)
- [ ] I have added tests that prove my fix is effective or that my feature works