### PR TITLE
fix: allow partial routing implementations

### DIFF
--- a/packages/libp2p/src/content-routing.ts
+++ b/packages/libp2p/src/content-routing.ts
@@ -104,7 +104,9 @@ export class CompoundContentRouting implements ContentRouting, Startable {
     const seen = new PeerSet()
 
     for await (const peer of merge(
-      ...self.routers.map(router => router.findProviders(key, options))
+      ...self.routers
+        .filter(router => router.findProviders instanceof Function)
+        .map(router => router.findProviders(key, options))
     )) {
       // the peer was yielded by a content router without multiaddrs and we
       // failed to load them
@@ -139,9 +141,12 @@ export class CompoundContentRouting implements ContentRouting, Startable {
       throw new NoContentRoutersError('No content routers available')
     }
 
-    await Promise.all(this.routers.map(async (router) => {
-      await router.provide(key, options)
-    }))
+    await Promise.all(
+      this.routers
+        .filter(router => router.provide instanceof Function)
+        .map(async (router) => {
+          await router.provide(key, options)
+        }))
   }
 
   async cancelReprovide (key: CID, options: AbortOptions = {}): Promise<void> {
@@ -149,9 +154,13 @@ export class CompoundContentRouting implements ContentRouting, Startable {
       throw new NoContentRoutersError('No content routers available')
     }
 
-    await Promise.all(this.routers.map(async (router) => {
-      await router.cancelReprovide(key, options)
-    }))
+    await Promise.all(
+      this.routers
+        .filter(router => router.cancelReprovide instanceof Function)
+        .map(async (router) => {
+          await router.cancelReprovide(key, options)
+        })
+    )
   }
 
   /**
@@ -162,9 +171,13 @@ export class CompoundContentRouting implements ContentRouting, Startable {
       throw new NotStartedError()
     }
 
-    await Promise.all(this.routers.map(async (router) => {
-      await router.put(key, value, options)
-    }))
+    await Promise.all(
+      this.routers
+        .filter(router => router.put instanceof Function)
+        .map(async (router) => {
+          await router.put(key, value, options)
+        })
+    )
   }
 
   /**
@@ -176,8 +189,12 @@ export class CompoundContentRouting implements ContentRouting, Startable {
       throw new NotStartedError()
     }
 
-    return Promise.any(this.routers.map(async (router) => {
-      return router.get(key, options)
-    }))
+    return Promise.any(
+      this.routers
+        .filter(router => router.get instanceof Function)
+        .map(async (router) => {
+          return router.get(key, options)
+        })
+    )
   }
 }

--- a/packages/libp2p/src/peer-routing.ts
+++ b/packages/libp2p/src/peer-routing.ts
@@ -72,13 +72,15 @@ export class DefaultPeerRouting implements PeerRouting {
 
     const self = this
     const source = merge(
-      ...this.routers.map(router => (async function * () {
-        try {
-          yield await router.findPeer(id, options)
-        } catch (err) {
-          self.log.error(err)
-        }
-      })())
+      ...this.routers
+        .filter(router => router.findPeer instanceof Function)
+        .map(router => (async function * () {
+          try {
+            yield await router.findPeer(id, options)
+          } catch (err) {
+            self.log.error(err)
+          }
+        })())
     )
 
     for await (const peer of source) {
@@ -113,7 +115,9 @@ export class DefaultPeerRouting implements PeerRouting {
     for await (const peer of parallel(
       async function * () {
         const source = merge(
-          ...self.routers.map(router => router.getClosestPeers(key, options))
+          ...self.routers
+            .filter(router => router.getClosestPeers instanceof Function)
+            .map(router => router.getClosestPeers(key, options))
         )
 
         for await (let peer of source) {

--- a/packages/libp2p/test/peer-routing/peer-routing.spec.ts
+++ b/packages/libp2p/test/peer-routing/peer-routing.spec.ts
@@ -459,4 +459,48 @@ describe('peer-routing', () => {
       expect(peers).to.be.an('array').with.a.lengthOf(1).that.deep.equals(results)
     })
   })
+
+  describe('partial implementation', () => {
+    let node: Libp2p
+    let router: StubbedInstance<Partial<PeerRouting>>
+
+    beforeEach(async () => {
+      router = {
+        findPeer: sinon.stub()
+      }
+
+      node = await createLibp2p({
+        services: {
+          router: () => ({
+            [peerRoutingSymbol]: router
+          })
+        }
+      })
+    })
+
+    afterEach(async () => {
+      await node?.stop()
+    })
+
+    it('should invoke a method defined on the service', async () => {
+      const peerInfo = {
+        id: peerIdFromPrivateKey(await generateKeyPair('Ed25519')),
+        multiaddrs: [
+          multiaddr('/ip4/123.123.123.123/tcp/4001')
+        ]
+      }
+
+      router.findPeer?.callsFake(async function () {
+        return peerInfo
+      })
+
+      await expect(node.peerRouting.findPeer(peerInfo.id)).to.eventually.deep.equal(peerInfo)
+    })
+
+    it('should not invoke a method not defined on the service', async () => {
+      const result = await all(node.peerRouting.getClosestPeers(Uint8Array.from([0, 1, 2, 3, 4])))
+
+      expect(result).to.be.empty()
+    })
+  })
 })


### PR DESCRIPTION
So routing implementations don't have to have empty methods for features they don't support, guard on the routing method being present before invoking it.

## Change checklist

- [x] I have performed a self-review of my own code
- [ ] I have made corresponding changes to the documentation if necessary (this includes comments as well)
- [x] I have added tests that prove my fix is effective or that my feature works