### PR TITLE
fix: use failure event instead of error

### DIFF
--- a/packages/kad-dht/src/content-routing/index.ts
+++ b/packages/kad-dht/src/content-routing/index.ts
@@ -134,8 +134,8 @@ export class ContentRouting {
     queue.addEventListener('idle', () => {
       events.end()
     })
-    queue.addEventListener('error', (err) => {
-      this.log.error('error publishing provider record to peer - %e', err)
+    queue.addEventListener('failure', (event) => {
+      this.log.error('error publishing provider record to peer - %e', event.detail.error)
     })
 
     queue.add(async () => {

--- a/packages/kad-dht/src/query/query-path.ts
+++ b/packages/kad-dht/src/query/query-path.ts
@@ -100,8 +100,8 @@ export async function * queryPath (options: QueryPathOptions): AsyncGenerator<Qu
 
     events.end()
   })
-  queue.addEventListener('error', (evt) => {
-    log.error('error during query - %e', evt.detail)
+  queue.addEventListener('failure', (evt) => {
+    log.error('error during query - %e', evt.detail.error)
   })
 
   const onAbort = (): void => {

--- a/packages/libp2p/src/connection-manager/dial-queue.ts
+++ b/packages/libp2p/src/connection-manager/dial-queue.ts
@@ -101,8 +101,8 @@ export class DialQueue {
       metrics: components.metrics
     })
     // a started job errored
-    this.queue.addEventListener('error', (event) => {
-      if (event.detail?.name !== AbortError.name) {
+    this.queue.addEventListener('failure', (event) => {
+      if (event.detail?.error.name !== AbortError.name) {
         this.log.error('error in dial queue - %e', event.detail)
       }
     })

--- a/packages/utils/src/queue/index.ts
+++ b/packages/utils/src/queue/index.ts
@@ -265,7 +265,6 @@ export class Queue<JobReturnType = unknown, JobOptions extends AbortOptions = Ab
           }
         }
 
-        this.safeDispatchEvent('error', { detail: err })
         this.safeDispatchEvent('failure', { detail: { job, error: err } })
 
         throw err
@@ -397,8 +396,8 @@ export class Queue<JobReturnType = unknown, JobOptions extends AbortOptions = Ab
       }
     }
 
-    const onQueueError = (evt: CustomEvent<Error>): void => {
-      cleanup(evt.detail)
+    const onQueueFailure = (evt: CustomEvent<QueueJobFailure<JobReturnType, JobOptions>>): void => {
+      cleanup(evt.detail.error)
     }
 
     const onQueueIdle = (): void => {
@@ -412,7 +411,7 @@ export class Queue<JobReturnType = unknown, JobOptions extends AbortOptions = Ab
 
     // add listeners
     this.addEventListener('completed', onQueueJobComplete)
-    this.addEventListener('error', onQueueError)
+    this.addEventListener('failure', onQueueFailure)
     this.addEventListener('idle', onQueueIdle)
     options?.signal?.addEventListener('abort', onSignalAbort)
 
@@ -421,7 +420,7 @@ export class Queue<JobReturnType = unknown, JobOptions extends AbortOptions = Ab
     } finally {
       // remove listeners
       this.removeEventListener('completed', onQueueJobComplete)
-      this.removeEventListener('error', onQueueError)
+      this.removeEventListener('failure', onQueueFailure)
       this.removeEventListener('idle', onQueueIdle)
       options?.signal?.removeEventListener('abort', onSignalAbort)
 

--- a/packages/utils/src/queue/index.ts
+++ b/packages/utils/src/queue/index.ts
@@ -101,6 +101,8 @@ export interface QueueEvents<JobReturnType, JobOptions extends AbortOptions = Ab
 
   /**
    * A job has failed
+   *
+   * @deprecated Listen for the 'failure' event instead - it gives more context and is generally more useful, this event will be removed in a future release
    */
   error: CustomEvent<Error>
 

--- a/packages/utils/test/peer-job-queue.spec.ts
+++ b/packages/utils/test/peer-job-queue.spec.ts
@@ -165,10 +165,7 @@ describe('peer queue', () => {
       peerId: peerIdA
     }).catch(() => {})
 
-    const event = await raceEvent<CustomEvent<QueueJobFailure<string, PeerQueueJobOptions>>>(queue, 'failure', AbortSignal.timeout(10_000), {
-      // TODO: remove this option when queues no longer emit an error event
-      errorEvent: 'ignore'
-    })
+    const event = await raceEvent<CustomEvent<QueueJobFailure<string, PeerQueueJobOptions>>>(queue, 'failure', AbortSignal.timeout(10_000))
 
     expect(event.detail.job.options.peerId).to.equal(peerIdA)
     expect(event.detail.error).to.equal(err)

--- a/packages/utils/test/peer-job-queue.spec.ts
+++ b/packages/utils/test/peer-job-queue.spec.ts
@@ -165,7 +165,10 @@ describe('peer queue', () => {
       peerId: peerIdA
     }).catch(() => {})
 
-    const event = await raceEvent<CustomEvent<QueueJobFailure<string, PeerQueueJobOptions>>>(queue, 'failure')
+    const event = await raceEvent<CustomEvent<QueueJobFailure<string, PeerQueueJobOptions>>>(queue, 'failure', AbortSignal.timeout(10_000), {
+      // TODO: remove this option when queues no longer emit an error event
+      errorEvent: 'ignore'
+    })
 
     expect(event.detail.job.options.peerId).to.equal(peerIdA)
     expect(event.detail.error).to.equal(err)

--- a/packages/utils/test/queue.spec.ts
+++ b/packages/utils/test/queue.spec.ts
@@ -508,10 +508,10 @@ describe('queue', () => {
   it('should emit completed / error events', async () => {
     const queue = new Queue({ concurrency: 1 })
 
-    let errorEvents = 0
+    let failureEvents = 0
     let completedEvents = 0
-    queue.addEventListener('error', () => {
-      errorEvents++
+    queue.addEventListener('failure', () => {
+      failureEvents++
     })
     queue.addEventListener('completed', () => {
       completedEvents++
@@ -522,7 +522,7 @@ describe('queue', () => {
     expect(queue).to.have.property('size', 1)
     expect(queue).to.have.property('queued', 0)
     expect(queue).to.have.property('running', 1)
-    expect(errorEvents).to.equal(0)
+    expect(failureEvents).to.equal(0)
     expect(completedEvents).to.equal(0)
 
     const job2 = queue.add(async () => {
@@ -533,7 +533,7 @@ describe('queue', () => {
     expect(queue).to.have.property('size', 2)
     expect(queue).to.have.property('queued', 1)
     expect(queue).to.have.property('running', 1)
-    expect(errorEvents).to.equal(0)
+    expect(failureEvents).to.equal(0)
     expect(completedEvents).to.equal(0)
 
     await job1
@@ -541,7 +541,7 @@ describe('queue', () => {
     expect(queue).to.have.property('size', 1)
     expect(queue).to.have.property('queued', 0)
     expect(queue).to.have.property('running', 1)
-    expect(errorEvents).to.equal(0)
+    expect(failureEvents).to.equal(0)
     expect(completedEvents).to.equal(1)
 
     await expect(job2).to.eventually.be.rejected()
@@ -549,7 +549,7 @@ describe('queue', () => {
     expect(queue).to.have.property('size', 0)
     expect(queue).to.have.property('queued', 0)
     expect(queue).to.have.property('running', 0)
-    expect(errorEvents).to.equal(1)
+    expect(failureEvents).to.equal(1)
     expect(completedEvents).to.equal(1)
 
     const job3 = queue.add(async () => delay(100))
@@ -557,7 +557,7 @@ describe('queue', () => {
     expect(queue).to.have.property('size', 1)
     expect(queue).to.have.property('queued', 0)
     expect(queue).to.have.property('running', 1)
-    expect(errorEvents).to.equal(1)
+    expect(failureEvents).to.equal(1)
     expect(completedEvents).to.equal(1)
 
     await job3
@@ -565,7 +565,7 @@ describe('queue', () => {
     expect(queue).to.have.property('size', 0)
     expect(queue).to.have.property('queued', 0)
     expect(queue).to.have.property('running', 0)
-    expect(errorEvents).to.equal(1)
+    expect(failureEvents).to.equal(1)
     expect(completedEvents).to.equal(2)
   })
 


### PR DESCRIPTION
Ignore the error event as it causes `raceEvent` to throw. In future we should remove the error event from the queue as all we do with it is log the error, and if we want that, the `failure` event gives more context around the error so can make the logs more informative.

## Change checklist

- [x] I have performed a self-review of my own code
- [x] I have made corresponding changes to the documentation if necessary (this includes comments as well)
- [x] I have added tests that prove my fix is effective or that my feature works