### PR TITLE
fix: return closest known peers, even if they are not closer

### DIFF
--- a/packages/kad-dht/src/query/manager.ts
+++ b/packages/kad-dht/src/query/manager.ts
@@ -168,7 +168,9 @@ export class QueryManager implements Startable {
       const id = await convertBuffer(key, {
         signal
       })
-      const peers = this.routingTable.closestPeers(id, this.routingTable.kBucketSize)
+      const peers = this.routingTable.closestPeers(id, {
+        count: this.routingTable.kBucketSize
+      })
 
       // split peers into d buckets evenly(ish)
       const peersToQuery = peers.sort(() => {

--- a/packages/kad-dht/src/routing-table/index.ts
+++ b/packages/kad-dht/src/routing-table/index.ts
@@ -7,7 +7,7 @@ import { TypedEventEmitter, setMaxListeners } from 'main-event'
 import * as utils from '../utils.js'
 import { ClosestPeers } from './closest-peers.js'
 import { KBucket, isLeafBucket } from './k-bucket.js'
-import type { Bucket, LeafBucket, Peer } from './k-bucket.js'
+import type { Bucket, GetClosestPeersOptions, LeafBucket, Peer } from './k-bucket.js'
 import type { Network } from '../network.js'
 import type { AbortOptions, ComponentLogger, CounterGroup, Logger, Metric, Metrics, PeerId, PeerStore, Startable, Stream } from '@libp2p/interface'
 import type { Ping } from '@libp2p/ping'
@@ -444,7 +444,9 @@ export class RoutingTable extends TypedEventEmitter<RoutingTableEvents> implemen
    * Retrieve the closest peers to the given kadId
    */
   closestPeer (kadId: Uint8Array): PeerId | undefined {
-    const res = this.closestPeers(kadId, 1)
+    const res = this.closestPeers(kadId, {
+      count: 1
+    })
 
     if (res.length > 0) {
       return res[0]
@@ -456,12 +458,12 @@ export class RoutingTable extends TypedEventEmitter<RoutingTableEvents> implemen
   /**
    * Retrieve the `count`-closest peers to the given kadId
    */
-  closestPeers (kadId: Uint8Array, count = this.kBucketSize): PeerId[] {
+  closestPeers (kadId: Uint8Array, options?: GetClosestPeersOptions): PeerId[] {
     if (this.kb == null) {
       return []
     }
 
-    return [...this.kb.closest(kadId, count)]
+    return [...this.kb.closest(kadId, options)]
   }
 
   /**

--- a/packages/kad-dht/src/rpc/handlers/find-node.ts
+++ b/packages/kad-dht/src/rpc/handlers/find-node.ts
@@ -42,38 +42,52 @@ export class FindNodeHandler implements DHTMessageHandler {
    * Process `FindNode` DHT messages
    */
   async handle (peerId: PeerId, msg: Message): Promise<Message> {
-    this.log('incoming request from %p for peers closer to %b', peerId, msg.key)
+    this.log('incoming request from %p for peers close to %b', peerId, msg.key)
+    try {
+      if (msg.key == null) {
+        throw new InvalidMessageError('Invalid FIND_NODE message received - key was missing')
+      }
 
-    if (msg.key == null) {
-      throw new InvalidMessageError('Invalid FIND_NODE message received - key was missing')
-    }
+      const closer: PeerInfo[] = await this.peerRouting.getClosestPeersOffline(msg.key, {
+        exclude: [
+        // never tell a peer about itself
+          peerId,
 
-    const closer: PeerInfo[] = await this.peerRouting.getCloserPeersOffline(msg.key, peerId)
-
-    if (uint8ArrayEquals(this.peerId.toMultihash().bytes, msg.key)) {
-      closer.push({
-        id: this.peerId,
-        multiaddrs: this.addressManager.getAddresses().map(ma => ma.decapsulateCode(protocols('p2p').code))
+          // do not include the server in the results
+          this.peerId
+        ]
       })
-    }
 
-    const response: Message = {
-      type: MessageType.FIND_NODE,
-      clusterLevel: msg.clusterLevel,
-      closer: closer
-        .map(this.peerInfoMapper)
-        .filter(({ multiaddrs }) => multiaddrs.length)
-        .map(peerInfo => ({
-          id: peerInfo.id.toMultihash().bytes,
-          multiaddrs: peerInfo.multiaddrs.map(ma => ma.bytes)
-        })),
-      providers: []
-    }
+      if (uint8ArrayEquals(this.peerId.toMultihash().bytes, msg.key)) {
+        closer.push({
+          id: this.peerId,
+          multiaddrs: this.addressManager.getAddresses().map(ma => ma.decapsulateCode(protocols('p2p').code))
+        })
+      }
 
-    if (response.closer.length === 0) {
-      this.log('could not find any peers closer to %b than %p', msg.key, peerId)
-    }
+      const response: Message = {
+        type: MessageType.FIND_NODE,
+        clusterLevel: msg.clusterLevel,
+        closer: closer
+          .map(this.peerInfoMapper)
+          .filter(({ multiaddrs }) => multiaddrs.length)
+          .map(peerInfo => ({
+            id: peerInfo.id.toMultihash().bytes,
+            multiaddrs: peerInfo.multiaddrs.map(ma => ma.bytes)
+          })),
+        providers: []
+      }
 
-    return response
+      if (response.closer.length === 0) {
+        this.log('could not find any peers closer to %b for %p', msg.key, peerId)
+      } else {
+        this.log('found %d peers close to %b for %p', response.closer.length, msg.key, peerId)
+      }
+
+      return response
+    } catch (err: any) {
+      this.log('error during finding peers closer to %b for %p - %e', msg.key, peerId, err)
+      throw err
+    }
   }
 }

--- a/packages/kad-dht/src/rpc/handlers/get-providers.ts
+++ b/packages/kad-dht/src/rpc/handlers/get-providers.ts
@@ -67,7 +67,7 @@ export class GetProvidersHandler implements DHTMessageHandler {
 
         return info
       })),
-      this.peerRouting.getCloserPeersOffline(msg.key, peerId)
+      this.peerRouting.getClosestPeersOffline(msg.key)
     ])
 
     const response: Message = {

--- a/packages/kad-dht/src/rpc/handlers/get-value.ts
+++ b/packages/kad-dht/src/rpc/handlers/get-value.ts
@@ -84,7 +84,7 @@ export class GetValueHandler implements DHTMessageHandler {
 
     const [record, closer] = await Promise.all([
       this._checkLocalDatastore(key),
-      this.peerRouting.getCloserPeersOffline(key, peerId)
+      this.peerRouting.getClosestPeersOffline(key)
     ])
 
     if (record != null) {

--- a/packages/kad-dht/test/routing-table.spec.ts
+++ b/packages/kad-dht/test/routing-table.spec.ts
@@ -210,7 +210,9 @@ describe('Routing Table', () => {
         const id = ids[random(ids.length - 1)]
         const key = await kadUtils.convertPeerId(id.peerId)
 
-        expect(table.closestPeers(key, 5).length)
+        expect(table.closestPeers(key, {
+          count: 5
+        }).length)
           .to.be.above(0)
       })
     )
@@ -291,7 +293,9 @@ describe('Routing Table', () => {
     }))
 
     const key = await kadUtils.convertPeerId(peers[2].peerId)
-    expect(table.closestPeers(key, 10)).to.have.length(10)
+    expect(table.closestPeers(key, {
+      count: 10
+    })).to.have.length(10)
     await expect(table.find(peers[5].peerId)).to.eventually.be.ok()
     expect(table.size).to.equal(10)
 
@@ -329,7 +333,9 @@ describe('Routing Table', () => {
     await Promise.all(peers.map(async (peer) => { await table.add(peer.peerId) }))
 
     const key = await kadUtils.convertPeerId(peers[2].peerId)
-    expect(table.closestPeers(key, 15)).to.have.length(15)
+    expect(table.closestPeers(key, {
+      count: 15
+    })).to.have.length(15)
   })
 
   it('favours old peers that respond to pings', async () => {

--- a/packages/kad-dht/test/rpc/handlers/find-node.spec.ts
+++ b/packages/kad-dht/test/rpc/handlers/find-node.spec.ts
@@ -61,8 +61,8 @@ describe('rpc - handlers - FindNode', () => {
       multiaddr('/ip4/221.4.67.0/tcp/4002')
     ])
 
-    peerRouting.getCloserPeersOffline
-      .withArgs(peerId.peerId.toMultihash().bytes, peerId.peerId)
+    peerRouting.getClosestPeersOffline
+      .withArgs(peerId.peerId.toMultihash().bytes)
       .resolves([{
         id: targetPeer.peerId, // closer peer
         multiaddrs: [
@@ -96,8 +96,8 @@ describe('rpc - handlers - FindNode', () => {
       providers: []
     }
 
-    peerRouting.getCloserPeersOffline
-      .withArgs(targetPeer.peerId.toMultihash().bytes, sourcePeer.peerId)
+    peerRouting.getClosestPeersOffline
+      .withArgs(targetPeer.peerId.toMultihash().bytes)
       .resolves([{
         id: targetPeer.peerId,
         multiaddrs: [
@@ -120,6 +120,26 @@ describe('rpc - handlers - FindNode', () => {
     expect(peer.multiaddrs).to.not.be.empty()
   })
 
+  it('does not return requesting peer in results', async () => {
+    const msg: Message = {
+      type: T,
+      key: targetPeer.peerId.toMultihash().bytes,
+      closer: [],
+      providers: []
+    }
+
+    peerRouting.getClosestPeersOffline
+      .withArgs(targetPeer.peerId.toMultihash().bytes)
+      .resolves([])
+
+    await handler.handle(sourcePeer.peerId, msg)
+
+    expect(peerRouting.getClosestPeersOffline.getCall(0).args[1]?.exclude)
+      .to.include(peerId.peerId, 'did not exclude server PeerId from results')
+    expect(peerRouting.getClosestPeersOffline.getCall(0).args[1]?.exclude)
+      .to.include(sourcePeer.peerId, 'did not exclude requesting peer id from results')
+  })
+
   it('handles no peers found', async () => {
     const msg: Message = {
       type: T,
@@ -128,7 +148,7 @@ describe('rpc - handlers - FindNode', () => {
       providers: []
     }
 
-    peerRouting.getCloserPeersOffline.resolves([])
+    peerRouting.getClosestPeersOffline.resolves([])
 
     const response = await handler.handle(sourcePeer.peerId, msg)
 
@@ -143,8 +163,8 @@ describe('rpc - handlers - FindNode', () => {
       providers: []
     }
 
-    peerRouting.getCloserPeersOffline
-      .withArgs(targetPeer.peerId.toMultihash().bytes, sourcePeer.peerId)
+    peerRouting.getClosestPeersOffline
+      .withArgs(targetPeer.peerId.toMultihash().bytes)
       .resolves([{
         id: targetPeer.peerId,
         multiaddrs: [
@@ -186,8 +206,8 @@ describe('rpc - handlers - FindNode', () => {
       providers: []
     }
 
-    peerRouting.getCloserPeersOffline
-      .withArgs(targetPeer.peerId.toMultihash().bytes, sourcePeer.peerId)
+    peerRouting.getClosestPeersOffline
+      .withArgs(targetPeer.peerId.toMultihash().bytes)
       .resolves([{
         id: targetPeer.peerId,
         multiaddrs: [

--- a/packages/kad-dht/test/rpc/handlers/get-providers.spec.ts
+++ b/packages/kad-dht/test/rpc/handlers/get-providers.spec.ts
@@ -107,7 +107,7 @@ describe('rpc - handlers - GetProviders', () => {
     }]
 
     providers.getProviders.withArgs(v.cid).resolves([providerPeer.peerId])
-    peerRouting.getCloserPeersOffline.withArgs(msg.key, sourcePeer.peerId).resolves(closer)
+    peerRouting.getClosestPeersOffline.withArgs(msg.key).resolves(closer)
 
     await peerStore.merge(providerPeer.peerId, {
       multiaddrs: provider[0].multiaddrs

--- a/packages/kad-dht/test/rpc/handlers/get-value.spec.ts
+++ b/packages/kad-dht/test/rpc/handlers/get-value.spec.ts
@@ -92,7 +92,7 @@ describe('rpc - handlers - GetValue', () => {
       providers: []
     }
 
-    peerRouting.getCloserPeersOffline.withArgs(msg.key, sourcePeer.peerId).resolves([])
+    peerRouting.getClosestPeersOffline.withArgs(msg.key).resolves([])
 
     const response = await handler.handle(sourcePeer.peerId, msg)
 
@@ -112,7 +112,7 @@ describe('rpc - handlers - GetValue', () => {
   it('responds with closer peers returned from the dht', async () => {
     const key = uint8ArrayFromString('hello')
 
-    peerRouting.getCloserPeersOffline.withArgs(key, sourcePeer.peerId)
+    peerRouting.getClosestPeersOffline.withArgs(key)
       .resolves([{
         id: closerPeer.peerId,
         multiaddrs: []
@@ -175,7 +175,7 @@ describe('rpc - handlers - GetValue', () => {
         providers: []
       }
 
-      peerRouting.getCloserPeersOffline.resolves([])
+      peerRouting.getClosestPeersOffline.resolves([])
 
       const response = await handler.handle(sourcePeer.peerId, msg)
 

--- a/packages/kad-dht/test/rpc/index.node.ts
+++ b/packages/kad-dht/test/rpc/index.node.ts
@@ -90,7 +90,7 @@ describe('rpc', () => {
       defer.resolve()
     }
 
-    peerRouting.getCloserPeersOffline.resolves([])
+    peerRouting.getClosestPeersOffline.resolves([])
 
     const source = pipe(
       [Message.encode(msg)],


### PR DESCRIPTION
Aligns with Kad-DHT spec PR, when responding to a `FIND_NODE` query, return the `k` known closest peers, excluding the server and the requester, even if they are not closer than the requester.

## Change checklist

- [x] I have performed a self-review of my own code
- [ ] I have made corresponding changes to the documentation if necessary (this includes comments as well)
- [x] I have added tests that prove my fix is effective or that my feature works