### PR TITLE
chore: disable connection monitor in ping tests

### DIFF
--- a/packages/integration-tests/test/fixtures/base-options.ts
+++ b/packages/integration-tests/test/fixtures/base-options.ts
@@ -19,6 +19,9 @@ export function createBaseOptions <T extends ServiceMap = Record<string, unknown
         '/webrtc'
       ]
     },
+    connectionMonitor: {
+      enabled: false
+    },
     transports: [
       tcp(),
       webRTC(),

--- a/packages/transport-webtransport/test/browser.ts
+++ b/packages/transport-webtransport/test/browser.ts
@@ -22,6 +22,9 @@ describe('libp2p-webtransport', () => {
       connectionGater: {
         denyDialMultiaddr: async () => false
       },
+      connectionMonitor: {
+        enabled: false
+      },
       services: {
         ping: ping()
       }


### PR DESCRIPTION
The connection monitor uses the ping protocol - if a test also uses the ping protocol it can exceed the max number of ping streams that are allowed to be open so disable it to prevent test failures.

## Change checklist

- [x] I have performed a self-review of my own code
- [ ] I have made corresponding changes to the documentation if necessary (this includes comments as well)
- [x] I have added tests that prove my fix is effective or that my feature works