### PR TITLE
fix: remove signal event listener used during query

### DIFF
--- a/packages/kad-dht/src/query/query-path.ts
+++ b/packages/kad-dht/src/query/query-path.ts
@@ -104,7 +104,7 @@ export async function * queryPath (options: QueryPathOptions): AsyncGenerator<Qu
     log.error('error during query - %e', evt.detail)
   })
 
-  const onAbort = () => {
+  const onAbort = (): void => {
     queue.abort()
     events.end(new AbortError())
   }


### PR DESCRIPTION
If the signal is long lived this accumulate over time.

## Change checklist

- [x] I have performed a self-review of my own code
- [ ] I have made corresponding changes to the documentation if necessary (this includes comments as well)
- [ ] I have added tests that prove my fix is effective or that my feature works