### PR TITLE
fix: metrics should persist beyond node restarts

### DIFF
--- a/packages/metrics-opentelemetry/src/index.ts
+++ b/packages/metrics-opentelemetry/src/index.ts
@@ -193,7 +193,13 @@ class OpenTelemetryMetrics implements Metrics {
     }
 
     if (isCalculatedMetricOptions<CalculatedMetricOptions>(opts)) {
-      const gauge = this.observables.get(name) ?? this.meter.createObservableGauge(name, {
+      let gauge = this.observables.get(name)
+
+      if (gauge != null) {
+        return
+      }
+
+      gauge = this.meter.createObservableGauge(name, {
         description: opts?.help ?? name
       })
 
@@ -230,7 +236,13 @@ class OpenTelemetryMetrics implements Metrics {
     const label = opts?.label ?? name
 
     if (isCalculatedMetricOptions<CalculatedMetricOptions<Record<string, number>>>(opts)) {
-      const gauge = this.observables.get(name) ?? this.meter.createObservableGauge(name, {
+      let gauge = this.observables.get(name)
+
+      if (gauge != null) {
+        return
+      }
+
+      gauge = this.meter.createObservableGauge(name, {
         description: opts?.help ?? name
       })
 
@@ -271,7 +283,13 @@ class OpenTelemetryMetrics implements Metrics {
     }
 
     if (isCalculatedMetricOptions<CalculatedMetricOptions>(opts)) {
-      const counter = this.observables.get(name) ?? this.meter.createObservableCounter(name, {
+      let counter = this.observables.get(name)
+
+      if (counter != null) {
+        return
+      }
+
+      counter = this.meter.createObservableCounter(name, {
         description: opts?.help ?? name
       })
 
@@ -308,7 +326,13 @@ class OpenTelemetryMetrics implements Metrics {
     const label = opts?.label ?? name
 
     if (isCalculatedMetricOptions<CalculatedMetricOptions<Record<string, number>>>(opts)) {
-      const counter = this.observables.get(name) ?? this.meter.createObservableCounter(name, {
+      let counter = this.observables.get(name)
+
+      if (counter != null) {
+        return
+      }
+
+      counter = this.meter.createObservableCounter(name, {
         description: opts?.help ?? name
       })
 

--- a/packages/metrics-opentelemetry/src/index.ts
+++ b/packages/metrics-opentelemetry/src/index.ts
@@ -118,7 +118,7 @@ class OpenTelemetryMetrics implements Metrics {
         }
 
         // reset counts for next time
-        this.transferStats = new Map()
+        this.transferStats.clear()
 
         return output
       }
@@ -139,8 +139,6 @@ class OpenTelemetryMetrics implements Metrics {
 
   stop (): void {
     this.transferStats.clear()
-    this.metrics.clear()
-    this.observables.clear()
   }
 
   /**

--- a/packages/metrics-opentelemetry/test/index.spec.ts
+++ b/packages/metrics-opentelemetry/test/index.spec.ts
@@ -27,7 +27,7 @@ describe('opentelemetry-metrics', () => {
     expect(wrapped).to.not.equal(target.wrapped)
   })
 
-  it('should not retain metrics after stop', async () => {
+  it('should retain metrics after stop', async () => {
     const metrics = openTelemetryMetrics()({
       nodeInfo: {
         name: 'test',
@@ -50,6 +50,6 @@ describe('opentelemetry-metrics', () => {
 
     const m3 = metrics.registerCounterGroup('test_metric')
 
-    expect(m3).to.not.equal(m1, 're-used metric')
+    expect(m3).to.equal(m1, 'did not re-use metric')
   })
 })

--- a/packages/metrics-prometheus/src/counter.ts
+++ b/packages/metrics-prometheus/src/counter.ts
@@ -1,31 +1,22 @@
 import { Counter as PromCounter } from 'prom-client'
 import { normalizeString } from './utils.js'
 import type { PrometheusCalculatedMetricOptions } from './index.js'
-import type { CalculatedMetric } from './utils.js'
-import type { CalculateMetric, Counter } from '@libp2p/interface'
+import type { Counter } from '@libp2p/interface'
 import type { CollectFunction } from 'prom-client'
 
-export class PrometheusCounter implements Counter, CalculatedMetric {
+export class PrometheusCounter implements Counter {
   private readonly counter: PromCounter
-  private readonly calculators: CalculateMetric[]
 
   constructor (name: string, opts: PrometheusCalculatedMetricOptions) {
     name = normalizeString(name)
     const help = normalizeString(opts.help ?? name)
     const labels = opts.label != null ? [normalizeString(opts.label)] : []
     let collect: CollectFunction<PromCounter<any>> | undefined
-    this.calculators = []
 
     // calculated metric
     if (opts?.calculate != null) {
-      this.calculators.push(opts.calculate)
-      const self = this
-
       collect = async function () {
-        const values = await Promise.all(self.calculators.map(async calculate => calculate()))
-        const sum = values.reduce((acc, curr) => acc + curr, 0)
-
-        this.inc(sum)
+        this.inc(await opts.calculate())
       }
     }
 
@@ -36,10 +27,6 @@ export class PrometheusCounter implements Counter, CalculatedMetric {
       registers: opts.registry !== undefined ? [opts.registry] : undefined,
       collect
     })
-  }
-
-  addCalculator (calculator: CalculateMetric): void {
-    this.calculators.push(calculator)
   }
 
   increment (value: number = 1): void {

--- a/packages/metrics-prometheus/src/histogram-group.ts
+++ b/packages/metrics-prometheus/src/histogram-group.ts
@@ -1,35 +1,27 @@
 import { Histogram as PromHistogram } from 'prom-client'
 import { normalizeString } from './utils.js'
 import type { PrometheusCalculatedHistogramOptions } from './index.js'
-import type { CalculatedMetric } from './utils.js'
-import type { CalculateMetric, HistogramGroup, StopTimer } from '@libp2p/interface'
+import type { HistogramGroup, StopTimer } from '@libp2p/interface'
 import type { CollectFunction } from 'prom-client'
 
-export class PrometheusHistogramGroup implements HistogramGroup, CalculatedMetric<Record<string, number>> {
+export class PrometheusHistogramGroup implements HistogramGroup {
   private readonly histogram: PromHistogram
   private readonly label: string
-  private readonly calculators: Array<CalculateMetric<Record<string, number>>>
 
   constructor (name: string, opts: PrometheusCalculatedHistogramOptions<Record<string, number>>) {
     name = normalizeString(name)
     const help = normalizeString(opts.help ?? name)
     const label = this.label = normalizeString(opts.label ?? name)
     let collect: CollectFunction<PromHistogram<any>> | undefined
-    this.calculators = []
 
     // calculated metric
     if (opts?.calculate != null) {
-      this.calculators.push(opts.calculate)
-      const self = this
-
       collect = async function () {
-        await Promise.all(self.calculators.map(async calculate => {
-          const values = await calculate()
+        const values = await opts.calculate()
 
-          Object.entries(values).forEach(([key, value]) => {
-            this.observe({ [label]: key }, value)
-          })
-        }))
+        Object.entries(values).forEach(([key, value]) => {
+          this.observe({ [label]: key }, value)
+        })
       }
     }
 
@@ -41,10 +33,6 @@ export class PrometheusHistogramGroup implements HistogramGroup, CalculatedMetri
       registers: opts.registry !== undefined ? [opts.registry] : undefined,
       collect
     })
-  }
-
-  addCalculator (calculator: CalculateMetric<Record<string, number>>): void {
-    this.calculators.push(calculator)
   }
 
   observe (values: Record<string, number>): void {

--- a/packages/metrics-prometheus/src/histogram.ts
+++ b/packages/metrics-prometheus/src/histogram.ts
@@ -1,30 +1,22 @@
 import { Histogram as PromHistogram } from 'prom-client'
 import { normalizeString } from './utils.js'
 import type { PrometheusCalculatedHistogramOptions } from './index.js'
-import type { StopTimer, CalculateMetric, Histogram } from '@libp2p/interface'
+import type { StopTimer, Histogram } from '@libp2p/interface'
 import type { CollectFunction } from 'prom-client'
 
 export class PrometheusHistogram implements Histogram {
   private readonly histogram: PromHistogram
-  private readonly calculators: CalculateMetric[]
 
   constructor (name: string, opts: PrometheusCalculatedHistogramOptions) {
     name = normalizeString(name)
     const help = normalizeString(opts.help ?? name)
     const labels = opts.label != null ? [normalizeString(opts.label)] : []
     let collect: CollectFunction<PromHistogram<any>> | undefined
-    this.calculators = []
 
     // calculated metric
     if (opts?.calculate != null) {
-      this.calculators.push(opts.calculate)
-      const self = this
-
       collect = async function () {
-        const values = await Promise.all(self.calculators.map(async calculate => calculate()))
-        for (const value of values) {
-          this.observe(value)
-        }
+        this.observe(await opts.calculate())
       }
     }
 
@@ -36,10 +28,6 @@ export class PrometheusHistogram implements Histogram {
       registers: opts.registry !== undefined ? [opts.registry] : undefined,
       collect
     })
-  }
-
-  addCalculator (calculator: CalculateMetric): void {
-    this.calculators.push(calculator)
   }
 
   observe (value: number): void {

--- a/packages/metrics-prometheus/src/index.ts
+++ b/packages/metrics-prometheus/src/index.ts
@@ -279,11 +279,6 @@ class PrometheusMetrics implements Metrics {
 
     if (metric != null) {
       this.log('reuse existing metric', name)
-
-      if (opts.calculate != null) {
-        metric.addCalculator(opts.calculate)
-      }
-
       return metric
     }
 
@@ -307,12 +302,7 @@ class PrometheusMetrics implements Metrics {
     let metricGroup = metrics.get(name)
 
     if (metricGroup != null) {
-      this.log('reuse existing metric group', name)
-
-      if (opts.calculate != null) {
-        metricGroup.addCalculator(opts.calculate)
-      }
-
+      this.log('reuse existing metric', name)
       return metricGroup
     }
 
@@ -337,11 +327,6 @@ class PrometheusMetrics implements Metrics {
 
     if (counter != null) {
       this.log('reuse existing counter', name)
-
-      if (opts.calculate != null) {
-        counter.addCalculator(opts.calculate)
-      }
-
       return counter
     }
 
@@ -366,11 +351,6 @@ class PrometheusMetrics implements Metrics {
 
     if (counterGroup != null) {
       this.log('reuse existing counter group', name)
-
-      if (opts.calculate != null) {
-        counterGroup.addCalculator(opts.calculate)
-      }
-
       return counterGroup
     }
 
@@ -395,11 +375,6 @@ class PrometheusMetrics implements Metrics {
 
     if (metric != null) {
       this.log('reuse existing histogram', name)
-
-      if (opts.calculate != null) {
-        metric.addCalculator(opts.calculate)
-      }
-
       return metric
     }
 
@@ -424,11 +399,6 @@ class PrometheusMetrics implements Metrics {
 
     if (metricGroup != null) {
       this.log('reuse existing histogram group', name)
-
-      if (opts.calculate != null) {
-        metricGroup.addCalculator(opts.calculate)
-      }
-
       return metricGroup
     }
 
@@ -453,11 +423,6 @@ class PrometheusMetrics implements Metrics {
 
     if (metric != null) {
       this.log('reuse existing summary', name)
-
-      if (opts.calculate != null) {
-        metric.addCalculator(opts.calculate)
-      }
-
       return metric
     }
 
@@ -482,11 +447,6 @@ class PrometheusMetrics implements Metrics {
 
     if (metricGroup != null) {
       this.log('reuse existing summary group', name)
-
-      if (opts.calculate != null) {
-        metricGroup.addCalculator(opts.calculate)
-      }
-
       return metricGroup
     }
 

--- a/packages/metrics-prometheus/src/index.ts
+++ b/packages/metrics-prometheus/src/index.ts
@@ -174,7 +174,7 @@ class PrometheusMetrics implements Metrics {
         }
 
         // reset counts for next time
-        this.transferStats = new Map()
+        this.transferStats.clear()
 
         return output
       }
@@ -222,8 +222,6 @@ class PrometheusMetrics implements Metrics {
 
   stop (): void {
     this.transferStats.clear()
-    metrics.clear()
-    register?.clear()
   }
 
   /**

--- a/packages/metrics-prometheus/src/metric-group.ts
+++ b/packages/metrics-prometheus/src/metric-group.ts
@@ -1,35 +1,27 @@
 import { Gauge } from 'prom-client'
 import { normalizeString } from './utils.js'
 import type { PrometheusCalculatedMetricOptions } from './index.js'
-import type { CalculatedMetric } from './utils.js'
-import type { CalculateMetric, MetricGroup, StopTimer } from '@libp2p/interface'
+import type { MetricGroup, StopTimer } from '@libp2p/interface'
 import type { CollectFunction } from 'prom-client'
 
-export class PrometheusMetricGroup implements MetricGroup, CalculatedMetric<Record<string, number>> {
+export class PrometheusMetricGroup implements MetricGroup {
   private readonly gauge: Gauge
   private readonly label: string
-  private readonly calculators: Array<CalculateMetric<Record<string, number>>>
 
   constructor (name: string, opts: PrometheusCalculatedMetricOptions<Record<string, number>>) {
     name = normalizeString(name)
     const help = normalizeString(opts.help ?? name)
     const label = this.label = normalizeString(opts.label ?? name)
     let collect: CollectFunction<Gauge<any>> | undefined
-    this.calculators = []
 
     // calculated metric
     if (opts?.calculate != null) {
-      this.calculators.push(opts.calculate)
-      const self = this
-
       collect = async function () {
-        await Promise.all(self.calculators.map(async calculate => {
-          const values = await calculate()
+        const values = await opts.calculate()
 
-          Object.entries(values).forEach(([key, value]) => {
-            this.set({ [label]: key }, value)
-          })
-        }))
+        Object.entries(values).forEach(([key, value]) => {
+          this.set({ [label]: key }, value)
+        })
       }
     }
 
@@ -40,10 +32,6 @@ export class PrometheusMetricGroup implements MetricGroup, CalculatedMetric<Reco
       registers: opts.registry !== undefined ? [opts.registry] : undefined,
       collect
     })
-  }
-
-  addCalculator (calculator: CalculateMetric<Record<string, number>>): void {
-    this.calculators.push(calculator)
   }
 
   update (values: Record<string, number>): void {

--- a/packages/metrics-prometheus/src/metric.ts
+++ b/packages/metrics-prometheus/src/metric.ts
@@ -1,30 +1,22 @@
 import { Gauge } from 'prom-client'
 import { normalizeString } from './utils.js'
 import type { PrometheusCalculatedMetricOptions } from './index.js'
-import type { Metric, StopTimer, CalculateMetric } from '@libp2p/interface'
+import type { Metric, StopTimer } from '@libp2p/interface'
 import type { CollectFunction } from 'prom-client'
 
 export class PrometheusMetric implements Metric {
   private readonly gauge: Gauge
-  private readonly calculators: CalculateMetric[]
 
   constructor (name: string, opts: PrometheusCalculatedMetricOptions) {
     name = normalizeString(name)
     const help = normalizeString(opts.help ?? name)
     const labels = opts.label != null ? [normalizeString(opts.label)] : []
     let collect: CollectFunction<Gauge<any>> | undefined
-    this.calculators = []
 
     // calculated metric
     if (opts?.calculate != null) {
-      this.calculators.push(opts.calculate)
-      const self = this
-
       collect = async function () {
-        const values = await Promise.all(self.calculators.map(async calculate => calculate()))
-        const sum = values.reduce((acc, curr) => acc + curr, 0)
-
-        this.set(sum)
+        this.set(await opts.calculate())
       }
     }
 
@@ -35,10 +27,6 @@ export class PrometheusMetric implements Metric {
       registers: opts.registry !== undefined ? [opts.registry] : undefined,
       collect
     })
-  }
-
-  addCalculator (calculator: CalculateMetric): void {
-    this.calculators.push(calculator)
   }
 
   update (value: number): void {

--- a/packages/metrics-prometheus/src/summary-group.ts
+++ b/packages/metrics-prometheus/src/summary-group.ts
@@ -1,35 +1,27 @@
 import { Summary as PromSummary } from 'prom-client'
 import { normalizeString } from './utils.js'
 import type { PrometheusCalculatedSummaryOptions } from './index.js'
-import type { CalculatedMetric } from './utils.js'
-import type { CalculateMetric, SummaryGroup, StopTimer } from '@libp2p/interface'
+import type { SummaryGroup, StopTimer } from '@libp2p/interface'
 import type { CollectFunction } from 'prom-client'
 
-export class PrometheusSummaryGroup implements SummaryGroup, CalculatedMetric<Record<string, number>> {
+export class PrometheusSummaryGroup implements SummaryGroup {
   private readonly summary: PromSummary
   private readonly label: string
-  private readonly calculators: Array<CalculateMetric<Record<string, number>>>
 
   constructor (name: string, opts: PrometheusCalculatedSummaryOptions<Record<string, number>>) {
     name = normalizeString(name)
     const help = normalizeString(opts.help ?? name)
     const label = this.label = normalizeString(opts.label ?? name)
     let collect: CollectFunction<PromSummary<any>> | undefined
-    this.calculators = []
 
     // calculated metric
     if (opts?.calculate != null) {
-      this.calculators.push(opts.calculate)
-      const self = this
-
       collect = async function () {
-        await Promise.all(self.calculators.map(async calculate => {
-          const values = await calculate()
+        const values = await opts.calculate()
 
-          Object.entries(values).forEach(([key, value]) => {
-            this.observe({ [label]: key }, value)
-          })
-        }))
+        Object.entries(values).forEach(([key, value]) => {
+          this.observe({ [label]: key }, value)
+        })
       }
     }
 
@@ -45,10 +37,6 @@ export class PrometheusSummaryGroup implements SummaryGroup, CalculatedMetric<Re
       registers: opts.registry !== undefined ? [opts.registry] : undefined,
       collect
     })
-  }
-
-  addCalculator (calculator: CalculateMetric<Record<string, number>>): void {
-    this.calculators.push(calculator)
   }
 
   observe (values: Record<string, number>): void {

--- a/packages/metrics-prometheus/src/summary.ts
+++ b/packages/metrics-prometheus/src/summary.ts
@@ -1,30 +1,22 @@
 import { Summary as PromSummary } from 'prom-client'
 import { normalizeString } from './utils.js'
 import type { PrometheusCalculatedSummaryOptions } from './index.js'
-import type { StopTimer, CalculateMetric, Summary } from '@libp2p/interface'
+import type { StopTimer, Summary } from '@libp2p/interface'
 import type { CollectFunction } from 'prom-client'
 
 export class PrometheusSummary implements Summary {
   private readonly summary: PromSummary
-  private readonly calculators: CalculateMetric[]
 
   constructor (name: string, opts: PrometheusCalculatedSummaryOptions) {
     name = normalizeString(name)
     const help = normalizeString(opts.help ?? name)
     const labels = opts.label != null ? [normalizeString(opts.label)] : []
     let collect: CollectFunction<PromSummary<any>> | undefined
-    this.calculators = []
 
     // calculated metric
     if (opts?.calculate != null) {
-      this.calculators.push(opts.calculate)
-      const self = this
-
       collect = async function () {
-        const values = await Promise.all(self.calculators.map(async calculate => calculate()))
-        for (const value of values) {
-          this.observe(value)
-        }
+        this.observe(await opts.calculate())
       }
     }
 
@@ -40,10 +32,6 @@ export class PrometheusSummary implements Summary {
       registers: opts.registry !== undefined ? [opts.registry] : undefined,
       collect
     })
-  }
-
-  addCalculator (calculator: CalculateMetric): void {
-    this.calculators.push(calculator)
   }
 
   observe (value: number): void {

--- a/packages/metrics-prometheus/src/utils.ts
+++ b/packages/metrics-prometheus/src/utils.ts
@@ -1,9 +1,3 @@
-import type { CalculateMetric } from '@libp2p/interface'
-
-export interface CalculatedMetric <T = number> {
-  addCalculator(calculator: CalculateMetric<T>): void
-}
-
 export const ONE_SECOND = 1000
 export const ONE_MINUTE = 60 * ONE_SECOND
 

--- a/packages/metrics-prometheus/test/index.spec.ts
+++ b/packages/metrics-prometheus/test/index.spec.ts
@@ -13,7 +13,7 @@ describe('simple-metrics', () => {
     }
   })
 
-  it('should not retain metrics after stop', async () => {
+  it('should retain metrics after stop', async () => {
     metrics = prometheusMetrics()({
       logger: defaultLogger()
     })
@@ -31,6 +31,6 @@ describe('simple-metrics', () => {
 
     const m3 = metrics.registerCounterGroup('test_metric')
 
-    expect(m3).to.not.equal(m1, 're-used metric')
+    expect(m3).to.equal(m1, 'did not re-use metric')
   })
 })

--- a/packages/metrics-simple/src/index.ts
+++ b/packages/metrics-simple/src/index.ts
@@ -440,7 +440,6 @@ class SimpleMetrics implements Metrics, Startable {
     this.started = false
 
     clearInterval(this.interval)
-    this.metrics.clear()
     this.transferStats.clear()
   }
 

--- a/packages/metrics-simple/test/index.spec.ts
+++ b/packages/metrics-simple/test/index.spec.ts
@@ -157,7 +157,7 @@ describe('simple-metrics', () => {
     })
   })
 
-  it('should not retain metrics after stop', async () => {
+  it('should retain metrics after stop', async () => {
     s = simpleMetrics({
       onMetrics: (metrics) => {
 
@@ -180,6 +180,6 @@ describe('simple-metrics', () => {
 
     const m3 = s.registerCounterGroup('test_metric')
 
-    expect(m3).to.not.equal(m1, 're-used metric')
+    expect(m3).to.equal(m1, 'did not re-use metric')
   })
 })


### PR DESCRIPTION
Partial revert of #3154 - metrics should persist when a node is
stopped and then started again and re-registering the same metric
should be a no-op.

## Change checklist

- [x] I have performed a self-review of my own code
- [ ] I have made corresponding changes to the documentation if necessary (this includes comments as well)
- [x] I have added tests that prove my fix is effective or that my feature works