### PR TITLE
fix: remove redundant types

### DIFF
--- a/packages/transport-webrtc/src/webrtc/index.ts
+++ b/packages/transport-webrtc/src/webrtc/index.ts
@@ -1,2 +1,1 @@
 export { RTCSessionDescription, RTCIceCandidate, RTCPeerConnection } from '@ipshipyard/node-datachannel/polyfill'
-export type { RTCDataChannel, RTCDataChannelEvent } from '@ipshipyard/node-datachannel/polyfill'

--- a/packages/transport-webrtc/test/muxer.spec.ts
+++ b/packages/transport-webrtc/test/muxer.spec.ts
@@ -5,7 +5,6 @@ import { expect } from 'aegir/chai'
 import pRetry from 'p-retry'
 import { stubInterface } from 'sinon-ts'
 import { DataChannelMuxerFactory } from '../src/muxer.js'
-import type { RTCPeerConnection, RTCDataChannelEvent, RTCDataChannel } from '../src/webrtc/index.js'
 
 describe('muxer', () => {
   it('should delay notification of early streams', async () => {


### PR DESCRIPTION
Since https://github.com/murat-dogan/node-datachannel/pull/346 `node-datachannel` returns global types where appropriate so it's no longer necessary to export the polyfill versions.

Refs https://github.com/libp2p/js-libp2p/pull/3095#issuecomment-2855245991

## Change checklist

- [x] I have performed a self-review of my own code
- [ ] I have made corresponding changes to the documentation if necessary (this includes comments as well)
- [ ] I have added tests that prove my fix is effective or that my feature works