### PR TITLE
test: fix flaky abort test in webrtc interface compliance

### DIFF
--- a/packages/interface-compliance-tests/src/stream-muxer/close-test.ts
+++ b/packages/interface-compliance-tests/src/stream-muxer/close-test.ts
@@ -9,15 +9,15 @@ import { Uint8ArrayList } from 'uint8arraylist'
 import { fromString as uint8ArrayFromString } from 'uint8arrays/from-string'
 import { Message } from './fixtures/pb/message.js'
 import type { TestSetup } from '../index.js'
-import type { MultiaddrConnection, Stream, StreamMuxer, StreamMuxerFactory } from '@libp2p/interface'
+import type { MultiaddrConnection, Stream, StreamCloseEvent, StreamMuxer, StreamMuxerFactory } from '@libp2p/interface'
 
 function randomBuffer (): Uint8Array {
   return uint8ArrayFromString(Math.random().toString())
 }
 
-async function * infiniteRandom (): AsyncGenerator<Uint8ArrayList, void, unknown> {
+async function * infiniteRandom (signal?: AbortSignal): AsyncGenerator<Uint8ArrayList, void, unknown> {
   while (true) {
-    await delay(10)
+    await delay(10, { signal })
     yield new Uint8ArrayList(randomBuffer())
   }
 }
@@ -153,18 +153,28 @@ export default (common: TestSetup<StreamMuxerFactory>): void => {
       )
 
       const streamPipes = streams.map(async stream => {
-        for await (const buf of infiniteRandom()) {
-          if (stream.writeStatus !== 'writable') {
-            break
-          }
+        const controller = new AbortController()
+        const onClose = (evt: StreamCloseEvent): void => {
+          controller.abort(evt.error ?? new Error('stream closed'))
+        }
+        stream.addEventListener('close', onClose, { once: true })
 
-          const sendMore = stream.send(buf)
+        try {
+          for await (const buf of infiniteRandom(controller.signal)) {
+            if (stream.writeStatus !== 'writable') {
+              break
+            }
 
-          if (!sendMore) {
-            await pEvent(stream, 'drain', {
-              rejectionEvents: ['close']
-            })
+            const sendMore = stream.send(buf)
+
+            if (!sendMore) {
+              await pEvent(stream, 'drain', {
+                rejectionEvents: ['close']
+              })
+            }
           }
+        } finally {
+          stream.removeEventListener('close', onClose)
         }
       })
 


### PR DESCRIPTION
## Title
<!---
The title of the PR will be the commit message of the merge commit, so please make sure it is descriptive enough.
We utilize the Conventional Commits specification for our commit messages. See <https://www.conventionalcommits.org/en/v1.0.0/#specification> for more information.
The commit tag types can be of one of the following: feat, fix, deps, refactor, chore, docs. See <https://github.com/libp2p/js-libp2p/blob/master/.github/workflows/main.yml#L235-L242>
The title must also be fewer than 72 characters long or it will fail the Semantic PR check. See <https://github.com/libp2p/js-libp2p/blob/master/.github/workflows/semantic-pull-request.yml>
--->

test: fix flaky abort test in webrtc interface compliance

## Description

The "calling abort aborts streams" test had a 20ms window (abort at 50ms, timeout at 70ms) for stream pipes to detect muxer abort. When streams were in the `await delay(10)` inside `infiniteRandom`, Firefox timer throttling could delay the `delay(10)` beyond the 70ms window, causing the timeout to fire first.

Fix by passing an AbortSignal to `infiniteRandom` that is aborted synchronously when the stream's 'close' event fires. Since `delay(milliseconds, { signal })` cancels its timer and rejects immediately when the signal aborts, the stream pipe now throws within microtasks of `dialer.abort()` being called — no timer resolution dependency.

<!--
Please write a summary of your changes and why you made them.
Please include any relevant issues in here, for example:
Related https://github.com/libp2p/js-libp2p/issues/ABCD.
Fixes https://github.com/libp2p/js-libp2p/issues/XYZ.
-->

## Notes & open questions

fixes https://github.com/libp2p/js-libp2p/actions/runs/23424112339/job/68135438630

May be good to look at adding a `.signal` property to the stream interface...

<!--
Any notes, remarks or open questions you have to make about the PR which don't need to go into the final commit message.
-->

## Change checklist

- [x] I have performed a self-review of my own code
- [ ] I have made corresponding changes to the documentation if necessary (this includes comments as well)
- [ ] I have added tests that prove my fix is effective or that my feature works