### PR TITLE
fix: allow setting interval repeatedly

### DIFF
--- a/packages/utils/src/repeating-task.ts
+++ b/packages/utils/src/repeating-task.ts
@@ -84,6 +84,11 @@ export function repeatingTask (fn: (options?: AbortOptions) => void | Promise<vo
 
   return {
     setInterval: (ms): void => {
+      if (interval === ms) {
+        // already running at this interval, nothing to do
+        return
+      }
+
       interval = ms
 
       // maybe reschedule

--- a/packages/utils/test/repeating-task.spec.ts
+++ b/packages/utils/test/repeating-task.spec.ts
@@ -113,4 +113,29 @@ describe('repeating-task', () => {
 
     expect(count).to.equal(1)
   })
+
+  it('should not reschedule the task if the interval is updated to the same value', async () => {
+    let count = 0
+
+    const task = repeatingTask(() => {
+      count++
+    }, 1_000, {
+      runImmediately: true
+    })
+    task.start()
+
+    await delay(100)
+
+    task.setInterval(200)
+
+    await delay(100)
+
+    task.setInterval(200)
+
+    await delay(100)
+
+    task.stop()
+
+    expect(count).to.equal(2)
+  })
 })


### PR DESCRIPTION
If we set the interval to the same value multiple times, do not reschedule the task as it is already running on that interval.

## Change checklist

- [x] I have performed a self-review of my own code
- [ ] I have made corresponding changes to the documentation if necessary (this includes comments as well)
- [x] I have added tests that prove my fix is effective or that my feature works