### PR TITLE
fix: add kad-dht to capabilities

### DIFF
--- a/packages/kad-dht/src/kad-dht.ts
+++ b/packages/kad-dht/src/kad-dht.ts
@@ -366,7 +366,8 @@ export class KadDHT extends TypedEventEmitter<PeerDiscoveryEvents> implements Ka
   readonly [serviceCapabilities]: string[] = [
     '@libp2p/content-routing',
     '@libp2p/peer-routing',
-    '@libp2p/peer-discovery'
+    '@libp2p/peer-discovery',
+    '@libp2p/kad-dht'
   ]
 
   readonly [serviceDependencies]: string[] = [


### PR DESCRIPTION
Report `@libp2p/kad-dht` as a capability of the kad module.

## Change checklist

- [ ] I have performed a self-review of my own code
- [ ] I have made corresponding changes to the documentation if necessary (this includes comments as well)
- [ ] I have added tests that prove my fix is effective or that my feature works