### PR TITLE
fix: allow stream unshift

### DIFF
--- a/packages/interface/src/message-stream.ts
+++ b/packages/interface/src/message-stream.ts
@@ -180,4 +180,10 @@ export interface MessageStream<Timeline extends MessageStreamTimeline = MessageS
    * next tick or sooner if data is received from the underlying resource.
    */
   push (buf: Uint8Array | Uint8ArrayList): void
+
+  /**
+   * Similar to the `.push` method, except this ensures the passed data is
+   * emitted before any other queued data.
+   */
+  unshift (data: Uint8Array | Uint8ArrayList): void
 }

--- a/packages/utils/test/stream-utils-test.spec.ts
+++ b/packages/utils/test/stream-utils-test.spec.ts
@@ -259,3 +259,43 @@ describe('stream-pair', () => {
     expect(incomingCloseEvent.error).to.be.ok()
   })
 })
+
+describe('stream-pair', () => {
+  it('should push data', async () => {
+    const [outgoing, incoming] = await streamPair()
+
+    outgoing.send(Uint8Array.from([0, 1, 2, 3]))
+    await delay(1)
+    incoming.push(Uint8Array.from([4, 5, 6, 7]))
+
+    const [
+      read
+    ] = await Promise.all([
+      all(incoming),
+      outgoing.close()
+    ])
+
+    expect(new Uint8ArrayList(...read).subarray()).to.equalBytes(
+      Uint8Array.from([0, 1, 2, 3, 4, 5, 6, 7])
+    )
+  })
+
+  it('should unshift data', async () => {
+    const [outgoing, incoming] = await streamPair()
+
+    outgoing.send(Uint8Array.from([0, 1, 2, 3]))
+    await delay(1)
+    incoming.unshift(Uint8Array.from([4, 5, 6, 7]))
+
+    const [
+      read
+    ] = await Promise.all([
+      all(incoming),
+      outgoing.close()
+    ])
+
+    expect(new Uint8ArrayList(...read).subarray()).to.equalBytes(
+      Uint8Array.from([4, 5, 6, 7, 0, 1, 2, 3])
+    )
+  })
+})


### PR DESCRIPTION
Allow pushing data onto the front of any queued data, not just after

## Change checklist

- [x] I have performed a self-review of my own code
- [x] I have made corresponding changes to the documentation if necessary (this includes comments as well)
- [x] I have added tests that prove my fix is effective or that my feature works