### PR TITLE
fix: silence max listeners warning for dht routing table

### DIFF
--- a/packages/kad-dht/src/routing-table/index.ts
+++ b/packages/kad-dht/src/routing-table/index.ts
@@ -118,6 +118,7 @@ export class RoutingTable extends TypedEventEmitter<RoutingTableEvents> implemen
     this.populateFromDatastoreOnStart = init.populateFromDatastoreOnStart ?? POPULATE_FROM_DATASTORE_ON_START
     this.populateFromDatastoreLimit = init.populateFromDatastoreLimit ?? POPULATE_FROM_DATASTORE_LIMIT
     this.shutdownController = new AbortController()
+    setMaxListeners(Infinity, this.shutdownController.signal)
 
     this.pingOldContactQueue = new PeerQueue({
       concurrency: init.pingOldContactConcurrency ?? PING_OLD_CONTACT_CONCURRENCY,
@@ -190,6 +191,8 @@ export class RoutingTable extends TypedEventEmitter<RoutingTableEvents> implemen
     this.running = true
 
     this.shutdownController = new AbortController()
+    setMaxListeners(Infinity, this.shutdownController.signal)
+
     await start(this.closestPeerTagger, this.kb)
   }
 


### PR DESCRIPTION
Increase the maximum number of listeners for the routing table's shutdown controller signal.

## Change checklist

- [x] I have performed a self-review of my own code
- [ ] I have made corresponding changes to the documentation if necessary (this includes comments as well)
- [ ] I have added tests that prove my fix is effective or that my feature works