### PR TITLE
fix: make event detail optional

### DIFF
--- a/packages/interface/src/event-target.ts
+++ b/packages/interface/src/event-target.ts
@@ -27,7 +27,7 @@ export interface TypedEventTarget <EventMap extends Record<string, any>> extends
 
   removeEventListener (type: string, listener?: EventHandler<Event>, options?: boolean | EventListenerOptions): void
 
-  safeDispatchEvent<Detail>(type: keyof EventMap, detail: CustomEventInit<Detail>): boolean
+  safeDispatchEvent<Detail>(type: keyof EventMap, detail?: CustomEventInit<Detail>): boolean
 }
 
 /**


### PR DESCRIPTION
When using `safeDispatchEvent`, make the detail arg optional as it is not always required.

## Change checklist

- [x] I have performed a self-review of my own code
- [ ] I have made corresponding changes to the documentation if necessary (this includes comments as well)
- [ ] I have added tests that prove my fix is effective or that my feature works