### PR TITLE
fix: finalize peerstore lock after use

### DIFF
--- a/packages/peer-store/package.json
+++ b/packages/peer-store/package.json
@@ -56,7 +56,7 @@
     "@multiformats/multiaddr": "^12.4.0",
     "interface-datastore": "^8.3.1",
     "it-all": "^3.0.8",
-    "mortice": "^3.0.6",
+    "mortice": "^3.2.1",
     "multiformats": "^13.3.6",
     "protons-runtime": "^5.5.0",
     "uint8arraylist": "^2.4.8",

--- a/packages/peer-store/src/store.ts
+++ b/packages/peer-store/src/store.ts
@@ -105,6 +105,7 @@ export class PersistentStore {
     lock.refs--
 
     if (lock.refs === 0) {
+      lock.lock.finalize()
       this.locks.delete(peerId)
     }
   }


### PR DESCRIPTION
Removes lock from storage after use

## Change checklist

- [x] I have performed a self-review of my own code
- [ ] I have made corresponding changes to the documentation if necessary (this includes comments as well)
- [ ] I have added tests that prove my fix is effective or that my feature works