### PR TITLE
fix: yamux benchmarks 

### DIFF
--- a/packages/stream-multiplexer-yamux/test/bench/codec.bench.ts
+++ b/packages/stream-multiplexer-yamux/test/bench/codec.bench.ts
@@ -1,4 +1,8 @@
-import { itBench } from '@dapplion/benchmark'
+import { createRequire } from 'node:module'
+const require = createRequire(import.meta.url)
+// Use the CJS build so the CLI and tests share benchmark global state
+const benchmark = require('@dapplion/benchmark') as typeof import('@dapplion/benchmark')
+const { itBench } = benchmark
 import { decodeHeader } from '../../src/decode.js'
 import { encodeHeader } from '../../src/encode.js'
 import { Flag, FrameType } from '../../src/frame.js'

--- a/packages/stream-multiplexer-yamux/test/bench/comparison.bench.ts
+++ b/packages/stream-multiplexer-yamux/test/bench/comparison.bench.ts
@@ -1,4 +1,8 @@
-import { itBench } from '@dapplion/benchmark'
+import { createRequire } from 'node:module'
+const require = createRequire(import.meta.url)
+// Use the CJS build so the CLI and tests share benchmark global state
+const benchmark = require('@dapplion/benchmark') as typeof import('@dapplion/benchmark')
+const { itBench } = benchmark
 import { mplex } from '@libp2p/mplex'
 import { multiaddrConnectionPair } from '@libp2p/utils'
 import { pEvent } from 'p-event'


### PR DESCRIPTION
## Title
Fixes the imports to use CJS so the benchmarks can potentially run. 

## Description

I am trying to run the benchmarks of `yamux` and a performance improvement BUT

