### PR TITLE
docs: update kad-dht api docs link

### DIFF
--- a/packages/kad-dht/README.md
+++ b/packages/kad-dht/README.md
@@ -170,7 +170,7 @@ Loading this module through a script tag will make its exports available as `Lib
 
 # API Docs
 
-- <https://libp2p.github.io/js-libp2p-kad-dht/>
+- <https://libp2p.github.io/js-libp2p/modules/_libp2p_kad-dht.html/>
 
 # License
 

--- a/packages/kad-dht/README.md
+++ b/packages/kad-dht/README.md
@@ -170,7 +170,7 @@ Loading this module through a script tag will make its exports available as `Lib
 
 # API Docs
 
-- <https://libp2p.github.io/js-libp2p/modules/_libp2p_kad_dht.html>
+- <https://libp2p.github.io/js-libp2p-kad-dht/>
 
 # License
 


### PR DESCRIPTION
Replaced the outdated API documentation link with the new, working URL (https://libp2p.github.io/js-libp2p-kad-dht/) in the README. This ensures users can access the latest auto-generated documentation for @libp2p/kad-dht.