### PR TITLE
fix: add multiaddr resolvers

### DIFF
--- a/packages/interface/package.json
+++ b/packages/interface/package.json
@@ -41,6 +41,7 @@
     "build": "aegir build"
   },
   "dependencies": {
+    "@multiformats/dns": "^1.0.6",
     "@multiformats/multiaddr": "^12.4.4",
     "it-pushable": "^3.2.3",
     "it-stream-types": "^2.0.2",

--- a/packages/interface/src/index.ts
+++ b/packages/interface/src/index.ts
@@ -26,10 +26,10 @@ import type { Startable } from './startable.js'
 import type { StreamHandler, StreamHandlerOptions } from './stream-handler.js'
 import type { Topology } from './topology.js'
 import type { Listener, OutboundConnectionUpgradeEvents } from './transport.js'
+import type { DNS } from '@multiformats/dns'
 import type { Multiaddr } from '@multiformats/multiaddr'
 import type { TypedEventTarget } from 'main-event'
 import type { ProgressOptions, ProgressEvent } from 'progress-events'
-import type { DNS } from '@multiformats/dns'
 
 /**
  * Used by the connection manager to sort addresses into order before dialling

--- a/packages/interface/src/index.ts
+++ b/packages/interface/src/index.ts
@@ -29,6 +29,7 @@ import type { Listener, OutboundConnectionUpgradeEvents } from './transport.js'
 import type { Multiaddr } from '@multiformats/multiaddr'
 import type { TypedEventTarget } from 'main-event'
 import type { ProgressOptions, ProgressEvent } from 'progress-events'
+import type { DNS } from '@multiformats/dns'
 
 /**
  * Used by the connection manager to sort addresses into order before dialling
@@ -171,6 +172,29 @@ export interface ComponentLogger {
    * ```
    */
   forComponent(name: string): Logger
+}
+
+export interface MultiaddrResolveOptions extends AbortOptions, LoggerOptions {
+  /**
+   * An optional DNS resolver
+   */
+  dns?: DNS
+}
+
+/**
+ * `MultiaddrResolver`s perform resolution of multiaddr components that require
+ * translation by external systems (for example DNSADDR to TXT records).
+ */
+export interface MultiaddrResolver {
+  /**
+   * Returns true if this resolver can resolve components of this multiaddr
+   */
+  canResolve (address: Multiaddr): boolean
+
+  /**
+   * Returns one or more multiaddrs with components resolved to other values
+   */
+  resolve (address: Multiaddr, options: MultiaddrResolveOptions): Promise<Multiaddr[]>
 }
 
 /**

--- a/packages/libp2p/src/config.ts
+++ b/packages/libp2p/src/config.ts
@@ -1,6 +1,6 @@
 import { FaultTolerance, InvalidParametersError } from '@libp2p/interface'
 import { mergeOptions } from '@libp2p/utils/merge-options'
-import { dnsaddrResolver } from '@multiformats/multiaddr/resolvers'
+import { dnsaddrResolver } from './connection-manager/resolvers/dnsaddr.ts'
 import type { Libp2pInit } from './index.js'
 import type { ServiceMap } from '@libp2p/interface'
 import type { Multiaddr } from '@multiformats/multiaddr'

--- a/packages/libp2p/src/connection-manager/constants.defaults.ts
+++ b/packages/libp2p/src/connection-manager/constants.defaults.ts
@@ -54,3 +54,8 @@ export const LAST_DIAL_SUCCESS_KEY = 'last-dial-success'
  * @see https://libp2p.github.io/js-libp2p/interfaces/index._internal_.ConnectionManagerConfig.html#maxDialQueueLength
  */
 export const MAX_DIAL_QUEUE_LENGTH = 500
+
+/**
+ * @see https://libp2p.github.io/js-libp2p/interfaces/index._internal_.ConnectionManagerConfig.html#maxRecursiveDepth
+ */
+export const MAX_RECURSIVE_DEPTH = 32

