### PR TITLE
fix: use a per-peer lock

### DIFF
--- a/packages/peer-store/package.json
+++ b/packages/peer-store/package.json
@@ -50,6 +50,7 @@
   "dependencies": {
     "@libp2p/crypto": "^5.1.4",
     "@libp2p/interface": "^2.10.2",
+    "@libp2p/peer-collections": "^6.0.30",
     "@libp2p/peer-id": "^5.1.5",
     "@libp2p/peer-record": "^8.0.30",
     "@multiformats/multiaddr": "^12.4.0",

--- a/packages/peer-store/src/utils/bytes-to-peer.ts
+++ b/packages/peer-store/src/utils/bytes-to-peer.ts
@@ -1,22 +1,20 @@
 import { publicKeyFromProtobuf } from '@libp2p/crypto/keys'
 import { peerIdFromPublicKey } from '@libp2p/peer-id'
 import { multiaddr } from '@multiformats/multiaddr'
-import { base58btc } from 'multiformats/bases/base58'
-import * as Digest from 'multiformats/hashes/digest'
 import { Peer as PeerPB } from '../pb/peer.js'
 import type { PeerId, Peer, Tag } from '@libp2p/interface'
+import type { Digest } from 'multiformats/hashes/digest'
 
 function populatePublicKey (peerId: PeerId, protobuf: PeerPB): PeerId {
   if (peerId.publicKey != null || protobuf.publicKey == null) {
     return peerId
   }
 
-  let digest: any
+  let digest: Digest<18, number> | undefined
 
   if (peerId.type === 'RSA') {
     // avoid hashing public key
-    const multihash = base58btc.decode(`z${peerId}`)
-    digest = Digest.decode(multihash)
+    digest = peerId.toMultihash()
   }
 
   const publicKey = publicKeyFromProtobuf(protobuf.publicKey, digest)

--- a/packages/peer-store/src/utils/to-peer-pb.ts
+++ b/packages/peer-store/src/utils/to-peer-pb.ts
@@ -252,8 +252,13 @@ function mapTag (key: string, tag: any): Tag {
     expiry = BigInt(Date.now() + Number(tag.ttl))
   }
 
-  return {
-    value: tag.value ?? 0,
-    expiry
+  const output: Tag = {
+    value: tag.value ?? 0
   }
+
+  if (expiry != null) {
+    output.expiry = expiry
+  }
+
+  return output
 }


### PR DESCRIPTION
Instead of locking the whole peer store on a multi-read/single-write basis, make the lock more granular and use a per-peer-id lock.

## Change checklist

- [x] I have performed a self-review of my own code
- [ ] I have made corresponding changes to the documentation if necessary (this includes comments as well)
- [x] I have added tests that prove my fix is effective or that my feature works