### PR TITLE
fix: clean up adaptive timeout signals in connection monitor

### DIFF
--- a/packages/libp2p/src/connection-monitor.ts
+++ b/packages/libp2p/src/connection-monitor.ts
@@ -96,10 +96,11 @@ export class ConnectionMonitor implements Startable {
       this.components.connectionManager.getConnections().forEach(conn => {
         Promise.resolve().then(async () => {
           let start = Date.now()
+          const signal = this.timeout.getTimeoutSignal({
+            signal: this.abortController?.signal
+          })
+
           try {
-            const signal = this.timeout.getTimeoutSignal({
-              signal: this.abortController?.signal
-            })
             const stream = await conn.newStream(this.protocol, {
               signal,
               runOnLimitedConnection: true
@@ -132,6 +133,8 @@ export class ConnectionMonitor implements Startable {
             // round trips (e.g. 1x for the mss header, then another for the
             // protocol) so divide the time it took by two
             conn.rtt = (Date.now() - start) / 2
+          } finally {
+            this.timeout.cleanUp(signal)
           }
         })
           .catch(err => {

--- a/packages/libp2p/test/connection-monitor/index.spec.ts
+++ b/packages/libp2p/test/connection-monitor/index.spec.ts
@@ -3,6 +3,7 @@ import { defaultLogger } from '@libp2p/logger'
 import { echoStream } from '@libp2p/utils'
 import { expect } from 'aegir/chai'
 import delay from 'delay'
+import Sinon from 'sinon'
 import { stubInterface } from 'sinon-ts'
 import { ConnectionMonitor } from '../../src/connection-monitor.js'
 import type { ComponentLogger, Stream, Connection } from '@libp2p/interface'
@@ -64,6 +65,26 @@ describe('connection monitor', () => {
     await delay(100)
 
     expect(connection.rtt).to.be.gte(0)
+  })
+
+  it('should clean up timeout signal listeners after each heartbeat', async () => {
+    monitor = new ConnectionMonitor(components, {
+      pingInterval: 10
+    })
+
+    await start(monitor)
+
+    const cleanUpSpy = Sinon.spy((monitor as any).timeout, 'cleanUp')
+
+    const connection = stubInterface<Connection>()
+    const stream = await echoStream()
+    connection.newStream.withArgs('/ipfs/ping/1.0.0').resolves(stream)
+
+    components.connectionManager.getConnections.returns([connection])
+
+    await delay(100)
+
+    expect(cleanUpSpy.callCount).to.be.gte(1)
   })
 
   it('should monitor the liveness of a connection that does not support ping', async () => {

--- a/packages/utils/src/adaptive-timeout.ts
+++ b/packages/utils/src/adaptive-timeout.ts
@@ -79,6 +79,8 @@ export class AdaptiveTimeout {
   }
 
   cleanUp (signal: AdaptiveTimeoutSignal): void {
+    signal.clear()
+
     const time = Date.now() - signal.start
 
     if (signal.aborted) {

--- a/packages/utils/test/adaptive-timeout.spec.ts
+++ b/packages/utils/test/adaptive-timeout.spec.ts
@@ -91,6 +91,16 @@ describe('adaptive-timeout', () => {
     expect(signal3).to.have.property('timeout', 8835)
   })
 
+  it('should clear timeout signal listeners on cleanUp', () => {
+    const adaptiveTimeout = new AdaptiveTimeout()
+    const signal = adaptiveTimeout.getTimeoutSignal()
+    const clearSpy = Sinon.spy(signal, 'clear')
+
+    adaptiveTimeout.cleanUp(signal)
+
+    expect(clearSpy).to.have.property('called', true)
+  })
+
   it('should wrap an existing signal', () => {
     const controller = new AbortController()
     const adaptiveTimeout = new AdaptiveTimeout()


### PR DESCRIPTION
## Context

Fixes a steady memory growth path in heartbeat pinging.

Related issue: #3391

## What this changes

### 1) Always clean up connection-monitor timeout signals

`ConnectionMonitor` now wraps each heartbeat ping attempt with:

- `const signal = this.timeout.getTimeoutSignal(...)`
- `finally { this.timeout.cleanUp(signal) }`

This ensures cleanup runs on success, timeout, and error paths.

### 2) Ensure `AdaptiveTimeout.cleanUp` releases composed signal listeners

`AdaptiveTimeout.cleanUp(signal)` now calls:

```ts
signal.clear()
```

before computing/recording timing stats.

This detaches listener chains created by `anySignal(...)`/`AbortSignal.timeout(...)`.

## Tests

Added tests:

- `packages/utils/test/adaptive-timeout.spec.ts`
  - verifies `cleanUp` calls `signal.clear()`
- `packages/libp2p/test/connection-monitor/index.spec.ts`
  - verifies `ConnectionMonitor` invokes timeout cleanup during heartbeat

## Notes

This patch was validated downstream with a long A/B soak where unpatched nodes grew ~2 MB/h faster than patched under identical conditions.
