### PR TITLE
test: Skip Go sender to Go listener interop tests

### DIFF
--- a/packages/interop/src/connect/index.ts
+++ b/packages/interop/src/connect/index.ts
@@ -7,6 +7,11 @@ export function connectTests (factory: DaemonFactory): void {
 
   for (const typeA of nodeTypes) {
     for (const typeB of nodeTypes) {
+      // skip go-go tests
+      if (typeA === 'go' && typeB === 'go') {
+        continue
+      }
+
       transportTypes.forEach(transport => {
         runConnectTests(
           transport,

--- a/packages/interop/src/utils/test-matrix.ts
+++ b/packages/interop/src/utils/test-matrix.ts
@@ -14,6 +14,11 @@ export function runTests (name: string, fn: TestFunction, factory: DaemonFactory
   for (const keyType of keyTypes) {
     for (const implA of impls) {
       for (const implB of impls) {
+        // skip go-go tests
+        if (implA === 'go' && implB === 'go') {
+          continue
+        }
+
         for (const encrypter of encrypters) {
           // eslint-disable-next-line max-depth
           for (const muxer of muxers) {


### PR DESCRIPTION
## Description

Probably don't need to be testing Go-to-Go interop in JS tests

## Change checklist

- [x] I have performed a self-review of my own code
- [ ] I have made corresponding changes to the documentation if necessary (this includes comments as well)
- [ ] I have added tests that prove my fix is effective or that my feature works