### PR TITLE
feat: allow async stream handlers

### DIFF
--- a/packages/interface-compliance-tests/src/mocks/connection.ts
+++ b/packages/interface-compliance-tests/src/mocks/connection.ts
@@ -143,7 +143,7 @@ export function mockConnection (maConn: MultiaddrConnection, opts: MockConnectio
         mss.handle(muxedStream, registrar.getProtocols(), {
           log
         })
-          .then(({ stream, protocol }) => {
+          .then(async ({ stream, protocol }) => {
             log('%s: incoming stream opened on %s', direction, protocol)
             muxedStream.protocol = protocol
             muxedStream.sink = stream.sink
@@ -152,7 +152,7 @@ export function mockConnection (maConn: MultiaddrConnection, opts: MockConnectio
             connection.streams.push(muxedStream)
             const { handler } = registrar.getHandler(protocol)
 
-            handler({ connection, stream: muxedStream })
+            await handler({ connection, stream: muxedStream })
           }).catch(err => {
             log.error(err)
           })

--- a/packages/interface/src/stream-handler.ts
+++ b/packages/interface/src/stream-handler.ts
@@ -17,7 +17,7 @@ export interface StreamHandler {
   /**
    * A callback function that accepts the incoming stream data
    */
-  (data: IncomingStreamData): void
+  (data: IncomingStreamData): void | Promise<void>
 }
 
 export interface StreamHandlerOptions extends AbortOptions {


### PR DESCRIPTION
Allow `await`ing promises inside stream handlers.

## Change checklist

- [x] I have performed a self-review of my own code
- [x] I have made corresponding changes to the documentation if necessary (this includes comments as well)
- [ ] I have added tests that prove my fix is effective or that my feature works