### PR TITLE
fix: pass metrics to peerstore

### DIFF
--- a/packages/libp2p/src/libp2p.ts
+++ b/packages/libp2p/src/libp2p.ts
@@ -86,15 +86,15 @@ export class Libp2p<T extends ServiceMap = ServiceMap> extends TypedEventEmitter
       dns: init.dns
     })
 
-    this.peerStore = this.configureComponent('peerStore', persistentPeerStore(components, {
-      addressFilter: this.components.connectionGater.filterMultiaddrForPeer,
-      ...init.peerStore
-    }))
-
     // Create Metrics
     if (init.metrics != null) {
       this.metrics = this.configureComponent('metrics', init.metrics(this.components))
     }
+
+    this.peerStore = this.configureComponent('peerStore', persistentPeerStore(components, {
+      addressFilter: this.components.connectionGater.filterMultiaddrForPeer,
+      ...init.peerStore
+    }))
 
     components.events.addEventListener('peer:update', evt => {
       // if there was no peer previously in the peer store this is a new peer


### PR DESCRIPTION
Allow the peerstore to record metrics

## Change checklist

- [x] I have performed a self-review of my own code
- [ ] I have made corresponding changes to the documentation if necessary (this includes comments as well)
- [ ] I have added tests that prove my fix is effective or that my feature works