### PR TITLE
fix: add tracking for long-lived maps

### DIFF
--- a/packages/libp2p/src/address-manager/dns-mappings.ts
+++ b/packages/libp2p/src/address-manager/dns-mappings.ts
@@ -1,4 +1,5 @@
 import { isPrivateIp } from '@libp2p/utils/private-ip'
+import { trackedMap } from '@libp2p/utils/tracked-map'
 import { multiaddr, protocols } from '@multiformats/multiaddr'
 import type { AddressManagerComponents, AddressManagerInit } from './index.js'
 import type { Logger } from '@libp2p/interface'
@@ -31,7 +32,10 @@ export class DNSMappings {
 
   constructor (components: AddressManagerComponents, init: AddressManagerInit = {}) {
     this.log = components.logger.forComponent('libp2p:address-manager:dns-mappings')
-    this.mappings = new Map()
+    this.mappings = trackedMap({
+      name: 'libp2p_address_manager_dns_mappings',
+      metrics: components.metrics
+    })
   }
 
   has (ma: Multiaddr): boolean {

--- a/packages/libp2p/src/address-manager/index.ts
+++ b/packages/libp2p/src/address-manager/index.ts
@@ -10,7 +10,7 @@ import { DNSMappings } from './dns-mappings.js'
 import { IPMappings } from './ip-mappings.js'
 import { ObservedAddresses } from './observed-addresses.js'
 import { TransportAddresses } from './transport-addresses.js'
-import type { ComponentLogger, Libp2pEvents, Logger, TypedEventTarget, PeerId, PeerStore } from '@libp2p/interface'
+import type { ComponentLogger, Libp2pEvents, Logger, TypedEventTarget, PeerId, PeerStore, Metrics } from '@libp2p/interface'
 import type { AddressManager as AddressManagerInterface, TransportManager, NodeAddress, ConfirmAddressOptions } from '@libp2p/interface-internal'
 import type { Filter } from '@libp2p/utils/filters'
 import type { Multiaddr } from '@multiformats/multiaddr'
@@ -83,6 +83,7 @@ export interface AddressManagerComponents {
   peerStore: PeerStore
   events: TypedEventTarget<Libp2pEvents>
   logger: ComponentLogger
+  metrics?: Metrics
 }
 
 /**

--- a/packages/libp2p/src/address-manager/ip-mappings.ts
+++ b/packages/libp2p/src/address-manager/ip-mappings.ts
@@ -1,4 +1,5 @@
 import { isIPv4 } from '@chainsafe/is-ip'
+import { trackedMap } from '@libp2p/utils/tracked-map'
 import { multiaddr, protocols } from '@multiformats/multiaddr'
 import type { AddressManagerComponents, AddressManagerInit } from './index.js'
 import type { Logger } from '@libp2p/interface'
@@ -32,7 +33,10 @@ export class IPMappings {
 
   constructor (components: AddressManagerComponents, init: AddressManagerInit = {}) {
     this.log = components.logger.forComponent('libp2p:address-manager:ip-mappings')
-    this.mappings = new Map()
+    this.mappings = trackedMap({
+      name: 'libp2p_address_manager_ip_mappings',
+      metrics: components.metrics
+    })
   }
 
   has (ma: Multiaddr): boolean {

--- a/packages/libp2p/src/address-manager/observed-addresses.ts
+++ b/packages/libp2p/src/address-manager/observed-addresses.ts
@@ -1,5 +1,6 @@
 import { isLinkLocal } from '@libp2p/utils/multiaddr/is-link-local'
 import { isPrivate } from '@libp2p/utils/multiaddr/is-private'
+import { trackedMap } from '@libp2p/utils/tracked-map'
 import { multiaddr } from '@multiformats/multiaddr'
 import type { AddressManagerComponents, AddressManagerInit } from './index.js'
 import type { Logger } from '@libp2p/interface'
@@ -23,7 +24,10 @@ export class ObservedAddresses {
 
   constructor (components: AddressManagerComponents, init: AddressManagerInit = {}) {
     this.log = components.logger.forComponent('libp2p:address-manager:observed-addresses')
-    this.addresses = new Map()
+    this.addresses = trackedMap({
+      name: 'libp2p_address_manager_observed_addresses',
+      metrics: components.metrics
+    })
     this.maxObservedAddresses = init.maxObservedAddresses ?? defaultValues.maxObservedAddresses
   }
 

--- a/packages/libp2p/src/address-manager/transport-addresses.ts
+++ b/packages/libp2p/src/address-manager/transport-addresses.ts
@@ -1,5 +1,6 @@
 import { isNetworkAddress } from '@libp2p/utils/multiaddr/is-network-address'
 import { isPrivate } from '@libp2p/utils/multiaddr/is-private'
+import { trackedMap } from '@libp2p/utils/tracked-map'
 import type { AddressManagerComponents, AddressManagerInit } from './index.js'
 import type { Logger } from '@libp2p/interface'
 import type { NodeAddress } from '@libp2p/interface-internal'
@@ -22,7 +23,10 @@ export class TransportAddresses {
 
   constructor (components: AddressManagerComponents, init: AddressManagerInit = {}) {
     this.log = components.logger.forComponent('libp2p:address-manager:observed-addresses')
-    this.addresses = new Map()
+    this.addresses = trackedMap({
+      name: 'libp2p_address_manager_transport_addresses',
+      metrics: components.metrics
+    })
     this.maxObservedAddresses = init.maxObservedAddresses ?? defaultValues.maxObservedAddresses
   }
 

--- a/packages/libp2p/src/transport-manager.ts
+++ b/packages/libp2p/src/transport-manager.ts
@@ -42,7 +42,10 @@ export class DefaultTransportManager implements TransportManager, Startable {
     this.log = components.logger.forComponent('libp2p:transports')
     this.components = components
     this.started = false
-    this.transports = new Map<string, Transport>()
+    this.transports = trackedMap({
+      name: 'libp2p_transport_manager_transports',
+      metrics: this.components.metrics
+    })
     this.listeners = trackedMap({
       name: 'libp2p_transport_manager_listeners',
       metrics: this.components.metrics

--- a/packages/libp2p/src/upgrader.ts
+++ b/packages/libp2p/src/upgrader.ts
@@ -1,6 +1,7 @@
 import { InvalidMultiaddrError, TooManyInboundProtocolStreamsError, TooManyOutboundProtocolStreamsError, LimitedConnectionError, setMaxListeners, InvalidPeerIdError } from '@libp2p/interface'
 import * as mss from '@libp2p/multistream-select'
 import { peerIdFromString } from '@libp2p/peer-id'
+import { trackedMap } from '@libp2p/utils/tracked-map'
 import { anySignal } from 'any-signal'
 import { CustomProgressEvent } from 'progress-events'
 import { raceSignal } from 'race-signal'
@@ -130,13 +131,19 @@ export class Upgrader implements UpgraderInterface {
 
   constructor (components: UpgraderComponents, init: UpgraderInit) {
     this.components = components
-    this.connectionEncrypters = new Map()
+    this.connectionEncrypters = trackedMap({
+      name: 'libp2p_upgrader_connection_encrypters',
+      metrics: this.components.metrics
+    })
 
     init.connectionEncrypters.forEach(encrypter => {
       this.connectionEncrypters.set(encrypter.protocol, encrypter)
     })
 
-    this.streamMuxers = new Map()
+    this.streamMuxers = trackedMap({
+      name: 'libp2p_upgrader_stream_multiplexers',
+      metrics: this.components.metrics
+    })
 
     init.streamMuxers.forEach(muxer => {
       this.streamMuxers.set(muxer.protocol, muxer)

--- a/packages/protocol-autonat/src/autonat.ts
+++ b/packages/protocol-autonat/src/autonat.ts
@@ -6,6 +6,7 @@ import { isGlobalUnicast } from '@libp2p/utils/multiaddr/is-global-unicast'
 import { isPrivate } from '@libp2p/utils/multiaddr/is-private'
 import { PeerQueue } from '@libp2p/utils/peer-queue'
 import { repeatingTask } from '@libp2p/utils/repeating-task'
+import { trackedMap } from '@libp2p/utils/tracked-map'
 import { multiaddr, protocols } from '@multiformats/multiaddr'
 import { anySignal } from 'any-signal'
 import { pbStream } from 'it-protobuf-stream'
@@ -105,7 +106,10 @@ export class AutoNATService implements Startable {
     this.maxOutboundStreams = init.maxOutboundStreams ?? MAX_OUTBOUND_STREAMS
     this.connectionThreshold = init.connectionThreshold ?? DEFAULT_CONNECTION_THRESHOLD
     this.maxMessageSize = init.maxMessageSize ?? MAX_MESSAGE_SIZE
-    this.dialResults = new Map()
+    this.dialResults = trackedMap({
+      name: 'libp2p_autonat_dial_results',
+      metrics: components.metrics
+    })
     this.findPeers = repeatingTask(this.findRandomPeers.bind(this), 60_000)
     this.addressFilter = createScalableCuckooFilter(1024)
   }

--- a/packages/protocol-autonat/src/index.ts
+++ b/packages/protocol-autonat/src/index.ts
@@ -31,7 +31,7 @@
  */
 
 import { AutoNATService } from './autonat.js'
-import type { ComponentLogger, Libp2pEvents, PeerId, PeerStore, TypedEventTarget } from '@libp2p/interface'
+import type { ComponentLogger, Libp2pEvents, Metrics, PeerId, PeerStore, TypedEventTarget } from '@libp2p/interface'
 import type { AddressManager, ConnectionManager, RandomWalk, Registrar, TransportManager } from '@libp2p/interface-internal'
 
 export interface AutoNATServiceInit {
@@ -95,6 +95,7 @@ export interface AutoNATComponents {
   randomWalk: RandomWalk
   events: TypedEventTarget<Libp2pEvents>
   peerStore: PeerStore
+  metrics?: Metrics
 }
 
 export function autoNAT (init: AutoNATServiceInit = {}): (components: AutoNATComponents) => unknown {


### PR DESCRIPTION
Adds metrics tracking the size of long-lived maps to make debugging memory leaks easier.

## Change checklist

- [x] I have performed a self-review of my own code
- [ ] I have made corresponding changes to the documentation if necessary (this includes comments as well)
- [ ] I have added tests that prove my fix is effective or that my feature works