### PR TITLE
deps: update @peculiar/x509 to 2.x.x

### DIFF
--- a/packages/connection-encrypter-tls/package.json
+++ b/packages/connection-encrypter-tls/package.json
@@ -48,10 +48,11 @@
     "@peculiar/asn1-schema": "^2.4.0",
     "@peculiar/asn1-x509": "^2.4.0",
     "@peculiar/webcrypto": "^1.5.0",
-    "@peculiar/x509": "^1.13.0",
+    "@peculiar/x509": "^2.0.0",
     "asn1js": "^3.0.6",
     "p-event": "^7.0.0",
     "protons-runtime": "^6.0.1",
+    "reflect-metadata": "^0.2.2",
     "uint8arraylist": "^2.4.8",
     "uint8arrays": "^5.1.0"
   },

--- a/packages/connection-encrypter-tls/src/utils.ts
+++ b/packages/connection-encrypter-tls/src/utils.ts
@@ -1,3 +1,4 @@
+import 'reflect-metadata'
 import net from 'node:net'
 import { Duplex } from 'node:stream'
 import tls from 'node:tls'

--- a/packages/connection-encrypter-tls/test/utils.spec.ts
+++ b/packages/connection-encrypter-tls/test/utils.spec.ts
@@ -1,3 +1,4 @@
+import 'reflect-metadata'
 import { EventEmitter } from 'node:events'
 import { logger } from '@libp2p/logger'
 import { streamPair } from '@libp2p/utils'

--- a/packages/transport-webrtc/package.json
+++ b/packages/transport-webrtc/package.json
@@ -55,7 +55,7 @@
     "@multiformats/multiaddr": "^13.0.1",
     "@multiformats/multiaddr-matcher": "^3.0.1",
     "@peculiar/webcrypto": "^1.5.0",
-    "@peculiar/x509": "^1.13.0",
+    "@peculiar/x509": "^2.0.0",
     "detect-browser": "^5.3.0",
     "get-port": "^7.1.0",
     "interface-datastore": "^9.0.1",
@@ -74,6 +74,7 @@
     "protons-runtime": "^6.0.1",
     "race-signal": "^2.0.0",
     "react-native-webrtc": "^124.0.6",
+    "reflect-metadata": "^0.2.2",
     "uint8-varint": "^2.0.4",
     "uint8arraylist": "^2.4.8",
     "uint8arrays": "^5.1.0"

--- a/packages/transport-webrtc/src/private-to-public/transport.ts
+++ b/packages/transport-webrtc/src/private-to-public/transport.ts
@@ -1,3 +1,4 @@
+import 'reflect-metadata'
 import { generateKeyPair, privateKeyToCryptoKeyPair } from '@libp2p/crypto/keys'
 import { InvalidParametersError, NotFoundError, NotStartedError } from '@libp2p/interface'
 import { WebRTCDirect } from '@multiformats/multiaddr-matcher'

--- a/packages/transport-webrtc/src/private-to-public/utils/generate-certificates.ts
+++ b/packages/transport-webrtc/src/private-to-public/utils/generate-certificates.ts
@@ -1,3 +1,4 @@
+import 'reflect-metadata'
 import { Crypto } from '@peculiar/webcrypto'
 import * as x509 from '@peculiar/x509'
 import { base64url } from 'multiformats/bases/base64'


### PR DESCRIPTION
Updates dep to latest version and adds mandatory extra dep to polyfill reflect api.

Imports polyfill in modules that use `@peculiar/x509` before importing that module.

## Change checklist

- [x] I have performed a self-review of my own code
- [ ] I have made corresponding changes to the documentation if necessary (this includes comments as well)
- [ ] I have added tests that prove my fix is effective or that my feature works