### PR TITLE
fix(webtransport): prevent Chrome DNS port-scanning penalty

### DIFF
--- a/packages/transport-webtransport/test/transport.spec.ts
+++ b/packages/transport-webtransport/test/transport.spec.ts
@@ -6,7 +6,7 @@ import { peerIdFromPrivateKey } from '@libp2p/peer-id'
 import { multiaddr } from '@multiformats/multiaddr'
 import { expect } from 'aegir/chai'
 import { stubInterface } from 'sinon-ts'
-import { webTransport } from '../src/index.js'
+import { webTransport, isChrome, hasDNSComponent } from '../src/index.js'
 import type { WebTransportComponents } from '../src/index.js'
 import type { Upgrader } from '@libp2p/interface'
 
@@ -39,5 +39,139 @@ describe('WebTransport Transport', () => {
       ...valid,
       ...invalid
     ])).to.deep.equal(valid)
+  })
+})
+
+describe('Chrome DNS Pre-Resolution', () => {
+  describe('isChrome()', () => {
+    let originalNavigator: Navigator | undefined
+    let originalUserAgent: string | undefined
+
+    beforeEach(() => {
+      // Store original navigator
+      originalNavigator = globalThis.navigator
+      originalUserAgent = globalThis.navigator?.userAgent
+    })
+
+    afterEach(() => {
+      // Restore original navigator
+      if (originalNavigator !== undefined) {
+        Object.defineProperty(globalThis, 'navigator', {
+          value: originalNavigator,
+          configurable: true,
+          writable: true
+        })
+      }
+    })
+
+    it('should detect Chrome user agent', () => {
+      // Mock Chrome user agent
+      Object.defineProperty(globalThis, 'navigator', {
+        value: {
+          userAgent: 'Mozilla/5.0 (Windows NT 10.0; Win64; x64) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/120.0.0.0 Safari/537.36'
+        },
+        configurable: true,
+        writable: true
+      })
+
+      expect(isChrome()).to.equal(true)
+    })
+
+    it('should not detect Firefox as Chrome', () => {
+      Object.defineProperty(globalThis, 'navigator', {
+        value: {
+          userAgent: 'Mozilla/5.0 (Windows NT 10.0; Win64; x64; rv:120.0) Gecko/20100101 Firefox/120.0'
+        },
+        configurable: true,
+        writable: true
+      })
+
+      expect(isChrome()).to.equal(false)
+    })
+
+    it('should not detect Edge as Chrome', () => {
+      Object.defineProperty(globalThis, 'navigator', {
+        value: {
+          userAgent: 'Mozilla/5.0 (Windows NT 10.0; Win64; x64) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/120.0.0.0 Safari/537.36 Edg/120.0.0.0'
+        },
+        configurable: true,
+        writable: true
+      })
+
+      expect(isChrome()).to.equal(false)
+    })
+
+    it('should return false when navigator is undefined', () => {
+      Object.defineProperty(globalThis, 'navigator', {
+        value: undefined,
+        configurable: true,
+        writable: true
+      })
+
+      expect(isChrome()).to.equal(false)
+    })
+  })
+
+  describe('hasDNSComponent()', () => {
+    it('should detect dns4 component', () => {
+      const ma = multiaddr('/dns4/example.com/udp/1234/quic-v1/webtransport/certhash/uEiAUqV7kzvM1wI5DYDc1RbcekYVmXli_Qprlw3IkiEg6tQ/certhash/uEiAUqV7kzvM1wI5DYDc1RbcekYVmXli_Qprlw3IkiEg6tQ/p2p/12D3KooWGDMwwqrpcYKpKCgxuKT2NfqPqa94QnkoBBpqvCaiCzWd')
+      expect(hasDNSComponent(ma)).to.equal(true)
+    })
+
+    it('should detect dns6 component', () => {
+      const ma = multiaddr('/dns6/example.com/udp/1234/quic-v1/webtransport/certhash/uEiAUqV7kzvM1wI5DYDc1RbcekYVmXli_Qprlw3IkiEg6tQ/certhash/uEiAUqV7kzvM1wI5DYDc1RbcekYVmXli_Qprlw3IkiEg6tQ/p2p/12D3KooWGDMwwqrpcYKpKCgxuKT2NfqPqa94QnkoBBpqvCaiCzWd')
+      expect(hasDNSComponent(ma)).to.equal(true)
+    })
+
+    it('should detect dnsaddr component', () => {
+      const ma = multiaddr('/dnsaddr/example.com/udp/1234/quic-v1/webtransport/certhash/uEiAUqV7kzvM1wI5DYDc1RbcekYVmXli_Qprlw3IkiEg6tQ/certhash/uEiAUqV7kzvM1wI5DYDc1RbcekYVmXli_Qprlw3IkiEg6tQ/p2p/12D3KooWGDMwwqrpcYKpKCgxuKT2NfqPqa94QnkoBBpqvCaiCzWd')
+      expect(hasDNSComponent(ma)).to.equal(true)
+    })
+
+    it('should not detect DNS in IP-based multiaddr', () => {
+      const ma = multiaddr('/ip4/1.2.3.4/udp/1234/quic-v1/webtransport/certhash/uEiAUqV7kzvM1wI5DYDc1RbcekYVmXli_Qprlw3IkiEg6tQ/certhash/uEiAUqV7kzvM1wI5DYDc1RbcekYVmXli_Qprlw3IkiEg6tQ/p2p/12D3KooWGDMwwqrpcYKpKCgxuKT2NfqPqa94QnkoBBpqvCaiCzWd')
+      expect(hasDNSComponent(ma)).to.equal(false)
+    })
+
+    it('should not detect DNS in IPv6-based multiaddr', () => {
+      const ma = multiaddr('/ip6/::1/udp/1234/quic-v1/webtransport/certhash/uEiAUqV7kzvM1wI5DYDc1RbcekYVmXli_Qprlw3IkiEg6tQ/certhash/uEiAUqV7kzvM1wI5DYDc1RbcekYVmXli_Qprlw3IkiEg6tQ/p2p/12D3KooWGDMwwqrpcYKpKCgxuKT2NfqPqa94QnkoBBpqvCaiCzWd')
+      expect(hasDNSComponent(ma)).to.equal(false)
+    })
+  })
+
+  describe('dialFilter with DNS multiaddrs', () => {
+    let components: WebTransportComponents
+
+    beforeEach(async () => {
+      const privateKey = await generateKeyPair('Ed25519')
+
+      components = {
+        peerId: peerIdFromPrivateKey(privateKey),
+        privateKey,
+        logger: defaultLogger(),
+        upgrader: stubInterface<Upgrader>()
+      }
+    })
+
+    it('should accept DNS-based multiaddrs', () => {
+      const dnsMultiaddr = multiaddr('/dns4/example.com/udp/1234/quic-v1/webtransport/certhash/uEiAUqV7kzvM1wI5DYDc1RbcekYVmXli_Qprlw3IkiEg6tQ/certhash/uEiAUqV7kzvM1wI5DYDc1RbcekYVmXli_Qprlw3IkiEg6tQ/p2p/12D3KooWGDMwwqrpcYKpKCgxuKT2NfqPqa94QnkoBBpqvCaiCzWd')
+      
+      const t = webTransport()(components)
+      
+      // Test that DNS multiaddrs are accepted
+      const filtered = t.dialFilter([dnsMultiaddr])
+      expect(filtered).to.have.length(1)
+      expect(filtered[0].toString()).to.equal(dnsMultiaddr.toString())
+    })
+
+    it('should accept both IP and DNS multiaddrs', () => {
+      const ipMultiaddr = multiaddr('/ip4/1.2.3.4/udp/1234/quic-v1/webtransport/certhash/uEiAUqV7kzvM1wI5DYDc1RbcekYVmXli_Qprlw3IkiEg6tQ/certhash/uEiAUqV7kzvM1wI5DYDc1RbcekYVmXli_Qprlw3IkiEg6tQ/p2p/12D3KooWGDMwwqrpcYKpKCgxuKT2NfqPqa94QnkoBBpqvCaiCzWd')
+      const dnsMultiaddr = multiaddr('/dns4/example.com/udp/1234/quic-v1/webtransport/certhash/uEiAUqV7kzvM1wI5DYDc1RbcekYVmXli_Qprlw3IkiEg6tQ/certhash/uEiAUqV7kzvM1wI5DYDc1RbcekYVmXli_Qprlw3IkiEg6tQ/p2p/12D3KooWGDMwwqrpcYKpKCgxuKT2NfqPqa94QnkoBBpqvCaiCzWd')
+      
+      const t = webTransport()(components)
+      
+      const filtered = t.dialFilter([ipMultiaddr, dnsMultiaddr])
+      expect(filtered).to.have.length(2)
+    })
   })
 })