--- a/packages/libp2p/src/connection-manager/dial-queue.ts
+++ b/packages/libp2p/src/connection-manager/dial-queue.ts
@@ -414,8 +414,8 @@ export class DialQueue {
       addrs.map(async addr => {
         const result = await resolveMultiaddr(addr.multiaddr, this.resolvers, {
           dns: this.components.dns,
-          ...options,
-          log: this.log
+          log: this.log,
+          ...options
         })
 
         if (result.length === 1 && result[0].equals(addr.multiaddr)) {

--- a/packages/libp2p/src/connection-manager/index.ts
+++ b/packages/libp2p/src/connection-manager/index.ts
@@ -2,21 +2,20 @@ import { ConnectionClosedError, InvalidMultiaddrError, InvalidParametersError, I
 import { PeerMap } from '@libp2p/peer-collections'
 import { RateLimiter } from '@libp2p/utils/rate-limiter'
 import { multiaddr } from '@multiformats/multiaddr'
-import { dnsaddrResolver } from './resolvers/index.ts'
 import { CustomProgressEvent } from 'progress-events'
 import { getPeerAddress } from '../get-peer.js'
 import { ConnectionPruner } from './connection-pruner.js'
 import { DIAL_TIMEOUT, INBOUND_CONNECTION_THRESHOLD, MAX_CONNECTIONS, MAX_DIAL_QUEUE_LENGTH, MAX_INCOMING_PENDING_CONNECTIONS, MAX_PARALLEL_DIALS, MAX_PEER_ADDRS_TO_DIAL } from './constants.js'
 import { DialQueue } from './dial-queue.js'
 import { ReconnectQueue } from './reconnect-queue.js'
+import { dnsaddrResolver } from './resolvers/index.ts'
 import { multiaddrToIpNet } from './utils.js'
 import type { IpNet } from '@chainsafe/netmask'
-import type { PendingDial, AddressSorter, Libp2pEvents, AbortOptions, ComponentLogger, Logger, Connection, MultiaddrConnection, ConnectionGater, Metrics, PeerId, PeerStore, Startable, PendingDialStatus, PeerRouting, IsDialableOptions } from '@libp2p/interface'
+import type { PendingDial, AddressSorter, Libp2pEvents, AbortOptions, ComponentLogger, Logger, Connection, MultiaddrConnection, ConnectionGater, Metrics, PeerId, PeerStore, Startable, PendingDialStatus, PeerRouting, IsDialableOptions, MultiaddrResolver } from '@libp2p/interface'
 import type { ConnectionManager, OpenConnectionOptions, TransportManager } from '@libp2p/interface-internal'
 import type { JobStatus } from '@libp2p/utils/queue'
 import type { Multiaddr } from '@multiformats/multiaddr'
 import type { TypedEventTarget } from 'main-event'
-import type { MultiaddrResolver } from '@libp2p/interface'
 
 export const DEFAULT_DIAL_PRIORITY = 50
 

--- a/packages/libp2p/src/connection-manager/index.ts
+++ b/packages/libp2p/src/connection-manager/index.ts
@@ -2,7 +2,7 @@ import { ConnectionClosedError, InvalidMultiaddrError, InvalidParametersError, I
 import { PeerMap } from '@libp2p/peer-collections'
 import { RateLimiter } from '@libp2p/utils/rate-limiter'
 import { multiaddr } from '@multiformats/multiaddr'
-import { dnsaddrResolver } from '@multiformats/multiaddr/resolvers'
+import { dnsaddrResolver } from './resolvers/index.ts'
 import { CustomProgressEvent } from 'progress-events'
 import { getPeerAddress } from '../get-peer.js'
 import { ConnectionPruner } from './connection-pruner.js'
@@ -14,8 +14,9 @@ import type { IpNet } from '@chainsafe/netmask'
 import type { PendingDial, AddressSorter, Libp2pEvents, AbortOptions, ComponentLogger, Logger, Connection, MultiaddrConnection, ConnectionGater, Metrics, PeerId, PeerStore, Startable, PendingDialStatus, PeerRouting, IsDialableOptions } from '@libp2p/interface'
 import type { ConnectionManager, OpenConnectionOptions, TransportManager } from '@libp2p/interface-internal'
 import type { JobStatus } from '@libp2p/utils/queue'
-import type { Multiaddr, Resolver } from '@multiformats/multiaddr'
+import type { Multiaddr } from '@multiformats/multiaddr'
 import type { TypedEventTarget } from 'main-event'
+import type { MultiaddrResolver } from '@libp2p/interface'
 
 export const DEFAULT_DIAL_PRIORITY = 50
 
@@ -112,7 +113,7 @@ export interface ConnectionManagerInit {
   /**
    * Multiaddr resolvers to use when dialling
    */
-  resolvers?: Record<string, Resolver>
+  resolvers?: Record<string, MultiaddrResolver>
 
   /**
    * A list of multiaddrs that will always be allowed (except if they are in the

--- a/packages/libp2p/src/connection-manager/resolvers/dnsaddr.ts
+++ b/packages/libp2p/src/connection-manager/resolvers/dnsaddr.ts
@@ -1,7 +1,8 @@
-import { dns, RecordType, type DNS } from '@multiformats/dns'
+import { dns, RecordType } from '@multiformats/dns'
 import { multiaddr } from '@multiformats/multiaddr'
-import type { Multiaddr } from '@multiformats/multiaddr'
 import type { MultiaddrResolver, MultiaddrResolveOptions } from '@libp2p/interface'
+import type { DNS } from '@multiformats/dns'
+import type { Multiaddr } from '@multiformats/multiaddr'
 
 class DNSAddrResolver implements MultiaddrResolver {
   private dns?: DNS

--- a/packages/libp2p/src/connection-manager/resolvers/dnsaddr.ts
+++ b/packages/libp2p/src/connection-manager/resolvers/dnsaddr.ts
@@ -1,0 +1,68 @@
+import { dns, RecordType, type DNS } from '@multiformats/dns'
+import { multiaddr } from '@multiformats/multiaddr'
+import type { Multiaddr } from '@multiformats/multiaddr'
+import type { MultiaddrResolver, MultiaddrResolveOptions } from '@libp2p/interface'
+
+class DNSAddrResolver implements MultiaddrResolver {
+  private dns?: DNS
+
+  canResolve (ma: Multiaddr): boolean {
+    return ma.getComponents().some(({ name }) => name === 'dnsaddr')
+  }
+
+  async resolve (ma: Multiaddr, options: MultiaddrResolveOptions): Promise<Multiaddr[]> {
+    const hostname = ma.getComponents()
+      .find(component => component.name === 'dnsaddr')
+      ?.value
+
+    if (hostname == null) {
+      return [ma]
+    }
+
+    const resolver = this.getDNS(options)
+    const result = await resolver.query(`_dnsaddr.${hostname}`, {
+      signal: options?.signal,
+      types: [
+        RecordType.TXT
+      ]
+    })
+
+    const peerId = ma.getComponents()
+      .find(component => component.name === 'p2p')
+      ?.value
+    const output: Multiaddr[] = []
+
+    for (const answer of result.Answer) {
+      const addr = answer.data
+        .replace(/["']/g, '')
+        .trim()
+        .split('=')[1]
+
+      if (addr == null) {
+        continue
+      }
+
+      if (peerId != null && !addr.includes(peerId)) {
+        continue
+      }
+
+      output.push(multiaddr(addr))
+    }
+
+    return output
+  }
+
+  private getDNS (options: MultiaddrResolveOptions): DNS {
+    if (options.dns != null) {
+      return options.dns
+    }
+
+    if (this.dns == null) {
+      this.dns = dns()
+    }
+
+    return this.dns
+  }
+}
+
+export const dnsaddrResolver = new DNSAddrResolver()

--- a/packages/libp2p/src/connection-manager/resolvers/index.ts
+++ b/packages/libp2p/src/connection-manager/resolvers/index.ts
@@ -1,0 +1,59 @@
+import type { Multiaddr } from '@multiformats/multiaddr'
+import { MAX_RECURSIVE_DEPTH } from '../constants.defaults.ts'
+import { RecursionLimitError } from '../../errors.ts'
+import type { MultiaddrResolveOptions, MultiaddrResolver } from '@libp2p/interface'
+
+export interface ResolveOptions extends MultiaddrResolveOptions {
+  /**
+   * When resolving DNSADDR Multiaddrs that resolve to other DNSADDR Multiaddrs,
+   * limit how many times we will recursively resolve them.
+   *
+   * @default 32
+   */
+  maxRecursiveDepth?: number
+
+  /**
+   * The current recursive depth
+   *
+   * @default 0
+   */
+  depth?: number
+}
+
+/**
+ * Recursively resolve multiaddrs
+ */
+export async function resolveMultiaddr (address: Multiaddr, resolvers: Record<string, MultiaddrResolver>, options: ResolveOptions): Promise<Multiaddr[]> {
+  const depth = options.depth ?? 0
+
+  if (depth > (options.maxRecursiveDepth ?? MAX_RECURSIVE_DEPTH)) {
+    throw new RecursionLimitError('Max recursive depth reached')
+  }
+
+  let resolved = false
+  const output: Multiaddr[] = []
+
+  for (const resolver of Object.values(resolvers)) {
+    if (resolver.canResolve(address)) {
+      resolved = true
+      const addresses = await resolver.resolve(address, options)
+
+      for (const address of addresses) {
+        output.push(
+          ...(await resolveMultiaddr(address, resolvers, {
+            ...options,
+            depth: depth + 1
+          }))
+        )
+      }
+    }
+  }
+
+  if (resolved === false) {
+    output.push(address)
+  }
+
+  return output
+}
+
+export { dnsaddrResolver } from './dnsaddr.js'

--- a/packages/libp2p/src/connection-manager/resolvers/index.ts
+++ b/packages/libp2p/src/connection-manager/resolvers/index.ts
@@ -1,7 +1,7 @@
-import type { Multiaddr } from '@multiformats/multiaddr'
-import { MAX_RECURSIVE_DEPTH } from '../constants.defaults.ts'
 import { RecursionLimitError } from '../../errors.ts'
+import { MAX_RECURSIVE_DEPTH } from '../constants.defaults.ts'
 import type { MultiaddrResolveOptions, MultiaddrResolver } from '@libp2p/interface'
+import type { Multiaddr } from '@multiformats/multiaddr'
 
 export interface ResolveOptions extends MultiaddrResolveOptions {
   /**

--- a/packages/libp2p/src/connection-manager/utils.ts
+++ b/packages/libp2p/src/connection-manager/utils.ts
@@ -1,35 +1,7 @@
-import { multiaddr, resolvers } from '@multiformats/multiaddr'
+import { multiaddr } from '@multiformats/multiaddr'
 import { convertToIpNet } from '@multiformats/multiaddr/convert'
 import type { IpNet } from '@chainsafe/netmask'
-import type { LoggerOptions } from '@libp2p/interface'
-import type { Multiaddr, ResolveOptions } from '@multiformats/multiaddr'
-
-/**
- * Recursively resolve DNSADDR multiaddrs
- */
-export async function resolveMultiaddrs (ma: Multiaddr, options: ResolveOptions & LoggerOptions): Promise<Multiaddr[]> {
-  // check multiaddr resolvers
-  let resolvable = false
-
-  for (const key of resolvers.keys()) {
-    resolvable = ma.protoNames().includes(key)
-
-    if (resolvable) {
-      break
-    }
-  }
-
-  // return multiaddr if it is not resolvable
-  if (!resolvable) {
-    return [ma]
-  }
-
-  const output = await ma.resolve(options)
-
-  options.log('resolved %s to', ma, output.map(ma => ma.toString()))
-
-  return output
-}
+import type { Multiaddr } from '@multiformats/multiaddr'
 
 /**
  * Converts a multiaddr string or object to an IpNet object.
@@ -50,9 +22,11 @@ export function multiaddrToIpNet (ma: string | Multiaddr): IpNet {
       parsedMa = ma
     }
 
+    const protoNames = new Set([...parsedMa.getComponents().map(component => component.name)])
+
     // Check if /ipcidr is already present
-    if (!parsedMa.protoNames().includes('ipcidr')) {
-      const isIPv6 = parsedMa.protoNames().includes('ip6')
+    if (!protoNames.has('ipcidr')) {
+      const isIPv6 = protoNames.has('ip6')
       const cidr = isIPv6 ? '/ipcidr/128' : '/ipcidr/32'
       parsedMa = parsedMa.encapsulate(cidr)
     }

--- a/packages/libp2p/src/errors.ts
+++ b/packages/libp2p/src/errors.ts
@@ -114,3 +114,10 @@ export class TransportUnavailableError extends Error {
     this.name = 'TransportUnavailableError'
   }
 }
+
+export class RecursionLimitError extends Error {
+  constructor (message = 'Max recursive depth reached') {
+    super(message)
+    this.name = 'RecursionLimitError'
+  }
+}

--- a/packages/libp2p/src/index.ts
+++ b/packages/libp2p/src/index.ts
@@ -34,6 +34,8 @@ export type ServiceFactoryMap<T extends ServiceMap = ServiceMap> = {
 
 export type { AddressManagerInit, AddressFilter }
 
+export { dnsaddrResolver } from './connection-manager/resolvers/index.ts'
+
 /**
  * For Libp2p configurations and modules details read the [Configuration Document](https://github.com/libp2p/js-libp2p/tree/main/doc/CONFIGURATION.md).
  */

--- a/packages/libp2p/test/connection-manager/dial-queue.spec.ts
+++ b/packages/libp2p/test/connection-manager/dial-queue.spec.ts
@@ -4,7 +4,7 @@ import { generateKeyPair } from '@libp2p/crypto/keys'
 import { NotFoundError } from '@libp2p/interface'
 import { peerLogger } from '@libp2p/logger'
 import { peerIdFromPrivateKey } from '@libp2p/peer-id'
-import { multiaddr, resolvers } from '@multiformats/multiaddr'
+import { multiaddr } from '@multiformats/multiaddr'
 import { TCP, WebRTC } from '@multiformats/multiaddr-matcher'
 import { expect } from 'aegir/chai'
 import delay from 'delay'
@@ -13,7 +13,7 @@ import { raceSignal } from 'race-signal'
 import sinon from 'sinon'
 import { stubInterface } from 'sinon-ts'
 import { DialQueue } from '../../src/connection-manager/dial-queue.js'
-import type { ComponentLogger, Connection, ConnectionGater, PeerId, PeerRouting, PeerStore, Transport } from '@libp2p/interface'
+import type { ComponentLogger, Connection, ConnectionGater, MultiaddrResolver, PeerId, PeerRouting, PeerStore, Transport } from '@libp2p/interface'
 import type { TransportManager } from '@libp2p/interface-internal'
 import type { StubbedInstance } from 'sinon-ts'
 
@@ -294,8 +294,8 @@ describe('dial queue', () => {
     const ma = multiaddr(`/dnsaddr/example.com/p2p/${remotePeer}`)
     const maStr = `/ip4/123.123.123.123/tcp/2348/p2p/${remotePeer}`
     const resolvedAddresses = [
-      `/ip4/234.234.234.234/tcp/4213/p2p/${otherRemotePeer}`,
-      maStr
+      multiaddr(`/ip4/234.234.234.234/tcp/4213/p2p/${otherRemotePeer}`),
+      multiaddr(maStr)
     ]
 
     let resolvedDNSAddrs = false
@@ -303,17 +303,23 @@ describe('dial queue', () => {
 
     // simulate a DNSAddr that resolves to multiple different peers like
     // bootstrap.libp2p.io
-    resolvers.set('dnsaddr', async (addr) => {
-      if (addr.equals(ma)) {
-        resolvedDNSAddrs = true
-        return resolvedAddresses
-      }
+    const resolvers: Record<string, MultiaddrResolver> = {
+      dnsaddr: {
+        canResolve: (ma) => ma.getComponents().some(({ name }) => name === 'dnsaddr'),
+        resolve: async (addr) => {
+          if (addr.equals(ma)) {
+            resolvedDNSAddrs = true
+            return resolvedAddresses
+          }
 
-      return []
-    })
+          return [ma]
+        }
+      }
+    }
 
     dialer = new DialQueue(components, {
-      maxParallelDials: 50
+      maxParallelDials: 50,
+      resolvers
     })
     components.transportManager.dialTransportForMultiaddr.returns(stubInterface<Transport>())
 
@@ -334,8 +340,6 @@ describe('dial queue', () => {
     await expect(dialer.dial(ma)).to.eventually.equal(connection)
     expect(resolvedDNSAddrs).to.be.true('Did not resolve DNSAddrs')
     expect(dialedBadAddress).to.be.false('Dialed address with wrong peer id')
-
-    resolvers.delete('dnsaddr')
   })
 
   it('should dial WebRTC address with peer id appended', async () => {

--- a/packages/libp2p/test/connection-manager/resolvers.spec.ts
+++ b/packages/libp2p/test/connection-manager/resolvers.spec.ts
@@ -1,0 +1,222 @@
+import { RecordType } from '@multiformats/dns'
+import { expect } from 'aegir/chai'
+import sinon from 'sinon'
+import { stubInterface } from 'sinon-ts'
+import { multiaddr } from '@multiformats/multiaddr'
+import { dnsaddrResolver, resolveMultiaddr } from '../../src/connection-manager/resolvers/index.js'
+import type { DNS } from '@multiformats/dns'
+import type { StubbedInstance } from 'sinon-ts'
+import type { ComponentLogger, Logger, MultiaddrResolver } from '@libp2p/interface'
+import { defaultLogger } from '@libp2p/logger'
+
+const stubs: Record<string, string[]> = {
+  '_dnsaddr.bootstrap.libp2p.io': [
+    'dnsaddr=/dnsaddr/ams-1.bootstrap.libp2p.io/p2p/QmSoLer265NRgSp2LA3dPaeykiS1J6DifTC88f5uVQKNAd',
+    'dnsaddr=/dnsaddr/ams-2.bootstrap.libp2p.io/p2p/QmbLHAnMoJPWSCR5Zhtx6BHJX9KiKNN6tpvbUcqanj75Nb'
+  ],
+  '_dnsaddr.ams-1.bootstrap.libp2p.io': [
+    'dnsaddr=/ip4/147.75.83.83/tcp/4001/p2p/QmSoLer265NRgSp2LA3dPaeykiS1J6DifTC88f5uVQKNAd',
+    'dnsaddr=/ip4/147.75.83.83/tcp/443/wss/p2p/QmSoLer265NRgSp2LA3dPaeykiS1J6DifTC88f5uVQKNAd',
+    'dnsaddr=/ip4/147.75.83.83/udp/4001/quic/p2p/QmSoLer265NRgSp2LA3dPaeykiS1J6DifTC88f5uVQKNAd',
+    'dnsaddr=/ip6/2604:1380:2000:7a00::1/tcp/4001/p2p/QmSoLer265NRgSp2LA3dPaeykiS1J6DifTC88f5uVQKNAd',
+    'dnsaddr=/ip6/2604:1380:2000:7a00::1/tcp/443/wss/p2p/QmSoLer265NRgSp2LA3dPaeykiS1J6DifTC88f5uVQKNAd',
+    'dnsaddr=/ip6/2604:1380:2000:7a00::1/udp/4001/quic/p2p/QmSoLer265NRgSp2LA3dPaeykiS1J6DifTC88f5uVQKNAd'
+  ],
+  '_dnsaddr.ams-2.bootstrap.libp2p.io': [
+    'dnsaddr=/ip4/147.75.83.83/tcp/4001/p2p/QmbLHAnMoJPWSCR5Zhtx6BHJX9KiKNN6tpvbUcqanj75Nb',
+    'dnsaddr=/ip4/147.75.83.83/tcp/443/wss/p2p/QmbLHAnMoJPWSCR5Zhtx6BHJX9KiKNN6tpvbUcqanj75Nb',
+    'dnsaddr=/ip4/147.75.83.83/udp/4001/quic/p2p/QmbLHAnMoJPWSCR5Zhtx6BHJX9KiKNN6tpvbUcqanj75Nb',
+    'dnsaddr=/ip6/2604:1380:2000:7a00::1/tcp/4001/p2p/QmbLHAnMoJPWSCR5Zhtx6BHJX9KiKNN6tpvbUcqanj75Nb',
+    'dnsaddr=/ip6/2604:1380:2000:7a00::1/tcp/443/wss/p2p/QmbLHAnMoJPWSCR5Zhtx6BHJX9KiKNN6tpvbUcqanj75Nb',
+    'dnsaddr=/ip6/2604:1380:2000:7a00::1/udp/4001/quic/p2p/QmbLHAnMoJPWSCR5Zhtx6BHJX9KiKNN6tpvbUcqanj75Nb'
+  ],
+  '_dnsaddr.bad-addrs.libp2p.io': [
+    'dnsaddr=/dnsaddr/sv15.bootstrap.libp2p.io/p2p/QmNnooDu7bfjPFoTZYxMNLWUQJyrVwtbZg5gBMjTezGAJN',
+    'dnsaddr=/dnsaddr/ny5.bootstrap.libp2p.io/p2p/QmQCU2EcMqAqQPR2i9bChDtGNJchTbq5TbXJJ16u19uLTa',
+    'dnsaddr_record_value',
+    'dnsaddr=/dnsaddr/am6.bootstrap.libp2p.io/p2p/QmbLHAnMoJPWSCR5Zhtx6BHJX9KiKNN6tpvbUcqanj75Nb',
+    'dnsaddr=/dnsaddr/sg1.bootstrap.libp2p.io/p2p/QmcZf59bWwK5XFi76CZX8cbJ4BhTzzA3gU1ZjYZcYW3dwt'
+  ],
+  '_dnsaddr.am6.bootstrap.libp2p.io': [
+    'dnsaddr=/ip4/147.75.83.83/tcp/4001/p2p/QmbLHAnMoJPWSCR5Zhtx6BHJX9KiKNN6tpvbUcqanj75Nb'
+  ],
+  '_dnsaddr.self-referential.io': [
+    'dnsaddr=/dnsaddr/self-referential.io'
+  ],
+  '_dnsaddr.double-quoted-answer.io': [
+    '"dnsaddr=/ip4/147.75.83.83/tcp/4001/p2p/QmbLHAnMoJPWSCR5Zhtx6BHJX9KiKNN6tpvbUcqanj75Nb"'
+  ],
+  '_dnsaddr.single-quoted-answer.io': [
+    "'dnsaddr=/ip4/147.75.83.83/tcp/4001/p2p/QmbLHAnMoJPWSCR5Zhtx6BHJX9KiKNN6tpvbUcqanj75Nb'"
+  ],
+  '_dnsaddr.mixed-quoted-answer.io': [
+    '"\'""" dnsaddr=/ip4/147.75.83.83/tcp/4001/p2p/QmbLHAnMoJPWSCR5Zhtx6BHJX9KiKNN6tpvbUcqanj75Nb"  "'
+  ]
+}
+
+describe.only('multiaddr resolve', () => {
+  let dns: StubbedInstance<DNS>
+  let resolvers: Record<string, MultiaddrResolver>
+  let log: Logger
+
+  beforeEach(() => {
+    dns = stubInterface<DNS>({
+      query: sinon.stub().callsFake((domain) => {
+        if (stubs[domain] != null) {
+          return {
+            Answer: stubs[domain].map(data => ({
+              name: '_dnsaddr.bootstrap.libp2p.io',
+              type: RecordType.TXT,
+              ttl: 100,
+              data
+            }))
+          }
+        }
+
+        throw new Error(`No result stubbed for ${domain}`)
+      })
+    })
+    log = defaultLogger().forComponent('test')
+
+    resolvers = {
+      dnsaddr: dnsaddrResolver
+    }
+  })
+
+  it('should throw if no resolver is available', async () => {
+    const ma = multiaddr('/dnsaddr/bootstrap.libp2p.io')
+
+    resolvers = {}
+
+    // Resolve
+    await expect(ma.resolve()).to.eventually.be.rejected()
+      .and.to.have.property('name', 'NoAvailableResolverError')
+  })
+
+  describe('dnsaddr', () => {
+    afterEach(() => {
+      sinon.restore()
+    })
+
+    it('can resolve dnsaddr without no peerId', async () => {
+      const ma = multiaddr('/dnsaddr/bootstrap.libp2p.io')
+
+      // Resolve
+      const resolvedMas = await resolveMultiaddr(ma, resolvers, {
+        dns,
+        log
+      })
+
+      expect(resolvedMas).to.deep.equal([
+        ...stubs['_dnsaddr.ams-1.bootstrap.libp2p.io'].map(addr => multiaddr(addr.split('=').pop())),
+        ...stubs['_dnsaddr.ams-2.bootstrap.libp2p.io'].map(addr => multiaddr(addr.split('=').pop()))
+      ])
+    })
+
+    it('can resolve dnsaddr with peerId', async () => {
+      const ma = multiaddr('/dnsaddr/bootstrap.libp2p.io/p2p/QmbLHAnMoJPWSCR5Zhtx6BHJX9KiKNN6tpvbUcqanj75Nb')
+
+      // Resolve
+      const resolvedMas = await resolveMultiaddr(ma, resolvers, {
+        dns,
+        log
+      })
+
+      expect(resolvedMas).to.deep.equal([
+        ...stubs['_dnsaddr.ams-2.bootstrap.libp2p.io'].map(addr => multiaddr(addr.split('=').pop()))
+      ])
+    })
+
+    it('can resolve dnsaddr with bad record', async () => {
+      const ma = multiaddr('/dnsaddr/bad-addrs.libp2p.io/p2p/QmbLHAnMoJPWSCR5Zhtx6BHJX9KiKNN6tpvbUcqanj75Nb')
+
+      // Resolve
+      const resolvedMas = await resolveMultiaddr(ma, resolvers, {
+        dns,
+        log
+      })
+
+      // Should only have one address with the same peer id and should ignore the bad record
+      expect(resolvedMas).to.have.lengthOf(1)
+      expect(resolvedMas[0].toString()).to.equal(stubs['_dnsaddr.am6.bootstrap.libp2p.io'][0].split('=').pop())
+    })
+
+    it('can cancel resolving', async () => {
+      const ma = multiaddr('/dnsaddr/bootstrap.libp2p.ii/p2p/QmbLHAnMoJPWSCR5Zhtx6BHJX9KiKNN6tpvbUcqanj75Nc')
+      const controller = new AbortController()
+
+      // Resolve
+      const resolvePromise = ma.resolve({
+        signal: controller.signal
+      })
+
+      controller.abort()
+
+      await expect(resolvePromise).to.eventually.be.rejected()
+    })
+
+    it('should abort resolving deeply nested records', async () => {
+      const ma = multiaddr('/dnsaddr/bootstrap.libp2p.io')
+
+      // Resolve
+      await expect(resolveMultiaddr(ma, resolvers, {
+        dns,
+        log,
+        maxRecursiveDepth: 1
+      })).to.eventually.be.rejected().with.property('name', 'RecursionLimitError')
+    })
+
+    it('should handle recursive loops', async () => {
+      const ma = multiaddr('/dnsaddr/self-referential.io')
+
+      // Resolve
+      await expect(resolveMultiaddr(ma, resolvers, {
+        dns,
+        log,
+        maxRecursiveDepth: 1
+      })).to.eventually.be.rejected().with.property('name', 'RecursionLimitError')
+    })
+
+    it('should handle double quotes', async () => {
+      const ma = multiaddr('/dnsaddr/double-quoted-answer.io')
+
+      // Resolve
+      const resolvedMas = await resolveMultiaddr(ma, resolvers, {
+        dns,
+        log
+      })
+
+      // Should ignore double quotes
+      expect(resolvedMas).to.have.lengthOf(1)
+      expect(resolvedMas[0].toString()).to.equal('/ip4/147.75.83.83/tcp/4001/p2p/QmbLHAnMoJPWSCR5Zhtx6BHJX9KiKNN6tpvbUcqanj75Nb')
+    })
+
+    it('should handle single quotes', async () => {
+      const ma = multiaddr('/dnsaddr/single-quoted-answer.io')
+
+      // Resolve
+      const resolvedMas = await resolveMultiaddr(ma, resolvers, {
+        dns,
+        log
+      })
+
+      // Should ignore double quotes
+      expect(resolvedMas).to.have.lengthOf(1)
+      expect(resolvedMas[0].toString()).to.equal('/ip4/147.75.83.83/tcp/4001/p2p/QmbLHAnMoJPWSCR5Zhtx6BHJX9KiKNN6tpvbUcqanj75Nb')
+    })
+
+    it('should handle mixed quotes', async () => {
+      const ma = multiaddr('/dnsaddr/mixed-quoted-answer.io')
+
+      // Resolve
+      const resolvedMas = await resolveMultiaddr(ma, resolvers, {
+        dns,
+        log
+      })
+
+      // Should ignore double quotes
+      expect(resolvedMas).to.have.lengthOf(1)
+      expect(resolvedMas[0].toString()).to.equal('/ip4/147.75.83.83/tcp/4001/p2p/QmbLHAnMoJPWSCR5Zhtx6BHJX9KiKNN6tpvbUcqanj75Nb')
+    })
+  })
+})

--- a/packages/libp2p/test/connection-manager/resolvers.spec.ts
+++ b/packages/libp2p/test/connection-manager/resolvers.spec.ts
@@ -1,13 +1,13 @@
+import { defaultLogger } from '@libp2p/logger'
 import { RecordType } from '@multiformats/dns'
+import { multiaddr } from '@multiformats/multiaddr'
 import { expect } from 'aegir/chai'
 import sinon from 'sinon'
 import { stubInterface } from 'sinon-ts'
-import { multiaddr } from '@multiformats/multiaddr'
 import { dnsaddrResolver, resolveMultiaddr } from '../../src/connection-manager/resolvers/index.js'
+import type { Logger, MultiaddrResolver } from '@libp2p/interface'
 import type { DNS } from '@multiformats/dns'
 import type { StubbedInstance } from 'sinon-ts'
-import type { ComponentLogger, Logger, MultiaddrResolver } from '@libp2p/interface'
-import { defaultLogger } from '@libp2p/logger'
 
 const stubs: Record<string, string[]> = {
   '_dnsaddr.bootstrap.libp2p.io': [
@@ -54,7 +54,7 @@ const stubs: Record<string, string[]> = {
   ]
 }
 
-describe.only('multiaddr resolve', () => {
+describe('multiaddr resolve', () => {
   let dns: StubbedInstance<DNS>
   let resolvers: Record<string, MultiaddrResolver>
   let log: Logger


### PR DESCRIPTION
Use internal multiaddr resolvers so they can be removed from the Multiaddr class to make it more lightweight.

## Change checklist

- [x] I have performed a self-review of my own code
- [x] I have made corresponding changes to the documentation if necessary (this includes comments as well)
- [ ] I have added tests that prove my fix is effective or that my feature works