However this is still not working. (this fix in the chainsafe repo which uses libp2p 2.x works. 

I get this error when running 


  1) comparison benchmark
       mplex send and receive 1 0.0625KB chunks:
     ValidationError: Value must be smaller than or equal to 65535 got 65537
      at file:///Users/admin/git/js-libp2p/node_modules/@multiformats/multiaddr/dist/src/validation.js:16:19
      at Object.validate (file:///Users/admin/git/js-libp2p/node_modules/@multiformats/multiaddr/dist/src/validation.js:23:13)
      at file:///Users/admin/git/js-libp2p/node_modules/@multiformats/multiaddr/dist/src/multiaddr.js:130:25
      at Array.forEach (<anonymous>)
      at validate (file:///Users/admin/git/js-libp2p/node_modules/@multiformats/multiaddr/dist/src/multiaddr.js:125:10)
      at new Multiaddr (file:///Users/admin/git/js-libp2p/node_modules/@multiformats/multiaddr/dist/src/multiaddr.js:45:13)
      at multiaddr (file:///Users/admin/git/js-libp2p/node_modules/@multiformats/multiaddr/dist/src/index.js:99:12)
      at multiaddrConnectionPair (file:///Users/admin/git/js-libp2p/packages/utils/dist/src/multiaddr-connection-pair.js:89:55)
      at Object.beforeEach (file:///Users/admin/git/js-libp2p/packages/stream-multiplexer-yamux/dist/test/bench/comparison.bench.js:28:69)
      at runBenchFn (/Users/admin/git/js-libp2p/node_modules/@dapplion/benchmark/lib/cjs/mochaPlugin/runBenchFn.js:36:52)

  2) comparison benchmark
       mplex send and receive 1 1KB chunks:
     ValidationError: Value must be smaller than or equal to 65535 got 65539
      at file:///Users/admin/git/js-libp2p/node_modules/@multiformats/multiaddr/dist/src/validation.js:16:19
      at Object.validate (file:///Users/admin/git/js-libp2p/node_modules/@multiformats/multiaddr/dist/src/validation.js:23:13)
      at file:///Users/admin/git/js-libp2p/node_modules/@multiformats/multiaddr/dist/src/multiaddr.js:130:25
      at Array.forEach (<anonymous>)
      at validate (file:///Users/admin/git/js-libp2p/node_modules/@multiformats/multiaddr/dist/src/multiaddr.js:125:10)
      at new Multiaddr (file:///Users/admin/git/js-libp2p/node_modules/@multiformats/multiaddr/dist/src/multiaddr.js:45:13)
      at multiaddr (file:///Users/admin/git/js-libp2p/node_modules/@multiformats/multiaddr/dist/src/index.js:99:12)
      at multiaddrConnectionPair (file:///Users/admin/git/js-libp2p/packages/utils/dist/src/multiaddr-connection-pair.js:89:55)
      at Object.beforeEach (file:///Users/admin/git/js-libp2p/packages/stream-multiplexer-yamux/dist/test/bench/comparison.bench.js:28:69)
      at runBenchFn (/Users/admin/git/js-libp2p/node_modules/@dapplion/benchmark/lib/cjs/mochaPlugin/runBenchFn.js:36:52)

  3) comparison benchmark
       mplex send and receive 1000 0.0625KB chunks:
     ValidationError: Value must be smaller than or equal to 65535 got 65541
      at file:///Users/admin/git/js-libp2p/node_modules/@multiformats/multiaddr/dist/src/validation.js:16:19
      at Object.validate (file:///Users/admin/git/js-libp2p/node_modules/@multiformats/multiaddr/dist/src/validation.js:23:13)
      at file:///Users/admin/git/js-libp2p/node_modules/@multiformats/multiaddr/dist/src/multiaddr.js:130:25
      at Array.forEach (<anonymous>)
      at validate (file:///Users/admin/git/js-libp2p/node_modules/@multiformats/multiaddr/dist/src/multiaddr.js:125:10)
      at new Multiaddr (file:///Users/admin/git/js-libp2p/node_modules/@multiformats/multiaddr/dist/src/multiaddr.js:45:13)
      at multiaddr (file:///Users/admin/git/js-libp2p/node_modules/@multiformats/multiaddr/dist/src/index.js:99:12)
      at multiaddrConnectionPair (file:///Users/admin/git/js-libp2p/packages/utils/dist/src/multiaddr-connection-pair.js:89:55)
      at Object.beforeEach (file:///Users/admin/git/js-libp2p/packages/stream-multiplexer-yamux/dist/test/bench/comparison.bench.js:28:69)
      at runBenchFn (/Users/admin/git/js-libp2p/node_modules/@dapplion/benchmark/lib/cjs/mochaPlugin/runBenchFn.js:36:52)

  4) comparison benchmark
       mplex send and receive 1000 1KB chunks:
     ValidationError: Value must be smaller than or equal to 65535 got 65543
      at file:///Users/admin/git/js-libp2p/node_modules/@multiformats/multiaddr/dist/src/validation.js:16:19
      at Object.validate (file:///Users/admin/git/js-libp2p/node_modules/@multiformats/multiaddr/dist/src/validation.js:23:13)
      at file:///Users/admin/git/js-libp2p/node_modules/@multiformats/multiaddr/dist/src/multiaddr.js:130:25
      at Array.forEach (<anonymous>)
      at validate (file:///Users/admin/git/js-libp2p/node_modules/@multiformats/multiaddr/dist/src/multiaddr.js:125:10)
      at new Multiaddr (file:///Users/admin/git/js-libp2p/node_modules/@multiformats/multiaddr/dist/src/multiaddr.js:45:13)
      at multiaddr (file:///Users/admin/git/js-libp2p/node_modules/@multiformats/multiaddr/dist/src/index.js:99:12)
      at multiaddrConnectionPair (file:///Users/admin/git/js-libp2p/packages/utils/dist/src/multiaddr-connection-pair.js:89:55)
      at Object.beforeEach (file:///Users/admin/git/js-libp2p/packages/stream-multiplexer-yamux/dist/test/bench/comparison.bench.js:28:69)
      at runBenchFn (/Users/admin/git/js-libp2p/node_modules/@dapplion/benchmark/lib/cjs/mochaPlugin/runBenchFn.js:36:52)



## Notes & open questions

What has changed in the defaults?

## Change checklist

- [ ] I have performed a self-review of my own code
- [ ] I have made corresponding changes to the documentation if necessary (this includes comments as well)
- [ ] I have added tests that prove my fix is effective or that my feature works