### PR TITLE
fix: empty routing table on stop

### DIFF
--- a/packages/kad-dht/src/routing-table/index.ts
+++ b/packages/kad-dht/src/routing-table/index.ts
@@ -96,6 +96,7 @@ export class RoutingTable extends TypedEventEmitter<RoutingTableEvents> implemen
     routingTableKadBucketMaxOccupancy: Metric
     kadBucketEvents: CounterGroup<'ping_old_contact' | 'ping_old_contact_error' | 'ping_new_contact' | 'ping_new_contact_error' | 'peer_added' | 'peer_removed'>
   }
+
   private shutdownController: AbortController
 
   constructor (components: RoutingTableComponents, init: RoutingTableInit) {

--- a/packages/kad-dht/src/routing-table/index.ts
+++ b/packages/kad-dht/src/routing-table/index.ts
@@ -96,6 +96,7 @@ export class RoutingTable extends TypedEventEmitter<RoutingTableEvents> implemen
     routingTableKadBucketMaxOccupancy: Metric
     kadBucketEvents: CounterGroup<'ping_old_contact' | 'ping_old_contact_error' | 'ping_new_contact' | 'ping_new_contact_error' | 'peer_added' | 'peer_removed'>
   }
+  private shutdownController: AbortController
 
   constructor (components: RoutingTableComponents, init: RoutingTableInit) {
     super()
@@ -114,6 +115,7 @@ export class RoutingTable extends TypedEventEmitter<RoutingTableEvents> implemen
     this.peerRemoved = this.peerRemoved.bind(this)
     this.populateFromDatastoreOnStart = init.populateFromDatastoreOnStart ?? POPULATE_FROM_DATASTORE_ON_START
     this.populateFromDatastoreLimit = init.populateFromDatastoreLimit ?? POPULATE_FROM_DATASTORE_LIMIT
+    this.shutdownController = new AbortController()
 
     this.pingOldContactQueue = new PeerQueue({
       concurrency: init.pingOldContactConcurrency ?? PING_OLD_CONTACT_CONCURRENCY,
@@ -185,11 +187,13 @@ export class RoutingTable extends TypedEventEmitter<RoutingTableEvents> implemen
 
     this.running = true
 
+    this.shutdownController = new AbortController()
     await start(this.closestPeerTagger, this.kb)
-    await this.kb.addSelfPeer(this.components.peerId)
   }
 
   async afterStart (): Promise<void> {
+    let peerStorePeers = 0
+
     // do this async to not block startup but iterate serially to not overwhelm
     // the ping queue
     Promise.resolve().then(async () => {
@@ -197,37 +201,48 @@ export class RoutingTable extends TypedEventEmitter<RoutingTableEvents> implemen
         return
       }
 
-      let peerStorePeers = 0
+      const signal = anySignal([
+        this.shutdownController.signal,
+        AbortSignal.timeout(20_000)
+      ])
+      setMaxListeners(Infinity, signal)
 
-      // add existing peers from the peer store to routing table
-      for (const peer of await this.components.peerStore.all({
-        filters: [(peer) => {
-          return peer.protocols.includes(this.protocol) && peer.tags.has(KAD_PEER_TAG_NAME)
-        }],
-        limit: this.populateFromDatastoreLimit
-      })) {
-        if (!this.running) {
-          // bail if we've been shut down
-          return
-        }
+      try {
+        // add existing peers from the peer store to routing table
+        for (const peer of await this.components.peerStore.all({
+          filters: [(peer) => {
+            return peer.protocols.includes(this.protocol) && peer.tags.has(KAD_PEER_TAG_NAME)
+          }],
+          limit: this.populateFromDatastoreLimit,
+          signal
+        })) {
+          if (!this.running) {
+            // bail if we've been shut down
+            return
+          }
 
-        try {
-          await this.add(peer.id)
-          peerStorePeers++
-        } catch (err) {
-          this.log('failed to add peer %p to routing table, removing kad-dht peer tags - %e')
-          await this.components.peerStore.merge(peer.id, {
-            tags: {
-              [this.peerTagName]: undefined
-            }
-          })
+          try {
+            await this.add(peer.id, {
+              signal
+            })
+            peerStorePeers++
+          } catch (err) {
+            this.log('failed to add peer %p to routing table, removing kad-dht peer tags - %e')
+            await this.components.peerStore.merge(peer.id, {
+              tags: {
+                [this.peerTagName]: undefined
+              }
+            })
+          }
         }
+      } finally {
+        signal.clear()
       }
 
       this.log('added %d peer store peers to the routing table', peerStorePeers)
     })
       .catch(err => {
-        this.log.error('error adding peer store peers to the routing table %e', err)
+        this.log.error('error adding %d, peer store peers to the routing table - %e', peerStorePeers, err)
       })
   }
 
@@ -236,6 +251,7 @@ export class RoutingTable extends TypedEventEmitter<RoutingTableEvents> implemen
     await stop(this.closestPeerTagger, this.kb)
     this.pingOldContactQueue.abort()
     this.pingNewContactQueue.abort()
+    this.shutdownController.abort()
   }
 
   private async peerAdded (peer: Peer, bucket: LeafBucket, options?: AbortOptions): Promise<void> {
@@ -310,7 +326,11 @@ export class RoutingTable extends TypedEventEmitter<RoutingTableEvents> implemen
 
         const result = await this.pingOldContactQueue.add(async (options) => {
           const signal = this.pingOldContactTimeout.getTimeoutSignal()
-          const signals = anySignal([signal, options?.signal])
+          const signals = anySignal([
+            signal,
+            this.shutdownController.signal,
+            options?.signal
+          ])
           setMaxListeners(Infinity, signal, signals)
 
           try {
@@ -342,7 +362,11 @@ export class RoutingTable extends TypedEventEmitter<RoutingTableEvents> implemen
 
   async verifyNewContact (contact: Peer, options?: AbortOptions): Promise<boolean> {
     const signal = this.pingNewContactTimeout.getTimeoutSignal()
-    const signals = anySignal([signal, options?.signal])
+    const signals = anySignal([
+      signal,
+      this.shutdownController.signal,
+      options?.signal
+    ])
     setMaxListeners(Infinity, signal, signals)
 
     try {

--- a/packages/kad-dht/test/routing-table.spec.ts
+++ b/packages/kad-dht/test/routing-table.spec.ts
@@ -549,6 +549,24 @@ describe('Routing Table', () => {
     }
   })
 
+  it('should remove peers on stop', async function () {
+    this.timeout(20 * 1000)
+
+    const ids = await createPeerIdsWithPrivateKey(20)
+
+    await Promise.all(
+      Array.from({ length: 1000 }).map(async () => { await table.add(ids[random(ids.length - 1)].peerId) })
+    )
+
+    expect(table.kb.root).to.have.property('peers').that.has.lengthOf(20)
+
+    await table.stop()
+
+    expect(table.kb.root).to.have.property('depth', 0)
+    expect(table.kb.root).to.have.property('prefix', '')
+    expect(table.kb.root).to.have.property('peers').that.is.empty()
+  })
+
   describe('max size', () => {
     it('should constrain size to 10', async () => {
       const prefixLength = 8


### PR DESCRIPTION
When the node is stopped, empty the routing table

## Change checklist

- [x] I have performed a self-review of my own code
- [ ] I have made corresponding changes to the documentation if necessary (this includes comments as well)
- [x] I have added tests that prove my fix is effective or that my feature works