### PR TITLE
fix: bump noise version

### DIFF
--- a/.release-please-manifest.json
+++ b/.release-please-manifest.json
@@ -48,6 +48,6 @@
   "packages/upnp-nat": "4.0.1",
   "packages/utils": "7.0.1",
   "packages/integration-tests": "1.0.1",
-  "packages/connection-encrypter-noise": "1.0.1",
+  "packages/connection-encrypter-noise": "17.0.1",
   "interop": "1.0.1"
 }

--- a/interop/package.json
+++ b/interop/package.json
@@ -11,7 +11,7 @@
     "dep-check": "aegir dep-check"
   },
   "devDependencies": {
-    "@libp2p/noise": "^1.0.1",
+    "@libp2p/noise": "^17.0.1",
     "@libp2p/yamux": "^8.0.1",
     "@libp2p/circuit-relay-v2": "^4.0.1",
     "@libp2p/identify": "^4.0.1",

--- a/packages/connection-encrypter-noise/package.json
+++ b/packages/connection-encrypter-noise/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@libp2p/noise",
-  "version": "1.0.1",
+  "version": "17.0.1",
   "description": "Noise libp2p handshake for js-libp2p",
   "author": "ChainSafe <info@chainsafe.io>",
   "license": "Apache-2.0 OR MIT",

--- a/packages/integration-tests/package.json
+++ b/packages/integration-tests/package.json
@@ -38,7 +38,7 @@
     "@libp2p/mdns": "^12.0.1",
     "@libp2p/memory": "^2.0.1",
     "@libp2p/mplex": "^12.0.1",
-    "@libp2p/noise": "^1.0.1",
+    "@libp2p/noise": "^17.0.1",
     "@libp2p/peer-collections": "^7.0.1",
     "@libp2p/peer-id": "^6.0.1",
     "@libp2p/ping": "^3.0.1",

--- a/packages/transport-webrtc/package.json
+++ b/packages/transport-webrtc/package.json
@@ -49,7 +49,7 @@
     "@libp2p/interface": "^3.0.0",
     "@libp2p/interface-internal": "^3.0.1",
     "@libp2p/keychain": "^6.0.1",
-    "@libp2p/noise": "^1.0.1",
+    "@libp2p/noise": "^17.0.1",
     "@libp2p/peer-id": "^6.0.1",
     "@libp2p/utils": "^7.0.1",
     "@multiformats/multiaddr": "^13.0.1",

--- a/packages/transport-webtransport/package.json
+++ b/packages/transport-webtransport/package.json
@@ -45,7 +45,7 @@
   },
   "dependencies": {
     "@libp2p/interface": "^3.0.0",
-    "@libp2p/noise": "^1.0.1",
+    "@libp2p/noise": "^17.0.1",
     "@libp2p/peer-id": "^6.0.1",
     "@libp2p/utils": "^7.0.1",
     "@multiformats/multiaddr": "^13.0.1",


### PR DESCRIPTION
Update noise version to align with `@chainsafe/libp2p-noise`.

## Change checklist

- [ ] I have performed a self-review of my own code
- [ ] I have made corresponding changes to the documentation if necessary (this includes comments as well)
- [ ] I have added tests that prove my fix is effective or that my feature works