### PR TITLE
fix: enable optimistic select by default

### DIFF
--- a/packages/multistream-select/src/select.ts
+++ b/packages/multistream-select/src/select.ts
@@ -65,7 +65,7 @@ export interface SelectStream extends Duplex<any, any, any> {
 export async function select <Stream extends SelectStream> (stream: Stream, protocols: string | string[], options: MultistreamSelectInit): Promise<ProtocolStream<Stream>> {
   protocols = Array.isArray(protocols) ? [...protocols] : [protocols]
 
-  if (protocols.length === 1 && options.negotiateFully === false) {
+  if (protocols.length === 1) {
     return optimisticSelect(stream, protocols[0], options)
   }
 


### PR DESCRIPTION
If only one protocol is specified, send it with the first data block to skip the mss round-trip tax.

## Change checklist

- [ ] I have performed a self-review of my own code
- [ ] I have made corresponding changes to the documentation if necessary (this includes comments as well)
- [ ] I have added tests that prove my fix is effective or that my feature works