### PR TITLE
fix: timeout sending rpc messages after a while

### DIFF
--- a/packages/metrics-devtools/package.json
+++ b/packages/metrics-devtools/package.json
@@ -77,7 +77,7 @@
     "cborg": "^4.2.6",
     "it-pipe": "^3.0.1",
     "it-pushable": "^3.2.3",
-    "it-rpc": "^1.0.2",
+    "it-rpc": "^1.1.0",
     "multiformats": "^13.3.1",
     "progress-events": "^1.0.1"
   },

--- a/packages/metrics-devtools/src/index.ts
+++ b/packages/metrics-devtools/src/index.ts
@@ -137,6 +137,13 @@ export interface DevToolsMetricsInit {
    * How often to pass metrics to the DevTools panel
    */
   intervalMs?: number
+
+  /**
+   * Outgoing RPC invocations must return within this timeout in ms
+   *
+   * @default 1_000
+   */
+  rpcSendTimeout?: number
 }
 
 export interface DevToolsMetricsComponents {
@@ -162,7 +169,7 @@ class DevToolsMetrics implements Metrics, Startable {
   private readonly rpc: RPC
   private readonly devTools: DevToolsRPC
 
-  constructor (components: DevToolsMetricsComponents, init?: Partial<DevToolsMetricsInit>) {
+  constructor (components: DevToolsMetricsComponents, init: DevToolsMetricsInit = {}) {
     this.log = components.logger.forComponent('libp2p:devtools-metrics')
     this.intervalMs = init?.intervalMs
     this.components = components
@@ -173,7 +180,7 @@ class DevToolsMetrics implements Metrics, Startable {
       valueCodecs
     })
     this.devTools = this.rpc.createClient('devTools', {
-      timeout: 1_000
+      timeout: init.rpcSendTimeout ?? DEVTOOLS_TIMEOUT
     })
 
     // collect information on current peers and sent it to the dev tools panel

--- a/packages/metrics-devtools/src/rpc/index.ts
+++ b/packages/metrics-devtools/src/rpc/index.ts
@@ -143,5 +143,5 @@ export interface DevToolsEvents {
  * RPC operations exposed by the DevTools
  */
 export interface DevToolsRPC {
-  safeDispatchEvent<Detail>(type: keyof DevToolsEvents, detail?: CustomEventInit<Detail>): Promise<void>
+  safeDispatchEvent<Detail>(type: keyof DevToolsEvents, detail?: CustomEventInit<Detail>, options?: AbortOptions): Promise<void>
 }


### PR DESCRIPTION
To prevent the outgoing message queue growing when remote consumers are slow, add a timeout for the outgoing messages.

## Change checklist

- [x] I have performed a self-review of my own code
- [ ] I have made corresponding changes to the documentation if necessary (this includes comments as well)
- [ ] I have added tests that prove my fix is effective or that my feature works