### PR TITLE
fix: do not dial bootstrap nodes

### DIFF
--- a/packages/integration-tests/test/bootstrap.spec.ts
+++ b/packages/integration-tests/test/bootstrap.spec.ts
@@ -3,9 +3,7 @@
 import { bootstrap } from '@libp2p/bootstrap'
 import { generateKeyPair } from '@libp2p/crypto/keys'
 import { TypedEventEmitter, peerDiscoverySymbol } from '@libp2p/interface'
-import { mplex } from '@libp2p/mplex'
 import { peerIdFromPrivateKey } from '@libp2p/peer-id'
-import { plaintext } from '@libp2p/plaintext'
 import { webSockets } from '@libp2p/websockets'
 import { multiaddr } from '@multiformats/multiaddr'
 import { expect } from 'aegir/chai'
@@ -96,52 +94,6 @@ describe('bootstrap', () => {
       expectedPeers.delete(id.toString())
       if (expectedPeers.size === 0) {
         libp2p.removeEventListener('peer:discovery')
-        deferred.resolve()
-      }
-    })
-
-    await libp2p.start()
-
-    return deferred.promise
-  })
-
-  it('bootstrap should dial all peers in the list', async () => {
-    const deferred = defer()
-
-    const list = [
-      `${process.env.RELAY_MULTIADDR}`
-    ]
-
-    libp2p = await createLibp2p({
-      connectionEncrypters: [
-        plaintext()
-      ],
-      transports: [
-        webSockets()
-      ],
-      streamMuxers: [
-        mplex()
-      ],
-      peerDiscovery: [
-        bootstrap({
-          list
-        })
-      ],
-      connectionGater: {
-        denyDialMultiaddr: () => false
-      }
-    })
-
-    const expectedPeers = new Set(
-      list.map(ma => multiaddr(ma).getPeerId())
-    )
-
-    libp2p.addEventListener('connection:open', (evt) => {
-      const { remotePeer } = evt.detail
-
-      expectedPeers.delete(remotePeer.toString())
-      if (expectedPeers.size === 0) {
-        libp2p.removeEventListener('connection:open')
         deferred.resolve()
       }
     })

--- a/packages/peer-discovery-bootstrap/package.json
+++ b/packages/peer-discovery-bootstrap/package.json
@@ -55,13 +55,13 @@
   },
   "dependencies": {
     "@libp2p/interface": "^2.9.0",
-    "@libp2p/interface-internal": "^2.3.11",
     "@libp2p/peer-id": "^5.1.2",
     "@multiformats/mafmt": "^12.1.6",
     "@multiformats/multiaddr": "^12.3.3"
   },
   "devDependencies": {
     "@libp2p/interface-compliance-tests": "^6.4.5",
+    "@libp2p/interface-internal": "^2.3.11",
     "@libp2p/logger": "^5.1.15",
     "aegir": "^45.1.1",
     "sinon-ts": "^2.0.0"

--- a/packages/peer-discovery-bootstrap/src/index.ts
+++ b/packages/peer-discovery-bootstrap/src/index.ts
@@ -37,7 +37,6 @@ import { peerIdFromString } from '@libp2p/peer-id'
 import { P2P } from '@multiformats/mafmt'
 import { multiaddr } from '@multiformats/multiaddr'
 import type { ComponentLogger, Logger, PeerDiscovery, PeerDiscoveryEvents, PeerInfo, PeerStore, Startable } from '@libp2p/interface'
-import type { ConnectionManager } from '@libp2p/interface-internal'
 
 const DEFAULT_BOOTSTRAP_TAG_NAME = 'bootstrap'
 const DEFAULT_BOOTSTRAP_TAG_VALUE = 50
@@ -77,7 +76,6 @@ export interface BootstrapInit {
 export interface BootstrapComponents {
   peerStore: PeerStore
   logger: ComponentLogger
-  connectionManager: ConnectionManager
 }
 
 /**
@@ -183,10 +181,6 @@ class Bootstrap extends TypedEventEmitter<PeerDiscoveryEvents> implements PeerDi
       }
 
       this.safeDispatchEvent('peer', { detail: peerData })
-      this.components.connectionManager.openConnection(peerData.id)
-        .catch(err => {
-          this.log.error('could not dial bootstrap peer %p', peerData.id, err)
-        })
     }
   }
 

--- a/packages/peer-discovery-bootstrap/test/bootstrap.spec.ts
+++ b/packages/peer-discovery-bootstrap/test/bootstrap.spec.ts
@@ -57,27 +57,6 @@ describe('bootstrap', () => {
     await stop(r)
   })
 
-  it('should dial bootstrap peers', async function () {
-    this.timeout(5 * 1000)
-    const r = bootstrap({
-      list: peerList,
-      timeout: 100
-    })(components)
-
-    await start(r)
-
-    await new Promise<void>(resolve => {
-      const interval = setInterval(() => {
-        if (components.connectionManager.openConnection.callCount === 1) {
-          clearInterval(interval)
-          resolve()
-        }
-      }, 100)
-    })
-
-    await stop(r)
-  })
-
   it('should tag bootstrap peers', async function () {
     this.timeout(5 * 1000)
 


### PR DESCRIPTION
Updates the bootstrap module to only discover the bootstrap nodes but not dial them.

Invidiual protocols that require bootstrapping (e.g. KAD-DHT) can then react to the disovery and choose to dial the peers.

This cuts down on unecessary dials for lightweight nodes and brings the bootstrap module in line with other peer discovery mechanisms.

## Change checklist

- [x] I have performed a self-review of my own code
- [ ] I have made corresponding changes to the documentation if necessary (this includes comments as well)
- [ ] I have added tests that prove my fix is effective or that my feature works