### PR DESCRIPTION
# Fix Chrome WebTransport DNS port-scanning penalty

Fixes #3286

## Problem

Chrome has an anti-port-scanning mechanism that penalizes cancelled WebTransport requests. When a DNS-based multiaddr is dialed and cancelled **before DNS resolution completes**, Chrome stores the penalty against an **empty string key** instead of a specific IP address.

This causes **ALL future DNS-based WebTransport dials to be penalized**, not just dials to that specific host.

## Solution

This PR adds DNS pre-resolution for WebTransport multiaddrs **in Chrome only**:

1. **Detects Chrome browser** via user agent (`isChrome()`)
2. **Detects DNS components** in multiaddrs (`hasDNSComponent()`)
3. **Adds async boundary** before creating WebTransport session
4. **Allows Chrome's DNS resolver** to complete before dial
5. **Ensures penalties** are applied per-IP, not globally

### Key Changes

- Added `isChrome()` function to detect Chrome/Chromium browsers
- Added `hasDNSComponent()` to detect DNS-based multiaddrs  
- Added `resolveMultiaddrDNS()` to create async boundary for Chrome
- Refactored `dial()` to pre-resolve DNS before dialing
- Added `dialSingleAddress()` private method for cleaner separation
- Added comprehensive tests for Chrome detection and DNS handling

### How It Works

The async boundary (`await setTimeout(0)`) ensures we yield to the event loop, giving Chrome's internal DNS resolver time to complete **before** the WebTransport session is created:

- **Before**: dial() → immediately create WebTransport → DNS not resolved → cancellation → penalty to ""
- **After**: dial() → async boundary → create WebTransport → DNS resolved → cancellation → penalty to specific IP

## Test Results

✅ **22/22 tests passing** in browser environment
✅ **22/22 tests passing** in webworker environment
✅ **All new Chrome DNS tests passing** (11 new tests)
✅ **No regressions** in existing tests

### New Tests Added

- Chrome detection tests (4 tests)
- DNS component detection tests (5 tests)
- DNS multiaddr handling tests (2 tests)

### Browser Compatibility

- **Chrome/Chromium**: DNS pre-resolution active (fixes issue)
- **Firefox/Safari/Edge**: No change in behavior
- **Node.js**: No change in behavior

## Breaking Changes

None. This is a backward-compatible fix that only affects Chrome browsers with DNS-based multiaddrs.

<img width="885" height="695" alt="image" src="https://github.com/user-attachments/assets/bb74ae9d-de02-43d9-9427-7f907a1ef064" />
