### PR TITLE
feat: add getInfo function to peerstore

### DIFF
--- a/packages/interface/src/peer-store.ts
+++ b/packages/interface/src/peer-store.ts
@@ -1,6 +1,7 @@
 import type { PublicKey } from './keys.js'
 import type { PeerId } from './peer-id.js'
 import type { Multiaddr } from '@multiformats/multiaddr'
+import type { PeerInfo } from './peer-info.js'
 
 /**
  * When a peer that is tagged with this prefix disconnects, we will attempt to
@@ -228,6 +229,33 @@ export interface PeerStore {
    * ```
    */
   get(peerId: PeerId): Promise<Peer>
+
+  /**
+   * Returns a PeerInfo object for the passed peer id. This is similar to `get`
+   * except the returned value contains fewer fields and the multiaddrs do not
+   * include the id of the peer so cannot be treated as opaque since depending
+   * on the transport the peer id may be required to dial a given address.
+   *
+   * The returned object can be passed to `JSON.stringify` without any
+   * additional processing.
+   *
+   * @see https://docs.libp2p.io/concepts/fundamentals/peers/#peer-info
+   *
+   * @example
+   *
+   * ```TypeScript
+   * const peerInfo = await peerStore.getInfo(peerId)
+   *
+   * console.info(JSON.stringify(peerInfo))
+   * // {
+   * //    id: 'peerId'
+   * //    multiaddrs: [
+   * //      '...'
+   * //    ]
+   * // }
+   * ```
+   */
+  getInfo (peerId: PeerId): Promise<PeerInfo>
 
   /**
    * Adds a peer to the peer store, overwriting any existing data

--- a/packages/interface/src/peer-store.ts
+++ b/packages/interface/src/peer-store.ts
@@ -232,9 +232,8 @@ export interface PeerStore {
 
   /**
    * Returns a PeerInfo object for the passed peer id. This is similar to `get`
-   * except the returned value contains fewer fields and the multiaddrs do not
-   * include the id of the peer so cannot be treated as opaque since depending
-   * on the transport the peer id may be required to dial a given address.
+   * except the returned value contains fewer fields and is often used to
+   * exchange peer information with other systems.
    *
    * The returned object can be passed to `JSON.stringify` without any
    * additional processing.

--- a/packages/interface/src/peer-store.ts
+++ b/packages/interface/src/peer-store.ts
@@ -1,7 +1,7 @@
 import type { PublicKey } from './keys.js'
 import type { PeerId } from './peer-id.js'
-import type { Multiaddr } from '@multiformats/multiaddr'
 import type { PeerInfo } from './peer-info.js'
+import type { Multiaddr } from '@multiformats/multiaddr'
 
 /**
  * When a peer that is tagged with this prefix disconnects, we will attempt to

--- a/packages/peer-store/src/index.ts
+++ b/packages/peer-store/src/index.ts
@@ -8,7 +8,7 @@ import { peerIdFromCID } from '@libp2p/peer-id'
 import { RecordEnvelope, PeerRecord } from '@libp2p/peer-record'
 import all from 'it-all'
 import { PersistentStore, type PeerUpdate } from './store.js'
-import type { ComponentLogger, Libp2pEvents, Logger, TypedEventTarget, PeerId, PeerStore, Peer, PeerData, PeerQuery } from '@libp2p/interface'
+import type { ComponentLogger, Libp2pEvents, Logger, TypedEventTarget, PeerId, PeerStore, Peer, PeerData, PeerQuery, PeerInfo } from '@libp2p/interface'
 import type { Multiaddr } from '@multiformats/multiaddr'
 import type { Datastore } from 'interface-datastore'
 
@@ -136,6 +136,15 @@ class PersistentPeerStore implements PeerStore {
     } finally {
       this.log.trace('get release read lock')
       release()
+    }
+  }
+
+  async getInfo (peerId: PeerId): Promise<PeerInfo> {
+    const peer = await this.get(peerId)
+
+    return {
+      id: peer.id,
+      multiaddrs: peer.addresses.map(({ multiaddr }) => multiaddr)
     }
   }
 

--- a/packages/peer-store/src/utils/dedupe-addresses.ts
+++ b/packages/peer-store/src/utils/dedupe-addresses.ts
@@ -42,8 +42,17 @@ export async function dedupeFilterAndSortAddresses (peerId: PeerId, filter: Addr
     .sort((a, b) => {
       return a.multiaddr.toString().localeCompare(b.multiaddr.toString())
     })
-    .map(({ isCertified, multiaddr }) => ({
-      isCertified,
-      multiaddr: multiaddr.bytes
-    }))
+    .map(({ isCertified, multiaddr: ma }) => {
+      // strip the trailing peerId if it is present
+      const addrPeer = ma.getPeerId()
+
+      if (peerId.equals(addrPeer)) {
+        ma = ma.decapsulate(multiaddr(`/p2p/${peerId}`))
+      }
+
+      return {
+        isCertified,
+        multiaddr: ma.bytes
+      }
+    })
 }

--- a/packages/peer-store/test/index.spec.ts
+++ b/packages/peer-store/test/index.spec.ts
@@ -495,4 +495,64 @@ describe('PersistentPeerStore', () => {
       }
     })
   })
+
+  it('should return peerInfo', async () => {
+    const peerStore = persistentPeerStore(components, {
+      maxAddressAge: 50,
+      maxPeerAge: 200
+    })
+
+    await peerStore.save(otherPeerId, {
+      multiaddrs: [
+        multiaddr('/ip4/123.123.123.123/tcp/1234')
+      ]
+    })
+
+    await expect(peerStore.getInfo(otherPeerId)).to.eventually.deep.equal({
+      id: otherPeerId,
+      multiaddrs: [
+        multiaddr('/ip4/123.123.123.123/tcp/1234')
+      ]
+    })
+  })
+
+  it('should not include peer id in multiaddrs in returned peerInfo', async () => {
+    const peerStore = persistentPeerStore(components, {
+      maxAddressAge: 50,
+      maxPeerAge: 200
+    })
+
+    await peerStore.save(otherPeerId, {
+      multiaddrs: [
+        multiaddr(`/ip4/123.123.123.123/tcp/1234/p2p/${otherPeerId}`)
+      ]
+    })
+
+    await expect(peerStore.getInfo(otherPeerId)).to.eventually.deep.equal({
+      id: otherPeerId,
+      multiaddrs: [
+        multiaddr('/ip4/123.123.123.123/tcp/1234')
+      ]
+    })
+  })
+
+  it('should serialize peerInfo', async () => {
+    const peerStore = persistentPeerStore(components, {
+      maxAddressAge: 50,
+      maxPeerAge: 200
+    })
+
+    await peerStore.save(otherPeerId, {
+      multiaddrs: [
+        multiaddr(`/ip4/123.123.123.123/tcp/1234/p2p/${otherPeerId}`)
+      ]
+    })
+
+    expect(JSON.parse(JSON.stringify(await peerStore.getInfo(otherPeerId)))).to.deep.equal({
+      id: otherPeerId.toString(),
+      multiaddrs: [
+        '/ip4/123.123.123.123/tcp/1234'
+      ]
+    })
+  })
 })


### PR DESCRIPTION
Adds a function to return a `PeerInfo` object - this is more lightweight than a full `Peer` object as it only contains the peer id and the listening addresses and is commonly used for exchanging peer information.

## Change checklist

- [x] I have performed a self-review of my own code
- [x] I have made corresponding changes to the documentation if necessary (this includes comments as well)
- [x] I have added tests that prove my fix is effective or that my feature works