### PR TITLE
feat: add path index to events

### DIFF
--- a/packages/interface-internal/src/connection-manager.ts
+++ b/packages/interface-internal/src/connection-manager.ts
@@ -1,4 +1,4 @@
-import type { AbortOptions, PendingDial, Connection, MultiaddrConnection, PeerId, IsDialableOptions, OpenConnectionProgressEvents } from '@libp2p/interface'
+import type { AbortOptions, PendingDial, Connection, MultiaddrConnection, PeerId, IsDialableOptions, OpenConnectionProgressEvents, Stream, NewStreamOptions } from '@libp2p/interface'
 import type { PeerMap } from '@libp2p/peer-collections'
 import type { Multiaddr } from '@multiformats/multiaddr'
 import type { ProgressOptions } from 'progress-events'
@@ -74,6 +74,18 @@ export interface ConnectionManager {
    * @returns A promise that resolves to a `Connection` object.
    */
   openConnection(peer: PeerId | Multiaddr | Multiaddr[], options?: OpenConnectionOptions): Promise<Connection>
+
+  /**
+   * Open a protocol stream with a remote peer. If a connection to this peer is
+   * already open, the stream will be opened on that connection, otherwise a new
+   * connection will first be established.
+   *
+   * @param peer - The target `PeerId`, `Multiaddr`, or an array of `Multiaddr`s.
+   * @param protocol - The protocol stream identifier
+   * @param options - Optional parameters for connection handling.
+   * @returns A promise that resolves to a `Stream` object.
+   */
+  openStream (peer: PeerId | Multiaddr | Multiaddr[], protocol: string, options?: NewStreamOptions): Promise<Stream>
 
   /**
    * Close our connections to a peer

--- a/packages/interface-internal/src/connection-manager.ts
+++ b/packages/interface-internal/src/connection-manager.ts
@@ -1,4 +1,4 @@
-import type { AbortOptions, PendingDial, Connection, MultiaddrConnection, PeerId, IsDialableOptions, OpenConnectionProgressEvents, Stream, NewStreamOptions } from '@libp2p/interface'
+import type { AbortOptions, PendingDial, Connection, MultiaddrConnection, PeerId, IsDialableOptions, OpenConnectionProgressEvents } from '@libp2p/interface'
 import type { PeerMap } from '@libp2p/peer-collections'
 import type { Multiaddr } from '@multiformats/multiaddr'
 import type { ProgressOptions } from 'progress-events'
@@ -74,18 +74,6 @@ export interface ConnectionManager {
    * @returns A promise that resolves to a `Connection` object.
    */
   openConnection(peer: PeerId | Multiaddr | Multiaddr[], options?: OpenConnectionOptions): Promise<Connection>
-
-  /**
-   * Open a protocol stream with a remote peer. If a connection to this peer is
-   * already open, the stream will be opened on that connection, otherwise a new
-   * connection will first be established.
-   *
-   * @param peer - The target `PeerId`, `Multiaddr`, or an array of `Multiaddr`s.
-   * @param protocol - The protocol stream identifier
-   * @param options - Optional parameters for connection handling.
-   * @returns A promise that resolves to a `Stream` object.
-   */
-  openStream (peer: PeerId | Multiaddr | Multiaddr[], protocol: string, options?: NewStreamOptions): Promise<Stream>
 
   /**
    * Close our connections to a peer

--- a/packages/kad-dht/src/content-routing/index.ts
+++ b/packages/kad-dht/src/content-routing/index.ts
@@ -112,7 +112,10 @@ export class ContentRouting {
         try {
           this.log('sending provider record for %s to %p', key, event.peer.id)
 
-          for await (const sendEvent of this.network.sendMessage(event.peer.id, msg, options)) {
+          for await (const sendEvent of this.network.sendMessage(event.peer.id, msg, {
+            ...options,
+            path: event.path ?? -1
+          })) {
             if (sendEvent.name === 'PEER_RESPONSE') {
               this.log('sent provider record for %s to %p', key, event.peer.id)
               sent++
@@ -181,7 +184,7 @@ export class ContentRouting {
         }
       }
 
-      yield peerResponseEvent({ from: this.components.peerId, messageType: MessageType.GET_PROVIDERS, providers }, options)
+      yield peerResponseEvent({ from: this.components.peerId, messageType: MessageType.GET_PROVIDERS, providers, path: -1 }, options)
       yield providerEvent({ from: this.components.peerId, providers }, options)
 
       found += providers.length
@@ -194,7 +197,7 @@ export class ContentRouting {
     /**
      * The query function to use on this particular disjoint path
      */
-    const findProvidersQuery: QueryFunc = async function * ({ peer, signal }) {
+    const findProvidersQuery: QueryFunc = async function * ({ peer, signal, path }) {
       const request = {
         type: MessageType.GET_PROVIDERS,
         key: target
@@ -202,7 +205,8 @@ export class ContentRouting {
 
       yield * self.network.sendRequest(peer, request, {
         ...options,
-        signal
+        signal,
+        path
       })
     }
 

--- a/packages/kad-dht/src/index.ts
+++ b/packages/kad-dht/src/index.ts
@@ -192,6 +192,7 @@ export interface SendQueryEvent {
   name: 'SEND_QUERY'
   messageName: keyof typeof MessageType
   messageType: MessageType
+  path: number
 }
 
 /**
@@ -207,6 +208,7 @@ export interface PeerResponseEvent {
   closer: PeerInfo[]
   providers: PeerInfo[]
   record?: DHTRecord
+  path: number
 }
 
 /**
@@ -217,6 +219,7 @@ export interface FinalPeerEvent {
   peer: PeerInfo
   type: EventTypes.FINAL_PEER
   name: 'FINAL_PEER'
+  path: number
 }
 
 /**
@@ -227,6 +230,7 @@ export interface QueryErrorEvent {
   type: EventTypes.QUERY_ERROR
   name: 'QUERY_ERROR'
   error: Error
+  path?: number
 }
 
 /**
@@ -256,10 +260,13 @@ export interface AddPeerEvent {
   type: EventTypes.ADD_PEER
   name: 'ADD_PEER'
   peer: PeerId
+  path: number
 }
 
 /**
  * Emitted when peers are dialled as part of a query
+ *
+ * @deprecated No longer emitted as sometimes connections are reused so it's not possible to say with certainty that a peer has been dialled
  */
 export interface DialPeerEvent {
   peer: PeerId
@@ -506,8 +513,8 @@ export interface KadDHTInit {
   initialQuerySelfInterval?: number
 
   /**
-   * After startup by default all queries will be paused until the initial
-   * self-query has run and there are some peers in the routing table.
+   * After startup by default all queries will be paused until there is at least
+   * one peer in the routing table.
    *
    * Pass true here to disable this behavior.
    *

--- a/packages/kad-dht/src/kad-dht.ts
+++ b/packages/kad-dht/src/kad-dht.ts
@@ -223,7 +223,8 @@ export class KadDHT extends TypedEventEmitter<PeerDiscoveryEvents> implements Ka
       logPrefix,
       metricsPrefix,
       initialQuerySelfHasRun,
-      routingTable: this.routingTable
+      routingTable: this.routingTable,
+      allowQueryWithZeroPeers: init.allowQueryWithZeroPeers
     })
 
     // DHT components
@@ -276,7 +277,6 @@ export class KadDHT extends TypedEventEmitter<PeerDiscoveryEvents> implements Ka
       initialInterval: init.initialQuerySelfInterval,
       logPrefix,
       initialQuerySelfHasRun,
-      routingTable: this.routingTable,
       operationMetrics
     })
     this.reprovider = new Reprovider(components, {

--- a/packages/kad-dht/src/peer-distance-list.ts
+++ b/packages/kad-dht/src/peer-distance-list.ts
@@ -6,6 +6,7 @@ import type { PeerId, PeerInfo } from '@libp2p/interface'
 interface PeerDistance {
   peer: PeerInfo
   distance: Uint8Array
+  path: number
 }
 
 /**
@@ -40,30 +41,31 @@ export class PeerDistanceList {
   /**
    * The peers in the list, in order of distance from the origin key
    */
-  get peers (): PeerInfo[] {
-    return this.peerDistances.map(pd => pd.peer)
+  get peers (): PeerDistance[] {
+    return [...this.peerDistances]
   }
 
   /**
    * Add a peerId to the list.
    */
-  async add (peer: PeerInfo): Promise<void> {
+  async add (peer: PeerInfo, path: number = -1): Promise<void> {
     const dhtKey = await convertPeerId(peer.id)
 
-    this.addWithKadId(peer, dhtKey)
+    this.addWithKadId(peer, dhtKey, path)
   }
 
   /**
    * Add a peerId to the list.
    */
-  addWithKadId (peer: PeerInfo, kadId: Uint8Array): void {
+  addWithKadId (peer: PeerInfo, kadId: Uint8Array, path: number = -1): void {
     if (this.peerDistances.find(pd => pd.peer.id.equals(peer.id)) != null) {
       return
     }
 
-    const el = {
+    const el: PeerDistance = {
       peer,
-      distance: uint8ArrayXor(this.originDhtKey, kadId)
+      distance: uint8ArrayXor(this.originDhtKey, kadId),
+      path
     }
 
     let added = false

--- a/packages/kad-dht/src/query-self.ts
+++ b/packages/kad-dht/src/query-self.ts
@@ -4,18 +4,16 @@ import length from 'it-length'
 import { pipe } from 'it-pipe'
 import take from 'it-take'
 import pDefer from 'p-defer'
-import { pEvent } from 'p-event'
 import { QUERY_SELF_INTERVAL, QUERY_SELF_TIMEOUT, K, QUERY_SELF_INITIAL_INTERVAL } from './constants.js'
 import { timeOperationMethod } from './utils.js'
 import type { OperationMetrics } from './kad-dht.js'
 import type { PeerRouting } from './peer-routing/index.js'
-import type { RoutingTable } from './routing-table/index.js'
 import type { ComponentLogger, Logger, Metrics, PeerId, Startable } from '@libp2p/interface'
 import type { DeferredPromise } from 'p-defer'
+
 export interface QuerySelfInit {
   logPrefix: string
   peerRouting: PeerRouting
-  routingTable: RoutingTable
   count?: number
   interval?: number
   initialInterval?: number
@@ -28,6 +26,7 @@ export interface QuerySelfComponents {
   peerId: PeerId
   logger: ComponentLogger
   metrics?: Metrics
+  events: EventTarget
 }
 
 /**
@@ -37,7 +36,7 @@ export class QuerySelf implements Startable {
   private readonly log: Logger
   private readonly peerId: PeerId
   private readonly peerRouting: PeerRouting
-  private readonly routingTable: RoutingTable
+  private readonly events: EventTarget
   private readonly count: number
   private readonly interval: number
   private readonly initialInterval: number
@@ -51,9 +50,9 @@ export class QuerySelf implements Startable {
   constructor (components: QuerySelfComponents, init: QuerySelfInit) {
     this.peerId = components.peerId
     this.log = components.logger.forComponent(`${init.logPrefix}:query-self`)
+    this.events = components.events
     this.running = false
     this.peerRouting = init.peerRouting
-    this.routingTable = init.routingTable
     this.count = init.count ?? K
     this.interval = init.interval ?? QUERY_SELF_INTERVAL
     this.initialInterval = init.initialInterval ?? QUERY_SELF_INITIAL_INTERVAL
@@ -122,20 +121,10 @@ export class QuerySelf implements Startable {
       setMaxListeners(Infinity, signal, this.controller.signal)
 
       try {
-        if (this.routingTable.size === 0) {
-          this.log('routing table was empty, waiting for some peers before running query')
-          // wait to discover at least one DHT peer that isn't us
-          await pEvent(this.routingTable, 'peer:add', {
-            signal,
-            filter: (event) => !this.peerId.equals(event.detail)
-          })
-          this.log('routing table has peers, continuing with query')
-        }
-
         this.log('run self-query, look for %d peers timing out after %dms', this.count, this.queryTimeout)
         const start = Date.now()
 
-        const found = await pipe(
+        const peers = await pipe(
           this.peerRouting.getClosestPeers(this.peerId.toMultihash().bytes, {
             signal,
             isSelfQuery: true
@@ -144,7 +133,16 @@ export class QuerySelf implements Startable {
           async (source) => length(source)
         )
 
-        this.log('self-query found %d peers in %dms', found, Date.now() - start)
+        const duration = Date.now() - start
+
+        this.log('self-query found %d peers in %dms', peers, duration)
+
+        this.events.dispatchEvent(new CustomEvent('kad-dht:query:self', {
+          detail: {
+            peers,
+            duration
+          }
+        }))
       } catch (err: any) {
         this.log.error('self-query error', err)
       } finally {

--- a/packages/kad-dht/src/query/events.ts
+++ b/packages/kad-dht/src/query/events.ts
@@ -1,4 +1,4 @@
-import type { MessageType, SendQueryEvent, PeerResponseEvent, DialPeerEvent, AddPeerEvent, ValueEvent, ProviderEvent, QueryErrorEvent, FinalPeerEvent } from '../index.js'
+import type { MessageType, SendQueryEvent, PeerResponseEvent, AddPeerEvent, ValueEvent, ProviderEvent, QueryErrorEvent, FinalPeerEvent } from '../index.js'
 import type { PeerId, PeerInfo } from '@libp2p/interface'
 import type { Libp2pRecord } from '@libp2p/record'
 import type { ProgressOptions } from 'progress-events'
@@ -6,6 +6,7 @@ import type { ProgressOptions } from 'progress-events'
 export interface QueryEventFields {
   to: PeerId
   type: MessageType
+  path: number
 }
 
 export function sendQueryEvent (fields: QueryEventFields, options: ProgressOptions = {}): SendQueryEvent {
@@ -25,6 +26,7 @@ export function sendQueryEvent (fields: QueryEventFields, options: ProgressOptio
 export interface PeerResponseEventFields {
   from: PeerId
   messageType: MessageType
+  path: number
   closer?: PeerInfo[]
   providers?: PeerInfo[]
   record?: Libp2pRecord
@@ -48,6 +50,7 @@ export function peerResponseEvent (fields: PeerResponseEventFields, options: Pro
 export interface FinalPeerEventFields {
   from: PeerId
   peer: PeerInfo
+  path: number
 }
 
 export function finalPeerEvent (fields: FinalPeerEventFields, options: ProgressOptions = {}): FinalPeerEvent {
@@ -65,6 +68,7 @@ export function finalPeerEvent (fields: FinalPeerEventFields, options: ProgressO
 export interface ErrorEventFields {
   from: PeerId
   error: Error
+  path?: number
 }
 
 export function queryErrorEvent (fields: ErrorEventFields, options: ProgressOptions = {}): QueryErrorEvent {
@@ -113,11 +117,12 @@ export function valueEvent (fields: ValueEventFields, options: ProgressOptions =
   return event
 }
 
-export interface PeerEventFields {
+export interface AddPeerEventFields {
   peer: PeerId
+  path: number
 }
 
-export function addPeerEvent (fields: PeerEventFields, options: ProgressOptions = {}): AddPeerEvent {
+export function addPeerEvent (fields: AddPeerEventFields, options: ProgressOptions = {}): AddPeerEvent {
   const event: AddPeerEvent = {
     ...fields,
     name: 'ADD_PEER',
@@ -125,22 +130,6 @@ export function addPeerEvent (fields: PeerEventFields, options: ProgressOptions 
   }
 
   options.onProgress?.(new CustomEvent('kad-dht:query:add-peer', { detail: event }))
-
-  return event
-}
-
-export interface DialPeerEventFields {
-  peer: PeerId
-}
-
-export function dialPeerEvent (fields: DialPeerEventFields, options: ProgressOptions = {}): DialPeerEvent {
-  const event: DialPeerEvent = {
-    ...fields,
-    name: 'DIAL_PEER',
-    type: 7
-  }
-
-  options.onProgress?.(new CustomEvent('kad-dht:query:dial-peer', { detail: event }))
 
   return event
 }

--- a/packages/kad-dht/src/query/types.ts
+++ b/packages/kad-dht/src/query/types.ts
@@ -9,7 +9,7 @@ export interface QueryContext {
   // if this signal emits an 'abort' event, any long-lived processes or requests started as part of this query should be terminated
   signal: AbortSignal
   // which disjoint path we are following
-  pathIndex: number
+  path: number
   // the total number of disjoint paths being executed
   numPaths: number
 }

--- a/packages/kad-dht/src/routing-table/closest-peers.ts
+++ b/packages/kad-dht/src/routing-table/closest-peers.ts
@@ -91,7 +91,7 @@ export class ClosestPeers implements Startable {
   }
 
   async updatePeerTags (): Promise<void> {
-    const newClosest = new PeerSet(this.newPeers?.peers.map(peer => peer.id))
+    const newClosest = new PeerSet(this.newPeers?.peers.map(({ peer }) => peer.id))
     const added = newClosest.difference(this.closestPeers)
     const removed = this.closestPeers.difference(newClosest)
     this.closestPeers = newClosest

--- a/packages/kad-dht/src/routing-table/k-bucket.ts
+++ b/packages/kad-dht/src/routing-table/k-bucket.ts
@@ -300,7 +300,7 @@ export class KBucket {
       list.addWithKadId({ id: peer.peerId, multiaddrs: [] }, peer.kadId)
     }
 
-    yield * map(list.peers, info => info.id)
+    yield * map(list.peers, ({ peer }) => peer.id)
   }
 
   /**

--- a/packages/kad-dht/test/kad-dht.spec.ts
+++ b/packages/kad-dht/test/kad-dht.spec.ts
@@ -15,7 +15,7 @@ import * as kadUtils from '../src/utils.js'
 import { createPeerIdsWithPrivateKey } from './utils/create-peer-id.js'
 import { sortDHTs } from './utils/sort-closest-peers.js'
 import { TestDHT } from './utils/test-dht.js'
-import type { PeerIdWithPrivateKey } from './utils/create-peer-id.js'
+import type { PeerAndKey } from './utils/create-peer-id.js'
 import type { FinalPeerEvent, QueryEvent, ValueEvent } from '../src/index.js'
 
 async function findEvent (events: AsyncIterable<QueryEvent>, name: 'FINAL_PEER'): Promise<FinalPeerEvent>
@@ -38,7 +38,7 @@ async function findEvent (events: AsyncIterable<QueryEvent>, name: string): Prom
 }
 
 describe('KadDHT', () => {
-  let peerIds: PeerIdWithPrivateKey[]
+  let peerIds: PeerAndKey[]
   let testDHT: TestDHT
 
   beforeEach(() => {
@@ -379,13 +379,14 @@ describe('KadDHT', () => {
       const dht = await testDHT.spawn()
 
       // Simulate returning a peer id to query
-      sinon.stub(dht.routingTable, 'closestPeers').returns([peerIds[1]])
+      sinon.stub(dht.routingTable, 'closestPeers').returns([peerIds[1].peerId])
       // Simulate going out to the network and returning the record
       sinon.stub(dht.peerRouting, 'getValueOrPeers').callsFake(async function * (peer) {
         yield peerResponseEvent({
           messageType: MessageType.GET_VALUE,
           from: peer,
-          record: rec
+          record: rec,
+          path: -1
         })
       }) // eslint-disable-line require-await
 

--- a/packages/kad-dht/test/kad-utils.spec.ts
+++ b/packages/kad-dht/test/kad-utils.spec.ts
@@ -6,7 +6,7 @@ import { concat as uint8ArrayConcat } from 'uint8arrays/concat'
 import { fromString as uint8ArrayFromString } from 'uint8arrays/from-string'
 import { toString as uint8ArrayToString } from 'uint8arrays/to-string'
 import * as utils from '../src/utils.js'
-import { createPeerId, createPeerIds } from './utils/create-peer-id.js'
+import { createPeerIdWithPrivateKey, createPeerIdsWithPrivateKey } from './utils/create-peer-id.js'
 
 describe('kad utils', () => {
   describe('bufferToKey', () => {
@@ -43,9 +43,9 @@ describe('kad utils', () => {
 
   describe('keyForPublicKey', () => {
     it('works', async () => {
-      const peer = await createPeerId()
-      expect(utils.keyForPublicKey(peer))
-        .to.eql(uint8ArrayConcat([uint8ArrayFromString('/pk/'), peer.toMultihash().bytes]))
+      const peer = await createPeerIdWithPrivateKey()
+      expect(utils.keyForPublicKey(peer.peerId))
+        .to.eql(uint8ArrayConcat([uint8ArrayFromString('/pk/'), peer.peerId.toMultihash().bytes]))
     })
   })
 
@@ -53,18 +53,18 @@ describe('kad utils', () => {
     it('round trips', async function () {
       this.timeout(40 * 1000)
 
-      const peers = await createPeerIds(50)
+      const peers = await createPeerIdsWithPrivateKey(50)
       peers.forEach((id, i) => {
-        expect(utils.isPublicKeyKey(utils.keyForPublicKey(id))).to.eql(true)
-        expect(utils.fromPublicKeyKey(utils.keyForPublicKey(id)).toMultihash().bytes)
-          .to.eql(id.toMultihash().bytes)
+        expect(utils.isPublicKeyKey(utils.keyForPublicKey(id.peerId))).to.eql(true)
+        expect(utils.fromPublicKeyKey(utils.keyForPublicKey(id.peerId)).toMultihash().bytes)
+          .to.eql(id.peerId.toMultihash().bytes)
       })
     })
   })
 
   describe('removePrivateAddresses', () => {
     it('filters private multiaddrs', async () => {
-      const id = await createPeerId()
+      const id = await createPeerIdWithPrivateKey()
 
       const multiaddrs = [
         multiaddr('/dns4/example.com/tcp/4001'),
@@ -73,7 +73,7 @@ describe('kad utils', () => {
         multiaddr('/dns4/localhost/tcp/4001')
       ]
 
-      const peerInfo = utils.removePrivateAddressesMapper({ id, multiaddrs })
+      const peerInfo = utils.removePrivateAddressesMapper({ id: id.peerId, multiaddrs })
       expect(peerInfo.multiaddrs.map((ma) => ma.toString()))
         .to.eql(['/dns4/example.com/tcp/4001', '/ip4/1.1.1.1/tcp/4001'])
     })
@@ -81,7 +81,7 @@ describe('kad utils', () => {
 
   describe('removePublicAddresses', () => {
     it('filters public multiaddrs', async () => {
-      const id = await createPeerId()
+      const id = await createPeerIdWithPrivateKey()
 
       const multiaddrs = [
         multiaddr('/dns4/example.com/tcp/4001'),
@@ -90,7 +90,7 @@ describe('kad utils', () => {
         multiaddr('/dns4/localhost/tcp/4001')
       ]
 
-      const peerInfo = utils.removePublicAddressesMapper({ id, multiaddrs })
+      const peerInfo = utils.removePublicAddressesMapper({ id: id.peerId, multiaddrs })
       expect(peerInfo.multiaddrs.map((ma) => ma.toString()))
         .to.eql(['/ip4/192.168.0.1/tcp/4001', '/dns4/localhost/tcp/4001'])
     })

--- a/packages/kad-dht/test/network.spec.ts
+++ b/packages/kad-dht/test/network.spec.ts
@@ -35,7 +35,9 @@ describe('Network', () => {
         key: uint8ArrayFromString('hello')
       }
 
-      const events = await all(dht.network.sendRequest(dht.components.peerId, msg))
+      const events = await all(dht.network.sendRequest(dht.components.peerId, msg, {
+        path: -1
+      }))
       const response = events
         .filter(event => event.name === 'PEER_RESPONSE')
         .pop()
@@ -90,7 +92,9 @@ describe('Network', () => {
         return connection
       }
 
-      const events = await all(dht.network.sendRequest(dht.components.peerId, msg))
+      const events = await all(dht.network.sendRequest(dht.components.peerId, msg, {
+        path: -1
+      }))
       const response = events
         .filter(event => event.name === 'PEER_RESPONSE')
         .pop()

--- a/packages/kad-dht/test/peer-distance-list.spec.ts
+++ b/packages/kad-dht/test/peer-distance-list.spec.ts
@@ -32,7 +32,7 @@ describe('PeerDistanceList', () => {
 
       // Note: p1 and p5 are equal
       expect(pdl.length).to.eql(4)
-      expect(pdl.peers).to.be.eql([p1, p4, p3, p2])
+      expect(pdl.peers.map(({ peer }) => peer)).to.be.eql([p1, p4, p3, p2])
     })
 
     it('capacity', async () => {
@@ -50,7 +50,7 @@ describe('PeerDistanceList', () => {
 
       // Closer peers added later should replace further
       // peers added earlier
-      expect(pdl.peers).to.be.eql([p1, p4, p3])
+      expect(pdl.peers.map(({ peer }) => peer)).to.be.eql([p1, p4, p3])
     })
   })
 

--- a/packages/kad-dht/test/providers.spec.ts
+++ b/packages/kad-dht/test/providers.spec.ts
@@ -7,15 +7,14 @@ import { MemoryDatastore } from 'datastore-core/memory'
 import createMortice from 'mortice'
 import { CID } from 'multiformats/cid'
 import { Providers } from '../src/providers.js'
-import { createPeerIds } from './utils/create-peer-id.js'
-import type { PeerId } from '@libp2p/interface'
+import { createPeerIdsWithPrivateKey, type PeerAndKey } from './utils/create-peer-id.js'
 
 describe('providers', () => {
-  let peers: PeerId[]
+  let peers: PeerAndKey[]
   let providers: Providers
 
   before(async function () {
-    peers = await createPeerIds(3)
+    peers = await createPeerIdsWithPrivateKey(3)
   })
 
   it('should add and get providers', async () => {
@@ -31,13 +30,13 @@ describe('providers', () => {
     const cid = CID.parse('QmdfTbBqBPQ7VNxZEYEj14VmRuZBkqFbiwReogJgS1zR1n')
 
     await Promise.all([
-      providers.addProvider(cid, peers[0]),
-      providers.addProvider(cid, peers[1])
+      providers.addProvider(cid, peers[0].peerId),
+      providers.addProvider(cid, peers[1].peerId)
     ])
 
     const provs = await providers.getProviders(cid)
     const ids = new Set(provs.map((peerId) => peerId.toString()))
-    expect(ids.has(peers[0].toString())).to.equal(true)
+    expect(ids.has(peers[0].peerId.toString())).to.equal(true)
   })
 
   it('should deduplicate multiple adds of same provider', async () => {
@@ -53,17 +52,17 @@ describe('providers', () => {
     const cid = CID.parse('QmdfTbBqBPQ7VNxZEYEj14VmRuZBkqFbiwReogJgS1zR1n')
 
     await Promise.all([
-      providers.addProvider(cid, peers[0]),
-      providers.addProvider(cid, peers[0]),
-      providers.addProvider(cid, peers[1]),
-      providers.addProvider(cid, peers[1]),
-      providers.addProvider(cid, peers[1])
+      providers.addProvider(cid, peers[0].peerId),
+      providers.addProvider(cid, peers[0].peerId),
+      providers.addProvider(cid, peers[1].peerId),
+      providers.addProvider(cid, peers[1].peerId),
+      providers.addProvider(cid, peers[1].peerId)
     ])
 
     const provs = await providers.getProviders(cid)
     expect(provs).to.have.length(2)
     const ids = new Set(provs.map((peerId) => peerId.toString()))
-    expect(ids.has(peers[0].toString())).to.equal(true)
+    expect(ids.has(peers[0].peerId.toString())).to.equal(true)
   })
 
   it('should deduplicate CIDs by multihash', async () => {
@@ -81,17 +80,17 @@ describe('providers', () => {
     const cidB = CID.createV1(6, cid.multihash)
 
     await Promise.all([
-      providers.addProvider(cidA, peers[0]),
-      providers.addProvider(cidB, peers[1]),
-      providers.addProvider(cid, peers[2])
+      providers.addProvider(cidA, peers[0].peerId),
+      providers.addProvider(cidB, peers[1].peerId),
+      providers.addProvider(cid, peers[2].peerId)
     ])
 
     const provs = await providers.getProviders(cid)
     expect(provs).to.have.length(3)
     expect(provs).to.include.deep.members([
-      peers[0],
-      peers[1],
-      peers[2]
+      peers[0].peerId,
+      peers[1].peerId,
+      peers[2].peerId
     ])
   })
 

--- a/packages/kad-dht/test/query-self.spec.ts
+++ b/packages/kad-dht/test/query-self.spec.ts
@@ -1,16 +1,17 @@
 /* eslint-env mocha */
 
 import { generateKeyPair } from '@libp2p/crypto/keys'
+import { TypedEventEmitter, type PeerId } from '@libp2p/interface'
 import { defaultLogger } from '@libp2p/logger'
 import { peerIdFromPrivateKey } from '@libp2p/peer-id'
 import { expect } from 'aegir/chai'
+import delay from 'delay'
 import pDefer from 'p-defer'
 import { stubInterface, type StubbedInstance } from 'sinon-ts'
 import { finalPeerEvent } from '../src/query/events.js'
 import { QuerySelf } from '../src/query-self.js'
 import type { PeerRouting } from '../src/peer-routing/index.js'
 import type { RoutingTable } from '../src/routing-table/index.js'
-import type { PeerId } from '@libp2p/interface'
 import type { DeferredPromise } from 'p-defer'
 
 describe('Query Self', () => {
@@ -28,7 +29,8 @@ describe('Query Self', () => {
 
     const components = {
       peerId,
-      logger: defaultLogger()
+      logger: defaultLogger(),
+      events: new TypedEventEmitter()
     }
 
     const init = {
@@ -55,69 +57,27 @@ describe('Query Self', () => {
     expect(peerRouting.getClosestPeers).to.have.property('callCount', 0)
   })
 
-  it('should wait for routing table peers before running first query', async () => {
-    querySelf.start()
-
-    // @ts-expect-error read-only property
-    routingTable.size = 0
-
-    const querySelfPromise = querySelf.querySelf()
-    const remotePeer = peerIdFromPrivateKey(await generateKeyPair('Ed25519'))
-
-    let initialQuerySelfHasRunResolved = false
-
-    void initialQuerySelfHasRun.promise.then(() => {
-      initialQuerySelfHasRunResolved = true
-    })
-
-    // should have registered a peer:add listener
-    expect(routingTable.addEventListener).to.have.property('callCount', 2)
-    expect(routingTable.addEventListener.getCall(0)).to.have.nested.property('args[0]', 'peer:add')
-
-    // self query results
-    peerRouting.getClosestPeers.withArgs(peerId.toMultihash().bytes).returns(async function * () {
-      yield finalPeerEvent({
-        from: remotePeer,
-        peer: {
-          id: remotePeer,
-          multiaddrs: []
-        }
-      })
-    }())
-
-    // @ts-expect-error args[1] type could be an object
-    routingTable.addEventListener.getCall(0).args[1](new CustomEvent('peer:add', { detail: remotePeer }))
-
-    // self-query should complete
-    await querySelfPromise
-
-    // should have resolved initial query self promise
-    expect(initialQuerySelfHasRunResolved).to.be.true()
-  })
-
   it('should join an existing query promise and not run twice', async () => {
     querySelf.start()
 
-    // @ts-expect-error read-only property
-    routingTable.size = 0
-
-    const querySelfPromise1 = querySelf.querySelf()
-    const querySelfPromise2 = querySelf.querySelf()
     const remotePeer = peerIdFromPrivateKey(await generateKeyPair('Ed25519'))
 
     // self query results
     peerRouting.getClosestPeers.withArgs(peerId.toMultihash().bytes).returns(async function * () {
+      await delay(10)
+
       yield finalPeerEvent({
         from: remotePeer,
         peer: {
           id: remotePeer,
           multiaddrs: []
-        }
+        },
+        path: 0
       })
     }())
 
-    // @ts-expect-error args[1] type could be an object
-    routingTable.addEventListener.getCall(0).args[1](new CustomEvent('peer:add', { detail: remotePeer }))
+    const querySelfPromise1 = querySelf.querySelf()
+    const querySelfPromise2 = querySelf.querySelf()
 
     // both self-query promises should resolve
     await Promise.all([querySelfPromise1, querySelfPromise2])

--- a/packages/kad-dht/test/reprovider.spec.ts
+++ b/packages/kad-dht/test/reprovider.spec.ts
@@ -9,7 +9,7 @@ import { pEvent } from 'p-event'
 import { stubInterface } from 'sinon-ts'
 import { Providers } from '../src/providers.js'
 import { Reprovider } from '../src/reprovider.js'
-import { createPeerId, createPeerIds } from './utils/create-peer-id.js'
+import { createPeerIdWithPrivateKey, createPeerIdsWithPrivateKey, type PeerAndKey } from './utils/create-peer-id.js'
 import type { ContentRouting } from '../src/content-routing/index.js'
 import type { ComponentLogger, PeerId } from '@libp2p/interface'
 import type { AddressManager } from '@libp2p/interface-internal'
@@ -28,14 +28,14 @@ describe('reprovider', () => {
   let providers: Providers
   let components: StubbedReproviderComponents
   let contentRouting: StubbedInstance<ContentRouting>
-  let peers: PeerId[]
+  let peers: PeerAndKey[]
 
   beforeEach(async () => {
-    peers = await createPeerIds(3)
-    const peerId = await createPeerId()
+    peers = await createPeerIdsWithPrivateKey(3)
+    const peer = await createPeerIdWithPrivateKey()
 
     components = {
-      peerId,
+      peerId: peer.peerId,
       datastore: new MemoryDatastore(),
       logger: defaultLogger(),
       addressManager: stubInterface()
@@ -114,15 +114,15 @@ describe('reprovider', () => {
   it('should remove expired provider records', async () => {
     const cid = CID.parse('QmdfTbBqBPQ7VNxZEYEj14VmRuZBkqFbiwReogJgS1zR1n')
     await Promise.all([
-      providers.addProvider(cid, peers[0]),
-      providers.addProvider(cid, peers[1])
+      providers.addProvider(cid, peers[0].peerId),
+      providers.addProvider(cid, peers[1].peerId)
     ])
 
     const provs = await providers.getProviders(cid)
 
     expect(provs).to.have.length(2)
-    expect(provs[0].toString()).to.be.equal(peers[0].toString())
-    expect(provs[1].toString()).to.be.deep.equal(peers[1].toString())
+    expect(provs[0].toString()).to.be.equal(peers[0].peerId.toString())
+    expect(provs[1].toString()).to.be.deep.equal(peers[1].peerId.toString())
 
     await delay(400)
 

--- a/packages/kad-dht/test/rpc/handlers/get-providers.spec.ts
+++ b/packages/kad-dht/test/rpc/handlers/get-providers.spec.ts
@@ -15,17 +15,17 @@ import { PeerRouting } from '../../../src/peer-routing/index.js'
 import { Providers } from '../../../src/providers.js'
 import { GetProvidersHandler, type GetProvidersHandlerComponents } from '../../../src/rpc/handlers/get-providers.js'
 import { passthroughMapper } from '../../../src/utils.js'
-import { createPeerId } from '../../utils/create-peer-id.js'
+import { createPeerIdWithPrivateKey, type PeerAndKey } from '../../utils/create-peer-id.js'
 import { createValues, type Value } from '../../utils/create-values.js'
-import type { Libp2pEvents, PeerId, PeerInfo, PeerStore } from '@libp2p/interface'
+import type { Libp2pEvents, PeerInfo, PeerStore } from '@libp2p/interface'
 
 const T = MessageType.GET_PROVIDERS
 
 describe('rpc - handlers - GetProviders', () => {
-  let peerId: PeerId
-  let sourcePeer: PeerId
-  let closerPeer: PeerId
-  let providerPeer: PeerId
+  let peerId: PeerAndKey
+  let sourcePeer: PeerAndKey
+  let closerPeer: PeerAndKey
+  let providerPeer: PeerAndKey
   let peerStore: PeerStore
   let providers: SinonStubbedInstance<Providers>
   let peerRouting: SinonStubbedInstance<PeerRouting>
@@ -33,23 +33,23 @@ describe('rpc - handlers - GetProviders', () => {
   let values: Value[]
 
   beforeEach(async () => {
-    peerId = await createPeerId()
-    sourcePeer = await createPeerId()
-    closerPeer = await createPeerId()
-    providerPeer = await createPeerId()
+    peerId = await createPeerIdWithPrivateKey()
+    sourcePeer = await createPeerIdWithPrivateKey()
+    closerPeer = await createPeerIdWithPrivateKey()
+    providerPeer = await createPeerIdWithPrivateKey()
     values = await createValues(1)
 
     peerRouting = Sinon.createStubInstance(PeerRouting)
     providers = Sinon.createStubInstance(Providers)
     peerStore = persistentPeerStore({
-      peerId,
+      peerId: peerId.peerId,
       datastore: new MemoryDatastore(),
       events: new TypedEventEmitter<Libp2pEvents>(),
       logger: defaultLogger()
     })
 
     const components: GetProvidersHandlerComponents = {
-      peerId,
+      peerId: peerId.peerId,
       peerStore,
       logger: defaultLogger()
     }
@@ -70,7 +70,7 @@ describe('rpc - handlers - GetProviders', () => {
       providers: []
     }
 
-    await expect(handler.handle(sourcePeer, msg)).to.eventually.be.rejected
+    await expect(handler.handle(sourcePeer.peerId, msg)).to.eventually.be.rejected
       .with.property('name', 'InvalidMessageError')
   })
 
@@ -84,7 +84,7 @@ describe('rpc - handlers - GetProviders', () => {
     }
 
     const closer: PeerInfo[] = [{
-      id: closerPeer,
+      id: closerPeer.peerId,
       multiaddrs: [
         multiaddr('/ip4/127.0.0.1/tcp/4002'),
         multiaddr('/ip4/192.168.2.6/tcp/4002'),
@@ -93,7 +93,7 @@ describe('rpc - handlers - GetProviders', () => {
     }]
 
     const provider: PeerInfo[] = [{
-      id: providerPeer,
+      id: providerPeer.peerId,
       multiaddrs: [
         multiaddr('/ip4/127.0.0.1/tcp/4002'),
         multiaddr('/ip4/192.168.1.5/tcp/4002'),
@@ -101,17 +101,17 @@ describe('rpc - handlers - GetProviders', () => {
       ]
     }]
 
-    providers.getProviders.withArgs(v.cid).resolves([providerPeer])
-    peerRouting.getCloserPeersOffline.withArgs(msg.key, peerId).resolves(closer)
+    providers.getProviders.withArgs(v.cid).resolves([providerPeer.peerId])
+    peerRouting.getCloserPeersOffline.withArgs(msg.key, peerId.peerId).resolves(closer)
 
-    await peerStore.merge(providerPeer, {
+    await peerStore.merge(providerPeer.peerId, {
       multiaddrs: provider[0].multiaddrs
     })
-    await peerStore.merge(closerPeer, {
+    await peerStore.merge(closerPeer.peerId, {
       multiaddrs: closer[0].multiaddrs
     })
 
-    const response = await handler.handle(sourcePeer, msg)
+    const response = await handler.handle(sourcePeer.peerId, msg)
 
     if (response == null) {
       throw new Error('No response received from handler')

--- a/packages/kad-dht/test/rpc/handlers/get-value.spec.ts
+++ b/packages/kad-dht/test/rpc/handlers/get-value.spec.ts
@@ -13,32 +13,32 @@ import { type Message, MessageType } from '../../../src/message/dht.js'
 import { PeerRouting } from '../../../src/peer-routing/index.js'
 import { GetValueHandler, type GetValueHandlerComponents } from '../../../src/rpc/handlers/get-value.js'
 import * as utils from '../../../src/utils.js'
-import { createPeerId } from '../../utils/create-peer-id.js'
-import type { Libp2pEvents, PeerId, PeerStore } from '@libp2p/interface'
+import { createPeerIdWithPrivateKey, type PeerAndKey } from '../../utils/create-peer-id.js'
+import type { Libp2pEvents, PeerStore } from '@libp2p/interface'
 import type { Datastore } from 'interface-datastore'
 import type { SinonStubbedInstance } from 'sinon'
 
 const T = MessageType.GET_VALUE
 
 describe('rpc - handlers - GetValue', () => {
-  let peerId: PeerId
-  let sourcePeer: PeerId
-  let closerPeer: PeerId
-  let targetPeer: PeerId
+  let peerId: PeerAndKey
+  let sourcePeer: PeerAndKey
+  let closerPeer: PeerAndKey
+  let targetPeer: PeerAndKey
   let handler: GetValueHandler
   let peerRouting: SinonStubbedInstance<PeerRouting>
   let peerStore: PeerStore
   let datastore: Datastore
 
   beforeEach(async () => {
-    peerId = await createPeerId()
-    sourcePeer = await createPeerId()
-    closerPeer = await createPeerId()
-    targetPeer = await createPeerId()
+    peerId = await createPeerIdWithPrivateKey()
+    sourcePeer = await createPeerIdWithPrivateKey()
+    closerPeer = await createPeerIdWithPrivateKey()
+    targetPeer = await createPeerIdWithPrivateKey()
     peerRouting = Sinon.createStubInstance(PeerRouting)
     datastore = new MemoryDatastore()
     peerStore = persistentPeerStore({
-      peerId,
+      peerId: peerId.peerId,
       datastore,
       events: new TypedEventEmitter<Libp2pEvents>(),
       logger: defaultLogger()
@@ -66,7 +66,7 @@ describe('rpc - handlers - GetValue', () => {
     }
 
     try {
-      await handler.handle(sourcePeer, msg)
+      await handler.handle(sourcePeer.peerId, msg)
     } catch (err: any) {
       expect(err.name).to.equal('InvalidMessageError')
       return
@@ -89,9 +89,9 @@ describe('rpc - handlers - GetValue', () => {
       providers: []
     }
 
-    peerRouting.getCloserPeersOffline.withArgs(msg.key, sourcePeer).resolves([])
+    peerRouting.getCloserPeersOffline.withArgs(msg.key, sourcePeer.peerId).resolves([])
 
-    const response = await handler.handle(sourcePeer, msg)
+    const response = await handler.handle(sourcePeer.peerId, msg)
 
     if (response == null) {
       throw new Error('No response received from handler')
@@ -109,9 +109,9 @@ describe('rpc - handlers - GetValue', () => {
   it('responds with closer peers returned from the dht', async () => {
     const key = uint8ArrayFromString('hello')
 
-    peerRouting.getCloserPeersOffline.withArgs(key, sourcePeer)
+    peerRouting.getCloserPeersOffline.withArgs(key, sourcePeer.peerId)
       .resolves([{
-        id: closerPeer,
+        id: closerPeer.peerId,
         multiaddrs: []
       }])
 
@@ -121,18 +121,18 @@ describe('rpc - handlers - GetValue', () => {
       closer: [],
       providers: []
     }
-    const response = await handler.handle(sourcePeer, msg)
+    const response = await handler.handle(sourcePeer.peerId, msg)
 
     if (response == null) {
       throw new Error('No response received from handler')
     }
 
-    expect(response).to.have.nested.property('closer[0].id').that.deep.equals(closerPeer.toMultihash().bytes)
+    expect(response).to.have.nested.property('closer[0].id').that.deep.equals(closerPeer.peerId.toMultihash().bytes)
   })
 
   describe('public key', () => {
     it('peer in peer store', async () => {
-      const key = utils.keyForPublicKey(targetPeer)
+      const key = utils.keyForPublicKey(targetPeer.peerId)
       const msg: Message = {
         type: T,
         key,
@@ -140,15 +140,15 @@ describe('rpc - handlers - GetValue', () => {
         providers: []
       }
 
-      if (targetPeer.publicKey == null) {
+      if (targetPeer.peerId.publicKey == null) {
         throw new Error('targetPeer had no public key')
       }
 
-      await peerStore.merge(targetPeer, {
-        publicKey: targetPeer.publicKey
+      await peerStore.merge(targetPeer.peerId, {
+        publicKey: targetPeer.peerId.publicKey
       })
 
-      const response = await handler.handle(sourcePeer, msg)
+      const response = await handler.handle(sourcePeer.peerId, msg)
 
       if (response == null) {
         throw new Error('No response received from handler')
@@ -160,11 +160,11 @@ describe('rpc - handlers - GetValue', () => {
 
       const responseRecord = Libp2pRecord.deserialize(response.record)
 
-      expect(responseRecord).to.have.property('value').that.equalBytes(publicKeyToProtobuf(targetPeer.publicKey))
+      expect(responseRecord).to.have.property('value').that.equalBytes(publicKeyToProtobuf(targetPeer.peerId.publicKey))
     })
 
     it('peer not in peer store', async () => {
-      const key = utils.keyForPublicKey(targetPeer)
+      const key = utils.keyForPublicKey(targetPeer.peerId)
       const msg: Message = {
         type: T,
         key,
@@ -174,7 +174,7 @@ describe('rpc - handlers - GetValue', () => {
 
       peerRouting.getCloserPeersOffline.resolves([])
 
-      const response = await handler.handle(sourcePeer, msg)
+      const response = await handler.handle(sourcePeer.peerId, msg)
 
       if (response == null) {
         throw new Error('No response received from handler')

--- a/packages/kad-dht/test/rpc/handlers/ping.spec.ts
+++ b/packages/kad-dht/test/rpc/handlers/ping.spec.ts
@@ -4,18 +4,17 @@ import { defaultLogger } from '@libp2p/logger'
 import { expect } from 'aegir/chai'
 import { type Message, MessageType } from '../../../src/message/dht.js'
 import { PingHandler } from '../../../src/rpc/handlers/ping.js'
-import { createPeerId } from '../../utils/create-peer-id.js'
+import { createPeerIdWithPrivateKey, type PeerAndKey } from '../../utils/create-peer-id.js'
 import type { DHTMessageHandler } from '../../../src/rpc/index.js'
-import type { PeerId } from '@libp2p/interface'
 
 const T = MessageType.PING
 
 describe('rpc - handlers - Ping', () => {
-  let sourcePeer: PeerId
+  let sourcePeer: PeerAndKey
   let handler: DHTMessageHandler
 
   beforeEach(async () => {
-    sourcePeer = await createPeerId()
+    sourcePeer = await createPeerIdWithPrivateKey()
   })
 
   beforeEach(async () => {
@@ -32,7 +31,7 @@ describe('rpc - handlers - Ping', () => {
       closer: [],
       providers: []
     }
-    const response = await handler.handle(sourcePeer, msg)
+    const response = await handler.handle(sourcePeer.peerId, msg)
 
     expect(response).to.be.deep.equal(msg)
   })

--- a/packages/kad-dht/test/rpc/handlers/put-value.spec.ts
+++ b/packages/kad-dht/test/rpc/handlers/put-value.spec.ts
@@ -10,21 +10,20 @@ import { fromString as uint8ArrayFromString } from 'uint8arrays/from-string'
 import { type Message, MessageType } from '../../../src/message/dht.js'
 import { PutValueHandler } from '../../../src/rpc/handlers/put-value.js'
 import * as utils from '../../../src/utils.js'
-import { createPeerId } from '../../utils/create-peer-id.js'
+import { createPeerIdWithPrivateKey, type PeerAndKey } from '../../utils/create-peer-id.js'
 import type { Validators } from '../../../src/index.js'
-import type { PeerId } from '@libp2p/interface'
 import type { Datastore } from 'interface-datastore'
 
 const T = MessageType.PUT_VALUE
 
 describe('rpc - handlers - PutValue', () => {
-  let sourcePeer: PeerId
+  let sourcePeer: PeerAndKey
   let handler: PutValueHandler
   let datastore: Datastore
   let validators: Validators
 
   beforeEach(async () => {
-    sourcePeer = await createPeerId()
+    sourcePeer = await createPeerIdWithPrivateKey()
     datastore = new MemoryDatastore()
     validators = {}
 
@@ -49,7 +48,7 @@ describe('rpc - handlers - PutValue', () => {
     }
 
     try {
-      await handler.handle(sourcePeer, msg)
+      await handler.handle(sourcePeer.peerId, msg)
     } catch (err: any) {
       expect(err.name).to.equal('InvalidMessageError')
       return
@@ -73,7 +72,7 @@ describe('rpc - handlers - PutValue', () => {
     msg.record = record.serialize()
     validators.val = async () => {}
 
-    const response = await handler.handle(sourcePeer, msg)
+    const response = await handler.handle(sourcePeer.peerId, msg)
     expect(response).to.deep.equal(msg)
 
     const key = utils.bufferToRecordKey('/dht/record', uint8ArrayFromString('hello'))

--- a/packages/kad-dht/test/rpc/index.node.ts
+++ b/packages/kad-dht/test/rpc/index.node.ts
@@ -21,15 +21,15 @@ import { Providers } from '../../src/providers.js'
 import { RoutingTable } from '../../src/routing-table/index.js'
 import { RPC, type RPCComponents } from '../../src/rpc/index.js'
 import { passthroughMapper } from '../../src/utils.js'
-import { createPeerId } from '../utils/create-peer-id.js'
+import { createPeerIdWithPrivateKey, type PeerAndKey } from '../utils/create-peer-id.js'
 import type { Validators } from '../../src/index.js'
-import type { Libp2pEvents, Connection, PeerId, PeerStore } from '@libp2p/interface'
+import type { Libp2pEvents, Connection, PeerStore } from '@libp2p/interface'
 import type { AddressManager } from '@libp2p/interface-internal'
 import type { Datastore } from 'interface-datastore'
 import type { Duplex, Source } from 'it-stream-types'
 
 describe('rpc', () => {
-  let peerId: PeerId
+  let peerId: PeerAndKey
   let rpc: RPC
   let providers: SinonStubbedInstance<Providers>
   let peerRouting: SinonStubbedInstance<PeerRouting>
@@ -38,11 +38,11 @@ describe('rpc', () => {
   let routingTable: RoutingTable
 
   beforeEach(async () => {
-    peerId = await createPeerId()
+    peerId = await createPeerIdWithPrivateKey()
     datastore = new MemoryDatastore()
 
     const components: RPCComponents = {
-      peerId,
+      peerId: peerId.peerId,
       datastore,
       peerStore: stubInterface<PeerStore>(),
       addressManager: stubInterface<AddressManager>(),

--- a/packages/kad-dht/test/utils/create-peer-id.ts
+++ b/packages/kad-dht/test/utils/create-peer-id.ts
@@ -2,31 +2,15 @@ import { generateKeyPair } from '@libp2p/crypto/keys'
 import { peerIdFromPrivateKey } from '@libp2p/peer-id'
 import type { PeerId, PrivateKey } from '@libp2p/interface'
 
-/**
- * Creates multiple PeerIds
- */
-export async function createPeerIds (length: number): Promise<PeerId[]> {
-  return Promise.all(
-    new Array(length).fill(0).map(async () => createPeerId())
-  )
-}
-
-/**
- * Creates a PeerId
- */
-export async function createPeerId (): Promise<PeerId> {
-  const privateKey = await generateKeyPair('Ed25519')
-  return peerIdFromPrivateKey(privateKey)
-}
-
-export type PeerIdWithPrivateKey = PeerId & {
+export interface PeerAndKey {
+  peerId: PeerId
   privateKey: PrivateKey
 }
 
 /**
  * Creates multiple PeerIds with private keys
  */
-export async function createPeerIdsWithPrivateKey (length: number): Promise<PeerIdWithPrivateKey[]> {
+export async function createPeerIdsWithPrivateKey (length: number): Promise<PeerAndKey[]> {
   return Promise.all(
     new Array(length).fill(0).map(async () => createPeerIdWithPrivateKey())
   )
@@ -35,10 +19,12 @@ export async function createPeerIdsWithPrivateKey (length: number): Promise<Peer
 /**
  * Creates a PeerId with a private key
  */
-export async function createPeerIdWithPrivateKey (): Promise<PeerIdWithPrivateKey> {
+export async function createPeerIdWithPrivateKey (): Promise<PeerAndKey> {
   const privateKey = await generateKeyPair('Ed25519')
-  const peerId = peerIdFromPrivateKey(privateKey) as unknown as PeerIdWithPrivateKey
-  peerId.privateKey = privateKey
+  const peerId = peerIdFromPrivateKey(privateKey)
 
-  return peerId
+  return {
+    peerId,
+    privateKey
+  }
 }

--- a/packages/kad-dht/test/utils/sort-closest-peers.ts
+++ b/packages/kad-dht/test/utils/sort-closest-peers.ts
@@ -3,16 +3,16 @@ import map from 'it-map'
 import { xor as uint8ArrayXor } from 'uint8arrays/xor'
 import { xorCompare as uint8ArrayXorCompare } from 'uint8arrays/xor-compare'
 import { convertPeerId } from '../../src/utils.js'
+import type { PeerAndKey } from './create-peer-id.js'
 import type { KadDHT } from '../../src/kad-dht.js'
-import type { PeerId } from '@libp2p/interface'
 
 /**
  * Sort peers by distance to the given `kadId`
  */
-export async function sortClosestPeers <T extends PeerId = PeerId> (peers: T[], kadId: Uint8Array): Promise<T[]> {
+export async function sortClosestPeers (peers: PeerAndKey[], kadId: Uint8Array): Promise<PeerAndKey[]> {
   const distances = await all(
     map(peers, async (peer) => {
-      const id = await convertPeerId(peer)
+      const id = await convertPeerId(peer.peerId)
 
       return {
         peer,


### PR DESCRIPTION
KAD-DHT queries operate on disjoint paths which can make following
query events hard.

Add a `.path` property to events with the numeric index of the
disjoint path the query is following, this makes reconciling events
in progress handlers much easier.## Title

## Change checklist

- [x] I have performed a self-review of my own code
- [x] I have made corresponding changes to the documentation if necessary (this includes comments as well)
- [ ] I have added tests that prove my fix is effective or that my feature works