### PR TITLE
chore: fix firefox tests

### DIFF
--- a/packages/interface-compliance-tests/src/transport/index.ts
+++ b/packages/interface-compliance-tests/src/transport/index.ts
@@ -241,7 +241,7 @@ export default (common: TestSetup<TransportTestFixtures>): void => {
     })
 
     it('should handle many small writes', async function () {
-      const timeout = 120_000
+      const timeout = 360_000
       this.timeout(timeout);
       ({ dialer, listener, dialAddrs } = await getSetup(common))
 


### PR DESCRIPTION
Not sure why FF is timing out on the circuit relay tests

## Change checklist

- [ ] I have performed a self-review of my own code
- [ ] I have made corresponding changes to the documentation if necessary (this includes comments as well)
- [ ] I have added tests that prove my fix is effective or that my feature works