### PR TITLE
fix: increase default adaptive timeout

### DIFF
--- a/packages/libp2p/test/connection-monitor/index.spec.ts
+++ b/packages/libp2p/test/connection-monitor/index.spec.ts
@@ -93,10 +93,7 @@ describe('connection monitor', () => {
 
   it('should abort a connection that times out', async () => {
     monitor = new ConnectionMonitor(components, {
-      pingInterval: 50,
-      pingTimeout: {
-        initialValue: 10
-      }
+      pingInterval: 50
     })
 
     await start(monitor)

--- a/packages/utils/src/adaptive-timeout.ts
+++ b/packages/utils/src/adaptive-timeout.ts
@@ -5,7 +5,7 @@ import type { MetricGroup, Metrics } from '@libp2p/interface'
 
 export const DEFAULT_TIMEOUT_MULTIPLIER = 1.2
 export const DEFAULT_FAILURE_MULTIPLIER = 2
-export const DEFAULT_MIN_TIMEOUT = 2000
+export const DEFAULT_MIN_TIMEOUT = 5000
 
 export interface AdaptiveTimeoutSignal extends ClearableSignal {
   start: number
@@ -16,7 +16,6 @@ export interface AdaptiveTimeoutInit {
   metricName?: string
   metrics?: Metrics
   interval?: number
-  initialValue?: number
   timeoutMultiplier?: number
   failureMultiplier?: number
   minTimeout?: number

--- a/packages/utils/test/adaptive-timeout.spec.ts
+++ b/packages/utils/test/adaptive-timeout.spec.ts
@@ -27,20 +27,20 @@ describe('adaptive-timeout', () => {
     const adaptiveTimeout = new AdaptiveTimeout()
     const signal1 = adaptiveTimeout.getTimeoutSignal()
 
-    clock.tick(2000)
+    clock.tick(5000)
 
     adaptiveTimeout.cleanUp(signal1)
 
     const signal2 = adaptiveTimeout.getTimeoutSignal()
 
-    expect(signal2).to.have.property('timeout', 2000 * DEFAULT_TIMEOUT_MULTIPLIER)
+    expect(signal2).to.have.property('timeout', 5000 * DEFAULT_TIMEOUT_MULTIPLIER)
   })
 
   it('should allow overriding the adapted timeout', () => {
     const adaptiveTimeout = new AdaptiveTimeout()
     const signal1 = adaptiveTimeout.getTimeoutSignal()
 
-    clock.tick(2000)
+    clock.tick(5000)
 
     adaptiveTimeout.cleanUp(signal1)
 
@@ -48,47 +48,47 @@ describe('adaptive-timeout', () => {
       timeoutFactor: 1
     })
 
-    expect(signal2).to.have.property('timeout', 2000)
+    expect(signal2).to.have.property('timeout', 5000)
   })
 
   it('should reduce the timeout', () => {
     const adaptiveTimeout = new AdaptiveTimeout()
 
     const signal1 = adaptiveTimeout.getTimeoutSignal()
-    clock.tick(3000)
+    clock.tick(8000)
     adaptiveTimeout.cleanUp(signal1)
 
     const signal2 = adaptiveTimeout.getTimeoutSignal({
       timeoutFactor: 1
     })
-    expect(signal2).to.have.property('timeout', 3000)
-    clock.tick(2000)
+    expect(signal2).to.have.property('timeout', 8000)
+    clock.tick(6000)
     adaptiveTimeout.cleanUp(signal2)
 
     const signal3 = adaptiveTimeout.getTimeoutSignal({
       timeoutFactor: 1
     })
-    expect(signal3).to.have.property('timeout', 2670)
+    expect(signal3).to.have.property('timeout', 6602)
   })
 
   it('should increase the timeout', () => {
     const adaptiveTimeout = new AdaptiveTimeout()
 
     const signal1 = adaptiveTimeout.getTimeoutSignal()
-    clock.tick(2000)
+    clock.tick(8000)
     adaptiveTimeout.cleanUp(signal1)
 
     const signal2 = adaptiveTimeout.getTimeoutSignal({
       timeoutFactor: 1
     })
-    expect(signal2).to.have.property('timeout', 2000)
-    clock.tick(3000)
+    expect(signal2).to.have.property('timeout', 8000)
+    clock.tick(9000)
     adaptiveTimeout.cleanUp(signal2)
 
     const signal3 = adaptiveTimeout.getTimeoutSignal({
       timeoutFactor: 1
     })
-    expect(signal3).to.have.property('timeout', 2451)
+    expect(signal3).to.have.property('timeout', 8835)
   })
 
   it('should wrap an existing signal', () => {


### PR DESCRIPTION
2s is too small, increase to 5s.

## Change checklist

- [x] I have performed a self-review of my own code
- [ ] I have made corresponding changes to the documentation if necessary (this includes comments as well)
- [x] I have added tests that prove my fix is effective or that my feature works