### PR TITLE
fix: abort async operations

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -1,8 +1,7 @@
 version: 2
 updates:
 - package-ecosystem: npm
-  directories:
-    - "/"
+  directory: "/"
   schedule:
     interval: daily
     time: "10:00"
@@ -11,7 +10,7 @@ updates:
     prefix: "deps"
     prefix-development: "chore"
   groups:
-    libp2p-deps: # group all deps that should be updated when Helia deps need updated
+    libp2p-deps:
       patterns:
         - "*libp2p*"
         - "*multiformats*"

--- a/packages/crypto/src/keys/ecdsa/ecdsa.ts
+++ b/packages/crypto/src/keys/ecdsa/ecdsa.ts
@@ -5,7 +5,7 @@ import { equals as uint8ArrayEquals } from 'uint8arrays/equals'
 import { publicKeyToProtobuf } from '../index.js'
 import { privateKeyToPKIMessage, publicKeyToPKIMessage } from './utils.js'
 import { hashAndVerify, hashAndSign } from './index.js'
-import type { ECDSAPublicKey as ECDSAPublicKeyInterface, ECDSAPrivateKey as ECDSAPrivateKeyInterface } from '@libp2p/interface'
+import type { ECDSAPublicKey as ECDSAPublicKeyInterface, ECDSAPrivateKey as ECDSAPrivateKeyInterface, AbortOptions } from '@libp2p/interface'
 import type { Digest } from 'multiformats/hashes/digest'
 import type { Uint8ArrayList } from 'uint8arraylist'
 
@@ -46,8 +46,8 @@ export class ECDSAPublicKey implements ECDSAPublicKeyInterface {
     return uint8ArrayEquals(this.raw, key.raw)
   }
 
-  async verify (data: Uint8Array | Uint8ArrayList, sig: Uint8Array): Promise<boolean> {
-    return hashAndVerify(this.jwk, sig, data)
+  async verify (data: Uint8Array | Uint8ArrayList, sig: Uint8Array, options?: AbortOptions): Promise<boolean> {
+    return hashAndVerify(this.jwk, sig, data, options)
   }
 }
 
@@ -85,7 +85,7 @@ export class ECDSAPrivateKey implements ECDSAPrivateKeyInterface {
     return uint8ArrayEquals(this.raw, key.raw)
   }
 
-  async sign (message: Uint8Array | Uint8ArrayList): Promise<Uint8Array> {
-    return hashAndSign(this.jwk, message)
+  async sign (message: Uint8Array | Uint8ArrayList, options?: AbortOptions): Promise<Uint8Array> {
+    return hashAndSign(this.jwk, message, options)
   }
 }

--- a/packages/crypto/src/keys/ecdsa/index.ts
+++ b/packages/crypto/src/keys/ecdsa/index.ts
@@ -1,3 +1,4 @@
+import type { AbortOptions } from '@libp2p/interface'
 import type { JWKKeyPair } from '../interface.js'
 import type { Uint8ArrayList } from 'uint8arraylist'
 
@@ -19,11 +20,12 @@ export async function generateECDSAKey (curve: Curve = 'P-256'): Promise<JWKKeyP
   }
 }
 
