### PR TITLE
feat: add DialTarget type

### DIFF
--- a/packages/interface-internal/src/connection-manager.ts
+++ b/packages/interface-internal/src/connection-manager.ts
@@ -1,4 +1,4 @@
-import type { AbortOptions, PendingDial, Connection, MultiaddrConnection, PeerId, IsDialableOptions, OpenConnectionProgressEvents, Stream, NewStreamOptions } from '@libp2p/interface'
+import type { AbortOptions, PendingDial, Connection, MultiaddrConnection, PeerId, IsDialableOptions, OpenConnectionProgressEvents, Stream, NewStreamOptions, DialTarget } from '@libp2p/interface'
 import type { PeerMap } from '@libp2p/peer-collections'
 import type { Multiaddr } from '@multiformats/multiaddr'
 import type { ProgressOptions } from 'progress-events'
@@ -80,7 +80,7 @@ export interface ConnectionManager {
    * @param options - Optional parameters for connection handling.
    * @returns A promise that resolves to a `Connection` object.
    */
-  openConnection(peer: PeerId | Multiaddr | Multiaddr[], options?: OpenConnectionOptions): Promise<Connection>
+  openConnection(peer: DialTarget, options?: OpenConnectionOptions): Promise<Connection>
 
   /**
    * Open a protocol stream with a remote peer. If the peer is already connected
@@ -96,7 +96,7 @@ export interface ConnectionManager {
    * @param options - Optional parameters for connection handling.
    * @returns A promise that resolves to a `Connection` object.
    */
-  openStream(peer: PeerId | Multiaddr | Multiaddr[], protocol: string | string[], options?: OpenConnectionOptions & NewStreamOptions): Promise<Stream>
+  openStream(peer: DialTarget, protocol: string | string[], options?: OpenConnectionOptions & NewStreamOptions): Promise<Stream>
 
   /**
    * Close our connections to a peer

--- a/packages/interface/src/index.ts
+++ b/packages/interface/src/index.ts
@@ -56,6 +56,11 @@ export interface SignedPeerRecord {
 }
 
 /**
+ * Things that libp2p can dial
+ */
+export type DialTarget = PeerId | Multiaddr | Multiaddr[]
+
+/**
  * A certificate that can be used to secure connections
  */
 export interface TLSCertificate {
@@ -678,7 +683,7 @@ export interface Libp2p<T extends ServiceMap = ServiceMap> extends Startable, Ty
    * await conn.close()
    * ```
    */
-  dial(peer: PeerId | Multiaddr | Multiaddr[], options?: DialOptions): Promise<Connection>
+  dial(peer: DialTarget, options?: DialOptions): Promise<Connection>
 
   /**
    * Dials to the provided peer and tries to handshake with the given protocols in order.
@@ -696,7 +701,7 @@ export interface Libp2p<T extends ServiceMap = ServiceMap> extends Startable, Ty
    * pipe([1, 2, 3], stream, consume)
    * ```
    */
-  dialProtocol(peer: PeerId | Multiaddr | Multiaddr[], protocols: string | string[], options?: DialProtocolOptions): Promise<Stream>
+  dialProtocol(peer: DialTarget, protocols: string | string[], options?: DialProtocolOptions): Promise<Stream>
 
   /**
    * Attempts to gracefully close an open connection to the given peer. If the

--- a/packages/kad-dht/test/network.spec.ts
+++ b/packages/kad-dht/test/network.spec.ts
@@ -7,8 +7,7 @@ import { fromString as uint8ArrayFromString } from 'uint8arrays/from-string'
 import { Message, MessageType } from '../src/message/dht.js'
 import { TestDHT } from './utils/test-dht.js'
 import type { KadDHTPeer } from './utils/test-dht.js'
-import type { PeerId } from '@libp2p/interface'
-import type { Multiaddr } from '@multiformats/multiaddr'
+import type { DialTarget } from '@libp2p/interface'
 
 describe('Network', () => {
   let dht: KadDHTPeer
@@ -60,7 +59,7 @@ describe('Network', () => {
       }
 
       // mock it
-      dht.dht.components.connectionManager.openStream = async (peer: PeerId | Multiaddr | Multiaddr[]) => {
+      dht.dht.components.connectionManager.openStream = async (peer: DialTarget) => {
         const [outboundStream, inboundStream] = await streamPair()
 
         inboundStream.addEventListener('message', (evt) => {

--- a/packages/libp2p/src/connection-manager/dial-queue.ts
+++ b/packages/libp2p/src/connection-manager/dial-queue.ts
@@ -22,7 +22,7 @@ import {
 import { resolveMultiaddr, dnsaddrResolver } from './resolvers/index.js'
 import { findExistingConnection } from './utils.ts'
 import { DEFAULT_DIAL_PRIORITY } from './index.js'
-import type { AddressSorter, ComponentLogger, Logger, Connection, ConnectionGater, Metrics, PeerId, Address, PeerStore, PeerRouting, IsDialableOptions, OpenConnectionProgressEvents, MultiaddrResolver } from '@libp2p/interface'
+import type { AddressSorter, ComponentLogger, Logger, Connection, ConnectionGater, Metrics, PeerId, Address, PeerStore, PeerRouting, IsDialableOptions, OpenConnectionProgressEvents, MultiaddrResolver, DialTarget } from '@libp2p/interface'
 import type { OpenConnectionOptions, TransportManager } from '@libp2p/interface-internal'
 import type { PriorityQueueJobOptions } from '@libp2p/utils'
 import type { DNS } from '@multiformats/dns'
@@ -134,7 +134,7 @@ export class DialQueue {
    * The dial to the first address that is successfully able to upgrade a
    * connection will be used, all other dials will be aborted when that happens.
    */
-  async dial (peerIdOrMultiaddr: PeerId | Multiaddr | Multiaddr[], options: OpenConnectionOptions = {}): Promise<Connection> {
+  async dial (peerIdOrMultiaddr: DialTarget, options: OpenConnectionOptions = {}): Promise<Connection> {
     const { peerId, multiaddrs } = getPeerAddress(peerIdOrMultiaddr)
 
     if (peerId != null && options.force !== true) {
@@ -142,7 +142,7 @@ export class DialQueue {
 
       if (existingConnection != null) {
         this.log('already connected to %a', existingConnection.remoteAddr)
-        options.onProgress?.(new CustomProgressEvent('dial-queue:already-connected'))
+        options.onProgress?.(new CustomProgressEvent('dial-queue:already-connected', existingConnection))
         return existingConnection
       }
     }

--- a/packages/libp2p/src/connection-manager/index.ts
+++ b/packages/libp2p/src/connection-manager/index.ts
@@ -12,7 +12,7 @@ import { ReconnectQueue } from './reconnect-queue.js'
 import { dnsaddrResolver } from './resolvers/index.ts'
 import { findExistingConnection, multiaddrToIpNet } from './utils.js'
 import type { IpNet } from '@chainsafe/netmask'
-import type { PendingDial, AddressSorter, Libp2pEvents, AbortOptions, ComponentLogger, Logger, Connection, MultiaddrConnection, ConnectionGater, Metrics, PeerId, PeerStore, Startable, PendingDialStatus, PeerRouting, IsDialableOptions, MultiaddrResolver, Stream, NewStreamOptions } from '@libp2p/interface'
+import type { PendingDial, AddressSorter, Libp2pEvents, AbortOptions, ComponentLogger, Logger, Connection, MultiaddrConnection, ConnectionGater, Metrics, PeerId, PeerStore, Startable, PendingDialStatus, PeerRouting, IsDialableOptions, MultiaddrResolver, Stream, NewStreamOptions, DialTarget } from '@libp2p/interface'
 import type { ConnectionManager, OpenConnectionOptions, TransportManager } from '@libp2p/interface-internal'
 import type { JobStatus } from '@libp2p/utils'
 import type { Multiaddr } from '@multiformats/multiaddr'
@@ -523,7 +523,7 @@ export class DefaultConnectionManager implements ConnectionManager, Startable {
     return this.connections
   }
 
-  async openConnection (peerIdOrMultiaddr: PeerId | Multiaddr | Multiaddr[], options: OpenConnectionOptions = {}): Promise<Connection> {
+  async openConnection (peerIdOrMultiaddr: DialTarget, options: OpenConnectionOptions = {}): Promise<Connection> {
     if (!this.started) {
       throw new NotStartedError('Not started')
     }
@@ -596,7 +596,7 @@ export class DefaultConnectionManager implements ConnectionManager, Startable {
     }
   }
 
-  async openStream (peerIdOrMultiaddr: PeerId | Multiaddr | Multiaddr[], protocol: string | string[], options: OpenConnectionOptions & NewStreamOptions = {}): Promise<Stream> {
+  async openStream (peerIdOrMultiaddr: DialTarget, protocol: string | string[], options: OpenConnectionOptions & NewStreamOptions = {}): Promise<Stream> {
     const connection = await this.openConnection(peerIdOrMultiaddr, options)
 
     return connection.newStream(protocol, options)

--- a/packages/libp2p/src/get-peer.ts
+++ b/packages/libp2p/src/get-peer.ts
@@ -2,7 +2,7 @@ import { InvalidMultiaddrError, InvalidParametersError, isPeerId } from '@libp2p
 import { peerIdFromString } from '@libp2p/peer-id'
 import { CODE_P2P, isMultiaddr } from '@multiformats/multiaddr'
 import { PEER_ID } from '@multiformats/multiaddr-matcher'
-import type { PeerId } from '@libp2p/interface'
+import type { DialTarget, PeerId } from '@libp2p/interface'
 import type { Multiaddr } from '@multiformats/multiaddr'
 
 export interface PeerAddress {
@@ -14,7 +14,7 @@ export interface PeerAddress {
  * Extracts a PeerId and/or multiaddr from the passed PeerId or Multiaddr or an
  * array of Multiaddrs
  */
-export function getPeerAddress (peer: PeerId | Multiaddr | Multiaddr[]): PeerAddress {
+export function getPeerAddress (peer: DialTarget): PeerAddress {
   if (isPeerId(peer)) {
     return { peerId: peer, multiaddrs: [] }
   }

--- a/packages/libp2p/src/libp2p.ts
+++ b/packages/libp2p/src/libp2p.ts
@@ -24,7 +24,7 @@ import { userAgent } from './user-agent.js'
 import * as pkg from './version.js'
 import type { Components } from './components.js'
 import type { Libp2p as Libp2pInterface, Libp2pInit } from './index.js'
-import type { PeerRouting, ContentRouting, Libp2pEvents, PendingDial, ServiceMap, AbortOptions, ComponentLogger, Logger, Connection, NewStreamOptions, Stream, Metrics, PeerId, PeerInfo, PeerStore, Topology, Libp2pStatus, IsDialableOptions, DialOptions, PublicKey, Ed25519PeerId, Secp256k1PeerId, RSAPublicKey, RSAPeerId, URLPeerId, Ed25519PublicKey, Secp256k1PublicKey, StreamHandler, StreamHandlerOptions, StreamMiddleware } from '@libp2p/interface'
+import type { PeerRouting, ContentRouting, Libp2pEvents, PendingDial, ServiceMap, AbortOptions, ComponentLogger, Logger, Connection, NewStreamOptions, Stream, Metrics, PeerId, PeerInfo, PeerStore, Topology, Libp2pStatus, IsDialableOptions, DialOptions, PublicKey, Ed25519PeerId, Secp256k1PeerId, RSAPublicKey, RSAPeerId, URLPeerId, Ed25519PublicKey, Secp256k1PublicKey, StreamHandler, StreamHandlerOptions, StreamMiddleware, DialTarget } from '@libp2p/interface'
 import type { Multiaddr } from '@multiformats/multiaddr'
 
 export class Libp2p<T extends ServiceMap = ServiceMap> extends TypedEventEmitter<Libp2pEvents> implements Libp2pInterface<T> {
@@ -286,7 +286,7 @@ export class Libp2p<T extends ServiceMap = ServiceMap> extends TypedEventEmitter
     return Array.from(peerSet)
   }
 
-  async dial (peer: PeerId | Multiaddr | Multiaddr[], options: DialOptions = {}): Promise<Connection> {
+  async dial (peer: DialTarget, options: DialOptions = {}): Promise<Connection> {
     return this.components.connectionManager.openConnection(peer, {
       // ensure any userland dials take top priority in the queue
       priority: 75,
@@ -294,7 +294,7 @@ export class Libp2p<T extends ServiceMap = ServiceMap> extends TypedEventEmitter
     })
   }
 
-  async dialProtocol (peer: PeerId | Multiaddr | Multiaddr[], protocols: string | string[], options: NewStreamOptions = {}): Promise<Stream> {
+  async dialProtocol (peer: DialTarget, protocols: string | string[], options: NewStreamOptions = {}): Promise<Stream> {
     if (protocols == null) {
       throw new InvalidParametersError('no protocols were provided to open a stream')
     }

--- a/packages/protocol-echo/package.json
+++ b/packages/protocol-echo/package.json
@@ -47,11 +47,11 @@
     "@libp2p/interface": "^3.1.1",
     "@libp2p/interface-internal": "^3.0.14",
     "@libp2p/utils": "^7.0.14",
-    "@multiformats/multiaddr": "^13.0.1",
     "p-event": "^7.0.0",
     "uint8arraylist": "^2.4.8"
   },
   "devDependencies": {
+    "@multiformats/multiaddr": "^13.0.1",
     "aegir": "^47.0.22",
     "it-all": "^3.0.9",
     "sinon": "^21.0.0",

--- a/packages/protocol-echo/src/echo.ts
+++ b/packages/protocol-echo/src/echo.ts
@@ -4,9 +4,8 @@ import { pEvent } from 'p-event'
 import { Uint8ArrayList } from 'uint8arraylist'
 import { PROTOCOL_NAME, PROTOCOL_VERSION } from './constants.js'
 import type { Echo as EchoInterface, EchoComponents, EchoInit } from './index.js'
-import type { PeerId, Startable, Stream } from '@libp2p/interface'
+import type { DialTarget, Startable, Stream } from '@libp2p/interface'
 import type { OpenConnectionOptions } from '@libp2p/interface-internal'
-import type { Multiaddr } from '@multiformats/multiaddr'
 
 /**
  * A simple echo stream, any data received will be sent back to the sender
@@ -85,7 +84,7 @@ export class Echo implements Startable, EchoInterface {
     })
   }
 
-  async echo (peer: PeerId | Multiaddr | Multiaddr[], buf: Uint8Array | Uint8ArrayList, options?: OpenConnectionOptions): Promise<Uint8ArrayList> {
+  async echo (peer: DialTarget, buf: Uint8Array | Uint8ArrayList, options?: OpenConnectionOptions): Promise<Uint8ArrayList> {
     const stream = await this.components.connectionManager.openStream(peer, this.protocol, {
       ...this.init,
       ...options

--- a/packages/protocol-echo/src/index.ts
+++ b/packages/protocol-echo/src/index.ts
@@ -43,9 +43,8 @@
  */
 
 import { Echo as EchoClass } from './echo.js'
-import type { PeerId } from '@libp2p/interface'
+import type { DialTarget } from '@libp2p/interface'
 import type { ConnectionManager, OpenConnectionOptions, Registrar } from '@libp2p/interface-internal'
-import type { Multiaddr } from '@multiformats/multiaddr'
 import type { Uint8ArrayList } from 'uint8arraylist'
 
 export interface EchoInit {
@@ -63,7 +62,7 @@ export interface EchoComponents {
 
 export interface Echo {
   protocol: string
-  echo(peer: PeerId | Multiaddr | Multiaddr[], buf: Uint8Array | Uint8ArrayList, options?: OpenConnectionOptions): Promise<Uint8ArrayList>
+  echo(peer: DialTarget, buf: Uint8Array | Uint8ArrayList, options?: OpenConnectionOptions): Promise<Uint8ArrayList>
 }
 
 export function echo (init: EchoInit = {}): (components: EchoComponents) => Echo {

--- a/packages/protocol-ping/package.json
+++ b/packages/protocol-ping/package.json
@@ -46,7 +46,6 @@
     "@libp2p/crypto": "^5.1.14",
     "@libp2p/interface": "^3.1.1",
     "@libp2p/interface-internal": "^3.0.14",
-    "@multiformats/multiaddr": "^13.0.1",
     "p-event": "^7.0.0",
     "race-signal": "^2.0.0",
     "uint8arraylist": "^2.4.8",

--- a/packages/protocol-ping/src/index.ts
+++ b/packages/protocol-ping/src/index.ts
@@ -23,12 +23,11 @@
  */
 
 import { Ping as PingClass } from './ping.js'
-import type { AbortOptions, PeerId } from '@libp2p/interface'
+import type { AbortOptions, DialTarget } from '@libp2p/interface'
 import type { ConnectionManager, Registrar } from '@libp2p/interface-internal'
-import type { Multiaddr } from '@multiformats/multiaddr'
 
 export interface Ping {
-  ping(peer: PeerId | Multiaddr | Multiaddr[], options?: AbortOptions): Promise<number>
+  ping(peer: DialTarget, options?: AbortOptions): Promise<number>
 }
 
 export interface PingInit {

--- a/packages/protocol-ping/src/ping.ts
+++ b/packages/protocol-ping/src/ping.ts
@@ -6,8 +6,7 @@ import { Uint8ArrayList } from 'uint8arraylist'
 import { equals as uint8ArrayEquals } from 'uint8arrays/equals'
 import { PROTOCOL_PREFIX, PROTOCOL_NAME, PING_LENGTH, PROTOCOL_VERSION, TIMEOUT, MAX_INBOUND_STREAMS, MAX_OUTBOUND_STREAMS } from './constants.js'
 import type { PingComponents, PingInit, Ping as PingInterface } from './index.js'
-import type { AbortOptions, Stream, PeerId, Startable, Connection, StreamMessageEvent } from '@libp2p/interface'
-import type { Multiaddr } from '@multiformats/multiaddr'
+import type { AbortOptions, Stream, Startable, Connection, StreamMessageEvent, DialTarget } from '@libp2p/interface'
 
 export class Ping implements Startable, PingInterface {
   public readonly protocol: string
@@ -95,7 +94,7 @@ export class Ping implements Startable, PingInterface {
   /**
    * Ping a given peer and wait for its response, getting the operation latency.
    */
-  async ping (peer: PeerId | Multiaddr | Multiaddr[], options: AbortOptions = {}): Promise<number> {
+  async ping (peer: DialTarget, options: AbortOptions = {}): Promise<number> {
     const data = randomBytes(PING_LENGTH)
     const stream = await this.components.connectionManager.openStream(peer, this.protocol, {
       runOnLimitedConnection: this.runOnLimitedConnection,


### PR DESCRIPTION
libp2p can dial `PeerId | Multiaddr | Multiaddr[]` and this is repeated in several places.

Add a `DialTarget` convenience type that is a union of the above.

This makes the code more concise and removes the need for some modules to have `@multiformats/multiaddr` as a production dep.

## Change checklist

- [x] I have performed a self-review of my own code
- [ ] I have made corresponding changes to the documentation if necessary (this includes comments as well)
- [ ] I have added tests that prove my fix is effective or that my feature works