### PR TITLE
fix: unwrap connection for boxed stream

### DIFF
--- a/packages/pnet/src/index.ts
+++ b/packages/pnet/src/index.ts
@@ -144,7 +144,7 @@ class PreSharedKeyConnectionProtector implements ConnectionProtector {
       localNonce,
       remoteNonce,
       psk: this.psk,
-      maConn: connection,
+      maConn: bytes.unwrap(),
       log
     })
   }


### PR DESCRIPTION
If the remote sends more data than just the pnet handshake it can be missed by the onwards boxed stream so unwrap the byte stream which will push the extra bytes back onto the connection.

## Change checklist

- [x] I have performed a self-review of my own code
- [ ] I have made corresponding changes to the documentation if necessary (this includes comments as well)
- [ ] I have added tests that prove my fix is effective or that my feature works