### PR TITLE
fix: increase signal listeners

### DIFF
--- a/packages/transport-circuit-relay-v2/src/transport/transport.ts
+++ b/packages/transport-circuit-relay-v2/src/transport/transport.ts
@@ -1,4 +1,4 @@
-import { DialError, InvalidMessageError, serviceCapabilities, serviceDependencies, start, stop, transportSymbol } from '@libp2p/interface'
+import { DialError, InvalidMessageError, serviceCapabilities, serviceDependencies, setMaxListeners, start, stop, transportSymbol } from '@libp2p/interface'
 import { peerFilter } from '@libp2p/peer-collections'
 import { peerIdFromMultihash, peerIdFromString } from '@libp2p/peer-id'
 import { streamToMaConnection } from '@libp2p/utils/stream-to-ma-conn'
@@ -129,6 +129,7 @@ export class CircuitRelayTransport implements Transport<CircuitRelayDialEvents> 
 
   async start (): Promise<void> {
     this.shutdownController = new AbortController()
+    setMaxListeners(Infinity, this.shutdownController.signal)
 
     await this.registrar.handle(RELAY_V2_STOP_CODEC, (data) => {
       const signal = this.upgrader.createInboundAbortSignal(this.shutdownController.signal)

--- a/packages/transport-memory/src/listener.ts
+++ b/packages/transport-memory/src/listener.ts
@@ -1,4 +1,4 @@
-import { ListenError, TypedEventEmitter } from '@libp2p/interface'
+import { ListenError, TypedEventEmitter, setMaxListeners } from '@libp2p/interface'
 import { multiaddr } from '@multiformats/multiaddr'
 import { nanoid } from 'nanoid'
 import { MemoryConnection, connections } from './connections.js'
@@ -23,6 +23,7 @@ export class MemoryTransportListener extends TypedEventEmitter<ListenerEvents> i
     this.components = components
     this.init = init
     this.shutdownController = new AbortController()
+    setMaxListeners(Infinity, this.shutdownController.signal)
   }
 
   async listen (ma: Multiaddr): Promise<void> {

--- a/packages/transport-webrtc/src/private-to-public/listener.ts
+++ b/packages/transport-webrtc/src/private-to-public/listener.ts
@@ -1,5 +1,5 @@
 import { isIPv4 } from '@chainsafe/is-ip'
-import { InvalidParametersError, TypedEventEmitter } from '@libp2p/interface'
+import { InvalidParametersError, TypedEventEmitter, setMaxListeners } from '@libp2p/interface'
 import { getThinWaistAddresses } from '@libp2p/utils/get-thin-waist-addresses'
 import { multiaddr, fromStringTuples } from '@multiformats/multiaddr'
 import { WebRTCDirect } from '@multiformats/multiaddr-matcher'
@@ -71,6 +71,7 @@ export class WebRTCDirectListener extends TypedEventEmitter<ListenerEvents> impl
     this.connections = new Map()
     this.log = components.logger.forComponent('libp2p:webrtc-direct:listener')
     this.shutdownController = new AbortController()
+    setMaxListeners(Infinity, this.shutdownController.signal)
     this.certificate = init.certificate
 
     if (components.metrics != null) {

--- a/packages/transport-websockets/src/listener.ts
+++ b/packages/transport-websockets/src/listener.ts
@@ -1,7 +1,7 @@
 import http from 'node:http'
 import https from 'node:https'
 import net from 'node:net'
-import { TypedEventEmitter } from '@libp2p/interface'
+import { TypedEventEmitter, setMaxListeners } from '@libp2p/interface'
 import { getThinWaistAddresses } from '@libp2p/utils/get-thin-waist-addresses'
 import { ipPortToMultiaddr as toMultiaddr } from '@libp2p/utils/ip-port-to-multiaddr'
 import { multiaddr } from '@multiformats/multiaddr'
@@ -64,6 +64,7 @@ export class WebSocketListener extends TypedEventEmitter<ListenerEvents> impleme
     this.httpsOptions = init.https ?? init.http
     this.sockets = new Set()
     this.shutdownController = new AbortController()
+    setMaxListeners(Infinity, this.shutdownController.signal)
 
     this.wsServer = new ws.WebSocketServer({
       noServer: true


### PR DESCRIPTION
Silences `MaxListenersExceededWarning` for shutdown controller signals
- it is expected because they are used a lot.

## Change checklist

- [ ] I have performed a self-review of my own code
- [ ] I have made corresponding changes to the documentation if necessary (this includes comments as well)
- [ ] I have added tests that prove my fix is effective or that my feature works