### PR TITLE
fix: allow connection gater classes

### DIFF
--- a/packages/integration-tests/test/connection-gater.spec.ts
+++ b/packages/integration-tests/test/connection-gater.spec.ts
@@ -7,7 +7,7 @@ import delay from 'delay'
 import { createLibp2p } from 'libp2p'
 import Sinon from 'sinon'
 import { stubInterface } from 'sinon-ts'
-import type { ConnectionGater, Libp2p } from '@libp2p/interface'
+import type { ConnectionGater, Libp2p, PeerId } from '@libp2p/interface'
 
 async function createLocalNode (connectionGater: ConnectionGater): Promise<Libp2p> {
   return createLibp2p({
@@ -29,7 +29,7 @@ async function createLocalNode (connectionGater: ConnectionGater): Promise<Libp2
   })
 }
 
-describe('connection-gater', () => {
+describe('connection-gater with arrow function properties', () => {
   let localNode: Libp2p
   let remoteNode: Libp2p
 
@@ -166,5 +166,187 @@ describe('connection-gater', () => {
       .with.property('name', 'ConnectionInterceptedError')
 
     expect(connectionGater.denyOutboundUpgradedConnection?.called).to.be.true()
+  })
+})
+
+describe('connection-gater with class methods', () => {
+  let localNode: Libp2p
+  let remoteNode: Libp2p
+
+  beforeEach(async () => {
+    remoteNode = await createLibp2p({
+      addresses: {
+        listen: [
+          '/memory/1'
+        ]
+      },
+      transports: [
+        memory()
+      ],
+      connectionEncrypters: [
+        plaintext()
+      ],
+      streamMuxers: [
+        mplex()
+      ]
+    })
+  })
+
+  afterEach(async () => {
+    await localNode?.stop()
+    await remoteNode?.stop()
+  })
+
+  it('should deny dialling a peer', async () => {
+    class TestGater implements ConnectionGater {
+      denyDialPeer (peerId: PeerId): boolean {
+        return true
+      }
+    }
+
+    const connectionGater = new TestGater()
+    const denyDialPeerStub = Sinon.spy(connectionGater, 'denyDialPeer')
+
+    localNode = await createLocalNode(connectionGater)
+
+    const ma = multiaddr(`/memory/1/p2p/${remoteNode.peerId}`)
+
+    await expect(localNode.dial(ma)).to.eventually.be.rejected
+      .with.property('name', 'DialDeniedError')
+
+    expect(denyDialPeerStub.called).to.be.true()
+    expect(denyDialPeerStub.getCall(0).args[0]).to.deep.equal(
+      remoteNode.peerId
+    )
+  })
+
+  it('should deny dialling a multiaddr', async () => {
+    class TestGater implements ConnectionGater {
+      denyDialMultiaddr? (multiaddr: any): boolean {
+        return true
+      }
+    }
+
+    const connectionGater = new TestGater()
+    const denyDialMultiaddrStub = Sinon.spy(connectionGater, 'denyDialMultiaddr')
+
+    localNode = await createLocalNode(connectionGater)
+
+    await expect(localNode.dial(remoteNode.getMultiaddrs())).to.eventually.be.rejected
+      .with.property('name', 'DialDeniedError')
+
+    expect(denyDialMultiaddrStub.called).to.be.true()
+  })
+
+  it('should deny an inbound connection', async () => {
+    class TestGater implements ConnectionGater {
+      denyInboundConnection? (maConn: any): boolean {
+        return true
+      }
+    }
+
+    const connectionGater = new TestGater()
+    const denyInboundConnectionStub = Sinon.spy(connectionGater, 'denyInboundConnection')
+
+    localNode = await createLocalNode(connectionGater)
+
+    await expect(remoteNode.dial(localNode.getMultiaddrs())).to.eventually.be.rejected
+      .with.property('name', 'EncryptionFailedError')
+
+    expect(denyInboundConnectionStub.called).to.be.true()
+  })
+
+  it('should deny an outbound connection', async () => {
+    class TestGater implements ConnectionGater {
+      denyOutboundConnection? (peerId: PeerId, maConn: any): boolean {
+        return true
+      }
+    }
+
+    const connectionGater = new TestGater()
+    const denyOutboundConnectionStub = Sinon.spy(connectionGater, 'denyOutboundConnection')
+
+    localNode = await createLocalNode(connectionGater)
+
+    await expect(localNode.dial(remoteNode.getMultiaddrs(), {
+      signal: AbortSignal.timeout(10_000)
+    })).to.eventually.be.rejected
+      .with.property('name', 'ConnectionInterceptedError')
+
+    expect(denyOutboundConnectionStub.called).to.be.true()
+  })
+
+  it('should deny an inbound encrypted connection', async () => {
+    class TestGater implements ConnectionGater {
+      denyInboundEncryptedConnection? (peerId: PeerId, maConn: any): boolean {
+        return true
+      }
+    }
+
+    const connectionGater = new TestGater()
+    const denyInboundEncryptedConnectionStub = Sinon.spy(connectionGater, 'denyInboundEncryptedConnection')
+
+    localNode = await createLocalNode(connectionGater)
+
+    await expect(remoteNode.dial(localNode.getMultiaddrs())).to.eventually.be.rejected
+      .with.property('name', 'MuxerUnavailableError')
+
+    expect(denyInboundEncryptedConnectionStub.called).to.be.true()
+  })
+
+  it('should deny an outbound encrypted connection', async () => {
+    class TestGater implements ConnectionGater {
+      denyOutboundEncryptedConnection? (peerId: PeerId, maConn: any): boolean {
+        return true
+      }
+    }
+
+    const connectionGater = new TestGater()
+    const denyOutboundEncryptedConnectionStub = Sinon.spy(connectionGater, 'denyOutboundEncryptedConnection')
+
+    localNode = await createLocalNode(connectionGater)
+
+    await expect(localNode.dial(remoteNode.getMultiaddrs())).to.eventually.be.rejected
+      .with.property('name', 'ConnectionInterceptedError')
+
+    expect(denyOutboundEncryptedConnectionStub.called).to.be.true()
+  })
+
+  it('should deny an inbound upgraded connection', async () => {
+    class TestGater implements ConnectionGater {
+      denyInboundUpgradedConnection? (peerId: PeerId, maConn: any): boolean {
+        return true
+      }
+    }
+
+    const connectionGater = new TestGater()
+    const denyInboundUpgradedConnectionStub = Sinon.spy(connectionGater, 'denyInboundUpgradedConnection')
+
+    localNode = await createLocalNode(connectionGater)
+
+    remoteNode.dial(localNode.getMultiaddrs()).catch(() => {})
+
+    await delay(100)
+
+    expect(localNode.getConnections()).to.be.empty()
+    expect(denyInboundUpgradedConnectionStub.called).to.be.true()
+  })
+
+  it('should deny an outbound upgraded connection', async () => {
+    class TestGater implements ConnectionGater {
+      denyOutboundUpgradedConnection? (peerId: PeerId, maConn: any): boolean {
+        return true
+      }
+    }
+
+    const connectionGater = new TestGater()
+    const denyOutboundUpgradedConnectionStub = Sinon.spy(connectionGater, 'denyOutboundUpgradedConnection')
+
+    localNode = await createLocalNode(connectionGater)
+
+    await expect(localNode.dial(remoteNode.getMultiaddrs())).to.eventually.be.rejected
+      .with.property('name', 'ConnectionInterceptedError')
+
+    expect(denyOutboundUpgradedConnectionStub.called).to.be.true()
   })
 })

--- a/packages/libp2p/src/config/connection-gater.browser.ts
+++ b/packages/libp2p/src/config/connection-gater.browser.ts
@@ -16,9 +16,8 @@ const CODEC_IP6 = 0x29
  * confusion.
  */
 export function connectionGater (gater: ConnectionGater = {}): ConnectionGater {
-  return {
-    denyDialPeer: async () => false,
-    denyDialMultiaddr: async (multiaddr: Multiaddr) => {
+  if (gater.denyDialMultiaddr == null) {
+    gater.denyDialMultiaddr = (multiaddr: Multiaddr) => {
       // do not connect to insecure websockets by default
       if (WebSockets.matches(multiaddr)) {
         return false
@@ -32,14 +31,8 @@ export function connectionGater (gater: ConnectionGater = {}): ConnectionGater {
       }
 
       return false
-    },
-    denyInboundConnection: async () => false,
-    denyOutboundConnection: async () => false,
-    denyInboundEncryptedConnection: async () => false,
-    denyOutboundEncryptedConnection: async () => false,
-    denyInboundUpgradedConnection: async () => false,
-    denyOutboundUpgradedConnection: async () => false,
-    filterMultiaddrForPeer: async () => true,
-    ...gater
+    }
   }
+
+  return gater
 }

--- a/packages/libp2p/src/config/connection-gater.ts
+++ b/packages/libp2p/src/config/connection-gater.ts
@@ -4,16 +4,5 @@ import type { ConnectionGater } from '@libp2p/interface'
  * Returns a default connection gater implementation that allows everything
  */
 export function connectionGater (gater: ConnectionGater = {}): ConnectionGater {
-  return {
-    denyDialPeer: async () => false,
-    denyDialMultiaddr: async () => false,
-    denyInboundConnection: async () => false,
-    denyOutboundConnection: async () => false,
-    denyInboundEncryptedConnection: async () => false,
-    denyOutboundEncryptedConnection: async () => false,
-    denyInboundUpgradedConnection: async () => false,
-    denyOutboundUpgradedConnection: async () => false,
-    filterMultiaddrForPeer: async () => true,
-    ...gater
-  }
+  return gater
 }


### PR DESCRIPTION
Allow connection gaters to be class instances as well as objects with function properties.

## Change checklist

- [x] I have performed a self-review of my own code
- [x] I have made corresponding changes to the documentation if necessary (this includes comments as well)
- [x] I have added tests that prove my fix is effective or that my feature works