### PR TITLE
feat: track protocol stream open/close count in metrics

### DIFF
--- a/packages/libp2p/src/connection.ts
+++ b/packages/libp2p/src/connection.ts
@@ -177,6 +177,20 @@ export class Connection extends TypedEventEmitter<MessageStreamEvents> implement
 
       this.components.metrics?.trackProtocolStream(muxedStream)
 
+      // track stream open/close counts
+      const streamKey = `${muxedStream.direction} ${muxedStream.protocol ?? 'unnegotiated'}`
+      this.components.metrics?.registerCounterGroup('libp2p_protocol_streams_opened_total', {
+        label: 'protocol',
+        help: 'Total count of protocol streams opened'
+      }).increment({ [streamKey]: true })
+
+      muxedStream.addEventListener('close', () => {
+        this.components.metrics?.registerCounterGroup('libp2p_protocol_streams_closed_total', {
+          label: 'protocol',
+          help: 'Total count of protocol streams closed'
+        }).increment({ [streamKey]: true })
+      }, { once: true })
+
       const middleware = this.components.registrar.getMiddleware(muxedStream.protocol)
 
       return await this.runMiddlewareChain(muxedStream, this, middleware)
@@ -230,6 +244,20 @@ export class Connection extends TypedEventEmitter<MessageStreamEvents> implement
       })
 
       this.components.metrics?.trackProtocolStream(muxedStream)
+
+      // track stream open/close counts
+      const streamKey = `${muxedStream.direction} ${muxedStream.protocol ?? 'unnegotiated'}`
+      this.components.metrics?.registerCounterGroup('libp2p_protocol_streams_opened_total', {
+        label: 'protocol',
+        help: 'Total count of protocol streams opened'
+      }).increment({ [streamKey]: true })
+
+      muxedStream.addEventListener('close', () => {
+        this.components.metrics?.registerCounterGroup('libp2p_protocol_streams_closed_total', {
+          label: 'protocol',
+          help: 'Total count of protocol streams closed'
+        }).increment({ [streamKey]: true })
+      }, { once: true })
 
       const { handler, options } = this.components.registrar.getHandler(muxedStream.protocol)
 


### PR DESCRIPTION
## Summary

- Adds two new counter metrics to track stream lifecycle events:
  - `libp2p_protocol_streams_opened_total` - incremented when a stream is opened
  - `libp2p_protocol_streams_closed_total` - incremented when a stream is closed
- Uses the same label format as the existing gauge: `{direction} {protocol}`
- Preserves the existing `libp2p_protocol_streams_total` gauge for backward compatibility

## Motivation

The existing gauge metric only shows current state. These counters enable:
- Calculating stream open/close **rates** using Prometheus `rate()` or `increase()`
- Analyzing stream **throughput** patterns over time
- Deriving current streams as `opened_total - closed_total`

## Test plan

- [x] All existing connection tests pass (20/20)
- [x] All existing connection-manager tests pass (18/18)
- [x] Build succeeds

Fixes #3262