### PR TITLE
feat: add isLibp2p function for type guarding

### DIFF
--- a/packages/libp2p/src/index.ts
+++ b/packages/libp2p/src/index.ts
@@ -212,3 +212,19 @@ export async function createLibp2p <T extends ServiceMap = ServiceMap> (options:
 
   return node
 }
+
+// a non-exhaustive list of methods found on the libp2p object
+const LIBP2P_METHODS = ['dial', 'dialProtocol', 'hangUp', 'handle', 'unhandle', 'getMultiaddrs', 'getProtocols']
+
+/**
+ * Returns true if the passed object is a libp2p node - this can be used for
+ * type guarding in TypeScript.
+ */
+export function isLibp2p <T extends ServiceMap = ServiceMap> (obj?: any): obj is Libp2p<T> {
+  if (obj == null) {
+    return false
+  }
+
+  // if these are all functions it's probably a libp2p object
+  return LIBP2P_METHODS.every(m => typeof obj[m] === 'function')
+}

--- a/packages/libp2p/test/core/core.spec.ts
+++ b/packages/libp2p/test/core/core.spec.ts
@@ -3,7 +3,7 @@
 import { multiaddr } from '@multiformats/multiaddr'
 import { expect } from 'aegir/chai'
 import { stubInterface } from 'sinon-ts'
-import { createLibp2p } from '../../src/index.js'
+import { createLibp2p, isLibp2p } from '../../src/index.js'
 import type { Libp2p, Transport } from '@libp2p/interface'
 
 describe('core', () => {
@@ -17,6 +17,19 @@ describe('core', () => {
     libp2p = await createLibp2p()
 
     expect(libp2p).to.have.property('status', 'started')
+  })
+
+  it('should detect the libp2p type', async () => {
+    libp2p = await createLibp2p()
+
+    expect(isLibp2p(libp2p)).to.be.true()
+  })
+
+  it('should not detect the libp2p type', async () => {
+    expect(isLibp2p({})).to.be.false()
+    expect(isLibp2p()).to.be.false()
+    expect(isLibp2p(null)).to.be.false()
+    expect(isLibp2p(undefined)).to.be.false()
   })
 
   it('should say an address is not dialable if we have no transport for it', async () => {


### PR DESCRIPTION
Adds a simple function that detects libp2p-like objects.

## Change checklist

- [x] I have performed a self-review of my own code
- [x] I have made corresponding changes to the documentation if necessary (this includes comments as well)
- [x] I have added tests that prove my fix is effective or that my feature works