### PR TITLE
feat: allow interrupting repeating task

### DIFF
--- a/packages/utils/test/repeating-task.spec.ts
+++ b/packages/utils/test/repeating-task.spec.ts
@@ -2,12 +2,19 @@ import { expect } from 'aegir/chai'
 import delay from 'delay'
 import pDefer from 'p-defer'
 import { repeatingTask } from '../src/repeating-task.js'
+import type { RepeatingTask } from '../src/repeating-task.js'
 
 describe('repeating-task', () => {
+  let task: RepeatingTask
+
+  afterEach(() => {
+    task?.stop()
+  })
+
   it('should repeat a task', async () => {
     let count = 0
 
-    const task = repeatingTask(() => {
+    task = repeatingTask(() => {
       count++
     }, 100)
     task.start()
@@ -22,7 +29,7 @@ describe('repeating-task', () => {
   it('should run a task immediately', async () => {
     let count = 0
 
-    const task = repeatingTask(() => {
+    task = repeatingTask(() => {
       count++
     }, 60000, {
       runImmediately: true
@@ -31,15 +38,13 @@ describe('repeating-task', () => {
 
     await delay(10)
 
-    task.stop()
-
     expect(count).to.equal(1)
   })
 
   it('should time out a task', async () => {
     const deferred = pDefer()
 
-    const task = repeatingTask((opts) => {
+    task = repeatingTask((opts) => {
       opts?.signal?.addEventListener('abort', () => {
         deferred.resolve()
       })
@@ -49,13 +54,12 @@ describe('repeating-task', () => {
     task.start()
 
     await deferred.promise
-    task.stop()
   })
 
   it('should repeat a task that throws', async () => {
     let count = 0
 
-    const task = repeatingTask(() => {
+    task = repeatingTask(() => {
       count++
       throw new Error('Urk!')
     }, 100)
@@ -63,15 +67,13 @@ describe('repeating-task', () => {
 
     await delay(1000)
 
-    task.stop()
-
     expect(count).to.be.greaterThan(1)
   })
 
   it('should update the interval of a task', async () => {
     let count = 0
 
-    const task = repeatingTask(() => {
+    task = repeatingTask(() => {
       count++
 
       if (count === 1) {
@@ -82,15 +84,13 @@ describe('repeating-task', () => {
 
     await delay(1000)
 
-    task.stop()
-
     expect(count).to.equal(1)
   })
 
   it('should update the timeout of a task', async () => {
     let count = 0
 
-    const task = repeatingTask(async (options) => {
+    task = repeatingTask(async (options) => {
       // simulate a delay
       await delay(100)
 
@@ -109,15 +109,13 @@ describe('repeating-task', () => {
 
     await delay(1000)
 
-    task.stop()
-
     expect(count).to.equal(1)
   })
 
   it('should not reschedule the task if the interval is updated to the same value', async () => {
     let count = 0
 
-    const task = repeatingTask(() => {
+    task = repeatingTask(() => {
       count++
     }, 1_000, {
       runImmediately: true
@@ -134,7 +132,69 @@ describe('repeating-task', () => {
 
     await delay(100)
 
-    task.stop()
+    expect(count).to.equal(2)
+  })
+
+  it('should allow interrupting the timeout to run the task immediately', async () => {
+    let count = 0
+
+    task = repeatingTask(() => {
+      count++
+    }, 1_000)
+    task.start()
+
+    // run immediately
+    task.run()
+
+    // less than the repeat interval
+    await delay(200)
+
+    expect(count).to.equal(1)
+  })
+
+  it('should debounce interrupting the timeout to run the task immediately', async () => {
+    let count = 0
+
+    task = repeatingTask(() => {
+      count++
+    }, 1_000, {
+      debounce: 10
+    })
+    task.start()
+
+    // run immediately
+    task.run()
+    task.run()
+    task.run()
+    task.run()
+    task.run()
+
+    // less than the repeat interval
+    await delay(50)
+
+    expect(count).to.equal(1)
+  })
+
+  it('should schedule re-running the task after interrupting the timeout', async () => {
+    let count = 0
+
+    task = repeatingTask(() => {
+      count++
+    }, 100, {
+      debounce: 10
+    })
+    task.start()
+
+    // run immediately
+    task.run()
+
+    // less than the repeat interval
+    await delay(50)
+
+    expect(count).to.equal(1)
+
+    // wait longer than the repeat interval
+    await delay(150)
 
     expect(count).to.equal(2)
   })


### PR DESCRIPTION
Adds a `.run` method to a repeating task that lets us interrupt the timeout to run immediately (debounced) before rescheduling the task to run again in the future.

## Change checklist

- [x] I have performed a self-review of my own code
- [x] I have made corresponding changes to the documentation if necessary (this includes comments as well)
- [x] I have added tests that prove my fix is effective or that my feature works