### PR TITLE
fix: remove it-ws

### DIFF
--- a/packages/transport-websockets/package.json
+++ b/packages/transport-websockets/package.json
@@ -72,8 +72,6 @@
     "@multiformats/multiaddr": "^13.0.1",
     "@multiformats/multiaddr-matcher": "^3.0.1",
     "@multiformats/multiaddr-to-uri": "^12.0.0",
-    "@types/ws": "^8.18.1",
-    "it-ws": "^6.1.5",
     "main-event": "^1.0.1",
     "p-event": "^7.0.0",
     "progress-events": "^1.0.1",
@@ -83,6 +81,7 @@
   },
   "devDependencies": {
     "@libp2p/logger": "^6.0.1",
+    "@types/ws": "^8.18.1",
     "aegir": "^47.0.22",
     "is-loopback-addr": "^2.0.2",
     "p-wait-for": "^6.0.0",

--- a/packages/transport-websockets/src/index.ts
+++ b/packages/transport-websockets/src/index.ts
@@ -32,13 +32,12 @@ import { createListener } from './listener.js'
 import { webSocketToMaConn } from './websocket-to-conn.js'
 import type { Transport, CreateListenerOptions, DialTransportOptions, Listener, AbortOptions, ComponentLogger, Logger, Connection, OutboundConnectionUpgradeEvents, Metrics, CounterGroup, Libp2pEvents } from '@libp2p/interface'
 import type { Multiaddr } from '@multiformats/multiaddr'
-import type { WebSocketOptions } from 'it-ws/client'
 import type { TypedEventTarget } from 'main-event'
 import type http from 'node:http'
 import type https from 'node:https'
 import type { ProgressEvent } from 'progress-events'
 
-export interface WebSocketsInit extends AbortOptions, WebSocketOptions {
+export interface WebSocketsInit extends AbortOptions {
   /**
    * Options used to create the HTTP server
    */


### PR DESCRIPTION
The global WebSocket instance is used in node.js now so remove unused options.

## Change checklist

- [x] I have performed a self-review of my own code
- [ ] I have made corresponding changes to the documentation if necessary (this includes comments as well)
- [ ] I have added tests that prove my fix is effective or that my feature works