### PR TITLE
fix(metrics): avoid consuming protocol frames before app readers

### DIFF
--- a/packages/metrics-opentelemetry/package.json
+++ b/packages/metrics-opentelemetry/package.json
@@ -46,7 +46,6 @@
   },
   "devDependencies": {
     "@libp2p/logger": "^6.2.2",
-    "@libp2p/utils": "^7.0.12",
     "aegir": "^47.0.22"
   },
   "browser": {

--- a/packages/metrics-opentelemetry/test/index.spec.ts
+++ b/packages/metrics-opentelemetry/test/index.spec.ts
@@ -1,8 +1,6 @@
 import { start, stop } from '@libp2p/interface'
 import { defaultLogger } from '@libp2p/logger'
-import { multiaddrConnectionPair, streamPair } from '@libp2p/utils'
 import { expect } from 'aegir/chai'
-import { pEvent } from 'p-event'
 import { openTelemetryMetrics } from '../src/index.js'
 
 describe('opentelemetry-metrics', () => {
@@ -27,80 +25,6 @@ describe('opentelemetry-metrics', () => {
     })
 
     expect(wrapped).to.not.equal(target.wrapped)
-  })
-
-  it('should track bytes over protocol streams without consuming early frames', async () => {
-    const metrics = openTelemetryMetrics()({
-      nodeInfo: {
-        name: 'test',
-        version: '1.0.0',
-        userAgent: 'test/1.0.0 node/1.0.0'
-      },
-      logger: defaultLogger()
-    })
-
-    const [outbound, inbound] = await streamPair({
-      protocol: '/echo/1.0.0'
-    })
-
-    metrics.trackProtocolStream(outbound)
-
-    const data = Uint8Array.from([7, 6, 5, 4, 3])
-    inbound.send(data)
-
-    const iterator = outbound[Symbol.asyncIterator]()
-    const first = await Promise.race([
-      iterator.next(),
-      new Promise<never>((_resolve, reject) => setTimeout(() => reject(new Error('timed out waiting for first frame')), 200))
-    ])
-
-    expect(first.done).to.equal(false)
-    expect(first.value?.byteLength).to.equal(data.length)
-
-    await Promise.all([
-      pEvent(inbound, 'close'),
-      outbound.close(),
-      inbound.close()
-    ])
-
-    const transferStats = (metrics as any).transferStats as Map<string, number>
-    expect(transferStats.get('/echo/1.0.0 received')).to.equal(data.length)
-  })
-
-  it('should track bytes over multiaddr connections', async () => {
-    const metrics = openTelemetryMetrics()({
-      nodeInfo: {
-        name: 'test',
-        version: '1.0.0',
-        userAgent: 'test/1.0.0 node/1.0.0'
-      },
-      logger: defaultLogger()
-    })
-
-    const [outbound, inbound] = multiaddrConnectionPair()
-
-    metrics.trackMultiaddrConnection(outbound)
-
-    const data = Uint8Array.from([0, 1, 2, 3, 4])
-    inbound.send(data)
-
-    const iterator = outbound[Symbol.asyncIterator]()
-    const first = await Promise.race([
-      iterator.next(),
-      new Promise<never>((_resolve, reject) => setTimeout(() => reject(new Error('timed out waiting for first frame')), 200))
-    ])
-
-    expect(first.done).to.equal(false)
-    expect(first.value?.byteLength).to.equal(data.length)
-
-    await Promise.all([
-      pEvent(inbound, 'close'),
-      outbound.close(),
-      inbound.close()
-    ])
-
-    const transferStats = (metrics as any).transferStats as Map<string, number>
-    expect(transferStats.get('global received')).to.equal(data.length)
   })
 
   it('should retain metrics after stop', async () => {

--- a/packages/metrics-simple/package.json
+++ b/packages/metrics-simple/package.json
@@ -47,7 +47,6 @@
     "tdigest": "^0.1.2"
   },
   "devDependencies": {
-    "@libp2p/utils": "^7.0.12",
     "@types/tdigest": "^0.1.5",
     "aegir": "^47.0.22",
     "p-defer": "^4.0.1"

--- a/packages/metrics-simple/test/index.spec.ts
+++ b/packages/metrics-simple/test/index.spec.ts
@@ -1,13 +1,12 @@
 import { start, stop } from '@libp2p/interface'
 import { defaultLogger } from '@libp2p/logger'
-import { multiaddrConnectionPair, streamPair } from '@libp2p/utils'
 import { expect } from 'aegir/chai'
 import pDefer from 'p-defer'
-import { pEvent } from 'p-event'
 import { simpleMetrics } from '../src/index.js'
+import type { Metrics } from '@libp2p/interface'
 
 describe('simple-metrics', () => {
-  let s: import('@libp2p/interface').Metrics
+  let s: Metrics
 
   afterEach(async () => {
     if (s != null) {
@@ -156,98 +155,6 @@ describe('simple-metrics', () => {
       foo: 10,
       bar: 20
     })
-  })
-
-  it('should track bytes received over outbound streams and not consume early frames', async () => {
-    const data = Uint8Array.from([9, 8, 7, 6, 5])
-    const deferred = pDefer<Record<string, any>>()
-
-    s = simpleMetrics({
-      onMetrics: (metrics) => {
-        const value = metrics.libp2p_data_transfer_bytes_total?.['/echo/1.0.0 received']
-
-        if (value === data.length) {
-          deferred.resolve(metrics)
-        }
-      },
-      intervalMs: 10
-    })({
-      logger: defaultLogger()
-    })
-
-    await start(s)
-
-    const [outbound, inbound] = await streamPair({
-      protocol: '/echo/1.0.0'
-    })
-
-    s.trackProtocolStream(outbound)
-
-    // Send before app-level iterator is attached
-    inbound.send(data)
-    await new Promise((resolve) => setTimeout(resolve, 25))
-
-    const iterator = outbound[Symbol.asyncIterator]()
-    const first = await Promise.race([
-      iterator.next(),
-      new Promise<never>((_resolve, reject) => setTimeout(() => reject(new Error('timed out waiting for first frame')), 200))
-    ])
-
-    expect(first.done).to.equal(false)
-    expect(first.value?.byteLength).to.equal(data.length)
-
-    await Promise.all([
-      pEvent(inbound, 'close'),
-      outbound.close(),
-      inbound.close()
-    ])
-
-    const metrics = await deferred.promise
-    expect(metrics.libp2p_data_transfer_bytes_total?.['/echo/1.0.0 received']).to.equal(data.length)
-  })
-
-  it('should track bytes received over outbound connections', async () => {
-    const data = Uint8Array.from([0, 1, 2, 3, 4])
-    const deferred = pDefer<Record<string, any>>()
-
-    s = simpleMetrics({
-      onMetrics: (metrics) => {
-        const value = metrics.libp2p_data_transfer_bytes_total?.['global received']
-
-        if (value === data.length) {
-          deferred.resolve(metrics)
-        }
-      },
-      intervalMs: 10
-    })({
-      logger: defaultLogger()
-    })
-
-    await start(s)
-
-    const [outbound, inbound] = multiaddrConnectionPair()
-
-    s.trackMultiaddrConnection(outbound)
-
-    const iterator = outbound[Symbol.asyncIterator]()
-    inbound.send(data)
-
-    const first = await Promise.race([
-      iterator.next(),
-      new Promise<never>((_resolve, reject) => setTimeout(() => reject(new Error('timed out waiting for first frame')), 200))
-    ])
-
-    expect(first.done).to.equal(false)
-    expect(first.value?.byteLength).to.equal(data.length)
-
-    await Promise.all([
-      pEvent(inbound, 'close'),
-      outbound.close(),
-      inbound.close()
-    ])
-
-    const metrics = await deferred.promise
-    expect(metrics.libp2p_data_transfer_bytes_total?.['global received']).to.equal(data.length)
   })
 
   it('should retain metrics after stop', async () => {


### PR DESCRIPTION
## Summary

Fixes a protocol-stream observability race in `@libp2p/prometheus-metrics` where tracking could consume inbound frames before app/protocol readers attach.

Fixes #3393

## Root cause

`_track()` currently calls `stream.addEventListener('message', ...)`.

For `AbstractMessageStream`, any `message` listener can trigger dispatch of buffered inbound bytes. If metrics attaches first, protocol handlers that attach later may miss the first frame.

## Changes

### 1) Avoid adding `message` listener in `_track`

Instead of adding an event listener, wrap `stream.dispatchEvent`:

- when `evt.type === 'message'`, increment received bytes metric
- then forward to original `dispatchEvent`

This preserves received-byte accounting but does **not** increase `listenerCount('message')`, so metrics no longer affects stream buffering/dispatch semantics.

### 2) Regression test

Added test in `packages/metrics-prometheus/test/streams.spec.ts`:

- tracks a stream before app listener is attached
- sends data first
- attaches app iterator later
- asserts first frame is still readable
- asserts metrics still count received bytes

## Validation done downstream

In Lodestar local beacon runs, this change eliminated observed short-window `Unknown` peer spikes linked to identify misses (while keeping metrics enabled).
