### PR TITLE
fix: abort open connection and new stream

### DIFF
--- a/packages/interface-compliance-tests/src/mocks/connection-manager.ts
+++ b/packages/interface-compliance-tests/src/mocks/connection-manager.ts
@@ -5,6 +5,7 @@ import { isMultiaddr, type Multiaddr } from '@multiformats/multiaddr'
 import { connectionPair } from './connection.js'
 import type { PrivateKey, PeerId, ComponentLogger, Libp2pEvents, PendingDial, Connection, TypedEventTarget, PubSub, Startable } from '@libp2p/interface'
 import type { ConnectionManager, Registrar } from '@libp2p/interface-internal'
+import type { AbortOptions } from 'it-pushable'
 
 export interface MockNetworkComponents {
   peerId: PeerId
@@ -101,10 +102,12 @@ class MockConnectionManager implements ConnectionManager, Startable {
     return 10_000
   }
 
-  async openConnection (peerId: PeerId | Multiaddr | Multiaddr[]): Promise<Connection> {
+  async openConnection (peerId: PeerId | Multiaddr | Multiaddr[], options?: AbortOptions): Promise<Connection> {
     if (isMultiaddr(peerId)) {
       throw new UnsupportedOperationError('Dialing multiaddrs not supported')
     }
+
+    options?.signal?.throwIfAborted()
 
     let existingConnections: Connection[] = []
 

--- a/packages/interface-compliance-tests/src/mocks/connection.ts
+++ b/packages/interface-compliance-tests/src/mocks/connection.ts
@@ -81,6 +81,8 @@ class MockConnection implements Connection {
       throw new ConnectionClosedError('connection must be open to create streams')
     }
 
+    options?.signal?.throwIfAborted()
+
     const id = `${Math.random()}`
     const stream = await this.muxer.newStream(id)
     const result = await mss.select(stream, protocols, {


### PR DESCRIPTION
Check the abort signal and throw if it has been aborted

## Change checklist

- [x] I have performed a self-review of my own code
- [ ] I have made corresponding changes to the documentation if necessary (this includes comments as well)
- [ ] I have added tests that prove my fix is effective or that my feature works