-export async function hashAndSign (key: JsonWebKey, msg: Uint8Array | Uint8ArrayList): Promise<Uint8Array> {
+export async function hashAndSign (key: JsonWebKey, msg: Uint8Array | Uint8ArrayList, options?: AbortOptions): Promise<Uint8Array> {
   const privateKey = await crypto.subtle.importKey('jwk', key, {
     name: 'ECDSA',
     namedCurve: key.crv ?? 'P-256'
   }, false, ['sign'])
+  options?.signal?.throwIfAborted()
 
   const signature = await crypto.subtle.sign({
     name: 'ECDSA',
@@ -31,20 +33,25 @@ export async function hashAndSign (key: JsonWebKey, msg: Uint8Array | Uint8Array
       name: 'SHA-256'
     }
   }, privateKey, msg.subarray())
+  options?.signal?.throwIfAborted()
 
   return new Uint8Array(signature, 0, signature.byteLength)
 }
 
-export async function hashAndVerify (key: JsonWebKey, sig: Uint8Array, msg: Uint8Array | Uint8ArrayList): Promise<boolean> {
+export async function hashAndVerify (key: JsonWebKey, sig: Uint8Array, msg: Uint8Array | Uint8ArrayList, options?: AbortOptions): Promise<boolean> {
   const publicKey = await crypto.subtle.importKey('jwk', key, {
     name: 'ECDSA',
     namedCurve: key.crv ?? 'P-256'
   }, false, ['verify'])
+  options?.signal?.throwIfAborted()
 
-  return crypto.subtle.verify({
+  const result = await crypto.subtle.verify({
     name: 'ECDSA',
     hash: {
       name: 'SHA-256'
     }
   }, publicKey, sig, msg.subarray())
+  options?.signal?.throwIfAborted()
+
+  return result
 }

--- a/packages/crypto/src/keys/ecdsa/index.ts
+++ b/packages/crypto/src/keys/ecdsa/index.ts
@@ -1,5 +1,5 @@
-import type { AbortOptions } from '@libp2p/interface'
 import type { JWKKeyPair } from '../interface.js'
+import type { AbortOptions } from '@libp2p/interface'
 import type { Uint8ArrayList } from 'uint8arraylist'
 
 export type Curve = 'P-256' | 'P-384' | 'P-521'

--- a/packages/crypto/src/keys/ed25519/ed25519.ts
+++ b/packages/crypto/src/keys/ed25519/ed25519.ts
@@ -5,7 +5,7 @@ import { equals as uint8ArrayEquals } from 'uint8arrays/equals'
 import { publicKeyToProtobuf } from '../index.js'
 import { ensureEd25519Key } from './utils.js'
 import * as crypto from './index.js'
-import type { Ed25519PublicKey as Ed25519PublicKeyInterface, Ed25519PrivateKey as Ed25519PrivateKeyInterface } from '@libp2p/interface'
+import type { Ed25519PublicKey as Ed25519PublicKeyInterface, Ed25519PrivateKey as Ed25519PrivateKeyInterface, AbortOptions } from '@libp2p/interface'
 import type { Digest } from 'multiformats/hashes/digest'
 import type { Uint8ArrayList } from 'uint8arraylist'
 
@@ -37,7 +37,8 @@ export class Ed25519PublicKey implements Ed25519PublicKeyInterface {
     return uint8ArrayEquals(this.raw, key.raw)
   }
 
-  verify (data: Uint8Array | Uint8ArrayList, sig: Uint8Array): boolean {
+  verify (data: Uint8Array | Uint8ArrayList, sig: Uint8Array, options?: AbortOptions): boolean {
+    options?.signal?.throwIfAborted()
     return crypto.hashAndVerify(this.raw, sig, data)
   }
 }
@@ -62,7 +63,8 @@ export class Ed25519PrivateKey implements Ed25519PrivateKeyInterface {
     return uint8ArrayEquals(this.raw, key.raw)
   }
 
-  sign (message: Uint8Array | Uint8ArrayList): Uint8Array {
+  sign (message: Uint8Array | Uint8ArrayList, options?: AbortOptions): Uint8Array {
+    options?.signal?.throwIfAborted()
     return crypto.hashAndSign(this.raw, message)
   }
 }

--- a/packages/crypto/src/keys/ed25519/index.ts
+++ b/packages/crypto/src/keys/ed25519/index.ts
@@ -72,7 +72,7 @@ export function generateKeyFromSeed (seed: Uint8Array): Uint8ArrayKeyPair {
   }
 }
 
-export function hashAndSign (key: Uint8Array, msg: Uint8Array | Uint8ArrayList): Buffer {
+export function hashAndSign (key: Uint8Array, msg: Uint8Array | Uint8ArrayList): Uint8Array {
   if (!(key instanceof Uint8Array)) {
     throw new TypeError('"key" must be a node.js Buffer, or Uint8Array.')
   }

--- a/packages/crypto/src/keys/rsa/index.browser.ts
+++ b/packages/crypto/src/keys/rsa/index.browser.ts
@@ -1,9 +1,10 @@
-import { InvalidParametersError, type AbortOptions } from '@libp2p/interface'
+import { InvalidParametersError } from '@libp2p/interface'
 import { fromString as uint8ArrayFromString } from 'uint8arrays/from-string'
 import randomBytes from '../../random-bytes.js'
 import webcrypto from '../../webcrypto/index.js'
 import * as utils from './utils.js'
 import type { JWKKeyPair } from '../interface.js'
+import type { AbortOptions } from '@libp2p/interface'
 import type { Uint8ArrayList } from 'uint8arraylist'
 
 export const RSAES_PKCS1_V1_5_OID = '1.2.840.113549.1.1.1'

--- a/packages/crypto/src/keys/rsa/index.ts
+++ b/packages/crypto/src/keys/rsa/index.ts
@@ -1,6 +1,6 @@
-import crypto from 'crypto'
-import { promisify } from 'util'
-import { InvalidParametersError } from '@libp2p/interface'
+import crypto from 'node:crypto'
+import { promisify } from 'node:util'
+import { InvalidParametersError, type AbortOptions } from '@libp2p/interface'
 import { fromString as uint8ArrayFromString } from 'uint8arrays/from-string'
 import randomBytes from '../../random-bytes.js'
 import * as utils from './utils.js'
@@ -13,13 +13,14 @@ export const RSAES_PKCS1_V1_5_OID = '1.2.840.113549.1.1.1'
 
 export { utils }
 
-export async function generateRSAKey (bits: number): Promise<JWKKeyPair> {
+export async function generateRSAKey (bits: number, options?: AbortOptions): Promise<JWKKeyPair> {
   // @ts-expect-error node types are missing jwk as a format
   const key = await keypair('rsa', {
     modulusLength: bits,
     publicKeyEncoding: { type: 'pkcs1', format: 'jwk' },
     privateKeyEncoding: { type: 'pkcs1', format: 'jwk' }
   })
+  options?.signal?.throwIfAborted()
 
   return {
     // @ts-expect-error node types are missing jwk as a format
@@ -31,7 +32,9 @@ export async function generateRSAKey (bits: number): Promise<JWKKeyPair> {
 
 export { randomBytes as getRandomValues }
 
-export async function hashAndSign (key: JsonWebKey, msg: Uint8Array | Uint8ArrayList): Promise<Uint8Array> {
+export function hashAndSign (key: JsonWebKey, msg: Uint8Array | Uint8ArrayList, options?: AbortOptions): Uint8Array {
+  options?.signal?.throwIfAborted()
+
   const hash = crypto.createSign('RSA-SHA256')
 
   if (msg instanceof Uint8Array) {
@@ -46,7 +49,9 @@ export async function hashAndSign (key: JsonWebKey, msg: Uint8Array | Uint8Array
   return hash.sign({ format: 'jwk', key })
 }
 
-export async function hashAndVerify (key: JsonWebKey, sig: Uint8Array, msg: Uint8Array | Uint8ArrayList): Promise<boolean> {
+export function hashAndVerify (key: JsonWebKey, sig: Uint8Array, msg: Uint8Array | Uint8ArrayList, options?: AbortOptions): boolean {
+  options?.signal?.throwIfAborted()
+
   const hash = crypto.createVerify('RSA-SHA256')
 
   if (msg instanceof Uint8Array) {

--- a/packages/crypto/src/keys/rsa/index.ts
+++ b/packages/crypto/src/keys/rsa/index.ts
@@ -1,10 +1,11 @@
 import crypto from 'node:crypto'
 import { promisify } from 'node:util'
-import { InvalidParametersError, type AbortOptions } from '@libp2p/interface'
+import { InvalidParametersError } from '@libp2p/interface'
 import { fromString as uint8ArrayFromString } from 'uint8arrays/from-string'
 import randomBytes from '../../random-bytes.js'
 import * as utils from './utils.js'
 import type { JWKKeyPair } from '../interface.js'
+import type { AbortOptions } from '@libp2p/interface'
 import type { Uint8ArrayList } from 'uint8arraylist'
 
 const keypair = promisify(crypto.generateKeyPair)

--- a/packages/crypto/src/keys/rsa/rsa.ts
+++ b/packages/crypto/src/keys/rsa/rsa.ts
@@ -2,7 +2,7 @@ import { base58btc } from 'multiformats/bases/base58'
 import { CID } from 'multiformats/cid'
 import { equals as uint8ArrayEquals } from 'uint8arrays/equals'
 import { hashAndSign, utils, hashAndVerify } from './index.js'
-import type { RSAPublicKey as RSAPublicKeyInterface, RSAPrivateKey as RSAPrivateKeyInterface } from '@libp2p/interface'
+import type { RSAPublicKey as RSAPublicKeyInterface, RSAPrivateKey as RSAPrivateKeyInterface, AbortOptions } from '@libp2p/interface'
 import type { Digest } from 'multiformats/hashes/digest'
 import type { Uint8ArrayList } from 'uint8arraylist'
 
@@ -45,8 +45,8 @@ export class RSAPublicKey implements RSAPublicKeyInterface {
     return uint8ArrayEquals(this.raw, key.raw)
   }
 
-  verify (data: Uint8Array | Uint8ArrayList, sig: Uint8Array): boolean | Promise<boolean> {
-    return hashAndVerify(this.jwk, sig, data)
+  verify (data: Uint8Array | Uint8ArrayList, sig: Uint8Array, options?: AbortOptions): boolean | Promise<boolean> {
+    return hashAndVerify(this.jwk, sig, data, options)
   }
 }
 
@@ -77,7 +77,7 @@ export class RSAPrivateKey implements RSAPrivateKeyInterface {
     return uint8ArrayEquals(this.raw, key.raw)
   }
 
-  sign (message: Uint8Array | Uint8ArrayList): Uint8Array | Promise<Uint8Array> {
-    return hashAndSign(this.jwk, message)
+  sign (message: Uint8Array | Uint8ArrayList, options?: AbortOptions): Uint8Array | Promise<Uint8Array> {
+    return hashAndSign(this.jwk, message, options)
   }
 }

--- a/packages/crypto/src/keys/secp256k1/index.browser.ts
+++ b/packages/crypto/src/keys/secp256k1/index.browser.ts
@@ -2,8 +2,8 @@ import { secp256k1 as secp } from '@noble/curves/secp256k1'
 import { sha256 } from 'multiformats/hashes/sha2'
 import { SigningError, VerificationError } from '../../errors.js'
 import { isPromise } from '../../util.js'
-import type { Uint8ArrayList } from 'uint8arraylist'
 import type { AbortOptions } from '@libp2p/interface'
+import type { Uint8ArrayList } from 'uint8arraylist'
 
 const PUBLIC_KEY_BYTE_LENGTH = 33
 const PRIVATE_KEY_BYTE_LENGTH = 32

--- a/packages/crypto/src/keys/secp256k1/index.ts
+++ b/packages/crypto/src/keys/secp256k1/index.ts
@@ -1,8 +1,8 @@
 import crypto from 'node:crypto'
 import { secp256k1 as secp } from '@noble/curves/secp256k1'
 import { SigningError, VerificationError } from '../../errors.js'
-import type { Uint8ArrayList } from 'uint8arraylist'
 import type { AbortOptions } from '@libp2p/interface'
+import type { Uint8ArrayList } from 'uint8arraylist'
 
 const PUBLIC_KEY_BYTE_LENGTH = 33
 const PRIVATE_KEY_BYTE_LENGTH = 32

--- a/packages/crypto/src/keys/secp256k1/index.ts
+++ b/packages/crypto/src/keys/secp256k1/index.ts
@@ -2,6 +2,7 @@ import crypto from 'node:crypto'
 import { secp256k1 as secp } from '@noble/curves/secp256k1'
 import { SigningError, VerificationError } from '../../errors.js'
 import type { Uint8ArrayList } from 'uint8arraylist'
+import type { AbortOptions } from '@libp2p/interface'
 
 const PUBLIC_KEY_BYTE_LENGTH = 33
 const PRIVATE_KEY_BYTE_LENGTH = 32
@@ -12,7 +13,9 @@ export { PRIVATE_KEY_BYTE_LENGTH as privateKeyLength }
 /**
  * Hash and sign message with private key
  */
-export function hashAndSign (key: Uint8Array, msg: Uint8Array | Uint8ArrayList): Uint8Array {
+export function hashAndSign (key: Uint8Array, msg: Uint8Array | Uint8ArrayList, options?: AbortOptions): Uint8Array {
+  options?.signal?.throwIfAborted()
+
   const hash = crypto.createHash('sha256')
 
   if (msg instanceof Uint8Array) {
@@ -36,7 +39,8 @@ export function hashAndSign (key: Uint8Array, msg: Uint8Array | Uint8ArrayList):
 /**
  * Hash message and verify signature with public key
  */
-export function hashAndVerify (key: Uint8Array, sig: Uint8Array, msg: Uint8Array | Uint8ArrayList): boolean {
+export function hashAndVerify (key: Uint8Array, sig: Uint8Array, msg: Uint8Array | Uint8ArrayList, options?: AbortOptions): boolean {
+  options?.signal?.throwIfAborted()
   const hash = crypto.createHash('sha256')
 
   if (msg instanceof Uint8Array) {

--- a/packages/crypto/src/keys/secp256k1/secp256k1.ts
+++ b/packages/crypto/src/keys/secp256k1/secp256k1.ts
@@ -5,7 +5,7 @@ import { equals as uint8ArrayEquals } from 'uint8arrays/equals'
 import { publicKeyToProtobuf } from '../index.js'
 import { validateSecp256k1PublicKey, compressSecp256k1PublicKey, computeSecp256k1PublicKey, validateSecp256k1PrivateKey } from './utils.js'
 import { hashAndVerify, hashAndSign } from './index.js'
-import type { Secp256k1PublicKey as Secp256k1PublicKeyInterface, Secp256k1PrivateKey as Secp256k1PrivateKeyInterface } from '@libp2p/interface'
+import type { Secp256k1PublicKey as Secp256k1PublicKeyInterface, Secp256k1PrivateKey as Secp256k1PrivateKeyInterface, AbortOptions } from '@libp2p/interface'
 import type { Digest } from 'multiformats/hashes/digest'
 import type { Uint8ArrayList } from 'uint8arraylist'
 
@@ -39,8 +39,8 @@ export class Secp256k1PublicKey implements Secp256k1PublicKeyInterface {
     return uint8ArrayEquals(this.raw, key.raw)
   }
 
-  verify (data: Uint8Array | Uint8ArrayList, sig: Uint8Array): boolean {
-    return hashAndVerify(this._key, sig, data)
+  verify (data: Uint8Array | Uint8ArrayList, sig: Uint8Array, options?: AbortOptions): boolean {
+    return hashAndVerify(this._key, sig, data, options)
   }
 }
 
@@ -62,7 +62,7 @@ export class Secp256k1PrivateKey implements Secp256k1PrivateKeyInterface {
     return uint8ArrayEquals(this.raw, key.raw)
   }
 
-  sign (message: Uint8Array | Uint8ArrayList): Uint8Array | Promise<Uint8Array> {
-    return hashAndSign(this.raw, message)
+  sign (message: Uint8Array | Uint8ArrayList, options?: AbortOptions): Uint8Array | Promise<Uint8Array> {
+    return hashAndSign(this.raw, message, options)
   }
 }

--- a/packages/crypto/test/helpers/test-garbage-error-handling.ts
+++ b/packages/crypto/test/helpers/test-garbage-error-handling.ts
@@ -4,7 +4,7 @@ import { fromString as uint8ArrayFromString } from 'uint8arrays/from-string'
 
 const garbage = [uint8ArrayFromString('00010203040506070809', 'base16'), {}, null, false, undefined, true, 1, 0, uint8ArrayFromString(''), 'aGVsbG93b3JsZA==', 'helloworld', '']
 
-export function testGarbage (fncName: string, fnc: (...args: Uint8Array[]) => any | Promise<any>, num?: number, skipBuffersAndStrings?: boolean): void {
+export function testGarbage (fncName: string, fnc: (...args: any[]) => any | Promise<any>, num?: number, skipBuffersAndStrings?: boolean): void {
   const count = num ?? 1
 
   garbage.forEach((garbage) => {

--- a/packages/crypto/test/keys/ecdsa.spec.ts
+++ b/packages/crypto/test/keys/ecdsa.spec.ts
@@ -39,6 +39,32 @@ describe('ECDSA', function () {
     expect(res).to.be.be.true()
   })
 
+  it('should abort signing', async () => {
+    const controller = new AbortController()
+    controller.abort()
+    const text = randomBytes(512)
+    await expect((async () => {
+      return key.sign(text, {
+        signal: controller.signal
+      })
+    })()).to.eventually.be.rejected
+      .with.property('name', 'AbortError')
+  })
+
+  it('should abort verifying', async () => {
+    const controller = new AbortController()
+    controller.abort()
+    const text = randomBytes(512)
+    const sig = await key.sign(text)
+
+    await expect((async () => {
+      return key.publicKey.verify(text, sig, {
+        signal: controller.signal
+      })
+    })()).to.eventually.be.rejected
+      .with.property('name', 'AbortError')
+  })
+
   it('signs a list', async () => {
     const text = new Uint8ArrayList(
       randomBytes(512),

--- a/packages/crypto/test/keys/ed25519.spec.ts
+++ b/packages/crypto/test/keys/ed25519.spec.ts
@@ -77,6 +77,32 @@ describe('ed25519', function () {
       .to.be.true('did not verify message as single buffer')
   })
 
+  it('should abort signing', async () => {
+    const controller = new AbortController()
+    controller.abort()
+    const text = randomBytes(512)
+    await expect((async () => {
+      return key.sign(text, {
+        signal: controller.signal
+      })
+    })()).to.eventually.be.rejected
+      .with.property('name', 'AbortError')
+  })
+
+  it('should abort verifying', async () => {
+    const controller = new AbortController()
+    controller.abort()
+    const text = randomBytes(512)
+    const sig = await key.sign(text)
+
+    await expect((async () => {
+      return key.publicKey.verify(text, sig, {
+        signal: controller.signal
+      })
+    })()).to.eventually.be.rejected
+      .with.property('name', 'AbortError')
+  })
+
   it('encoding', () => {
     const keyMarshal = key.raw
     const key2 = unmarshalEd25519PrivateKey(keyMarshal)

--- a/packages/crypto/test/keys/secp256k1.spec.ts
+++ b/packages/crypto/test/keys/secp256k1.spec.ts
@@ -48,6 +48,32 @@ describe('secp256k1 keys', () => {
       .to.be.true('did not verify message as single buffer')
   })
 
+  it('should abort signing', async () => {
+    const controller = new AbortController()
+    controller.abort()
+    const text = randomBytes(512)
+    await expect((async () => {
+      return key.sign(text, {
+        signal: controller.signal
+      })
+    })()).to.eventually.be.rejected
+      .with.property('name', 'AbortError')
+  })
+
+  it('should abort verifying', async () => {
+    const controller = new AbortController()
+    controller.abort()
+    const text = randomBytes(512)
+    const sig = await key.sign(text)
+
+    await expect((async () => {
+      return key.publicKey.verify(text, sig, {
+        signal: controller.signal
+      })
+    })()).to.eventually.be.rejected
+      .with.property('name', 'AbortError')
+  })
+
   it('encoding', () => {
     const keyMarshal = key.raw
     const key2 = unmarshalSecp256k1PrivateKey(keyMarshal)

--- a/packages/interface-internal/src/registrar.ts
+++ b/packages/interface-internal/src/registrar.ts
@@ -1,4 +1,5 @@
 import type { StreamHandler, StreamHandlerOptions, StreamHandlerRecord, Topology, IncomingStreamData } from '@libp2p/interface'
+import type { AbortOptions } from '@multiformats/multiaddr'
 
 export type {
   /**
@@ -58,7 +59,7 @@ export interface Registrar {
    * @param protocol - The protocol to unhandle.
    * @returns A promise that resolves once the handler is removed.
    */
-  unhandle(protocol: string): Promise<void>
+  unhandle(protocol: string, options?: AbortOptions): Promise<void>
 
   /**
    * Retrieve the registered handler for a given protocol.
@@ -80,7 +81,7 @@ export interface Registrar {
    * @param topology - The topology handler to register.
    * @returns A promise resolving to a unique ID for the registered topology.
    */
-  register(protocol: string, topology: Topology): Promise<string>
+  register(protocol: string, topology: Topology, options?: AbortOptions): Promise<string>
 
   /**
    * Unregister a topology handler using its unique ID.

--- a/packages/interface/src/index.ts
+++ b/packages/interface/src/index.ts
@@ -685,7 +685,7 @@ export interface Libp2p<T extends ServiceMap = ServiceMap> extends Startable, Ty
    * libp2p.unhandle(['/echo/1.0.0'])
    * ```
    */
-  unhandle(protocols: string[] | string): Promise<void>
+  unhandle(protocols: string[] | string, options?: AbortOptions): Promise<void>
 
   /**
    * Register a topology to be informed when peers are encountered that
@@ -704,7 +704,7 @@ export interface Libp2p<T extends ServiceMap = ServiceMap> extends Startable, Ty
    * })
    * ```
    */
-  register(protocol: string, topology: Topology): Promise<string>
+  register(protocol: string, topology: Topology, options?: AbortOptions): Promise<string>
 
   /**
    * Unregister topology to no longer be informed when peers connect or

--- a/packages/interface/src/keys.ts
+++ b/packages/interface/src/keys.ts
@@ -1,6 +1,7 @@
 import type { CID } from 'multiformats/cid'
 import type { MultihashDigest } from 'multiformats/hashes/interface'
 import type { Uint8ArrayList } from 'uint8arraylist'
+import type { AbortOptions } from './index.ts'
 
 export type KeyType = 'RSA' | 'Ed25519' | 'secp256k1' | 'ECDSA'
 
@@ -44,7 +45,7 @@ export interface RSAPublicKey {
    * Verify the passed data was signed by the private key corresponding to this
    * public key
    */
-  verify(data: Uint8Array | Uint8ArrayList, sig: Uint8Array): boolean | Promise<boolean>
+  verify(data: Uint8Array | Uint8ArrayList, sig: Uint8Array, options?: AbortOptions): boolean | Promise<boolean>
 
   /**
    * Returns this key as a multihash with base58btc encoding
@@ -86,7 +87,7 @@ export interface Ed25519PublicKey {
    * Verify the passed data was signed by the private key corresponding to this
    * public key
    */
-  verify(data: Uint8Array | Uint8ArrayList, sig: Uint8Array): boolean | Promise<boolean>
+  verify(data: Uint8Array | Uint8ArrayList, sig: Uint8Array, options?: AbortOptions): boolean | Promise<boolean>
 
   /**
    * Returns this key as a multihash with base58btc encoding
@@ -128,7 +129,7 @@ export interface Secp256k1PublicKey {
    * Verify the passed data was signed by the private key corresponding to this
    * public key
    */
-  verify(data: Uint8Array | Uint8ArrayList, sig: Uint8Array): boolean | Promise<boolean>
+  verify(data: Uint8Array | Uint8ArrayList, sig: Uint8Array, options?: AbortOptions): boolean | Promise<boolean>
 
   /**
    * Returns this key as a multihash with base58btc encoding
@@ -175,7 +176,7 @@ export interface ECDSAPublicKey {
    * Verify the passed data was signed by the private key corresponding to this
    * public key
    */
-  verify(data: Uint8Array | Uint8ArrayList, sig: Uint8Array): boolean | Promise<boolean>
+  verify(data: Uint8Array | Uint8ArrayList, sig: Uint8Array, options?: AbortOptions): boolean | Promise<boolean>
 
   /**
    * Returns this key as a multihash with base58btc encoding
@@ -235,7 +236,7 @@ export interface RSAPrivateKey {
    * Sign the passed data with this private key and return the signature for
    * later verification
    */
-  sign(data: Uint8Array | Uint8ArrayList): Uint8Array | Promise<Uint8Array>
+  sign(data: Uint8Array | Uint8ArrayList, options?: AbortOptions): Uint8Array | Promise<Uint8Array>
 }
 
 export interface Ed25519PrivateKey {
@@ -263,7 +264,7 @@ export interface Ed25519PrivateKey {
    * Sign the passed data with this private key and return the signature for
    * later verification
    */
-  sign(data: Uint8Array | Uint8ArrayList): Uint8Array | Promise<Uint8Array>
+  sign(data: Uint8Array | Uint8ArrayList, options?: AbortOptions): Uint8Array | Promise<Uint8Array>
 }
 
 export interface Secp256k1PrivateKey {
@@ -291,7 +292,7 @@ export interface Secp256k1PrivateKey {
    * Sign the passed data with this private key and return the signature for
    * later verification
    */
-  sign(data: Uint8Array | Uint8ArrayList): Uint8Array | Promise<Uint8Array>
+  sign(data: Uint8Array | Uint8ArrayList, options?: AbortOptions): Uint8Array | Promise<Uint8Array>
 }
 
 export interface ECDSAPrivateKey {
@@ -324,7 +325,7 @@ export interface ECDSAPrivateKey {
    * Sign the passed data with this private key and return the signature for
    * later verification
    */
-  sign(data: Uint8Array | Uint8ArrayList): Uint8Array | Promise<Uint8Array>
+  sign(data: Uint8Array | Uint8ArrayList, options?: AbortOptions): Uint8Array | Promise<Uint8Array>
 }
 
 export type PrivateKey = RSAPrivateKey | Ed25519PrivateKey | Secp256k1PrivateKey | ECDSAPrivateKey

--- a/packages/interface/src/keys.ts
+++ b/packages/interface/src/keys.ts
@@ -1,7 +1,7 @@
+import type { AbortOptions } from './index.ts'
 import type { CID } from 'multiformats/cid'
 import type { MultihashDigest } from 'multiformats/hashes/interface'
 import type { Uint8ArrayList } from 'uint8arraylist'
-import type { AbortOptions } from './index.ts'
 
 export type KeyType = 'RSA' | 'Ed25519' | 'secp256k1' | 'ECDSA'
 

--- a/packages/interface/src/peer-store.ts
+++ b/packages/interface/src/peer-store.ts
@@ -1,3 +1,4 @@
+import type { AbortOptions } from './index.ts'
 import type { PublicKey } from './keys.js'
 import type { PeerId } from './peer-id.js'
 import type { PeerInfo } from './peer-info.js'
@@ -147,11 +148,15 @@ export interface PeerQueryOrder { (a: Peer, b: Peer): -1 | 0 | 1 }
 /**
  * A query for getting lists of peers
  */
-export interface PeerQuery {
+export interface PeerQuery extends AbortOptions {
   filters?: PeerQueryFilter[]
   orders?: PeerQueryOrder[]
   limit?: number
   offset?: number
+}
+
+export interface ConsumePeerRecordOptions extends AbortOptions {
+  expectedPeer?: PeerId
 }
 
 export interface PeerStore {
@@ -201,7 +206,7 @@ export interface PeerStore {
    * // []
    * ```
    */
-  delete(peerId: PeerId): Promise<void>
+  delete(peerId: PeerId, options?: AbortOptions): Promise<void>
 
   /**
    * Returns true if the passed PeerId is in the peer store
@@ -216,7 +221,7 @@ export interface PeerStore {
    * // true
    * ```
    */
-  has(peerId: PeerId): Promise<boolean>
+  has(peerId: PeerId, options?: AbortOptions): Promise<boolean>
 
   /**
    * Returns all data stored for the passed PeerId
@@ -228,7 +233,7 @@ export interface PeerStore {
    * // { .. }
    * ```
    */
-  get(peerId: PeerId): Promise<Peer>
+  get(peerId: PeerId, options?: AbortOptions): Promise<Peer>
 
   /**
    * Returns a PeerInfo object for the passed peer id. This is similar to `get`
@@ -254,7 +259,7 @@ export interface PeerStore {
    * // }
    * ```
    */
-  getInfo (peerId: PeerId): Promise<PeerInfo>
+  getInfo (peerId: PeerId, options?: AbortOptions): Promise<PeerInfo>
 
   /**
    * Adds a peer to the peer store, overwriting any existing data
@@ -267,7 +272,7 @@ export interface PeerStore {
    * })
    * ```
    */
-  save(id: PeerId, data: PeerData): Promise<Peer>
+  save(id: PeerId, data: PeerData, options?: AbortOptions): Promise<Peer>
 
   /**
    * Adds a peer to the peer store, overwriting only the passed fields
@@ -280,7 +285,7 @@ export interface PeerStore {
    * })
    * ```
    */
-  patch(id: PeerId, data: PeerData): Promise<Peer>
+  patch(id: PeerId, data: PeerData, options?: AbortOptions): Promise<Peer>
 
   /**
    * Adds a peer to the peer store, deeply merging any existing data.
@@ -293,7 +298,7 @@ export interface PeerStore {
    * })
    * ```
    */
-  merge(id: PeerId, data: PeerData): Promise<Peer>
+  merge(id: PeerId, data: PeerData, options?: AbortOptions): Promise<Peer>
 
   /**
    * Unmarshal and verify a signed peer record, extract the multiaddrs and
@@ -308,5 +313,10 @@ export interface PeerStore {
    * await peerStore.consumePeerRecord(buf, expectedPeer)
    * ```
    */
-  consumePeerRecord(buf: Uint8Array, expectedPeer?: PeerId): Promise<boolean>
+  consumePeerRecord(buf: Uint8Array, options?: ConsumePeerRecordOptions): Promise<boolean>
+
+  /**
+   * @deprecated Pass `expectedPeer` as a property of `options` instead
+   */
+  consumePeerRecord(buf: Uint8Array, expectedPeer?: PeerId, options?: AbortOptions): Promise<boolean>
 }

--- a/packages/interface/src/stream-handler.ts
+++ b/packages/interface/src/stream-handler.ts
@@ -1,4 +1,5 @@
 import type { Connection, Stream } from './connection.js'
+import type { AbortOptions } from './index.ts'
 
 export interface IncomingStreamData {
   /**
@@ -19,7 +20,7 @@ export interface StreamHandler {
   (data: IncomingStreamData): void
 }
 
-export interface StreamHandlerOptions {
+export interface StreamHandlerOptions extends AbortOptions {
   /**
    * How many incoming streams can be open for this protocol at the same time on each connection
    *

--- a/packages/kad-dht/src/constants.ts
+++ b/packages/kad-dht/src/constants.ts
@@ -27,7 +27,13 @@ export const REPROVIDE_MAX_QUEUE_SIZE = 16_384
 // How often to check if records need re-providing
 export const REPROVIDE_INTERVAL = hour
 
+// How long to reprovide for
+export const REPROVIDE_TIMEOUT = hour
+
 export const READ_MESSAGE_TIMEOUT = 10 * second
+
+// How long to process newly connected peers for
+export const ON_PEER_CONNECT_TIMEOUT = 10 * second
 
 // The number of records that will be retrieved on a call to getMany()
 export const GET_MANY_RECORD_COUNT = 16

--- a/packages/kad-dht/src/content-routing/index.ts
+++ b/packages/kad-dht/src/content-routing/index.ts
@@ -83,7 +83,7 @@ export class ContentRouting {
     const target = key.multihash.bytes
 
     // Add peer as provider
-    await this.providers.addProvider(key, this.components.peerId)
+    await this.providers.addProvider(key, this.components.peerId, options)
 
     const msg: Partial<Message> = {
       type: MessageType.ADD_PROVIDER,
@@ -182,7 +182,7 @@ export class ContentRouting {
 
     this.log('findProviders %c', key)
 
-    const provs = await this.providers.getProviders(key)
+    const provs = await this.providers.getProviders(key, options)
 
     // yield values if we have some, also slice because maybe we got lucky and already have too many?
     if (provs.length > 0) {
@@ -190,7 +190,7 @@ export class ContentRouting {
 
       for (const peerId of provs.slice(0, toFind)) {
         try {
-          const peer = await this.components.peerStore.get(peerId)
+          const peer = await this.components.peerStore.get(peerId, options)
 
           providers.push({
             id: peerId,

--- a/packages/kad-dht/src/errors.ts
+++ b/packages/kad-dht/src/errors.ts
@@ -9,16 +9,6 @@ export class QueryError extends Error {
 }
 
 /**
- * A query was aborted
- */
-export class QueryAbortedError extends Error {
-  constructor (message = 'Query aborted') {
-    super(message)
-    this.name = 'QueryAbortedError'
-  }
-}
-
-/**
  * An invalid record was received
  */
 export class InvalidRecordError extends Error {

--- a/packages/kad-dht/src/kad-dht.ts
+++ b/packages/kad-dht/src/kad-dht.ts
@@ -24,8 +24,8 @@ import {
 } from './utils.js'
 import type { KadDHTComponents, KadDHTInit, Validators, Selectors, KadDHT as KadDHTInterface, QueryEvent, PeerInfoMapper, SetModeOptions } from './index.js'
 import type { ContentRouting, CounterGroup, Logger, MetricGroup, PeerDiscovery, PeerDiscoveryEvents, PeerId, PeerInfo, PeerRouting, RoutingOptions, Startable } from '@libp2p/interface'
-import type { CID } from 'multiformats/cid'
 import type { AbortOptions } from 'it-pushable'
+import type { CID } from 'multiformats/cid'
 
 /**
  * Wrapper class to convert events into returned values

--- a/packages/kad-dht/src/peer-distance-list.ts
+++ b/packages/kad-dht/src/peer-distance-list.ts
@@ -2,7 +2,7 @@ import { xor as uint8ArrayXor } from 'uint8arrays/xor'
 import { xorCompare as uint8ArrayXorCompare } from 'uint8arrays/xor-compare'
 import { convertPeerId } from './utils.js'
 import type { DisjointPath } from './index.js'
-import type { PeerId, PeerInfo } from '@libp2p/interface'
+import type { AbortOptions, PeerId, PeerInfo } from '@libp2p/interface'
 
 interface PeerDistance {
   peer: PeerInfo
@@ -49,8 +49,8 @@ export class PeerDistanceList {
   /**
    * Add a peerId to the list.
    */
-  async add (peer: PeerInfo, path: DisjointPath = { index: -1, queued: 0, running: 0, total: 0 }): Promise<void> {
-    const dhtKey = await convertPeerId(peer.id)
+  async add (peer: PeerInfo, path: DisjointPath = { index: -1, queued: 0, running: 0, total: 0 }, options?: AbortOptions): Promise<void> {
+    const dhtKey = await convertPeerId(peer.id, options)
 
     this.addWithKadId(peer, dhtKey, path)
   }
@@ -100,12 +100,12 @@ export class PeerDistanceList {
    * Indicates whether any of the peerIds passed as a parameter are closer
    * to the origin key than the furthest peerId in the PeerDistanceList.
    */
-  async isCloser (peerId: PeerId): Promise<boolean> {
+  async isCloser (peerId: PeerId, options?: AbortOptions): Promise<boolean> {
     if (this.length === 0) {
       return true
     }
 
-    const dhtKey = await convertPeerId(peerId)
+    const dhtKey = await convertPeerId(peerId, options)
     const dhtKeyXor = uint8ArrayXor(dhtKey, this.originDhtKey)
     const furthestDistance = this.peerDistances[this.peerDistances.length - 1].distance
 
@@ -116,13 +116,13 @@ export class PeerDistanceList {
    * Indicates whether any of the peerIds passed as a parameter are closer
    * to the origin key than the furthest peerId in the PeerDistanceList.
    */
-  async anyCloser (peerIds: PeerId[]): Promise<boolean> {
+  async anyCloser (peerIds: PeerId[], options?: AbortOptions): Promise<boolean> {
     if (peerIds.length === 0) {
       return false
     }
 
     return Promise.any(
-      peerIds.map(async peerId => this.isCloser(peerId))
+      peerIds.map(async peerId => this.isCloser(peerId, options))
     )
   }
 }

--- a/packages/kad-dht/src/query-self.ts
+++ b/packages/kad-dht/src/query-self.ts
@@ -10,6 +10,7 @@ import type { OperationMetrics } from './kad-dht.js'
 import type { PeerRouting } from './peer-routing/index.js'
 import type { ComponentLogger, Logger, Metrics, PeerId, Startable } from '@libp2p/interface'
 import type { DeferredPromise } from 'p-defer'
+import type { AbortOptions } from 'it-pushable'
 
 export interface QuerySelfInit {
   logPrefix: string
@@ -132,6 +133,8 @@ export class QuerySelf implements Startable {
           (source) => take(source, this.count),
           async (source) => length(source)
         )
+
+        signal?.throwIfAborted()
 
         const duration = Date.now() - start
 

--- a/packages/kad-dht/src/query-self.ts
+++ b/packages/kad-dht/src/query-self.ts
@@ -10,7 +10,6 @@ import type { OperationMetrics } from './kad-dht.js'
 import type { PeerRouting } from './peer-routing/index.js'
 import type { ComponentLogger, Logger, Metrics, PeerId, Startable } from '@libp2p/interface'
 import type { DeferredPromise } from 'p-defer'
-import type { AbortOptions } from 'it-pushable'
 
 export interface QuerySelfInit {
   logPrefix: string

--- a/packages/kad-dht/src/query/manager.ts
+++ b/packages/kad-dht/src/query/manager.ts
@@ -165,7 +165,9 @@ export class QueryManager implements Startable {
 
       log('query:start')
 
-      const id = await convertBuffer(key)
+      const id = await convertBuffer(key, {
+        signal
+      })
       const peers = this.routingTable.closestPeers(id, this.routingTable.kBucketSize)
 
       // split peers into d buckets evenly(ish)

--- a/packages/kad-dht/src/query/query-path.ts
+++ b/packages/kad-dht/src/query/query-path.ts
@@ -1,3 +1,4 @@
+import { AbortError } from '@libp2p/interface'
 import { Queue } from '@libp2p/utils/queue'
 import { pushable } from 'it-pushable'
 import { xor as uint8ArrayXor } from 'uint8arrays/xor'
@@ -6,7 +7,7 @@ import { convertPeerId, convertBuffer } from '../utils.js'
 import { pathEndedEvent, queryErrorEvent } from './events.js'
 import type { QueryEvent } from '../index.js'
 import type { QueryFunc } from '../query/types.js'
-import { type Logger, type PeerId, type RoutingOptions, type AbortOptions, type PeerInfo, AbortError } from '@libp2p/interface'
+import type { Logger, PeerId, RoutingOptions, AbortOptions, PeerInfo } from '@libp2p/interface'
 import type { ConnectionManager } from '@libp2p/interface-internal'
 import type { Filter } from '@libp2p/utils/filters'
 

--- a/packages/kad-dht/src/query/query-path.ts
+++ b/packages/kad-dht/src/query/query-path.ts
@@ -2,12 +2,11 @@ import { Queue } from '@libp2p/utils/queue'
 import { pushable } from 'it-pushable'
 import { xor as uint8ArrayXor } from 'uint8arrays/xor'
 import { xorCompare as uint8ArrayXorCompare } from 'uint8arrays/xor-compare'
-import { QueryAbortedError } from '../errors.js'
 import { convertPeerId, convertBuffer } from '../utils.js'
 import { pathEndedEvent, queryErrorEvent } from './events.js'
 import type { QueryEvent } from '../index.js'
 import type { QueryFunc } from '../query/types.js'
-import type { Logger, PeerId, RoutingOptions, AbortOptions, PeerInfo } from '@libp2p/interface'
+import { type Logger, type PeerId, type RoutingOptions, type AbortOptions, type PeerInfo, AbortError } from '@libp2p/interface'
 import type { ConnectionManager } from '@libp2p/interface-internal'
 import type { Filter } from '@libp2p/utils/filters'
 
@@ -106,11 +105,13 @@ export async function * queryPath (options: QueryPathOptions): AsyncGenerator<Qu
 
   signal.addEventListener('abort', () => {
     queue.abort()
-    events.end(new QueryAbortedError())
+    events.end(new AbortError())
   })
 
   // perform lookups on kadId, not the actual value
-  const kadId = await convertBuffer(key)
+  const kadId = await convertBuffer(key, {
+    signal
+  })
 
   /**
    * Adds the passed peer to the query queue if it's not us and no other path
@@ -159,7 +160,9 @@ export async function * queryPath (options: QueryPathOptions): AsyncGenerator<Qu
                 continue
               }
 
-              const closerPeerKadId = await convertPeerId(closerPeer.id)
+              const closerPeerKadId = await convertPeerId(closerPeer.id, {
+                signal
+              })
               const closerPeerXor = uint8ArrayXor(closerPeerKadId, kadId)
 
               // only continue query if closer peer is actually closer
@@ -206,7 +209,9 @@ export async function * queryPath (options: QueryPathOptions): AsyncGenerator<Qu
   // begin the query with the starting peers
   await Promise.all(
     startingPeers.map(async startingPeer => {
-      queryPeer({ id: startingPeer, multiaddrs: [] }, await convertPeerId(startingPeer))
+      queryPeer({ id: startingPeer, multiaddrs: [] }, await convertPeerId(startingPeer, {
+        signal
+      }))
     })
   )
 

--- a/packages/kad-dht/src/record/validators.ts
+++ b/packages/kad-dht/src/record/validators.ts
@@ -4,13 +4,14 @@ import { equals as uint8ArrayEquals } from 'uint8arrays/equals'
 import { toString as uint8ArrayToString } from 'uint8arrays/to-string'
 import type { Validators } from '../index.js'
 import type { Libp2pRecord } from '@libp2p/record'
+import type { AbortOptions } from 'it-pushable'
 
 /**
  * Checks a record and ensures it is still valid.
  * It runs the needed validators.
  * If verification fails the returned Promise will reject with the error.
  */
-export async function verifyRecord (validators: Validators, record: Libp2pRecord): Promise<void> {
+export async function verifyRecord (validators: Validators, record: Libp2pRecord, options?: AbortOptions): Promise<void> {
   const key = record.key
   const keyString = uint8ArrayToString(key)
   const parts = keyString.split('/')
@@ -26,7 +27,7 @@ export async function verifyRecord (validators: Validators, record: Libp2pRecord
     throw new InvalidParametersError(`No validator available for key type "${parts[1]}"`)
   }
 
-  await validator(key, record.value)
+  await validator(key, record.value, options)
 }
 
 /**
@@ -38,7 +39,7 @@ export async function verifyRecord (validators: Validators, record: Libp2pRecord
  * @param {Uint8Array} key - A valid key is of the form `'/pk/<keymultihash>'`
  * @param {Uint8Array} publicKey - The public key to validate against (protobuf encoded).
  */
-const validatePublicKeyRecord = async (key: Uint8Array, publicKey: Uint8Array): Promise<void> => {
+const validatePublicKeyRecord = async (key: Uint8Array, publicKey: Uint8Array, options?: AbortOptions): Promise<void> => {
   if (!(key instanceof Uint8Array)) {
     throw new InvalidParametersError('"key" must be a Uint8Array')
   }

--- a/packages/kad-dht/src/routing-table/k-bucket.ts
+++ b/packages/kad-dht/src/routing-table/k-bucket.ts
@@ -170,7 +170,7 @@ export class KBucket {
     }
   }
 
-  stop () {
+  stop (): void {
     this.addingPeerMap.clear()
   }
 

--- a/packages/kad-dht/src/routing-table/k-bucket.ts
+++ b/packages/kad-dht/src/routing-table/k-bucket.ts
@@ -1,4 +1,4 @@
-import { PeerMap } from '@libp2p/peer-collections'
+import { PeerMap, trackedPeerMap } from '@libp2p/peer-collections'
 import map from 'it-map'
 import { equals as uint8ArrayEquals } from 'uint8arrays/equals'
 import { toString as uint8ArrayToString } from 'uint8arrays/to-string'
@@ -6,7 +6,7 @@ import { xor as uint8ArrayXor } from 'uint8arrays/xor'
 import { PeerDistanceList } from '../peer-distance-list.js'
 import { convertPeerId } from '../utils.js'
 import { KBUCKET_SIZE, LAST_PING_THRESHOLD, PING_OLD_CONTACT_COUNT, PREFIX_LENGTH } from './index.js'
-import type { PeerId, AbortOptions } from '@libp2p/interface'
+import type { PeerId, AbortOptions, Metrics } from '@libp2p/interface'
 
 export interface PingFunction {
   /**
@@ -28,21 +28,25 @@ export interface OnAddCallback {
   /**
    * Invoked when a new peer is added to the routing tables
    */
-  (peer: Peer, bucket: LeafBucket): Promise<void>
+  (peer: Peer, bucket: LeafBucket, options?: AbortOptions): Promise<void>
 }
 
 export interface OnRemoveCallback {
   /**
    * Invoked when a peer is evicted from the routing tables
    */
-  (peer: Peer, bucket: LeafBucket): Promise<void>
+  (peer: Peer, bucket: LeafBucket, options?: AbortOptions): Promise<void>
 }
 
 export interface OnMoveCallback {
   /**
    * Invoked when a peer is moved between buckets in the routing tables
    */
-  (peer: Peer, oldBucket: LeafBucket, newBucket: LeafBucket): Promise<void>
+  (peer: Peer, oldBucket: LeafBucket, newBucket: LeafBucket, options?: AbortOptions): Promise<void>
+}
+
+export interface KBucketComponents {
+  metrics?: Metrics
 }
 
 export interface KBucketOptions {
@@ -97,6 +101,7 @@ export interface KBucketOptions {
   verify: VerifyFunction
   onAdd?: OnAddCallback
   onRemove?: OnRemoveCallback
+  metricsPrefix?: string
 }
 
 export interface Peer {
@@ -143,7 +148,7 @@ export class KBucket {
   private readonly onMove?: OnMoveCallback
   private readonly addingPeerMap: PeerMap<Promise<void>>
 
-  constructor (options: KBucketOptions) {
+  constructor (components: KBucketComponents, options: KBucketOptions) {
     this.prefixLength = options.prefixLength ?? PREFIX_LENGTH
     this.kBucketSize = options.kBucketSize ?? KBUCKET_SIZE
     this.splitThreshold = options.splitThreshold ?? this.kBucketSize
@@ -153,7 +158,10 @@ export class KBucket {
     this.verify = options.verify
     this.onAdd = options.onAdd
     this.onRemove = options.onRemove
-    this.addingPeerMap = new PeerMap()
+    this.addingPeerMap = trackedPeerMap({
+      name: `${options.metricsPrefix}_adding_peer_map`,
+      metrics: components.metrics
+    })
 
     this.root = {
       prefix: '',
@@ -162,10 +170,14 @@ export class KBucket {
     }
   }
 
-  async addSelfPeer (peerId: PeerId): Promise<void> {
+  stop () {
+    this.addingPeerMap.clear()
+  }
+
+  async addSelfPeer (peerId: PeerId, options?: AbortOptions): Promise<void> {
     this.localPeer = {
       peerId,
-      kadId: await convertPeerId(peerId),
+      kadId: await convertPeerId(peerId, options),
       lastPing: Date.now()
     }
   }
@@ -176,7 +188,7 @@ export class KBucket {
   async add (peerId: PeerId, options?: AbortOptions): Promise<void> {
     const peer = {
       peerId,
-      kadId: await convertPeerId(peerId),
+      kadId: await convertPeerId(peerId, options),
       lastPing: 0
     }
 
@@ -206,7 +218,7 @@ export class KBucket {
     // are there too many peers in the bucket and can we make the trie deeper?
     if (bucket.peers.length === this.splitThreshold && bucket.depth < this.prefixLength) {
       // split the bucket
-      await this._split(bucket)
+      await this._split(bucket, options)
 
       // try again
       await this._add(peer, options)
@@ -219,7 +231,7 @@ export class KBucket {
       // we've ping this peer previously, just add them to the bucket
       if (!needsPing(peer, this.lastPingThreshold)) {
         bucket.peers.push(peer)
-        await this.onAdd?.(peer, bucket)
+        await this.onAdd?.(peer, bucket, options)
         return
       }
 
@@ -274,7 +286,7 @@ export class KBucket {
 
     for await (const toEvict of this.ping(toPing, options)) {
       evicted = true
-      await this.remove(toEvict.kadId)
+      await this.remove(toEvict.kadId, options)
     }
 
     // did not evict any peers, cannot add new contact
@@ -351,14 +363,14 @@ export class KBucket {
    *
    * @param {Uint8Array} kadId - The ID of the contact to remove
    */
-  async remove (kadId: Uint8Array): Promise<void> {
+  async remove (kadId: Uint8Array, options?: AbortOptions): Promise<void> {
     const bucket = this._determineBucket(kadId)
     const index = this._indexOf(bucket, kadId)
 
     if (index > -1) {
       const peer = bucket.peers.splice(index, 1)[0]
 
-      await this.onRemove?.(peer, bucket)
+      await this.onRemove?.(peer, bucket, options)
     }
   }
 
@@ -439,7 +451,7 @@ export class KBucket {
    *
    * @param {any} bucket - bucket for splitting
    */
-  private async _split (bucket: LeafBucket): Promise<void> {
+  private async _split (bucket: LeafBucket, options?: AbortOptions): Promise<void> {
     // create child buckets
     const left: LeafBucket = {
       prefix: '0',
@@ -458,10 +470,10 @@ export class KBucket {
 
       if (bitString[bucket.depth] === '0') {
         left.peers.push(peer)
-        await this.onMove?.(peer, bucket, left)
+        await this.onMove?.(peer, bucket, left, options)
       } else {
         right.peers.push(peer)
-        await this.onMove?.(peer, bucket, right)
+        await this.onMove?.(peer, bucket, right, options)
       }
     }
 

--- a/packages/kad-dht/src/routing-table/refresh.ts
+++ b/packages/kad-dht/src/routing-table/refresh.ts
@@ -1,6 +1,7 @@
 import { randomBytes } from '@libp2p/crypto'
 import { setMaxListeners } from '@libp2p/interface'
 import { peerIdFromMultihash } from '@libp2p/peer-id'
+import { anySignal } from 'any-signal'
 import length from 'it-length'
 import * as Digest from 'multiformats/hashes/digest'
 import { sha256 } from 'multiformats/hashes/sha2'
@@ -10,7 +11,6 @@ import GENERATED_PREFIXES from './generated-prefix-list.js'
 import type { RoutingTable } from './index.js'
 import type { PeerRouting } from '../peer-routing/index.js'
 import type { AbortOptions, ComponentLogger, Logger, PeerId } from '@libp2p/interface'
-import { anySignal } from 'any-signal'
 
 /**
  * Cannot generate random KadIds longer than this + 1

--- a/packages/kad-dht/src/utils.ts
+++ b/packages/kad-dht/src/utils.ts
@@ -11,7 +11,7 @@ import { concat as uint8ArrayConcat } from 'uint8arrays/concat'
 import { fromString as uint8ArrayFromString } from 'uint8arrays/from-string'
 import { toString as uint8ArrayToString } from 'uint8arrays/to-string'
 import type { Operation, OperationMetrics } from './kad-dht.js'
-import type { PeerId, PeerInfo } from '@libp2p/interface'
+import type { AbortOptions, PeerId, PeerInfo } from '@libp2p/interface'
 import type { Multiaddr } from '@multiformats/multiaddr'
 
 // const IPNS_PREFIX = uint8ArrayFromString('/ipns/')
@@ -90,8 +90,9 @@ export function passthroughMapper (info: PeerInfo): PeerInfo {
 /**
  * Creates a DHT ID by hashing a given Uint8Array
  */
-export async function convertBuffer (buf: Uint8Array): Promise<Uint8Array> {
+export async function convertBuffer (buf: Uint8Array, options?: AbortOptions): Promise<Uint8Array> {
   const multihash = await sha256.digest(buf)
+  options?.signal?.throwIfAborted()
 
   return multihash.digest
 }
@@ -99,8 +100,8 @@ export async function convertBuffer (buf: Uint8Array): Promise<Uint8Array> {
 /**
  * Creates a DHT ID by hashing a Peer ID
  */
-export async function convertPeerId (peerId: PeerId): Promise<Uint8Array> {
-  return convertBuffer(peerId.toMultihash().bytes)
+export async function convertPeerId (peerId: PeerId, options?: AbortOptions): Promise<Uint8Array> {
+  return convertBuffer(peerId.toMultihash().bytes, options)
 }
 
 /**

--- a/packages/kad-dht/test/generate-peers/generate-peers.node.ts
+++ b/packages/kad-dht/test/generate-peers/generate-peers.node.ts
@@ -105,7 +105,7 @@ describe.skip('generate peers', function () {
       const localKadId = await convertPeerId(peerId)
 
       const goOutput = await fromGo(targetCpl, randPrefix, uintArrayToString(localKadId, 'base64pad'))
-      const jsOutput = await refresh._makePeerId(localKadId, randPrefix, targetCpl)
+      const jsOutput = refresh._makePeerId(localKadId, randPrefix, targetCpl)
 
       expect(goOutput).to.deep.equal(jsOutput)
     })

--- a/packages/kad-dht/test/query.spec.ts
+++ b/packages/kad-dht/test/query.spec.ts
@@ -402,7 +402,7 @@ describe('QueryManager', () => {
 
     // the should have been aborted
     await expect(queryPromise).to.eventually.be.rejected()
-      .with.property('name', 'QueryAbortedError')
+      .with.property('name', 'AbortError')
 
     expect(aborted).to.be.true()
 

--- a/packages/libp2p/src/content-routing.ts
+++ b/packages/libp2p/src/content-routing.ts
@@ -118,7 +118,7 @@ export class CompoundContentRouting implements ContentRouting, Startable {
       if (peer.multiaddrs.length > 0) {
         await this.components.peerStore.merge(peer.id, {
           multiaddrs: peer.multiaddrs
-        })
+        }, options)
       }
 
       // deduplicate peers

--- a/packages/libp2p/src/libp2p.ts
+++ b/packages/libp2p/src/libp2p.ts
@@ -340,7 +340,7 @@ export class Libp2p<T extends ServiceMap = ServiceMap> extends TypedEventEmitter
     }
 
     try {
-      const peerInfo = await this.peerStore.get(peer)
+      const peerInfo = await this.peerStore.get(peer, options)
 
       if (peerInfo.id.publicKey != null) {
         return peerInfo.id.publicKey
@@ -364,7 +364,7 @@ export class Libp2p<T extends ServiceMap = ServiceMap> extends TypedEventEmitter
 
     await this.peerStore.patch(peer, {
       publicKey
-    })
+    }, options)
 
     return publicKey
   }
@@ -381,20 +381,20 @@ export class Libp2p<T extends ServiceMap = ServiceMap> extends TypedEventEmitter
     )
   }
 
-  async unhandle (protocols: string[] | string): Promise<void> {
+  async unhandle (protocols: string[] | string, options?: AbortOptions): Promise<void> {
     if (!Array.isArray(protocols)) {
       protocols = [protocols]
     }
 
     await Promise.all(
       protocols.map(async protocol => {
-        await this.components.registrar.unhandle(protocol)
+        await this.components.registrar.unhandle(protocol, options)
       })
     )
   }
 
-  async register (protocol: string, topology: Topology): Promise<string> {
-    return this.components.registrar.register(protocol, topology)
+  async register (protocol: string, topology: Topology, options?: AbortOptions): Promise<string> {
+    return this.components.registrar.register(protocol, topology, options)
   }
 
   unregister (id: string): void {

--- a/packages/libp2p/src/peer-routing.ts
+++ b/packages/libp2p/src/peer-routing.ts
@@ -92,7 +92,7 @@ export class DefaultPeerRouting implements PeerRouting {
       if (peer.multiaddrs.length > 0) {
         await this.peerStore.merge(peer.id, {
           multiaddrs: peer.multiaddrs
-        })
+        }, options)
       }
 
       return peer
@@ -148,7 +148,7 @@ export class DefaultPeerRouting implements PeerRouting {
       if (peer.multiaddrs.length > 0) {
         await this.peerStore.merge(peer.id, {
           multiaddrs: peer.multiaddrs
-        })
+        }, options)
       }
 
       // deduplicate peers

--- a/packages/libp2p/src/upgrader.ts
+++ b/packages/libp2p/src/upgrader.ts
@@ -3,13 +3,13 @@ import * as mss from '@libp2p/multistream-select'
 import { peerIdFromString } from '@libp2p/peer-id'
 import { anySignal } from 'any-signal'
 import { CustomProgressEvent } from 'progress-events'
+import { raceSignal } from 'race-signal'
 import { createConnection } from './connection/index.js'
 import { PROTOCOL_NEGOTIATION_TIMEOUT, INBOUND_UPGRADE_TIMEOUT } from './connection-manager/constants.js'
 import { ConnectionDeniedError, ConnectionInterceptedError, EncryptionFailedError, MuxerUnavailableError } from './errors.js'
 import { DEFAULT_MAX_INBOUND_STREAMS, DEFAULT_MAX_OUTBOUND_STREAMS } from './registrar.js'
 import type { Libp2pEvents, AbortOptions, ComponentLogger, MultiaddrConnection, Connection, Stream, ConnectionProtector, NewStreamOptions, ConnectionEncrypter, SecuredConnection, ConnectionGater, TypedEventTarget, Metrics, PeerId, PeerStore, StreamMuxer, StreamMuxerFactory, Upgrader as UpgraderInterface, UpgraderOptions, ConnectionLimits, SecureConnectionOptions, CounterGroup, ClearableSignal } from '@libp2p/interface'
 import type { ConnectionManager, Registrar } from '@libp2p/interface-internal'
-import { raceSignal } from 'race-signal'
 
 interface CreateConnectionOptions {
   cryptoProtocol: string

--- a/packages/peer-record/src/envelope/index.ts
+++ b/packages/peer-record/src/envelope/index.ts
@@ -19,7 +19,7 @@ export class RecordEnvelope implements Envelope {
   /**
    * Unmarshal a serialized Envelope protobuf message
    */
-  static createFromProtobuf = (data: Uint8Array | Uint8ArrayList) => {
+  static createFromProtobuf = (data: Uint8Array | Uint8ArrayList): RecordEnvelope => {
     const envelopeData = Protobuf.decode(data)
     const publicKey = publicKeyFromProtobuf(envelopeData.publicKey)
 

--- a/packages/peer-record/src/envelope/index.ts
+++ b/packages/peer-record/src/envelope/index.ts
@@ -6,6 +6,7 @@ import { fromString as uint8arraysFromString } from 'uint8arrays/from-string'
 import { Envelope as Protobuf } from './envelope.js'
 import { InvalidSignatureError } from './errors.js'
 import type { Record, Envelope, PrivateKey, PublicKey } from '@libp2p/interface'
+import type { AbortOptions } from '@multiformats/multiaddr'
 
 export interface RecordEnvelopeInit {
   publicKey: PublicKey
@@ -18,7 +19,7 @@ export class RecordEnvelope implements Envelope {
   /**
    * Unmarshal a serialized Envelope protobuf message
    */
-  static createFromProtobuf = async (data: Uint8Array | Uint8ArrayList): Promise<RecordEnvelope> => {
+  static createFromProtobuf = (data: Uint8Array | Uint8ArrayList) => {
     const envelopeData = Protobuf.decode(data)
     const publicKey = publicKeyFromProtobuf(envelopeData.publicKey)
 
@@ -34,7 +35,7 @@ export class RecordEnvelope implements Envelope {
    * Seal marshals the given Record, places the marshaled bytes inside an Envelope
    * and signs it with the given peerId's private key
    */
-  static seal = async (record: Record, privateKey: PrivateKey): Promise<RecordEnvelope> => {
+  static seal = async (record: Record, privateKey: PrivateKey, options?: AbortOptions): Promise<RecordEnvelope> => {
     if (privateKey == null) {
       throw new Error('Missing private key')
     }
@@ -43,7 +44,7 @@ export class RecordEnvelope implements Envelope {
     const payloadType = record.codec
     const payload = record.marshal()
     const signData = formatSignaturePayload(domain, payloadType, payload)
-    const signature = await privateKey.sign(signData.subarray())
+    const signature = await privateKey.sign(signData.subarray(), options)
 
     return new RecordEnvelope({
       publicKey: privateKey.publicKey,
@@ -57,9 +58,9 @@ export class RecordEnvelope implements Envelope {
    * Open and certify a given marshaled envelope.
    * Data is unmarshaled and the signature validated for the given domain.
    */
-  static openAndCertify = async (data: Uint8Array | Uint8ArrayList, domain: string): Promise<RecordEnvelope> => {
-    const envelope = await RecordEnvelope.createFromProtobuf(data)
-    const valid = await envelope.validate(domain)
+  static openAndCertify = async (data: Uint8Array | Uint8ArrayList, domain: string, options?: AbortOptions): Promise<RecordEnvelope> => {
+    const envelope = RecordEnvelope.createFromProtobuf(data)
+    const valid = await envelope.validate(domain, options)
 
     if (!valid) {
       throw new InvalidSignatureError('Envelope signature is not valid for the given domain')
@@ -117,10 +118,10 @@ export class RecordEnvelope implements Envelope {
   /**
    * Validate envelope data signature for the given domain
    */
-  async validate (domain: string): Promise<boolean> {
+  async validate (domain: string, options?: AbortOptions): Promise<boolean> {
     const signData = formatSignaturePayload(domain, this.payloadType, this.payload)
 
-    return this.publicKey.verify(signData.subarray(), this.signature)
+    return this.publicKey.verify(signData.subarray(), this.signature, options)
   }
 }
 

--- a/packages/peer-store/src/index.ts
+++ b/packages/peer-store/src/index.ts
@@ -4,12 +4,13 @@
  * The peer store is where libp2p stores data about the peers it has encountered on the network.
  */
 
+import { isPeerId } from '@libp2p/interface'
 import { peerIdFromCID } from '@libp2p/peer-id'
 import { RecordEnvelope, PeerRecord } from '@libp2p/peer-record'
 import all from 'it-all'
 import { PersistentStore } from './store.js'
 import type { PeerUpdate } from './store.js'
-import { type ComponentLogger, type Libp2pEvents, type Logger, type TypedEventTarget, type PeerId, type PeerStore, type Peer, type PeerData, type PeerQuery, type PeerInfo, type AbortOptions, type ConsumePeerRecordOptions, isPeerId } from '@libp2p/interface'
+import type { ComponentLogger, Libp2pEvents, Logger, TypedEventTarget, PeerId, PeerStore, Peer, PeerData, PeerQuery, PeerInfo, AbortOptions, ConsumePeerRecordOptions } from '@libp2p/interface'
 import type { Multiaddr } from '@multiformats/multiaddr'
 import type { Datastore } from 'interface-datastore'
 

--- a/packages/peer-store/src/store.ts
+++ b/packages/peer-store/src/store.ts
@@ -11,9 +11,9 @@ import { NAMESPACE_COMMON, peerIdToDatastoreKey } from './utils/peer-id-to-datas
 import { toPeerPB } from './utils/to-peer-pb.js'
 import type { AddressFilter, PersistentPeerStoreComponents, PersistentPeerStoreInit } from './index.js'
 import type { PeerUpdate as PeerUpdateExternal, PeerId, Peer, PeerData, PeerQuery, Logger } from '@libp2p/interface'
+import type { AbortOptions } from '@multiformats/multiaddr'
 import type { Datastore, Key, Query } from 'interface-datastore'
 import type { Mortice } from 'mortice'
-import type { AbortOptions } from '@multiformats/multiaddr'
 
 /**
  * Event detail emitted when peer data changes

--- a/packages/peer-store/src/store.ts
+++ b/packages/peer-store/src/store.ts
@@ -13,6 +13,7 @@ import type { AddressFilter, PersistentPeerStoreComponents, PersistentPeerStoreI
 import type { PeerUpdate as PeerUpdateExternal, PeerId, Peer, PeerData, PeerQuery, Logger } from '@libp2p/interface'
 import type { Datastore, Key, Query } from 'interface-datastore'
 import type { Mortice } from 'mortice'
+import type { AbortOptions } from '@multiformats/multiaddr'
 
 /**
  * Event detail emitted when peer data changes
@@ -74,9 +75,9 @@ export class PersistentStore {
     this.maxPeerAge = init.maxPeerAge ?? MAX_PEER_AGE
   }
 
-  async has (peerId: PeerId): Promise<boolean> {
+  async has (peerId: PeerId, options?: AbortOptions): Promise<boolean> {
     try {
-      await this.load(peerId)
+      await this.load(peerId, options)
 
       return true
     } catch (err: any) {
@@ -88,41 +89,43 @@ export class PersistentStore {
     return false
   }
 
-  async delete (peerId: PeerId): Promise<void> {
+  async delete (peerId: PeerId, options?: AbortOptions): Promise<void> {
     if (this.peerId.equals(peerId)) {
       return
     }
 
-    await this.datastore.delete(peerIdToDatastoreKey(peerId))
+    await this.datastore.delete(peerIdToDatastoreKey(peerId), options)
   }
 
-  async load (peerId: PeerId): Promise<Peer> {
+  async load (peerId: PeerId, options?: AbortOptions): Promise<Peer> {
     const key = peerIdToDatastoreKey(peerId)
-    const buf = await this.datastore.get(key)
+    const buf = await this.datastore.get(key, options)
     const peer = PeerPB.decode(buf)
 
     if (this.#peerIsExpired(peerId, peer)) {
-      await this.datastore.delete(key)
+      await this.datastore.delete(key, options)
       throw new NotFoundError()
     }
 
     return pbToPeer(peerId, peer, this.peerId.equals(peerId) ? Infinity : this.maxAddressAge)
   }
 
-  async save (peerId: PeerId, data: PeerData): Promise<PeerUpdate> {
-    const existingPeer = await this.#findExistingPeer(peerId)
+  async save (peerId: PeerId, data: PeerData, options?: AbortOptions): Promise<PeerUpdate> {
+    const existingPeer = await this.#findExistingPeer(peerId, options)
 
     const peerPb: PeerPB = await toPeerPB(peerId, data, 'patch', {
+      ...options,
       addressFilter: this.addressFilter
     })
 
     return this.#saveIfDifferent(peerId, peerPb, existingPeer)
   }
 
-  async patch (peerId: PeerId, data: Partial<PeerData>): Promise<PeerUpdate> {
-    const existingPeer = await this.#findExistingPeer(peerId)
+  async patch (peerId: PeerId, data: Partial<PeerData>, options?: AbortOptions): Promise<PeerUpdate> {
+    const existingPeer = await this.#findExistingPeer(peerId, options)
 
     const peerPb: PeerPB = await toPeerPB(peerId, data, 'patch', {
+      ...options,
       addressFilter: this.addressFilter,
       existingPeer
     })
@@ -130,8 +133,8 @@ export class PersistentStore {
     return this.#saveIfDifferent(peerId, peerPb, existingPeer)
   }
 
-  async merge (peerId: PeerId, data: PeerData): Promise<PeerUpdate> {
-    const existingPeer = await this.#findExistingPeer(peerId)
+  async merge (peerId: PeerId, data: PeerData, options?: AbortOptions): Promise<PeerUpdate> {
+    const existingPeer = await this.#findExistingPeer(peerId, options)
 
     const peerPb: PeerPB = await toPeerPB(peerId, data, 'merge', {
       addressFilter: this.addressFilter,
@@ -141,8 +144,8 @@ export class PersistentStore {
     return this.#saveIfDifferent(peerId, peerPb, existingPeer)
   }
 
-  async * all (query?: PeerQuery): AsyncGenerator<Peer, void, unknown> {
-    for await (const { key, value } of this.datastore.query(mapQuery(query ?? {}, this.maxAddressAge))) {
+  async * all (options?: PeerQuery): AsyncGenerator<Peer, void, unknown> {
+    for await (const { key, value } of this.datastore.query(mapQuery(options ?? {}, this.maxAddressAge), options)) {
       const peerId = keyToPeerId(key)
 
       // skip self peer if present
@@ -154,7 +157,7 @@ export class PersistentStore {
 
       // remove expired peer
       if (this.#peerIsExpired(peerId, peer)) {
-        await this.datastore.delete(key)
+        await this.datastore.delete(key, options)
         continue
       }
 
@@ -162,15 +165,15 @@ export class PersistentStore {
     }
   }
 
-  async #findExistingPeer (peerId: PeerId): Promise<ExistingPeer | undefined> {
+  async #findExistingPeer (peerId: PeerId, options?: AbortOptions): Promise<ExistingPeer | undefined> {
     try {
       const key = peerIdToDatastoreKey(peerId)
-      const buf = await this.datastore.get(key)
+      const buf = await this.datastore.get(key, options)
       const peerPB = PeerPB.decode(buf)
 
       // remove expired peer
       if (this.#peerIsExpired(peerId, peerPB)) {
-        await this.datastore.delete(key)
+        await this.datastore.delete(key, options)
         throw new NotFoundError()
       }
 
@@ -185,12 +188,12 @@ export class PersistentStore {
     }
   }
 
-  async #saveIfDifferent (peerId: PeerId, peer: PeerPB, existingPeer?: ExistingPeer): Promise<PeerUpdate> {
+  async #saveIfDifferent (peerId: PeerId, peer: PeerPB, existingPeer?: ExistingPeer, options?: AbortOptions): Promise<PeerUpdate> {
     // record last update
     peer.updated = Date.now()
     const buf = PeerPB.encode(peer)
 
-    await this.datastore.put(peerIdToDatastoreKey(peerId), buf)
+    await this.datastore.put(peerIdToDatastoreKey(peerId), buf, options)
 
     return {
       peer: bytesToPeer(peerId, buf, this.maxAddressAge),

--- a/packages/peer-store/src/utils/dedupe-addresses.ts
+++ b/packages/peer-store/src/utils/dedupe-addresses.ts
@@ -1,10 +1,10 @@
 import { InvalidParametersError } from '@libp2p/interface'
-import { isMultiaddr, multiaddr } from '@multiformats/multiaddr'
+import { isMultiaddr, multiaddr, type AbortOptions } from '@multiformats/multiaddr'
 import type { AddressFilter } from '../index.js'
 import type { Address as AddressPB } from '../pb/peer.js'
 import type { PeerId, Address } from '@libp2p/interface'
 
-export async function dedupeFilterAndSortAddresses (peerId: PeerId, filter: AddressFilter, addresses: Array<Address | AddressPB | undefined>, existingAddresses?: AddressPB[]): Promise<AddressPB[]> {
+export async function dedupeFilterAndSortAddresses (peerId: PeerId, filter: AddressFilter, addresses: Array<Address | AddressPB | undefined>, existingAddresses?: AddressPB[], options?: AbortOptions): Promise<AddressPB[]> {
   const addressMap = new Map<string, Address>()
 
   for (const addr of addresses) {
@@ -20,7 +20,7 @@ export async function dedupeFilterAndSortAddresses (peerId: PeerId, filter: Addr
       throw new InvalidParametersError('Multiaddr was invalid')
     }
 
-    if (!(await filter(peerId, addr.multiaddr))) {
+    if (!(await filter(peerId, addr.multiaddr, options))) {
       continue
     }
 

--- a/packages/peer-store/src/utils/dedupe-addresses.ts
+++ b/packages/peer-store/src/utils/dedupe-addresses.ts
@@ -1,8 +1,9 @@
 import { InvalidParametersError } from '@libp2p/interface'
-import { isMultiaddr, multiaddr, type AbortOptions } from '@multiformats/multiaddr'
+import { isMultiaddr, multiaddr } from '@multiformats/multiaddr'
 import type { AddressFilter } from '../index.js'
 import type { Address as AddressPB } from '../pb/peer.js'
 import type { PeerId, Address } from '@libp2p/interface'
+import type { AbortOptions } from '@multiformats/multiaddr'
 
 export async function dedupeFilterAndSortAddresses (peerId: PeerId, filter: AddressFilter, addresses: Array<Address | AddressPB | undefined>, existingAddresses?: AddressPB[], options?: AbortOptions): Promise<AddressPB[]> {
   const addressMap = new Map<string, Address>()

--- a/packages/peer-store/src/utils/to-peer-pb.ts
+++ b/packages/peer-store/src/utils/to-peer-pb.ts
@@ -7,8 +7,9 @@ import type { AddressFilter } from '../index.js'
 import type { Tag, Peer as PeerPB } from '../pb/peer.js'
 import type { ExistingPeer } from '../store.js'
 import type { PeerId, Address, PeerData, TagOptions } from '@libp2p/interface'
+import type { AbortOptions } from '@multiformats/multiaddr'
 
-export interface ToPBPeerOptions {
+export interface ToPBPeerOptions extends AbortOptions {
   addressFilter?: AddressFilter
   existingPeer?: ExistingPeer
 }
@@ -148,7 +149,8 @@ export async function toPeerPB (peerId: PeerId, data: Partial<PeerData>, strateg
       peerId,
       options.addressFilter ?? (async () => true),
       addresses,
-      options.existingPeer?.peerPB.addresses
+      options.existingPeer?.peerPB.addresses,
+      options
     ),
     protocols: [...protocols.values()].sort((a, b) => {
       return a.localeCompare(b)

--- a/packages/peer-store/test/index.spec.ts
+++ b/packages/peer-store/test/index.spec.ts
@@ -266,7 +266,9 @@ describe('PersistentPeerStore', () => {
       }), key)
 
       await expect(peerStore.has(peerId)).to.eventually.be.false()
-      await expect(peerStore.consumePeerRecord(signedPeerRecord.marshal(), otherPeerId)).to.eventually.equal(false)
+      await expect(peerStore.consumePeerRecord(signedPeerRecord.marshal(), {
+        expectedPeer: otherPeerId
+      })).to.eventually.equal(false)
       await expect(peerStore.has(peerId)).to.eventually.be.false()
     })
 

--- a/packages/protocol-identify/src/utils.ts
+++ b/packages/protocol-identify/src/utils.ts
@@ -113,7 +113,7 @@ export async function consumeIdentifyMessage (peerStore: PeerStore, events: Type
 
       // if we have previously received a signed record for this peer, compare it to the incoming one
       if (existingPeer.peerRecordEnvelope != null) {
-        const storedEnvelope = await RecordEnvelope.createFromProtobuf(existingPeer.peerRecordEnvelope)
+        const storedEnvelope = RecordEnvelope.createFromProtobuf(existingPeer.peerRecordEnvelope)
         const storedRecord = PeerRecord.createFromProtobuf(storedEnvelope.payload)
 
         // ensure seq is greater than, or equal to, the last received


### PR DESCRIPTION
Some async operations do not accept an abort signal. This means calling code can fail to abort a long-running operation if the abort signal fires it's "abort" event while execution is suspended.

For example in the following code the signal can fire while the directory is being created and this code would be none the wiser:

```js
import fs from 'node:fs/promises'

async function doSomthing (signal) {
  await fs.mkdir()
}
```

Instead we need to check if the signal is aborted before starting the async operation (to prevent doing needless work), and after, in case it aborted while the onward call was happening.

```js
import fs from 'node:fs/promises'

async function doSomthing (signal) {
  signal.throwIfAborted()
  await fs.mkdir()
  signal.throwIfAborted()
}
```

This still waits for the operation to complete before checking the signal to see if it has been aborted.  Instead we can use `raceSignal` to throw immediately, though the operation will continue in the background.

```js
import fs from 'node:fs/promises'
import { raceSignal } from 'race-signal'

async function doSomthing (signal) {
  signal.throwIfAborted()
  await raceSignal(fs.mkdir(), signal)
}
```

Synchronous operations have a similar problem when they are able to return optional promises, since the result may be awaited on.  In this case we still need to check if the signal was aborted, though we only need to do it once.

```ts
interface MyOp<T> {
  (signal: AbortSignal): Promise<T> | T
}

const fn: MyOp = (signal) => {
  signal.throwIfAborted()
  return 'hello'
}

// awaiting this shifts the continuation into the microtask queue
await fn(AbortSignal.timeout(1_000))

// could use optional await but `fn` cannot tell if it's being awaited on or not
// so it always has to check the signal
const p = fn(AbortSignal.timeout(1_000))

if (p.then) {
  await p
}
```

This PR applies the above patterns to `@libp2p/crypto` keys, `@libp2p/peer-store` operations and `@libp2p/kad-dht` to ensure the `.provide` and `.findProviders` operations can be successfully aborted.
