### PR TITLE
test: change RSA to Ed25519 in "can rotate keychain passphrase" test

### DIFF
--- a/packages/keychain/test/keychain.spec.ts
+++ b/packages/keychain/test/keychain.spec.ts
@@ -400,7 +400,7 @@ describe('keychain', () => {
     })
 
     it('can rotate keychain passphrase', async () => {
-      const key = await generateKeyPair('RSA', 2048)
+      const key = await generateKeyPair('Ed25519')
       await kc.importKey('keyCreatedWithOldPassword', key)
 
       await kc.rotateKeychainPass(oldPass, 'newInsecurePassphrase')
@@ -434,7 +434,7 @@ describe('keychain', () => {
 
       // Dek with new password should work:
       await expect(importPrivateKey(pem, newDek))
-        .to.eventually.have.property('type', 'RSA')
+        .to.eventually.have.property('type', 'Ed25519')
     }).timeout(10000)
   })
 


### PR DESCRIPTION
## Description

Attempt to fix flakey `can rotate keychain passphrase` test by changing slow RSA key to Ed25519


## Change checklist

- [x] I have performed a self-review of my own code
- [ ] I have made corresponding changes to the documentation if necessary (this includes comments as well)
- [x] I have added tests that prove my fix is effective or that my feature works