### PR TITLE
deps: update cborg to 5.x.x

### DIFF
--- a/packages/utils/package.json
+++ b/packages/utils/package.json
@@ -52,7 +52,7 @@
     "@multiformats/multiaddr": "^13.0.1",
     "@sindresorhus/fnv1a": "^3.1.0",
     "any-signal": "^4.1.1",
-    "cborg": "^4.2.14",
+    "cborg": "^5.1.0",
     "delay": "^7.0.0",
     "is-loopback-addr": "^2.0.2",
     "it-length-prefixed": "^10.0.1",


### PR DESCRIPTION
No code changes necessary because we don't use custom tags with cborg.

Update is necessary to reduce dependency duplication in browser bundles.

## Change checklist

- [x] I have performed a self-review of my own code
- [ ] I have made corresponding changes to the documentation if necessary (this includes comments as well)
- [ ] I have added tests that prove my fix is effective or that my feature works