### PR TITLE
fix(connection-manager): skip stale connections in findExisting

### DIFF
--- a/packages/libp2p/src/connection-manager/utils.ts
+++ b/packages/libp2p/src/connection-manager/utils.ts
@@ -116,6 +116,11 @@ export function findExistingConnection (peerId?: PeerId, connections?: Connectio
   }
 
   const existingConnection = connections
+    // only consider connections that are still open - a closing/closed
+    // connection may still appear in the connection list if the 'close' event
+    // hasn't been processed yet (e.g. TCP FIN received at OS level but the JS
+    // event hasn't fired in this tick)
+    .filter(con => con.status === 'open')
     .sort((a, b) => {
       if (a.direct) {
         return -1

--- a/packages/libp2p/test/connection-manager/utils.spec.ts
+++ b/packages/libp2p/test/connection-manager/utils.spec.ts
@@ -1,7 +1,125 @@
+import { multiaddr } from '@multiformats/multiaddr'
 import { expect } from 'aegir/chai'
 import { stubInterface } from 'sinon-ts'
-import { safelyCloseConnectionIfUnused } from '../../src/connection-manager/utils.js'
+import { findExistingConnection, safelyCloseConnectionIfUnused } from '../../src/connection-manager/utils.js'
 import type { Connection, Stream } from '@libp2p/interface'
+
+describe('findExistingConnection', () => {
+  it('should return an open unlimited connection', () => {
+    const connection = stubInterface<Connection>({
+      status: 'open',
+      limits: undefined,
+      direct: true
+    })
+
+    const result = findExistingConnection(connection.remotePeer, [connection])
+
+    expect(result).to.equal(connection)
+  })
+
+  it('should not return a closing connection', () => {
+    const connection = stubInterface<Connection>({
+      status: 'closing',
+      limits: undefined,
+      direct: true
+    })
+
+    const result = findExistingConnection(connection.remotePeer, [connection])
+
+    expect(result).to.be.undefined()
+  })
+
+  it('should not return a closed connection', () => {
+    const connection = stubInterface<Connection>({
+      status: 'closed',
+      limits: undefined,
+      direct: true
+    })
+
+    const result = findExistingConnection(connection.remotePeer, [connection])
+
+    expect(result).to.be.undefined()
+  })
+
+  it('should not return a limited connection', () => {
+    const connection = stubInterface<Connection>({
+      status: 'open',
+      limits: { seconds: 60 },
+      direct: true
+    })
+
+    const result = findExistingConnection(connection.remotePeer, [connection])
+
+    expect(result).to.be.undefined()
+  })
+
+  it('should prefer a direct open connection over a relay open connection', () => {
+    const directConnection = stubInterface<Connection>({
+      status: 'open',
+      limits: undefined,
+      direct: true
+    })
+    const relayConnection = stubInterface<Connection>({
+      status: 'open',
+      limits: undefined,
+      direct: false
+    })
+
+    const result = findExistingConnection(directConnection.remotePeer, [relayConnection, directConnection])
+
+    expect(result).to.equal(directConnection)
+  })
+
+  it('should not return a closing direct connection when an open relay connection exists', () => {
+    const directConnection = stubInterface<Connection>({
+      status: 'closing',
+      limits: undefined,
+      direct: true
+    })
+    const relayConnection = stubInterface<Connection>({
+      status: 'open',
+      limits: undefined,
+      direct: false
+    })
+
+    const result = findExistingConnection(directConnection.remotePeer, [relayConnection, directConnection])
+
+    // the closing direct connection is excluded; the relay is returned
+    expect(result).to.equal(relayConnection)
+  })
+
+  it('should return undefined when no connections are provided', () => {
+    const result = findExistingConnection(stubInterface<Connection>().remotePeer, [])
+
+    expect(result).to.be.undefined()
+  })
+
+  it('should return undefined when peerId is not provided', () => {
+    const connection = stubInterface<Connection>({
+      status: 'open',
+      limits: undefined
+    })
+
+    const result = findExistingConnection(undefined, [connection])
+
+    expect(result).to.be.undefined()
+  })
+
+  it('should allow a direct connection upgrade when an open relay connection exists and dial addresses include a direct address', () => {
+    const relayConnection = stubInterface<Connection>({
+      status: 'open',
+      limits: undefined,
+      direct: false
+    })
+    // a real TCP multiaddr is not a circuit relay address, so isDirect() returns true
+    const directAddr = multiaddr('/ip4/1.2.3.4/tcp/4001')
+
+    // relay + direct dial addr → findExistingConnection allows upgrade → returns undefined
+    const result = findExistingConnection(relayConnection.remotePeer, [relayConnection], [directAddr])
+
+    expect(result).to.be.undefined()
+  })
+})
 
 describe('closing', () => {
   describe('connections', () => {


### PR DESCRIPTION
## Summary

`findExistingConnection` in `ConnectionManager` now filters out connections with status `'closing'` or `'closed'` before returning an existing connection.

Previously, when a remote peer restarted cleanly (sending a TCP FIN), the OS-level close could arrive before the JavaScript `'close'` event was processed. In that window the stale connection was still in the ConnectionManager's map, causing `openConnection` to return it and skip the dial entirely. With no new connection, `identify` never ran and `topology.onConnect` was never called for the restarted peer, so protocol handlers registered via `register()` (e.g. DHT, GossipSub) were never notified.

## Test plan

  - [x] New unit tests for `findExistingConnection` covering `'closing'`,
    `'closed'`, and `'open'` status filtering
  - [x] Regression guard: open direct connection is still returned
  - [x] Regression guard: closing direct connection falls back to open relay
    connection rather than returning nothing
  - [x] Upgrade path: relay connection not returned when dial addresses include
    a direct address

  Fixes #2378