### PR TITLE
fix: do not re-register metrics

### DIFF
--- a/packages/transport-tcp/src/index.ts
+++ b/packages/transport-tcp/src/index.ts
@@ -28,11 +28,25 @@
  */
 
 import { TCP } from './tcp.js'
-import type { CloseServerOnMaxConnectionsOpts } from './listener.js'
 import type { ComponentLogger, CounterGroup, Metrics, CreateListenerOptions, DialTransportOptions, Transport, OutboundConnectionUpgradeEvents } from '@libp2p/interface'
 import type { ProgressEvent } from 'progress-events'
 
-export type { CloseServerOnMaxConnectionsOpts }
+export interface CloseServerOnMaxConnectionsOpts {
+  /**
+   * Server listens once connection count is less than `listenBelow`
+   */
+  listenBelow: number
+
+  /**
+   * Close server once connection count is greater than or equal to `closeAbove`
+   */
+  closeAbove: number
+
+  /**
+   * Invoked when there was an error listening on a socket
+   */
+  onListenError?(err: Error): void
+}
 
 export interface TCPOptions {
   /**

--- a/packages/transport-tcp/src/listener.ts
+++ b/packages/transport-tcp/src/listener.ts
@@ -38,7 +38,7 @@ interface Context extends TCPCreateListenerOptions {
   logger: ComponentLogger
 }
 
-export interface TCPListenerMetrics {
+interface TCPListenerMetrics {
   status?: MetricGroup
   errors?: CounterGroup
   events?: CounterGroup

--- a/packages/transport-tcp/src/listener.ts
+++ b/packages/transport-tcp/src/listener.ts
@@ -5,27 +5,10 @@ import { multiaddr } from '@multiformats/multiaddr'
 import { pEvent } from 'p-event'
 import { toMultiaddrConnection } from './socket-to-conn.js'
 import { multiaddrToNetConfig } from './utils.js'
-import type { TCPCreateListenerOptions } from './index.js'
+import type { CloseServerOnMaxConnectionsOpts, TCPCreateListenerOptions } from './index.js'
 import type { NetConfig } from './utils.js'
 import type { ComponentLogger, Logger, MultiaddrConnection, CounterGroup, MetricGroup, Metrics, Listener, ListenerEvents, Upgrader } from '@libp2p/interface'
 import type { Multiaddr } from '@multiformats/multiaddr'
-
-export interface CloseServerOnMaxConnectionsOpts {
-  /**
-   * Server listens once connection count is less than `listenBelow`
-   */
-  listenBelow: number
-
-  /**
-   * Close server once connection count is greater than or equal to `closeAbove`
-   */
-  closeAbove: number
-
-  /**
-   * Invoked when there was an error listening on a socket
-   */
-  onListenError?(err: Error): void
-}
 
 interface Context extends TCPCreateListenerOptions {
   upgrader: Upgrader


### PR DESCRIPTION
If the server is paused and resumed, the `listening` event handler is invoked again.

Move metric registration out of the handler so it is not repeated.

## Change checklist

- [x] I have performed a self-review of my own code
- [ ] I have made corresponding changes to the documentation if necessary (this includes comments as well)
- [ ] I have added tests that prove my fix is effective or that my feature works