### PR TITLE
docs: fix broken links

### DIFF
--- a/interop/README.md
+++ b/interop/README.md
@@ -116,8 +116,8 @@ $ docker run -e transport=tcp -e muxer=yamux -e security=noise -e is_dialer=fals
 
 Licensed under either of
 
-- Apache 2.0, ([LICENSE-APACHE](https://github.com/libp2p/js-libp2p/blob/main/interop/LICENSE-APACHE) / <http://www.apache.org/licenses/LICENSE-2.0>)
-- MIT ([LICENSE-MIT](https://github.com/libp2p/js-libp2p/blob/main/interop/LICENSE-MIT) / <http://opensource.org/licenses/MIT>)
+- Apache 2.0, ([LICENSE-APACHE](https://github.com/libp2p/js-libp2p/blob/main/packages/interop/LICENSE-APACHE) / <http://www.apache.org/licenses/LICENSE-2.0>)
+- MIT ([LICENSE-MIT](https://github.com/libp2p/js-libp2p/blob/main/packages/interop/LICENSE-MIT) / <http://opensource.org/licenses/MIT>)
 
 # Contribution
 


### PR DESCRIPTION
## Description

some links of licence were broken
https://github.com/libp2p/js-libp2p/blob/main/interop/LICENSE-APACHE
https://github.com/libp2p/js-libp2p/blob/main/interop/LICENSE-MIT
but now correct are:
https://github.com/libp2p/js-libp2p/blob/main/packages/interop/LICENSE-APACHE
https://github.com/libp2p/js-libp2p/blob/main/packages/interop/LICENSE-MIT

## Change checklist

- [ ] I have performed a self-review of my own code
- [ ] I have made corresponding changes to the documentation if necessary (this includes comments as well)
- [ ] I have added tests that prove my fix is effective or that my feature works