### PR TITLE
fix: constrain maximum timeout value

### DIFF
--- a/packages/utils/test/adaptive-timeout.spec.ts
+++ b/packages/utils/test/adaptive-timeout.spec.ts
@@ -107,4 +107,41 @@ describe('adaptive-timeout', () => {
 
     adaptiveTimeout.cleanUp(signal)
   })
+
+  it('should have a minimum timeout', () => {
+    const adaptiveTimeout = new AdaptiveTimeout({
+      minTimeout: 10_000
+    })
+
+    const signal1 = adaptiveTimeout.getTimeoutSignal()
+    adaptiveTimeout.cleanUp(signal1)
+
+    const signal2 = adaptiveTimeout.getTimeoutSignal()
+    adaptiveTimeout.cleanUp(signal2)
+
+    const signal3 = adaptiveTimeout.getTimeoutSignal()
+    adaptiveTimeout.cleanUp(signal3)
+
+    expect(signal3).to.have.property('timeout', 10_000)
+  })
+
+  it('should have a maximum timeout', () => {
+    const adaptiveTimeout = new AdaptiveTimeout({
+      maxTimeout: 10_000
+    })
+
+    const signal1 = adaptiveTimeout.getTimeoutSignal()
+    clock.tick(20_000)
+    adaptiveTimeout.cleanUp(signal1)
+
+    const signal2 = adaptiveTimeout.getTimeoutSignal()
+    clock.tick(20_000)
+    adaptiveTimeout.cleanUp(signal2)
+
+    const signal3 = adaptiveTimeout.getTimeoutSignal()
+    clock.tick(20_000)
+    adaptiveTimeout.cleanUp(signal3)
+
+    expect(signal3).to.have.property('timeout', 10_000)
+  })
 })


### PR DESCRIPTION
Add a setting to allow constraining the timeout value to a maximum.

## Change checklist

- [x] I have performed a self-review of my own code
- [x] I have made corresponding changes to the documentation if necessary (this includes comments as well)
- [x] I have added tests that prove my fix is effective or that my feature works