### PR TITLE
feat: add routing field to providers

### DIFF
--- a/packages/integration-tests/test/fixtures/utils.ts
+++ b/packages/integration-tests/test/fixtures/utils.ts
@@ -5,7 +5,7 @@ import { Circuit } from '@multiformats/multiaddr-matcher'
 import { detect } from 'detect-browser'
 import pWaitFor from 'p-wait-for'
 import { toString as uint8ArrayToString } from 'uint8arrays/to-string'
-import type { Libp2p, AbortOptions, ContentRouting, PeerId, PeerInfo } from '@libp2p/interface'
+import type { Libp2p, AbortOptions, ContentRouting, PeerId, Provider } from '@libp2p/interface'
 import type { AddressManager } from '@libp2p/interface-internal'
 import type { Multiaddr } from '@multiformats/multiaddr'
 import type { CID, Version } from 'multiformats'
@@ -153,7 +153,7 @@ export interface MockContentRoutingComponents {
 }
 
 export class MockContentRouting implements ContentRouting {
-  static providers = new Map<string, PeerInfo[]>()
+  static providers = new Map<string, Provider[]>()
   static data = new Map<string, Uint8Array>()
 
   static reset (): void {
@@ -175,7 +175,8 @@ export class MockContentRouting implements ContentRouting {
 
     providers.push({
       id: this.peerId,
-      multiaddrs: this.addressManager.getAddresses()
+      multiaddrs: this.addressManager.getAddresses(),
+      routing: 'mock-content-routing'
     })
 
     MockContentRouting.providers.set(cid.toString(), providers)
@@ -185,7 +186,7 @@ export class MockContentRouting implements ContentRouting {
 
   }
 
-  async * findProviders (cid: CID<unknown, number, number, Version>, options?: AbortOptions | undefined): AsyncGenerator<PeerInfo, void, undefined> {
+  async * findProviders (cid: CID<unknown, number, number, Version>, options?: AbortOptions | undefined): AsyncGenerator<Provider, void, undefined> {
     yield * MockContentRouting.providers.get(cid.toString()) ?? []
   }
 

--- a/packages/interface/src/content-routing.ts
+++ b/packages/interface/src/content-routing.ts
@@ -2,6 +2,13 @@ import type { RoutingOptions } from './index.js'
 import type { PeerInfo } from './peer-info.js'
 import type { CID } from 'multiformats/cid'
 
+export interface Provider extends PeerInfo {
+  /**
+   * Which routing subsystem found the provider
+   */
+  routing: string
+}
+
 /**
  * Any object that implements this Symbol as a property should return a
  * Partial<ContentRouting> instance as the property value, similar to how
@@ -64,7 +71,7 @@ export interface ContentRouting {
    * }
    * ```
    */
-  findProviders(cid: CID, options?: RoutingOptions): AsyncIterable<PeerInfo>
+  findProviders(cid: CID, options?: RoutingOptions): AsyncIterable<Provider>
 
   /**
    * Puts a value corresponding to the passed key in a way that can later be

--- a/packages/kad-dht/src/kad-dht.ts
+++ b/packages/kad-dht/src/kad-dht.ts
@@ -24,7 +24,7 @@ import {
   timeOperationGenerator
 } from './utils.js'
 import type { KadDHTComponents, KadDHTInit, Validators, Selectors, KadDHT as KadDHTInterface, QueryEvent, PeerInfoMapper, SetModeOptions } from './index.js'
-import type { ContentRouting, CounterGroup, Logger, MetricGroup, PeerDiscovery, PeerDiscoveryEvents, PeerId, PeerInfo, PeerRouting, RoutingOptions, Startable } from '@libp2p/interface'
+import type { ContentRouting, CounterGroup, Logger, MetricGroup, PeerDiscovery, PeerDiscoveryEvents, PeerId, PeerInfo, PeerRouting, Provider, RoutingOptions, Startable } from '@libp2p/interface'
 import type { AbortOptions } from 'it-pushable'
 import type { CID } from 'multiformats/cid'
 
@@ -46,10 +46,13 @@ class DHTContentRouting implements ContentRouting {
     await this.dht.cancelReprovide(key)
   }
 
-  async * findProviders (cid: CID, options: RoutingOptions = {}): AsyncGenerator<PeerInfo, void, undefined> {
+  async * findProviders (cid: CID, options: RoutingOptions = {}): AsyncGenerator<Provider, void, undefined> {
     for await (const event of this.dht.findProviders(cid, options)) {
       if (event.name === 'PROVIDER') {
-        yield * event.providers
+        yield * event.providers.map(peer => ({
+          ...peer,
+          routing: 'kad-dht'
+        }))
       }
     }
   }

--- a/packages/libp2p/src/connection-manager/dial-queue.ts
+++ b/packages/libp2p/src/connection-manager/dial-queue.ts
@@ -515,8 +515,8 @@ export class DialQueue {
       }
 
       return true
-    } catch (err) {
-      this.log.trace('error calculating if multiaddr(s) were dialable', err)
+    } catch {
+
     }
 
     return false

--- a/packages/libp2p/src/content-routing.ts
+++ b/packages/libp2p/src/content-routing.ts
@@ -3,7 +3,7 @@ import { PeerSet } from '@libp2p/peer-collections'
 import merge from 'it-merge'
 import { toString as uint8ArrayToString } from 'uint8arrays/to-string'
 import { NoContentRoutersError } from './errors.js'
-import type { AbortOptions, ComponentLogger, ContentRouting, Metrics, PeerInfo, PeerRouting, PeerStore, RoutingOptions, Startable } from '@libp2p/interface'
+import type { AbortOptions, ComponentLogger, ContentRouting, Metrics, PeerRouting, PeerStore, Provider, RoutingOptions, Startable } from '@libp2p/interface'
 import type { CID } from 'multiformats/cid'
 
 export interface CompoundContentRoutingInit {
@@ -95,7 +95,7 @@ export class CompoundContentRouting implements ContentRouting, Startable {
   /**
    * Iterates over all content routers in parallel to find providers of the given key
    */
-  async * findProviders (key: CID, options: RoutingOptions = {}): AsyncGenerator<PeerInfo> {
+  async * findProviders (key: CID, options: RoutingOptions = {}): AsyncGenerator<Provider> {
     if (this.routers.length === 0) {
       throw new NoContentRoutersError('No content routers available')
     }

--- a/packages/libp2p/test/content-routing/content-routing.spec.ts
+++ b/packages/libp2p/test/content-routing/content-routing.spec.ts
@@ -13,7 +13,7 @@ import sinon from 'sinon'
 import { stubInterface } from 'sinon-ts'
 import { createLibp2p } from '../../src/index.js'
 import type { Libp2p } from '../../src/index.js'
-import type { ContentRouting, PeerInfo } from '@libp2p/interface'
+import type { ContentRouting, Provider } from '@libp2p/interface'
 import type { StubbedInstance } from 'sinon-ts'
 
 describe('content-routing', () => {
@@ -87,7 +87,8 @@ describe('content-routing', () => {
           id: peerIdFromPrivateKey(await generateKeyPair('Ed25519')),
           multiaddrs: [
             multiaddr('/ip4/123.123.123.123/tcp/4001')
-          ]
+          ],
+          routing: 'test'
         }
         deferred.resolve()
       })
@@ -136,7 +137,8 @@ describe('content-routing', () => {
       delegate.findProviders.returns(async function * () {
         yield {
           id: node.peerId,
-          multiaddrs: []
+          multiaddrs: [],
+          routing: 'test'
         }
         deferred.resolve()
       }())
@@ -173,7 +175,8 @@ describe('content-routing', () => {
           id: peerIdFromString(provider),
           multiaddrs: [
             multiaddr('/ip4/0.0.0.0/tcp/0')
-          ]
+          ],
+          routing: 'test'
         }
       }())
 
@@ -224,11 +227,12 @@ describe('content-routing', () => {
 
     it('should store the multiaddrs of a peer', async () => {
       const providerPeerId = peerIdFromPrivateKey(await generateKeyPair('Ed25519'))
-      const result: PeerInfo = {
+      const result: Provider = {
         id: providerPeerId,
         multiaddrs: [
           multiaddr('/ip4/123.123.123.123/tcp/49320')
-        ]
+        ],
+        routing: 'test'
       }
 
       router.findProviders.callsFake(async function * () {})
@@ -252,7 +256,8 @@ describe('content-routing', () => {
         id: providerPeerId,
         multiaddrs: [
           multiaddr('/ip4/123.123.123.123/tcp/49320')
-        ]
+        ],
+        routing: 'test'
       }
 
       const defer = pDefer()
@@ -278,7 +283,8 @@ describe('content-routing', () => {
         id: providerPeerId,
         multiaddrs: [
           multiaddr('/ip4/123.123.123.123/tcp/49320')
-        ]
+        ],
+        routing: 'test'
       }
 
       router.findProviders.callsFake(async function * () {
@@ -299,13 +305,15 @@ describe('content-routing', () => {
         id: providerPeerId,
         multiaddrs: [
           multiaddr('/ip4/123.123.123.123/tcp/49320')
-        ]
+        ],
+        routing: 'test'
       }
       const result2 = {
         id: providerPeerId,
         multiaddrs: [
           multiaddr('/ip4/213.213.213.213/tcp/2344')
-        ]
+        ],
+        routing: 'test'
       }
 
       router.findProviders.callsFake(async function * () {
@@ -352,7 +360,8 @@ describe('content-routing', () => {
         id: providerPeerId,
         multiaddrs: [
           multiaddr('/ip4/123.123.123.123/tcp/2341')
-        ]
+        ],
+        routing: 'test'
       }]
 
       router.findProviders.callsFake(async function * () {
@@ -377,7 +386,8 @@ describe('content-routing', () => {
         id: providerPeerId,
         multiaddrs: [
           multiaddr('/ip4/123.123.123.123/tcp/2341')
-        ]
+        ],
+        routing: 'test'
       }]
 
       router.findProviders.callsFake(async function * () {})

--- a/packages/logger/src/index.ts
+++ b/packages/logger/src/index.ts
@@ -107,7 +107,7 @@ function formatError (v: Error): string {
 }
 
 function isAggregateError (err?: any): err is AggregateError {
-  return err?.name === 'AggregateError'
+  return err instanceof AggregateError || (err?.name === 'AggregateError' && Array.isArray(err.errors))
 }
 
 // Add a formatter for stringifying Errors

--- a/packages/transport-circuit-relay-v2/test/utils.ts
+++ b/packages/transport-circuit-relay-v2/test/utils.ts
@@ -4,7 +4,7 @@ import { Circuit } from '@multiformats/multiaddr-matcher'
 import pWaitFor from 'p-wait-for'
 import { toString as uint8ArrayToString } from 'uint8arrays/to-string'
 import { RELAY_V2_HOP_CODEC } from '../../../packages/transport-circuit-relay-v2/src/constants.js'
-import type { Libp2p, AbortOptions, ContentRouting, PeerId, PeerInfo } from '@libp2p/interface'
+import type { Libp2p, AbortOptions, ContentRouting, PeerId, Provider } from '@libp2p/interface'
 import type { AddressManager } from '@libp2p/interface-internal'
 import type { Multiaddr } from '@multiformats/multiaddr'
 import type { CID, Version } from 'multiformats'
@@ -133,7 +133,7 @@ export interface MockContentRoutingComponents {
 }
 
 export class MockContentRouting implements ContentRouting {
-  static providers = new Map<string, PeerInfo[]>()
+  static providers = new Map<string, Provider[]>()
   static data = new Map<string, Uint8Array>()
 
   static reset (): void {
@@ -155,7 +155,8 @@ export class MockContentRouting implements ContentRouting {
 
     providers.push({
       id: this.peerId,
-      multiaddrs: this.addressManager.getAddresses()
+      multiaddrs: this.addressManager.getAddresses(),
+      routing: 'mock-content-routing'
     })
 
     MockContentRouting.providers.set(cid.toString(), providers)
@@ -165,7 +166,7 @@ export class MockContentRouting implements ContentRouting {
 
   }
 
-  async * findProviders (cid: CID<unknown, number, number, Version>, options?: AbortOptions | undefined): AsyncGenerator<PeerInfo, void, undefined> {
+  async * findProviders (cid: CID<unknown, number, number, Version>, options?: AbortOptions | undefined): AsyncGenerator<Provider, void, undefined> {
     yield * MockContentRouting.providers.get(cid.toString()) ?? []
   }
 


### PR DESCRIPTION
To better debug which routing system supplied a given provider, add a string field to the return type of `findProviders` which allows this information to be reported.
