### PR TITLE
fix: debounce queue idle/empty events

### DIFF
--- a/packages/utils/test/queue.spec.ts
+++ b/packages/utils/test/queue.spec.ts
@@ -340,6 +340,9 @@ describe('queue', () => {
     expect(queue).to.have.property('size', 0)
     expect(queue).to.have.property('queued', 0)
     expect(queue).to.have.property('running', 0)
+
+    await delay(10)
+
     expect(timesCalled).to.equal(1)
 
     const job3 = queue.add(async () => delay(100))
@@ -355,6 +358,8 @@ describe('queue', () => {
     expect(queue).to.have.property('size', 0)
     expect(queue).to.have.property('queued', 0)
     expect(queue).to.have.property('running', 0)
+
+    await delay(10)
 
     expect(timesCalled).to.equal(2)
   })
@@ -392,6 +397,9 @@ describe('queue', () => {
     expect(queue).to.have.property('size', 0)
     expect(queue).to.have.property('queued', 0)
     expect(queue).to.have.property('running', 0)
+
+    await delay(10)
+
     expect(timesCalled).to.equal(1)
   })
 


### PR DESCRIPTION
Browsers and Node.js handle resuming control from `yield` slightly differently - a queue that empties in browsers can end up repeating it's idle even when a new job is being added so debounce the call to trigger after a (very) short time has passed.

## Change checklist

- [x] I have performed a self-review of my own code
- [ ] I have made corresponding changes to the documentation if necessary (this includes comments as well)
- [x] I have added tests that prove my fix is effective or that my feature works