### PR TITLE
ci: remove usage of self-hosted runners

### DIFF
--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -210,39 +210,39 @@ jobs:
           directories: ${{ env.CACHE_DIRS }}
       - run: npm run test:interop -- --bail
 
-  transport-interop:
-    needs: build
-    runs-on: ubuntu-latest
-    steps:
-      - name: Free Disk Space
-        uses: jlumbroso/free-disk-space@54081f138730dfa15788a46383842cd2f914a1be # v1.3.1
-        with:
-          tool-cache: true
-      - uses: actions/checkout@v5
-      - uses: actions/setup-node@v4
-        with:
-          node-version: lts/*
-      - uses: ipfs/aegir/actions/cache-node-modules@main
-        with:
-         directories: ${{ env.CACHE_DIRS }}
-      - name: Build images
-        run: (cd interop && make -j 4)
-      - name: Save package-lock.json as artifact
-        uses: actions/upload-artifact@v4
-        with:
-          name: package locks
-          path: |
-            package-lock.json
-            interop/package-lock.json
-      - uses: libp2p/test-plans/.github/actions/run-transport-interop-test@master
-        with:
-          test-filter: js-libp2p-head
-          test-ignore: nim jvm js-v1.x rust-v0.53 go-v0.40 go-v0.41
-          extra-versions: ${{ github.workspace }}/interop/node-version.json ${{ github.workspace }}/interop/chromium-version.json ${{ github.workspace }}/interop/firefox-version.json ${{ github.workspace }}/interop/webkit-version.json
-          s3-cache-bucket: ${{ vars.S3_LIBP2P_BUILD_CACHE_BUCKET_NAME }}
-          s3-access-key-id: ${{ vars.S3_LIBP2P_BUILD_CACHE_AWS_ACCESS_KEY_ID }}
-          s3-secret-access-key: ${{ secrets.S3_LIBP2P_BUILD_CACHE_AWS_SECRET_ACCESS_KEY }}
-          worker-count: 16
+  # transport-interop:
+  #   needs: build
+  #   runs-on: ubuntu-latest
+  #   steps:
+  #     - name: Free Disk Space
+  #       uses: jlumbroso/free-disk-space@54081f138730dfa15788a46383842cd2f914a1be # v1.3.1
+  #       with:
+  #         tool-cache: true
+  #     - uses: actions/checkout@v5
+  #     - uses: actions/setup-node@v4
+  #       with:
+  #         node-version: lts/*
+  #     - uses: ipfs/aegir/actions/cache-node-modules@main
+  #       with:
+  #        directories: ${{ env.CACHE_DIRS }}
+  #     - name: Build images
+  #       run: (cd interop && make -j 4)
+  #     - name: Save package-lock.json as artifact
+  #       uses: actions/upload-artifact@v4
+  #       with:
+  #         name: package locks
+  #         path: |
+  #           package-lock.json
+  #           interop/package-lock.json
+  #     - uses: libp2p/test-plans/.github/actions/run-transport-interop-test@master
+  #       with:
+  #         test-filter: js-libp2p-head
+  #         test-ignore: nim
+  #         extra-versions: ${{ github.workspace }}/interop/node-version.json ${{ github.workspace }}/interop/chromium-version.json ${{ github.workspace }}/interop/firefox-version.json ${{ github.workspace }}/interop/webkit-version.json
+  #         s3-cache-bucket: ${{ vars.S3_LIBP2P_BUILD_CACHE_BUCKET_NAME }}
+  #         s3-access-key-id: ${{ vars.S3_LIBP2P_BUILD_CACHE_AWS_ACCESS_KEY_ID }}
+  #         s3-secret-access-key: ${{ secrets.S3_LIBP2P_BUILD_CACHE_AWS_SECRET_ACCESS_KEY }}
+  #         worker-count: 16
 
   release:
     runs-on: ubuntu-latest
@@ -254,8 +254,8 @@ jobs:
       test-firefox-webworker,
       test-electron-main,
       test-electron-renderer,
-      test-interop ,
-      transport-interop
+      test-interop
+      # transport-interop
     ]
     if: github.event_name == 'push' && github.ref == 'refs/heads/main'
     permissions:

--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -214,6 +214,10 @@ jobs:
     needs: build
     runs-on: ubuntu-latest
     steps:
+      - name: Free Disk Space
+        uses: jlumbroso/free-disk-space@54081f138730dfa15788a46383842cd2f914a1be # v1.3.1
+        with:
+          tool-cache: true
       - uses: actions/checkout@v5
       - uses: actions/setup-node@v4
         with:

--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -233,7 +233,7 @@ jobs:
       - uses: libp2p/test-plans/.github/actions/run-transport-interop-test@master
         with:
           test-filter: js-libp2p-head
-          test-ignore: nim
+          test-ignore: nim jvm js-v1.x rust-v0.53 go-v0.40 go-v0.41
           extra-versions: ${{ github.workspace }}/interop/node-version.json ${{ github.workspace }}/interop/chromium-version.json ${{ github.workspace }}/interop/firefox-version.json ${{ github.workspace }}/interop/webkit-version.json
           s3-cache-bucket: ${{ vars.S3_LIBP2P_BUILD_CACHE_BUCKET_NAME }}
           s3-access-key-id: ${{ vars.S3_LIBP2P_BUILD_CACHE_AWS_ACCESS_KEY_ID }}

--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -237,7 +237,7 @@ jobs:
       - uses: libp2p/test-plans/.github/actions/run-transport-interop-test@master
         with:
           test-filter: js-libp2p-head
-          test-ignore: nim
+          test-ignore: nim jvm js-v1.x rust-v0.53 go-v0.40 go-v0.41
           extra-versions: ${{ github.workspace }}/interop/node-version.json ${{ github.workspace }}/interop/chromium-version.json ${{ github.workspace }}/interop/firefox-version.json ${{ github.workspace }}/interop/webkit-version.json
           s3-cache-bucket: ${{ vars.S3_LIBP2P_BUILD_CACHE_BUCKET_NAME }}
           s3-access-key-id: ${{ vars.S3_LIBP2P_BUILD_CACHE_AWS_ACCESS_KEY_ID }}

--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -233,7 +233,7 @@ jobs:
       - uses: libp2p/test-plans/.github/actions/run-transport-interop-test@master
         with:
           test-filter: js-libp2p-head
-          test-ignore: nim jvm js-v1.x rust-v0.53 go-v0.40 go-v0.41
+          test-ignore: nim
           extra-versions: ${{ github.workspace }}/interop/node-version.json ${{ github.workspace }}/interop/chromium-version.json ${{ github.workspace }}/interop/firefox-version.json ${{ github.workspace }}/interop/webkit-version.json
           s3-cache-bucket: ${{ vars.S3_LIBP2P_BUILD_CACHE_BUCKET_NAME }}
           s3-access-key-id: ${{ vars.S3_LIBP2P_BUILD_CACHE_AWS_ACCESS_KEY_ID }}

--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -212,7 +212,7 @@ jobs:
 
   transport-interop:
     needs: build
-    runs-on: ${{ fromJSON(github.repository == 'libp2p/js-libp2p' && '["self-hosted", "linux", "x64", "4xlarge"]' || '"ubuntu-latest"') }}
+    runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@v5
       - uses: actions/setup-node@v4


### PR DESCRIPTION
## Title
<!---
The title of the PR will be the commit message of the merge commit, so please make sure it is descriptive enough.
We utilize the Conventional Commits specification for our commit messages. See <https://www.conventionalcommits.org/en/v1.0.0/#specification> for more information.
The commit tag types can be of one of the following: feat, fix, deps, refactor, chore, docs. See <https://github.com/libp2p/js-libp2p/blob/master/.github/workflows/main.yml#L235-L242>
The title must also be fewer than 72 characters long or it will fail the Semantic PR check. See <https://github.com/libp2p/js-libp2p/blob/master/.github/workflows/semantic-pull-request.yml>
--->

Remove usage of self-hosted runners.

## Description

<!--
Please write a summary of your changes and why you made them.
Please include any relevant issues in here, for example:
Related https://github.com/libp2p/js-libp2p/issues/ABCD.
Fixes https://github.com/libp2p/js-libp2p/issues/XYZ.
-->

This PR removes usage of self-hosted runners from the test-interop job.

## Notes & open questions

<!--
Any notes, remarks or open questions you have to make about the PR which don't need to go into the final commit message.
-->

It is part of libp2p DX services offboarding initiative.

> [!WARNING]
> The interop tests are not failing on the default branch.

## Change checklist

- [ ] I have performed a self-review of my own code
- [ ] I have made corresponding changes to the documentation if necessary (this includes comments as well)
- [ ] I have added tests that prove my fix is effective or that my feature works