### PR TITLE
fix: ensure greater spec compliance

### DIFF
--- a/packages/kad-dht/package.json
+++ b/packages/kad-dht/package.json
@@ -77,6 +77,7 @@
     "it-parallel": "^3.0.8",
     "it-pipe": "^3.0.1",
     "it-protobuf-stream": "^2.0.1",
+    "it-pushable": "^3.2.3",
     "it-take": "^3.0.6",
     "mortice": "^3.0.6",
     "multiformats": "^13.3.1",

--- a/packages/kad-dht/src/constants.ts
+++ b/packages/kad-dht/src/constants.ts
@@ -36,7 +36,7 @@ export const GET_MANY_RECORD_COUNT = 16
 export const K = 20
 
 // Alpha is the concurrency for asynchronous requests
-export const ALPHA = 3
+export const ALPHA = 10
 
 // How often we look for our closest DHT neighbors
 export const QUERY_SELF_INTERVAL = 5 * minute

--- a/packages/kad-dht/src/content-fetching/index.ts
+++ b/packages/kad-dht/src/content-fetching/index.ts
@@ -212,6 +212,7 @@ export class ContentFetching {
     for await (const event of this.getMany(key, options)) {
       if (event.name === 'VALUE') {
         vals.push(event)
+        continue
       }
 
       yield event
@@ -242,7 +243,12 @@ export class ContentFetching {
 
     yield * this.sendCorrectionRecord(key, vals, best, {
       ...options,
-      path: -1
+      path: {
+        index: -1,
+        queued: 0,
+        running: 0,
+        total: 0
+      }
     })
 
     yield vals[i]
@@ -259,7 +265,13 @@ export class ContentFetching {
 
       yield valueEvent({
         value: localRec.value,
-        from: this.components.peerId
+        from: this.components.peerId,
+        path: {
+          index: -1,
+          running: 0,
+          queued: 0,
+          total: 0
+        }
       }, options)
     } catch (err: any) {
       this.log('error getting local value for %b', key, err)
@@ -276,7 +288,11 @@ export class ContentFetching {
         yield event
 
         if (event.name === 'PEER_RESPONSE' && (event.record != null)) {
-          yield valueEvent({ from: peer, value: event.record.value }, options)
+          yield valueEvent({
+            from: peer,
+            value: event.record.value,
+            path
+          }, options)
         }
       }
     }

--- a/packages/kad-dht/src/content-fetching/index.ts
+++ b/packages/kad-dht/src/content-fetching/index.ts
@@ -129,7 +129,7 @@ export class ContentFetching {
       }
 
       if (!sentCorrection) {
-        yield queryErrorEvent({ from, error: new QueryError('Value not put correctly') }, options)
+        throw new QueryError('Could not send correction')
       }
 
       this.log.error('Failed error correcting entry')
@@ -182,7 +182,11 @@ export class ContentFetching {
             }
 
             if (!(putEvent.record != null && uint8ArrayEquals(putEvent.record.value, Libp2pRecord.deserialize(record).value))) {
-              events.push(queryErrorEvent({ from: event.peer.id, error: new QueryError('Value not put correctly') }, options))
+              events.push(queryErrorEvent({
+                from: event.peer.id,
+                error: new QueryError('Value not put correctly'),
+                path: putEvent.path
+              }, options))
             }
           }
 

--- a/packages/kad-dht/src/content-fetching/index.ts
+++ b/packages/kad-dht/src/content-fetching/index.ts
@@ -284,7 +284,7 @@ export class ContentFetching {
     const self = this // eslint-disable-line @typescript-eslint/no-this-alias
 
     const getValueQuery: QueryFunc = async function * ({ peer, signal, path }) {
-      for await (const event of self.peerRouting.getValueOrPeers(peer, key, {
+      for await (const event of self.peerRouting.getValueOrPeers(peer.id, key, {
         ...options,
         signal,
         path
@@ -293,7 +293,7 @@ export class ContentFetching {
 
         if (event.name === 'PEER_RESPONSE' && (event.record != null)) {
           yield valueEvent({
-            from: peer,
+            from: peer.id,
             value: event.record.value,
             path
           }, options)

--- a/packages/kad-dht/src/content-routing/index.ts
+++ b/packages/kad-dht/src/content-routing/index.ts
@@ -114,7 +114,7 @@ export class ContentRouting {
 
           for await (const sendEvent of this.network.sendMessage(event.peer.id, msg, {
             ...options,
-            path: event.path ?? -1
+            path: event.path
           })) {
             if (sendEvent.name === 'PEER_RESPONSE') {
               this.log('sent provider record for %s to %p', key, event.peer.id)
@@ -184,8 +184,21 @@ export class ContentRouting {
         }
       }
 
-      yield peerResponseEvent({ from: this.components.peerId, messageType: MessageType.GET_PROVIDERS, providers, path: -1 }, options)
-      yield providerEvent({ from: this.components.peerId, providers }, options)
+      yield peerResponseEvent({
+        from: this.components.peerId,
+        messageType: MessageType.GET_PROVIDERS,
+        providers,
+        path: {
+          index: -1,
+          queued: 0,
+          running: 0,
+          total: 0
+        }
+      }, options)
+      yield providerEvent({
+        from: this.components.peerId,
+        providers
+      }, options)
 
       found += providers.length
 

--- a/packages/kad-dht/src/content-routing/index.ts
+++ b/packages/kad-dht/src/content-routing/index.ts
@@ -1,7 +1,6 @@
 import { PeerSet } from '@libp2p/peer-collections'
-import map from 'it-map'
-import parallel from 'it-parallel'
-import { pipe } from 'it-pipe'
+import { Queue } from '@libp2p/utils/queue'
+import { pushable } from 'it-pushable'
 import { ALPHA } from '../constants.js'
 import { MessageType } from '../message/dht.js'
 import { toPbPeerInfo } from '../message/utils.js'
@@ -10,7 +9,7 @@ import {
   peerResponseEvent,
   providerEvent
 } from '../query/events.js'
-import type { KadDHTComponents, PeerResponseEvent, ProviderEvent, QueryEvent } from '../index.js'
+import type { FinalPeerEvent, KadDHTComponents, PeerResponseEvent, ProviderEvent, QueryEvent } from '../index.js'
 import type { Message } from '../message/dht.js'
 import type { Network } from '../network.js'
 import type { PeerRouting } from '../peer-routing/index.js'
@@ -98,58 +97,76 @@ export class ContentRouting {
     }
 
     let sent = 0
+    const self = this
 
-    const maybeNotifyPeer = (event: QueryEvent) => {
-      return async () => {
-        if (event.name !== 'FINAL_PEER') {
-          return [event]
-        }
+    async function * publishProviderRecord (event: FinalPeerEvent): AsyncGenerator<QueryEvent, void, undefined> {
+      try {
+        self.log('sending provider record for %s to %p', key, event.peer.id)
 
-        const events = []
-
-        this.log('putProvider %s to %p', key, event.peer.id)
-
-        try {
-          this.log('sending provider record for %s to %p', key, event.peer.id)
-
-          for await (const sendEvent of this.network.sendMessage(event.peer.id, msg, {
-            ...options,
-            path: event.path
-          })) {
-            if (sendEvent.name === 'PEER_RESPONSE') {
-              this.log('sent provider record for %s to %p', key, event.peer.id)
-              sent++
-            }
-
-            events.push(sendEvent)
+        for await (const addProviderEvent of self.network.sendMessage(event.peer.id, msg, {
+          ...options,
+          path: event.path
+        })) {
+          if (addProviderEvent.name === 'PEER_RESPONSE') {
+            self.log('sent provider record for %s to %p', key, event.peer.id)
+            sent++
           }
-        } catch (err: any) {
-          this.log.error('error sending provide record to peer %p', event.peer.id, err)
-          events.push(queryErrorEvent({
-            from: event.peer.id,
-            error: err,
-            path: event.path
-          }, options))
-        }
 
-        return events
+          yield addProviderEvent
+        }
+      } catch (err: any) {
+        self.log.error('error sending provide record to peer %p', event.peer.id, err)
+        yield queryErrorEvent({
+          from: event.peer.id,
+          error: err,
+          path: event.path
+        }, options)
       }
     }
 
-    // Notify closest peers
-    yield * pipe(
-      this.peerRouting.getClosestPeers(target, options),
-      (source) => map(source, (event) => maybeNotifyPeer(event)),
-      (source) => parallel(source, {
-        ordered: false,
-        concurrency: ALPHA
-      }),
-      async function * (source) {
-        for await (const events of source) {
-          yield * events
+    const events = pushable<QueryEvent>({
+      objectMode: true
+    })
+
+    const queue = new Queue({
+      concurrency: ALPHA
+    })
+    queue.addEventListener('idle', () => {
+      events.end()
+    })
+    queue.addEventListener('error', (err) => {
+      this.log.error('error publishing provider record to peer - %e', err)
+    })
+
+    queue.add(async () => {
+      const finalPeerEvents: FinalPeerEvent[] = []
+
+      for await (const event of this.peerRouting.getClosestPeers(target, options)) {
+        events.push(event)
+
+        if (event.name !== 'FINAL_PEER') {
+          continue
         }
+
+        finalPeerEvents.push(event)
       }
-    )
+
+      finalPeerEvents.forEach(event => {
+        queue.add(async () => {
+          for await (const notifyEvent of publishProviderRecord(event)) {
+            events.push(notifyEvent)
+          }
+        })
+          .catch(err => {
+            this.log.error('error publishing provider record to peer - %e', err)
+          })
+      })
+    })
+      .catch(err => {
+        events.end(err)
+      })
+
+    yield * events
 
     this.log('sent provider records to %d peers', sent)
   }
@@ -226,7 +243,7 @@ export class ContentRouting {
         key: target
       }
 
-      yield * self.network.sendRequest(peer, request, {
+      yield * self.network.sendRequest(peer.id, request, {
         ...options,
         signal,
         path

--- a/packages/kad-dht/src/content-routing/index.ts
+++ b/packages/kad-dht/src/content-routing/index.ts
@@ -125,7 +125,11 @@ export class ContentRouting {
           }
         } catch (err: any) {
           this.log.error('error sending provide record to peer %p', event.peer.id, err)
-          events.push(queryErrorEvent({ from: event.peer.id, error: err }, options))
+          events.push(queryErrorEvent({
+            from: event.peer.id,
+            error: err,
+            path: event.path
+          }, options))
         }
 
         return events
@@ -197,7 +201,13 @@ export class ContentRouting {
       }, options)
       yield providerEvent({
         from: this.components.peerId,
-        providers
+        providers,
+        path: {
+          index: -1,
+          queued: 0,
+          running: 0,
+          total: 0
+        }
       }, options)
 
       found += providers.length
@@ -243,7 +253,11 @@ export class ContentRouting {
         }
 
         if (newProviders.length > 0) {
-          yield providerEvent({ from: event.from, providers: newProviders }, options)
+          yield providerEvent({
+            from: event.from,
+            providers: newProviders,
+            path: event.path
+          }, options)
 
           found += newProviders.length
 

--- a/packages/kad-dht/src/index.ts
+++ b/packages/kad-dht/src/index.ts
@@ -238,7 +238,7 @@ export interface QueryErrorEvent {
   type: EventTypes.QUERY_ERROR
   name: 'QUERY_ERROR'
   error: Error
-  path?: DisjointPath
+  path: DisjointPath
 }
 
 /**
@@ -249,6 +249,7 @@ export interface ProviderEvent {
   type: EventTypes.PROVIDER
   name: 'PROVIDER'
   providers: PeerInfo[]
+  path: DisjointPath
 }
 
 /**
@@ -273,14 +274,13 @@ export interface AddPeerEvent {
 }
 
 /**
- * Emitted when peers are dialled as part of a query
- *
- * @deprecated No longer emitted as sometimes connections are reused so it's not possible to say with certainty that a peer has been dialled
+ * Emitted when peers are dialled and a new stream is opened as part of a query
  */
 export interface DialPeerEvent {
   peer: PeerId
   type: EventTypes.DIAL_PEER
   name: 'DIAL_PEER'
+  path: DisjointPath
 }
 
 /**

--- a/packages/kad-dht/src/network.ts
+++ b/packages/kad-dht/src/network.ts
@@ -166,7 +166,6 @@ export class Network extends TypedEventEmitter<NetworkEvents> implements Startab
 
     this.log('sending %s to %p', msg.type, to)
     yield sendQueryEvent({ to, type, path: options.path }, options)
-    signal.throwIfAborted()
 
     options = {
       ...options,

--- a/packages/kad-dht/src/peer-routing/index.ts
+++ b/packages/kad-dht/src/peer-routing/index.ts
@@ -230,10 +230,7 @@ export class PeerRouting {
     }
 
     if (!foundPeer) {
-      yield queryErrorEvent({
-        from: this.components.peerId,
-        error: new NotFoundError('Not found')
-      }, options)
+      throw new NotFoundError('Not found')
     }
   }
 

--- a/packages/kad-dht/src/peer-routing/index.ts
+++ b/packages/kad-dht/src/peer-routing/index.ts
@@ -3,7 +3,6 @@ import { InvalidPublicKeyError, NotFoundError } from '@libp2p/interface'
 import { peerIdFromPublicKey, peerIdFromMultihash } from '@libp2p/peer-id'
 import { Libp2pRecord } from '@libp2p/record'
 import * as Digest from 'multiformats/hashes/digest'
-import { toString as uint8ArrayToString } from 'uint8arrays/to-string'
 import { xor as uint8ArrayXor } from 'uint8arrays/xor'
 import { xorCompare as uint8ArrayXorCompare } from 'uint8arrays/xor-compare'
 import { QueryError, InvalidRecordError } from '../errors.js'
@@ -23,12 +22,14 @@ import type { QueryManager, QueryOptions } from '../query/manager.js'
 import type { QueryFunc } from '../query/types.js'
 import type { RoutingTable } from '../routing-table/index.js'
 import type { ComponentLogger, Logger, Metrics, PeerId, PeerInfo, PeerStore, RoutingOptions } from '@libp2p/interface'
+import type { ConnectionManager } from '@libp2p/interface-internal'
 
 export interface PeerRoutingComponents {
   peerId: PeerId
   peerStore: PeerStore
   logger: ComponentLogger
   metrics?: Metrics
+  connectionManager: ConnectionManager
 }
 
 export interface PeerRoutingInit {
@@ -45,16 +46,14 @@ export class PeerRouting {
   private readonly network: Network
   private readonly validators: Validators
   private readonly queryManager: QueryManager
-  private readonly peerStore: PeerStore
-  private readonly peerId: PeerId
+  private readonly components: PeerRoutingComponents
 
   constructor (components: PeerRoutingComponents, init: PeerRoutingInit) {
     this.routingTable = init.routingTable
     this.network = init.network
     this.validators = init.validators
     this.queryManager = init.queryManager
-    this.peerStore = components.peerStore
-    this.peerId = components.peerId
+    this.components = components
     this.log = components.logger.forComponent(`${init.logPrefix}:peer-routing`)
 
     this.findPeer = components.metrics?.traceFunction('libp2p.kadDHT.findPeer', this.findPeer.bind(this), {
@@ -77,7 +76,7 @@ export class PeerRouting {
       this.log('findPeerLocal found %p in routing table', peer)
 
       try {
-        peerData = await this.peerStore.get(p)
+        peerData = await this.components.peerStore.get(p)
       } catch (err: any) {
         if (err.name !== 'NotFoundError') {
           throw err
@@ -87,7 +86,7 @@ export class PeerRouting {
 
     if (peerData == null) {
       try {
-        peerData = await this.peerStore.get(peer)
+        peerData = await this.components.peerStore.get(peer)
       } catch (err: any) {
         if (err.name !== 'NotFoundError') {
           throw err
@@ -124,10 +123,16 @@ export class PeerRouting {
    */
   async * getPublicKeyFromNode (peer: PeerId, options: RoutingOptions = {}): AsyncGenerator<QueryEvent> {
     const pkKey = keyForPublicKey(peer)
+    const path = {
+      index: -1,
+      queued: 0,
+      running: 0,
+      total: 0
+    }
 
     for await (const event of this._getValueSingle(peer, pkKey, {
       ...options,
-      path: -1
+      path
     })) {
       yield event
 
@@ -146,7 +151,8 @@ export class PeerRouting {
 
         yield valueEvent({
           from: peer,
-          value: event.record.value
+          value: event.record.value,
+          path
         }, options)
       }
     }
@@ -168,9 +174,14 @@ export class PeerRouting {
       if (pi != null) {
         this.log('found local')
         yield finalPeerEvent({
-          from: this.peerId,
+          from: this.components.peerId,
           peer: pi,
-          path: -1
+          path: {
+            index: -1,
+            queued: 0,
+            running: 0,
+            total: 0
+          }
         }, options)
         return
       }
@@ -220,27 +231,24 @@ export class PeerRouting {
 
     if (!foundPeer) {
       yield queryErrorEvent({
-        from: this.peerId,
+        from: this.components.peerId,
         error: new NotFoundError('Not found')
       }, options)
     }
   }
 
   /**
-   * Kademlia 'FIND_NODE' operation on a key, which could be the bytes from
-   * a multihash or a peer ID
+   * Kademlia 'FIND_NODE' operation on a key, which could be the bytes from a
+   * multihash or a peer ID
    */
   async * getClosestPeers (key: Uint8Array, options: QueryOptions = {}): AsyncGenerator<QueryEvent> {
     this.log('getClosestPeers to %b', key)
     const kadId = await convertBuffer(key)
-    const tablePeers = this.routingTable.closestPeers(kadId)
+    const peers = new PeerDistanceList(kadId, this.routingTable.kBucketSize)
     const self = this // eslint-disable-line @typescript-eslint/no-this-alias
 
-    const peers = new PeerDistanceList(kadId, this.routingTable.kBucketSize)
-    await Promise.all(tablePeers.map(async peer => { await peers.add({ id: peer, multiaddrs: [] }, -1) }))
-
-    const getCloserPeersQuery: QueryFunc = async function * ({ peer, signal, path }) {
-      self.log('closerPeersSingle %s from %p', uint8ArrayToString(key, 'base32'), peer)
+    const getCloserPeersQuery: QueryFunc = async function * ({ peer, path, peerKadId }) {
+      self.log('getClosestPeers asking %p', peer)
       const request: Partial<Message> = {
         type: MessageType.FIND_NODE,
         key
@@ -248,28 +256,27 @@ export class PeerRouting {
 
       yield * self.network.sendRequest(peer, request, {
         ...options,
-        signal,
         path
       })
+
+      // add the peer to the list if we've managed to contact it successfully
+      peers.addWithKadId({ id: peer, multiaddrs: [] }, peerKadId, path)
     }
 
-    for await (const event of this.queryManager.run(key, getCloserPeersQuery, options)) {
-      if (event.name === 'PEER_RESPONSE') {
-        await Promise.all(event.closer.map(async peerData => {
-          await peers.add(peerData, event.path)
-        }))
-      }
-
-      yield event
-    }
+    yield * this.queryManager.run(key, getCloserPeersQuery, options)
 
     this.log('found %d peers close to %b', peers.length, key)
 
     for (const { peer, path } of peers.peers) {
       yield finalPeerEvent({
-        from: this.peerId,
-        peer,
-        path
+        from: this.components.peerId,
+        peer: await self.components.peerStore.getInfo(peer.id),
+        path: {
+          index: path.index,
+          queued: 0,
+          running: 0,
+          total: 0
+        }
       }, options)
     }
   }
@@ -318,7 +325,8 @@ export class PeerRouting {
   }
 
   /**
-   * Get the nearest peers to the given query, but if closer than self
+   * Get the peers in our routing table that are closer than the passed PeerId
+   * to the passed key
    */
   async getCloserPeersOffline (key: Uint8Array, closerThan: PeerId): Promise<PeerInfo[]> {
     const output: PeerInfo[] = []
@@ -328,7 +336,7 @@ export class PeerRouting {
       const multihash = Digest.decode(key)
       const targetPeerId = peerIdFromMultihash(multihash)
 
-      const peer = await this.peerStore.get(targetPeerId)
+      const peer = await this.components.peerStore.get(targetPeerId)
 
       output.push({
         id: peer.id,
@@ -351,12 +359,7 @@ export class PeerRouting {
       }
 
       try {
-        const peer = await this.peerStore.get(peerId)
-
-        output.push({
-          id: peerId,
-          multiaddrs: peer.addresses.map(({ multiaddr }) => multiaddr)
-        })
+        output.push(await this.components.peerStore.getInfo(peerId))
       } catch (err: any) {
         if (err.name !== 'NotFoundError') {
           throw err

--- a/packages/kad-dht/src/peer-routing/index.ts
+++ b/packages/kad-dht/src/peer-routing/index.ts
@@ -247,7 +247,7 @@ export class PeerRouting {
     const peers = new PeerDistanceList(kadId, this.routingTable.kBucketSize)
     const self = this // eslint-disable-line @typescript-eslint/no-this-alias
 
-    const getCloserPeersQuery: QueryFunc = async function * ({ peer, path, peerKadId }) {
+    const getCloserPeersQuery: QueryFunc = async function * ({ peer, path, peerKadId, signal }) {
       self.log('getClosestPeers asking %p', peer)
       const request: Partial<Message> = {
         type: MessageType.FIND_NODE,
@@ -256,6 +256,7 @@ export class PeerRouting {
 
       yield * self.network.sendRequest(peer, request, {
         ...options,
+        signal,
         path
       })
 

--- a/packages/kad-dht/src/providers.ts
+++ b/packages/kad-dht/src/providers.ts
@@ -41,7 +41,7 @@ export class Providers {
     const release = await this.lock.readLock()
 
     try {
-      this.log('%p provides %s', provider, cid)
+      this.log.trace('%p provides %s', provider, cid)
       await this.writeProviderEntry(cid, provider)
     } finally {
       release()
@@ -56,7 +56,7 @@ export class Providers {
 
     try {
       const key = toProviderKey(this.datastorePrefix, cid, provider)
-      this.log('%p no longer provides %s', provider, cid)
+      this.log.trace('%p no longer provides %s', provider, cid)
       await this.datastore.delete(key)
     } finally {
       release()
@@ -70,9 +70,9 @@ export class Providers {
     const release = await this.lock.readLock()
 
     try {
-      this.log('get providers for %c', cid)
+      this.log.trace('get providers for %c', cid)
       const provs = await this.loadProviders(cid, options)
-      this.log('got %d providers for %c', provs.size, cid)
+      this.log.trace('got %d providers for %c', provs.size, cid)
 
       return [...provs.keys()]
     } finally {

--- a/packages/kad-dht/src/query/events.ts
+++ b/packages/kad-dht/src/query/events.ts
@@ -1,4 +1,4 @@
-import type { MessageType, SendQueryEvent, PeerResponseEvent, AddPeerEvent, ValueEvent, ProviderEvent, QueryErrorEvent, FinalPeerEvent } from '../index.js'
+import type { MessageType, SendQueryEvent, PeerResponseEvent, AddPeerEvent, ValueEvent, ProviderEvent, QueryErrorEvent, FinalPeerEvent, DisjointPath, PathEndedEvent } from '../index.js'
 import type { PeerId, PeerInfo } from '@libp2p/interface'
 import type { Libp2pRecord } from '@libp2p/record'
 import type { ProgressOptions } from 'progress-events'
@@ -6,7 +6,7 @@ import type { ProgressOptions } from 'progress-events'
 export interface QueryEventFields {
   to: PeerId
   type: MessageType
-  path: number
+  path: DisjointPath
 }
 
 export function sendQueryEvent (fields: QueryEventFields, options: ProgressOptions = {}): SendQueryEvent {
@@ -26,7 +26,7 @@ export function sendQueryEvent (fields: QueryEventFields, options: ProgressOptio
 export interface PeerResponseEventFields {
   from: PeerId
   messageType: MessageType
-  path: number
+  path: DisjointPath
   closer?: PeerInfo[]
   providers?: PeerInfo[]
   record?: Libp2pRecord
@@ -50,7 +50,7 @@ export function peerResponseEvent (fields: PeerResponseEventFields, options: Pro
 export interface FinalPeerEventFields {
   from: PeerId
   peer: PeerInfo
-  path: number
+  path: DisjointPath
 }
 
 export function finalPeerEvent (fields: FinalPeerEventFields, options: ProgressOptions = {}): FinalPeerEvent {
@@ -68,7 +68,7 @@ export function finalPeerEvent (fields: FinalPeerEventFields, options: ProgressO
 export interface ErrorEventFields {
   from: PeerId
   error: Error
-  path?: number
+  path?: DisjointPath
 }
 
 export function queryErrorEvent (fields: ErrorEventFields, options: ProgressOptions = {}): QueryErrorEvent {
@@ -103,6 +103,7 @@ export function providerEvent (fields: ProviderEventFields, options: ProgressOpt
 export interface ValueEventFields {
   from: PeerId
   value: Uint8Array
+  path: DisjointPath
 }
 
 export function valueEvent (fields: ValueEventFields, options: ProgressOptions = {}): ValueEvent {
@@ -119,7 +120,7 @@ export function valueEvent (fields: ValueEventFields, options: ProgressOptions =
 
 export interface AddPeerEventFields {
   peer: PeerId
-  path: number
+  path: DisjointPath
 }
 
 export function addPeerEvent (fields: AddPeerEventFields, options: ProgressOptions = {}): AddPeerEvent {
@@ -130,6 +131,22 @@ export function addPeerEvent (fields: AddPeerEventFields, options: ProgressOptio
   }
 
   options.onProgress?.(new CustomEvent('kad-dht:query:add-peer', { detail: event }))
+
+  return event
+}
+
+export interface PathEndedEventFields {
+  path: DisjointPath
+}
+
+export function pathEndedEvent (fields: PathEndedEventFields, options: ProgressOptions = {}): PathEndedEvent {
+  const event: PathEndedEvent = {
+    ...fields,
+    name: 'PATH_ENDED',
+    type: 8
+  }
+
+  options.onProgress?.(new CustomEvent('kad-dht:query:path-ended', { detail: event }))
 
   return event
 }

--- a/packages/kad-dht/src/query/events.ts
+++ b/packages/kad-dht/src/query/events.ts
@@ -1,4 +1,4 @@
-import type { MessageType, SendQueryEvent, PeerResponseEvent, AddPeerEvent, ValueEvent, ProviderEvent, QueryErrorEvent, FinalPeerEvent, DisjointPath, PathEndedEvent } from '../index.js'
+import type { MessageType, SendQueryEvent, PeerResponseEvent, AddPeerEvent, ValueEvent, ProviderEvent, QueryErrorEvent, FinalPeerEvent, DisjointPath, PathEndedEvent, DialPeerEvent } from '../index.js'
 import type { PeerId, PeerInfo } from '@libp2p/interface'
 import type { Libp2pRecord } from '@libp2p/record'
 import type { ProgressOptions } from 'progress-events'
@@ -68,7 +68,7 @@ export function finalPeerEvent (fields: FinalPeerEventFields, options: ProgressO
 export interface ErrorEventFields {
   from: PeerId
   error: Error
-  path?: DisjointPath
+  path: DisjointPath
 }
 
 export function queryErrorEvent (fields: ErrorEventFields, options: ProgressOptions = {}): QueryErrorEvent {
@@ -86,6 +86,7 @@ export function queryErrorEvent (fields: ErrorEventFields, options: ProgressOpti
 export interface ProviderEventFields {
   from: PeerId
   providers: PeerInfo[]
+  path: DisjointPath
 }
 
 export function providerEvent (fields: ProviderEventFields, options: ProgressOptions = {}): ProviderEvent {
@@ -131,6 +132,23 @@ export function addPeerEvent (fields: AddPeerEventFields, options: ProgressOptio
   }
 
   options.onProgress?.(new CustomEvent('kad-dht:query:add-peer', { detail: event }))
+
+  return event
+}
+
+export interface DialPeerEventFields {
+  peer: PeerId
+  path: DisjointPath
+}
+
+export function dialPeerEvent (fields: DialPeerEventFields, options: ProgressOptions = {}): DialPeerEvent {
+  const event: DialPeerEvent = {
+    ...fields,
+    name: 'DIAL_PEER',
+    type: 7
+  }
+
+  options.onProgress?.(new CustomEvent('kad-dht:query:dial-peer', { detail: event }))
 
   return event
 }

--- a/packages/kad-dht/src/query/manager.ts
+++ b/packages/kad-dht/src/query/manager.ts
@@ -233,7 +233,6 @@ export class QueryManager implements Startable {
         }
 
         yield event
-        signal.throwIfAborted()
       }
 
       queryFinished = true

--- a/packages/kad-dht/src/query/manager.ts
+++ b/packages/kad-dht/src/query/manager.ts
@@ -232,6 +232,7 @@ export class QueryManager implements Startable {
           }
         }
 
+        signal.throwIfAborted()
         yield event
       }
 

--- a/packages/kad-dht/src/query/manager.ts
+++ b/packages/kad-dht/src/query/manager.ts
@@ -1,5 +1,6 @@
+/* eslint-disable complexity */
 import { setMaxListeners } from '@libp2p/interface'
-import { PeerSet } from '@libp2p/peer-collections'
+import { createScalableCuckooFilter } from '@libp2p/utils/filters'
 import { anySignal } from 'any-signal'
 import merge from 'it-merge'
 import { pEvent } from 'p-event'
@@ -39,11 +40,6 @@ export interface QueryManagerComponents {
 }
 
 export interface QueryOptions extends RoutingOptions {
-  /**
-   * A timeout for subqueries executed as part of the main query
-   */
-  queryFuncTimeout?: number
-
   isSelfQuery?: boolean
 }
 
@@ -161,7 +157,7 @@ export class QueryManager implements Startable {
       }
 
       if (options.isSelfQuery !== true && this.initialQuerySelfHasRun != null) {
-        log('waiting for initial query-self query before continuing')
+        log('waiting for initial self query before continuing')
 
         await raceSignal(this.initialQuerySelfHasRun.promise, signal)
 
@@ -171,8 +167,22 @@ export class QueryManager implements Startable {
       log('query:start')
 
       const id = await convertBuffer(key)
-      const peers = this.routingTable.closestPeers(id)
-      const peersToQuery = peers.slice(0, Math.min(this.disjointPaths, peers.length))
+      const peers = this.routingTable.closestPeers(id, this.routingTable.kBucketSize)
+
+      // split peers into d buckets evenly(ish)
+      const peersToQuery = peers.sort(() => {
+        if (Math.random() > 0.5) {
+          return 1
+        }
+
+        return -1
+      })
+        .reduce((acc: PeerId[][], curr, index) => {
+          acc[index % this.disjointPaths].push(curr)
+
+          return acc
+        }, new Array(this.disjointPaths).fill(0).map(() => []))
+        .filter(peers => peers.length > 0)
 
       if (peers.length === 0) {
         log.error('running query with no peers')
@@ -180,21 +190,20 @@ export class QueryManager implements Startable {
       }
 
       // make sure we don't get trapped in a loop
-      const peersSeen = new PeerSet()
+      const peersSeen = createScalableCuckooFilter(1024)
 
       // Create query paths from the starting peers
       const paths = peersToQuery.map((peer, index) => {
         return queryPath({
           ...options,
           key,
-          startingPeer: peer,
+          startingPeers: peer,
           ourPeerId: this.peerId,
           signal,
           query: queryFunc,
           path: index,
           numPaths: peersToQuery.length,
           alpha: this.alpha,
-          queryFuncTimeout: options.queryFuncTimeout,
           log,
           peersSeen,
           onProgress: options.onProgress,
@@ -241,7 +250,7 @@ export class QueryManager implements Startable {
 
       signal.clear()
 
-      log('query:done')
+      log('query finished')
     }
   }
 }

--- a/packages/kad-dht/src/query/query-path.ts
+++ b/packages/kad-dht/src/query/query-path.ts
@@ -1,15 +1,14 @@
-import { setMaxListeners } from '@libp2p/interface'
 import { Queue } from '@libp2p/utils/queue'
-import { anySignal } from 'any-signal'
+import { pushable } from 'it-pushable'
 import { xor as uint8ArrayXor } from 'uint8arrays/xor'
 import { xorCompare as uint8ArrayXorCompare } from 'uint8arrays/xor-compare'
 import { convertPeerId, convertBuffer } from '../utils.js'
-import { queryErrorEvent } from './events.js'
+import { pathEndedEvent, queryErrorEvent } from './events.js'
 import type { QueryEvent } from '../index.js'
 import type { QueryFunc } from '../query/types.js'
 import type { Logger, PeerId, RoutingOptions, AbortOptions } from '@libp2p/interface'
 import type { ConnectionManager } from '@libp2p/interface-internal'
-import type { PeerSet } from '@libp2p/peer-collections'
+import type { Filter } from '@libp2p/utils/filters'
 
 export interface QueryPathOptions extends RoutingOptions {
   /**
@@ -20,17 +19,12 @@ export interface QueryPathOptions extends RoutingOptions {
   /**
    * Where we start our query
    */
-  startingPeer: PeerId
+  startingPeers: PeerId[]
 
   /**
    * Who we are
    */
   ourPeerId: PeerId
-
-  /**
-   * When to stop querying
-   */
-  signal: AbortSignal
 
   /**
    * The query function to run with each peer
@@ -53,11 +47,6 @@ export interface QueryPathOptions extends RoutingOptions {
   numPaths: number
 
   /**
-   * A timeout for queryFunc in ms
-   */
-  queryFuncTimeout?: number
-
-  /**
    * Query log
    */
   log: Logger
@@ -65,7 +54,7 @@ export interface QueryPathOptions extends RoutingOptions {
   /**
    * Set of peers seen by this and other paths
    */
-  peersSeen: PeerSet
+  peersSeen: Filter
 
   /**
    * The libp2p connection manager
@@ -82,60 +71,69 @@ interface QueryQueueOptions extends AbortOptions {
  * every peer encountered that we have not seen before
  */
 export async function * queryPath (options: QueryPathOptions): AsyncGenerator<QueryEvent, void, undefined> {
-  const { key, startingPeer, ourPeerId, signal, query, alpha, path, numPaths, queryFuncTimeout, log, peersSeen, connectionManager } = options
+  const { key, startingPeers, ourPeerId, query, alpha, path, numPaths, log, peersSeen, connectionManager } = options
+  const events = pushable<QueryEvent>({
+    objectMode: true
+  })
+
   // Only ALPHA node/value lookups are allowed at any given time for each process
   // https://github.com/libp2p/specs/tree/master/kad-dht#alpha-concurrency-parameter-%CE%B1
-  const queue = new Queue<QueryEvent | undefined, QueryQueueOptions>({
+  const queue = new Queue<undefined, QueryQueueOptions>({
     concurrency: alpha,
     sort: (a, b) => uint8ArrayXorCompare(a.options.distance, b.options.distance)
+  })
+  queue.addEventListener('idle', () => {
+    events.push(pathEndedEvent({
+      path: {
+        index: path,
+        queued: queue.queued,
+        running: queue.running,
+        total: queue.size
+      }
+    }, options))
+
+    events.end()
+  })
+  queue.addEventListener('error', (evt) => {
+    log.error('error during query - %e', evt.detail)
   })
 
   // perform lookups on kadId, not the actual value
   const kadId = await convertBuffer(key)
 
   /**
-   * Adds the passed peer to the query queue if it's not us and no
-   * other path has passed through this peer
+   * Adds the passed peer to the query queue if it's not us and no other path
+   * has passed through this peer
    */
   function queryPeer (peer: PeerId, peerKadId: Uint8Array): void {
     if (peer == null) {
       return
     }
 
-    peersSeen.add(peer)
+    peersSeen.add(peer.toMultihash().bytes)
 
     const peerXor = uint8ArrayXor(peerKadId, kadId)
 
     queue.add(async () => {
-      const signals = [signal]
-
-      if (queryFuncTimeout != null) {
-        signals.push(AbortSignal.timeout(queryFuncTimeout))
-      }
-
-      const compoundSignal = anySignal(signals)
-
-      // this signal can get listened to a lot
-      setMaxListeners(Infinity, compoundSignal)
-
       try {
         for await (const event of query({
           ...options,
           key,
           peer,
-          signal: compoundSignal,
-          path,
-          numPaths
+          path: {
+            index: path,
+            queued: queue.queued,
+            running: queue.running,
+            total: queue.size
+          },
+          numPaths,
+          peerKadId
         })) {
-          if (compoundSignal.aborted) {
-            return
-          }
-
           // if there are closer peers and the query has not completed, continue the query
           if (event.name === 'PEER_RESPONSE') {
             for (const closerPeer of event.closer) {
-              if (peersSeen.has(closerPeer.id)) { // eslint-disable-line max-depth
-                log.trace('already seen %p in query', closerPeer.id)
+              if (peersSeen.has(closerPeer.id.toMultihash().bytes)) { // eslint-disable-line max-depth
+                log('already seen %p in query', closerPeer.id)
                 continue
               }
 
@@ -154,44 +152,53 @@ export async function * queryPath (options: QueryPathOptions): AsyncGenerator<Qu
 
               // only continue query if closer peer is actually closer
               if (uint8ArrayXorCompare(closerPeerXor, peerXor) !== -1) { // eslint-disable-line max-depth
-                log.trace('skipping %p as they are not closer to %b than %p', closerPeer.id, key, peer)
+                log('skipping %p as they are not closer to %b than %p', closerPeer.id, key, peer)
                 continue
               }
 
-              log.trace('querying closer peer %p', closerPeer.id)
+              log('querying closer peer %p', closerPeer.id)
               queryPeer(closerPeer.id, closerPeerKadId)
             }
           }
 
-          queue.safeDispatchEvent('completed', {
-            detail: event
+          events.push({
+            ...event,
+            // @ts-expect-error wat
+            path: {
+              index: path,
+              queued: queue.queued,
+              running: queue.running,
+              total: queue.size
+            }
           })
         }
       } catch (err: any) {
-        if (!signal.aborted) {
-          return queryErrorEvent({
-            from: peer,
-            error: err,
-            path
-          }, options)
-        }
-      } finally {
-        compoundSignal.clear()
+        // yield error event if query is continuing
+        events.push(queryErrorEvent({
+          from: peer,
+          error: err,
+          path: {
+            index: path,
+            queued: queue.queued,
+            running: queue.running - 1,
+            total: queue.size - 1
+          }
+        }, options))
       }
     }, {
       distance: peerXor
     }).catch(err => {
-      log.error(err)
+      log.error('error during query - %e', err)
     })
   }
 
-  // begin the query with the starting peer
-  queryPeer(startingPeer, await convertPeerId(startingPeer))
+  // begin the query with the starting peers
+  await Promise.all(
+    startingPeers.map(async startingPeer => {
+      queryPeer(startingPeer, await convertPeerId(startingPeer))
+    })
+  )
 
   // yield results as they come in
-  for await (const event of queue.toGenerator({ signal })) {
-    if (event != null) {
-      yield event
-    }
-  }
+  yield * events
 }

--- a/packages/kad-dht/src/query/types.ts
+++ b/packages/kad-dht/src/query/types.ts
@@ -1,4 +1,4 @@
-import type { QueryEvent } from '../index.js'
+import type { DisjointPath, QueryEvent } from '../index.js'
 import type { PeerId } from '@libp2p/interface'
 
 export interface QueryContext {
@@ -6,10 +6,12 @@ export interface QueryContext {
   key: Uint8Array
   // the current peer being queried
   peer: PeerId
+  // the KADID of the peer being queried
+  peerKadId: Uint8Array
   // if this signal emits an 'abort' event, any long-lived processes or requests started as part of this query should be terminated
-  signal: AbortSignal
+  signal?: AbortSignal
   // which disjoint path we are following
-  path: number
+  path: DisjointPath
   // the total number of disjoint paths being executed
   numPaths: number
 }

--- a/packages/kad-dht/src/query/types.ts
+++ b/packages/kad-dht/src/query/types.ts
@@ -6,7 +6,7 @@ export interface QueryContext {
   key: Uint8Array
   // the current peer being queried
   peer: PeerId
-  // the KADID of the peer being queried
+  // the KAD ID of the peer being queried
   peerKadId: Uint8Array
   // if this signal emits an 'abort' event, any long-lived processes or requests started as part of this query should be terminated
   signal?: AbortSignal

--- a/packages/kad-dht/src/query/types.ts
+++ b/packages/kad-dht/src/query/types.ts
@@ -1,11 +1,11 @@
 import type { DisjointPath, QueryEvent } from '../index.js'
-import type { PeerId } from '@libp2p/interface'
+import type { PeerInfo } from '@libp2p/interface'
 
 export interface QueryContext {
   // the key we are looking up
   key: Uint8Array
   // the current peer being queried
-  peer: PeerId
+  peer: PeerInfo
   // the KAD ID of the peer being queried
   peerKadId: Uint8Array
   // if this signal emits an 'abort' event, any long-lived processes or requests started as part of this query should be terminated

--- a/packages/kad-dht/src/rpc/handlers/get-providers.ts
+++ b/packages/kad-dht/src/rpc/handlers/get-providers.ts
@@ -67,7 +67,7 @@ export class GetProvidersHandler implements DHTMessageHandler {
 
         return info
       })),
-      this.peerRouting.getCloserPeersOffline(msg.key, this.peerId)
+      this.peerRouting.getCloserPeersOffline(msg.key, peerId)
     ])
 
     const response: Message = {

--- a/packages/kad-dht/src/utils.ts
+++ b/packages/kad-dht/src/utils.ts
@@ -140,6 +140,15 @@ export function fromPublicKeyKey (key: Uint8Array): PeerId {
   return peerIdFromMultihash(multihash)
 }
 
+export function uint8ArrayToBigInt (buf: Uint8Array): bigint {
+  return BigInt(
+    `0x${
+      Array.from(buf)
+        .map(val => val.toString(16).padStart(2, '0')).join('')
+    }`
+  )
+}
+
 /**
  * Create a new put record, encodes and signs it if enabled
  */

--- a/packages/kad-dht/test/content-routing.spec.ts
+++ b/packages/kad-dht/test/content-routing.spec.ts
@@ -46,7 +46,7 @@ describe('content routing', () => {
       testDHT.spawn()
     ]), await kadUtils.convertBuffer(cid.multihash.bytes))
 
-    sinon.spy(dhts[3].network, 'sendMessage')
+    const sendMessageSpy = sinon.spy(dhts[3].network, 'sendMessage')
 
     // connect peers
     await Promise.all([
@@ -59,8 +59,7 @@ describe('content routing', () => {
     await drain(dhts[3].provide(cid))
 
     // check network messages
-    // @ts-expect-error fn is a spy
-    const calls = dhts[3].network.sendMessage.getCalls().map(c => c.args)
+    const calls = sendMessageSpy.getCalls().map(c => c.args)
 
     const peersSentMessage = new Set<string>()
 
@@ -69,8 +68,8 @@ describe('content routing', () => {
 
       expect(msg.type).equals(MessageType.ADD_PROVIDER)
       expect(msg.key).equalBytes(cid.multihash.bytes)
-      expect(msg.providers.length).equals(1)
-      expect(msg.providers[0].id).to.equalBytes(dhts[3].components.peerId.toMultihash().bytes)
+      expect(msg.providers?.length).equals(1)
+      expect(msg.providers?.[0].id).to.equalBytes(dhts[3].components.peerId.toMultihash().bytes)
     }
 
     // expect an ADD_PROVIDER message to be sent to each peer for each value

--- a/packages/kad-dht/test/kad-dht.spec.ts
+++ b/packages/kad-dht/test/kad-dht.spec.ts
@@ -301,8 +301,8 @@ describe('KadDHT', () => {
       this.timeout(20 * 1000)
 
       const key = uint8ArrayFromString('/v/hello')
-      const valueA = uint8ArrayFromString('worldA')
-      const valueB = uint8ArrayFromString('worldB')
+      const valueA = uint8ArrayFromString('world2')
+      const valueB = uint8ArrayFromString('world1')
 
       const [dhtA, dhtB] = await Promise.all([
         testDHT.spawn(),
@@ -311,18 +311,19 @@ describe('KadDHT', () => {
 
       const dhtASpy = sinon.spy(dhtA.network, 'sendRequest')
 
-      // Put before peers connected
+      // put before peers connected
       await drain(dhtA.put(key, valueA))
       await drain(dhtB.put(key, valueB))
 
-      // Connect peers
+      // connect peers
       await testDHT.connect(dhtA, dhtB)
 
-      // Get values
+      // get values
       const resA = await last(dhtA.get(key))
       const resB = await last(dhtB.get(key))
 
-      // First is selected
+      // first is selected because the selector sorts alphabetically and chooses
+      // the last value
       expect(resA).to.have.property('value').that.equalBytes(valueA)
       expect(resB).to.have.property('value').that.equalBytes(valueA)
 
@@ -386,7 +387,12 @@ describe('KadDHT', () => {
           messageType: MessageType.GET_VALUE,
           from: peer,
           record: rec,
-          path: -1
+          path: {
+            index: -1,
+            queued: 0,
+            running: 0,
+            total: 0
+          }
         })
       }) // eslint-disable-line require-await
 
@@ -459,7 +465,7 @@ describe('KadDHT', () => {
       const res = await all(dhts[1].getClosestPeers(dhts[2].components.peerId.toMultihash().bytes))
       expect(res).to.not.be.empty()
 
-      // no peer should include itself in the response, only other peers that it
+      // should not include requester in the response, only other peers that it
       // knows who are closer
       for (const event of res) {
         if (event.name !== 'PEER_RESPONSE') {

--- a/packages/kad-dht/test/libp2p-routing.spec.ts
+++ b/packages/kad-dht/test/libp2p-routing.spec.ts
@@ -115,7 +115,8 @@ describe('content routing', () => {
     dht = kadDHT({
       protocol: PROTOCOL,
       peerInfoMapper: passthroughMapper,
-      clientMode: false
+      clientMode: false,
+      initialQuerySelfInterval: 10_000
     })(components)
 
     // @ts-expect-error not part of public api
@@ -138,6 +139,10 @@ describe('content routing', () => {
     const remotePeer = createPeer(peers[0].peerId)
 
     components.peerStore.get.withArgs(remotePeer.id).resolves(remotePeer)
+    components.peerStore.getInfo.withArgs(remotePeer.id).resolves({
+      id: remotePeer.id,
+      multiaddrs: remotePeer.addresses.map(({ multiaddr }) => multiaddr)
+    })
 
     const {
       connection,
@@ -176,6 +181,10 @@ describe('content routing', () => {
     const providerPeer = createPeer(peers[2].peerId)
 
     components.peerStore.get.withArgs(remotePeer.id).resolves(remotePeer)
+    components.peerStore.getInfo.withArgs(remotePeer.id).resolves({
+      id: remotePeer.id,
+      multiaddrs: remotePeer.addresses.map(({ multiaddr }) => multiaddr)
+    })
 
     const {
       connection,
@@ -322,7 +331,15 @@ describe('peer routing', () => {
     const closestPeerInteractionsComplete = pDefer()
 
     components.peerStore.get.withArgs(remotePeer.id).resolves(remotePeer)
+    components.peerStore.getInfo.withArgs(remotePeer.id).resolves({
+      id: remotePeer.id,
+      multiaddrs: remotePeer.addresses.map(({ multiaddr }) => multiaddr)
+    })
     components.peerStore.get.withArgs(closestPeer.id).resolves(closestPeer)
+    components.peerStore.getInfo.withArgs(closestPeer.id).resolves({
+      id: closestPeer.id,
+      multiaddrs: closestPeer.addresses.map(({ multiaddr }) => multiaddr)
+    })
 
     const {
       connection,
@@ -379,10 +396,10 @@ describe('peer routing', () => {
     await expect(all(map(peerRouting.getClosestPeers(key.multihash.bytes), prov => ({
       id: prov.id.toString(),
       multiaddrs: prov.multiaddrs.map(ma => ma.toString())
-    })))).to.eventually.deep.equal([{
+    })))).to.eventually.deep.include({
       id: closestPeer.id.toString(),
       multiaddrs: closestPeer.addresses.map(({ multiaddr }) => multiaddr.toString())
-    }])
+    })
 
     await expect(remotePeerInteractionsComplete.promise).to.eventually.be.undefined()
     await expect(closestPeerInteractionsComplete.promise).to.eventually.be.undefined()

--- a/packages/kad-dht/test/network.spec.ts
+++ b/packages/kad-dht/test/network.spec.ts
@@ -36,7 +36,12 @@ describe('Network', () => {
       }
 
       const events = await all(dht.network.sendRequest(dht.components.peerId, msg, {
-        path: -1
+        path: {
+          index: -1,
+          queued: 0,
+          running: 0,
+          total: 0
+        }
       }))
       const response = events
         .filter(event => event.name === 'PEER_RESPONSE')
@@ -93,7 +98,12 @@ describe('Network', () => {
       }
 
       const events = await all(dht.network.sendRequest(dht.components.peerId, msg, {
-        path: -1
+        path: {
+          index: -1,
+          queued: 0,
+          running: 0,
+          total: 0
+        }
       }))
       const response = events
         .filter(event => event.name === 'PEER_RESPONSE')

--- a/packages/kad-dht/test/query-self.spec.ts
+++ b/packages/kad-dht/test/query-self.spec.ts
@@ -72,7 +72,12 @@ describe('Query Self', () => {
           id: remotePeer,
           multiaddrs: []
         },
-        path: 0
+        path: {
+          index: -1,
+          queued: 0,
+          running: 0,
+          total: 0
+        }
       })
     }())
 

--- a/packages/kad-dht/test/query.spec.ts
+++ b/packages/kad-dht/test/query.spec.ts
@@ -389,7 +389,7 @@ describe('QueryManager', () => {
 
     // the should have been aborted
     await expect(queryPromise).to.eventually.be.rejected()
-      .with.property('name', 'AbortError')
+      .with.property('name', 'QueryAbortedError')
 
     expect(aborted).to.be.true()
 

--- a/packages/kad-dht/test/query.spec.ts
+++ b/packages/kad-dht/test/query.spec.ts
@@ -76,7 +76,16 @@ describe('QueryManager', () => {
           }
         })
       } else if (config.error != null) {
-        event = queryErrorEvent({ from, error: config.error })
+        event = queryErrorEvent({
+          from,
+          error: config.error,
+          path: {
+            index: -1,
+            queued: 0,
+            running: 0,
+            total: 0
+          }
+        })
       } else {
         event = peerResponseEvent({
           from,

--- a/packages/kad-dht/test/query.spec.ts
+++ b/packages/kad-dht/test/query.spec.ts
@@ -122,7 +122,7 @@ describe('QueryManager', () => {
     const queryFunc: QueryFunc = async function * (context) {
       const { peer } = context
 
-      const res = topology[peer.toString()]
+      const res = topology[peer.id.toString()]
       res.context = context
 
       if (res.delay != null) {
@@ -207,9 +207,9 @@ describe('QueryManager', () => {
       expect(context).to.have.property('path').that.includes({ index: 0 })
       expect(context).to.have.property('numPaths').that.equals(1)
 
-      if (peers[0].peerId.equals(context.peer)) {
+      if (peers[0].peerId.equals(context.peer.id)) {
         yield valueEvent({
-          from: context.peer,
+          from: context.peer.id,
           value: uint8ArrayFromString('cool'),
           path: {
             index: 0,
@@ -250,12 +250,12 @@ describe('QueryManager', () => {
 
     const queryFunc: QueryFunc = async function * ({ peer, signal, path }) { // eslint-disable-line require-await
       expect(signal).to.be.an.instanceOf(AbortSignal)
-      peersQueried.push(peer)
+      peersQueried.push(peer.id)
 
       if (peersQueried.length === 1) {
         // query more peers
         yield peerResponseEvent({
-          from: peer,
+          from: peer.id,
           messageType: MessageType.GET_VALUE,
           closer: peers.slice(0, 5).map(peer => ({ id: peer.peerId, multiaddrs: [], protocols: [] })),
           path
@@ -263,7 +263,7 @@ describe('QueryManager', () => {
       } else if (peersQueried.length === 6) {
         // all peers queried, return result
         yield valueEvent({
-          from: peer,
+          from: peer.id,
           value: uint8ArrayFromString('cool'),
           path: {
             index: 0,
@@ -275,7 +275,7 @@ describe('QueryManager', () => {
       } else {
         // a peer that cannot help in our query
         yield peerResponseEvent({
-          from: peer,
+          from: peer.id,
           messageType: MessageType.GET_VALUE,
           path
         })
@@ -314,12 +314,12 @@ describe('QueryManager', () => {
     const peersQueried: PeerId[] = []
 
     const queryFunc: QueryFunc = async function * ({ peer, path }) { // eslint-disable-line require-await
-      peersQueried.push(peer)
+      peersQueried.push(peer.id)
 
       if (peersQueried.length === 1) {
         // query more peers
         yield peerResponseEvent({
-          from: peer,
+          from: peer.id,
           messageType: MessageType.GET_VALUE,
           closer: peers.slice(0, 5).map(peer => ({ id: peer.peerId, multiaddrs: [], protocols: [] })),
           path
@@ -327,7 +327,7 @@ describe('QueryManager', () => {
       } else {
         // a peer that cannot help in our query
         yield peerResponseEvent({
-          from: peer,
+          from: peer.id,
           messageType: MessageType.GET_VALUE,
           path
         })
@@ -384,7 +384,7 @@ describe('QueryManager', () => {
 
       await delay(1000)
 
-      yield topology[peer.toString()].event
+      yield topology[peer.id.toString()].event
     }
 
     // start the query
@@ -433,7 +433,7 @@ describe('QueryManager', () => {
       // simulate network timeout rather than using query signal passed in
       // context which would abort the whole query
       const signal = AbortSignal.timeout(100)
-      const res = topology[peer.toString()]
+      const res = topology[peer.id.toString()]
 
       if (res.delay != null) {
         await delay(res.delay)
@@ -476,7 +476,7 @@ describe('QueryManager', () => {
         throw new Error('Urk!')
       } else {
         yield peerResponseEvent({
-          from: peer,
+          from: peer.id,
           messageType: MessageType.GET_VALUE,
           path
         })
@@ -522,7 +522,7 @@ describe('QueryManager', () => {
 
     const queryFunc: QueryFunc = async function * ({ peer }) { // eslint-disable-line require-await
       yield valueEvent({
-        from: peer,
+        from: peer.id,
         value: uint8ArrayFromString('cool'),
         path: {
           index: 0,
@@ -655,7 +655,7 @@ describe('QueryManager', () => {
 
     const queryFunc: QueryFunc = async function * ({ peer, path }) { // eslint-disable-line require-await
       yield peerResponseEvent({
-        from: peer,
+        from: peer.id,
         messageType: MessageType.GET_VALUE,
         closer: [{
           id: peers[2].peerId,
@@ -740,10 +740,10 @@ describe('QueryManager', () => {
     const visited: PeerId[] = []
 
     const queryFunc: QueryFunc = async function * ({ peer }) { // eslint-disable-line require-await
-      visited.push(peer)
+      visited.push(peer.id)
 
       const getResult = async (): Promise<QueryEvent> => {
-        const res = topology[peer.toString()]
+        const res = topology[peer.id.toString()]
         // this delay is necessary so `dhtA.stop` has time to stop the
         // requests before they all complete
         await delay(100)
@@ -752,7 +752,7 @@ describe('QueryManager', () => {
       }
 
       // Shut down after visiting peers[2]
-      if (peer.equals(peers[2].peerId)) {
+      if (peer.id.equals(peers[2].peerId)) {
         await manager.stop()
 
         yield getResult()
@@ -876,7 +876,7 @@ describe('QueryManager', () => {
     const queryFunc: QueryFunc = async function * ({ peer }) { // eslint-disable-line require-await
       // yield query result
       yield valueEvent({
-        from: peer,
+        from: peer.id,
         value: uint8ArrayFromString('cool'),
         path: {
           index: 0,

--- a/packages/kad-dht/test/rpc/handlers/get-providers.spec.ts
+++ b/packages/kad-dht/test/rpc/handlers/get-providers.spec.ts
@@ -102,7 +102,7 @@ describe('rpc - handlers - GetProviders', () => {
     }]
 
     providers.getProviders.withArgs(v.cid).resolves([providerPeer.peerId])
-    peerRouting.getCloserPeersOffline.withArgs(msg.key, peerId.peerId).resolves(closer)
+    peerRouting.getCloserPeersOffline.withArgs(msg.key, sourcePeer.peerId).resolves(closer)
 
     await peerStore.merge(providerPeer.peerId, {
       multiaddrs: provider[0].multiaddrs

--- a/packages/kad-dht/test/utils/test-dht.ts
+++ b/packages/kad-dht/test/utils/test-dht.ts
@@ -9,6 +9,7 @@ import { MemoryDatastore } from 'datastore-core/memory'
 import delay from 'delay'
 import pRetry from 'p-retry'
 import { stubInterface } from 'sinon-ts'
+import { toString as uint8ArrayToString } from 'uint8arrays/to-string'
 import { PROTOCOL } from '../../src/constants.js'
 import { type KadDHT, type KadDHTComponents, type KadDHTInit } from '../../src/index.js'
 import { KadDHT as KadDHTClass } from '../../src/kad-dht.js'
@@ -81,10 +82,19 @@ export class TestDHT {
         }
       },
       selectors: {
-        v: () => 0
+        v: (key, values) => {
+          const strings = values
+            .map(buf => uint8ArrayToString(buf))
+          const sortedStrings = strings
+            .toSorted((a, b) => a.localeCompare(b))
+
+          const target = sortedStrings[sortedStrings.length - 1]
+
+          return strings.findIndex(str => str === target)
+        }
       },
-      querySelfInterval: 600000,
-      initialQuerySelfInterval: 600000,
+      querySelfInterval: 600_000,
+      initialQuerySelfInterval: 600_000,
       allowQueryWithZeroPeers: true,
       clientMode: false,
       ...options


### PR DESCRIPTION
- Increase alpha to 10
- Split starting peers into multiple disjoint buckets
- Report disjoint path info on events
- Abort slow subqueries at the network level instead of query and network
- Use a filter to separate disjoint paths
- Only add closer peers to our list of closer peers if they are actually closer

## Change checklist

- [x] I have performed a self-review of my own code
- [ ] I have made corresponding changes to the documentation if necessary (this includes comments as well)
- [x] I have added tests that prove my fix is effective or that my feature works