### PR TITLE
fix: support require

### DIFF
--- a/packages/config/package.json
+++ b/packages/config/package.json
@@ -26,7 +26,8 @@
   "exports": {
     ".": {
       "types": "./dist/src/index.d.ts",
-      "import": "./dist/src/index.js"
+      "import": "./dist/src/index.js",
+      "module-sync": "./dist/src/index.js"
     }
   },
   "scripts": {

--- a/packages/connection-encrypter-plaintext/package.json
+++ b/packages/connection-encrypter-plaintext/package.json
@@ -26,7 +26,8 @@
   "exports": {
     ".": {
       "types": "./dist/src/index.d.ts",
-      "import": "./dist/src/index.js"
+      "import": "./dist/src/index.js",
+      "module-sync": "./dist/src/index.js"
     }
   },
   "scripts": {

--- a/packages/connection-encrypter-tls/package.json
+++ b/packages/connection-encrypter-tls/package.json
@@ -26,7 +26,8 @@
   "exports": {
     ".": {
       "types": "./dist/src/index.d.ts",
-      "import": "./dist/src/index.js"
+      "import": "./dist/src/index.js",
+      "module-sync": "./dist/src/index.js"
     }
   },
   "scripts": {

--- a/packages/crypto/package.json
+++ b/packages/crypto/package.json
@@ -49,23 +49,28 @@
   "exports": {
     ".": {
       "types": "./dist/src/index.d.ts",
-      "import": "./dist/src/index.js"
+      "import": "./dist/src/index.js",
+      "module-sync": "./dist/src/index.js"
     },
     "./ciphers": {
       "types": "./dist/src/ciphers/index.d.ts",
-      "import": "./dist/src/ciphers/index.js"
+      "import": "./dist/src/ciphers/index.js",
+      "module-sync": "./dist/src/ciphers/index.js"
     },
     "./hmac": {
       "types": "./dist/src/hmac/index.d.ts",
-      "import": "./dist/src/hmac/index.js"
+      "import": "./dist/src/hmac/index.js",
+      "module-sync": "./dist/src/hmac/index.js"
     },
     "./keys": {
       "types": "./dist/src/keys/index.d.ts",
-      "import": "./dist/src/keys/index.js"
+      "import": "./dist/src/keys/index.js",
+      "module-sync": "./dist/src/keys/index.js"
     },
     "./webcrypto": {
       "types": "./dist/src/webcrypto/index.d.ts",
-      "import": "./dist/src/webcrypto/index.js"
+      "import": "./dist/src/webcrypto/index.js",
+      "module-sync": "./dist/src/webcrypto/index.js"
     }
   },
   "scripts": {

--- a/packages/floodsub/package.json
+++ b/packages/floodsub/package.json
@@ -34,7 +34,8 @@
   "exports": {
     ".": {
       "types": "./dist/src/index.d.ts",
-      "import": "./dist/src/index.js"
+      "import": "./dist/src/index.js",
+      "module-sync": "./dist/src/index.js"
     }
   },
   "scripts": {

--- a/packages/gossipsub/package.json
+++ b/packages/gossipsub/package.json
@@ -13,23 +13,28 @@
   "exports": {
     ".": {
       "types": "./dist/src/index.d.ts",
-      "import": "./dist/src/index.js"
-    },
-    "./metrics": {
-      "types": "./dist/src/metrics.d.ts",
-      "import": "./dist/src/metrics.js"
+      "import": "./dist/src/index.js",
+      "module-sync": "./dist/src/index.js"
     },
     "./message": {
       "types": "./dist/src/message/index.d.ts",
-      "import": "./dist/src/message/index.js"
+      "import": "./dist/src/message/index.js",
+      "module-sync": "./dist/src/message/index.js"
+    },
+    "./metrics": {
+      "types": "./dist/src/metrics.d.ts",
+      "import": "./dist/src/metrics.js",
+      "module-sync": "./dist/src/metrics.js"
     },
     "./score": {
       "types": "./dist/src/score/index.d.ts",
-      "import": "./dist/src/score/index.js"
+      "import": "./dist/src/score/index.js",
+      "module-sync": "./dist/src/score/index.js"
     },
     "./types": {
       "types": "./dist/src/types.d.ts",
-      "import": "./dist/src/types.js"
+      "import": "./dist/src/types.js",
+      "module-sync": "./dist/src/types.js"
     }
   },
   "typesVersions": {

--- a/packages/interface-compliance-tests/package.json
+++ b/packages/interface-compliance-tests/package.json
@@ -46,23 +46,28 @@
   "exports": {
     ".": {
       "types": "./dist/src/index.d.ts",
-      "import": "./dist/src/index.js"
+      "import": "./dist/src/index.js",
+      "module-sync": "./dist/src/index.js"
     },
     "./connection-encryption": {
       "types": "./dist/src/connection-encryption/index.d.ts",
-      "import": "./dist/src/connection-encryption/index.js"
+      "import": "./dist/src/connection-encryption/index.js",
+      "module-sync": "./dist/src/connection-encryption/index.js"
     },
     "./peer-discovery": {
       "types": "./dist/src/peer-discovery/index.d.ts",
-      "import": "./dist/src/peer-discovery/index.js"
+      "import": "./dist/src/peer-discovery/index.js",
+      "module-sync": "./dist/src/peer-discovery/index.js"
     },
     "./stream-muxer": {
       "types": "./dist/src/stream-muxer/index.d.ts",
-      "import": "./dist/src/stream-muxer/index.js"
+      "import": "./dist/src/stream-muxer/index.js",
+      "module-sync": "./dist/src/stream-muxer/index.js"
     },
     "./transport": {
       "types": "./dist/src/transport/index.d.ts",
-      "import": "./dist/src/transport/index.js"
+      "import": "./dist/src/transport/index.js",
+      "module-sync": "./dist/src/transport/index.js"
     }
   },
   "scripts": {

--- a/packages/interface-internal/package.json
+++ b/packages/interface-internal/package.json
@@ -30,7 +30,8 @@
   "exports": {
     ".": {
       "types": "./dist/src/index.d.ts",
-      "import": "./dist/src/index.js"
+      "import": "./dist/src/index.js",
+      "module-sync": "./dist/src/index.js"
     }
   },
   "scripts": {

--- a/packages/interface/package.json
+++ b/packages/interface/package.json
@@ -30,7 +30,8 @@
   "exports": {
     ".": {
       "types": "./dist/src/index.d.ts",
-      "import": "./dist/src/index.js"
+      "import": "./dist/src/index.js",
+      "module-sync": "./dist/src/index.js"
     }
   },
   "scripts": {

--- a/packages/interop/package.json
+++ b/packages/interop/package.json
@@ -29,7 +29,8 @@
   "exports": {
     ".": {
       "types": "./src/index.d.ts",
-      "import": "./dist/src/index.js"
+      "import": "./dist/src/index.js",
+      "module-sync": "./dist/src/index.js"
     }
   },
   "scripts": {

--- a/packages/kad-dht/package.json
+++ b/packages/kad-dht/package.json
@@ -29,7 +29,8 @@
   "exports": {
     ".": {
       "types": "./dist/src/index.d.ts",
-      "import": "./dist/src/index.js"
+      "import": "./dist/src/index.js",
+      "module-sync": "./dist/src/index.js"
     }
   },
   "scripts": {

--- a/packages/keychain/package.json
+++ b/packages/keychain/package.json
@@ -34,7 +34,8 @@
   "exports": {
     ".": {
       "types": "./dist/src/index.d.ts",
-      "import": "./dist/src/index.js"
+      "import": "./dist/src/index.js",
+      "module-sync": "./dist/src/index.js"
     }
   },
   "scripts": {

--- a/packages/libp2p-daemon-client/package.json
+++ b/packages/libp2p-daemon-client/package.json
@@ -29,7 +29,8 @@
   "exports": {
     ".": {
       "types": "./src/index.d.ts",
-      "import": "./dist/src/index.js"
+      "import": "./dist/src/index.js",
+      "module-sync": "./dist/src/index.js"
     }
   },
   "scripts": {
@@ -52,8 +53,8 @@
     "multiformats": "^13.4.0"
   },
   "devDependencies": {
-    "@libp2p/gossipsub": "^15.0.17",
     "@libp2p/daemon-server": "^9.0.17",
+    "@libp2p/gossipsub": "^15.0.17",
     "@libp2p/kad-dht": "^16.2.0",
     "aegir": "^47.0.22",
     "it-all": "^3.0.9",

--- a/packages/libp2p-daemon-protocol/package.json
+++ b/packages/libp2p-daemon-protocol/package.json
@@ -43,15 +43,18 @@
   "exports": {
     ".": {
       "types": "./src/index.d.ts",
-      "import": "./dist/src/index.js"
+      "import": "./dist/src/index.js",
+      "module-sync": "./dist/src/index.js"
     },
     "./stream-handler": {
       "types": "./dist/src/stream-handler.d.ts",
-      "import": "./dist/src/stream-handler.js"
+      "import": "./dist/src/stream-handler.js",
+      "module-sync": "./dist/src/stream-handler.js"
     },
     "./upgrader": {
       "types": "./dist/src/upgrader.d.ts",
-      "import": "./dist/src/upgrader.js"
+      "import": "./dist/src/upgrader.js",
+      "module-sync": "./dist/src/upgrader.js"
     }
   },
   "scripts": {

--- a/packages/libp2p-daemon-server/package.json
+++ b/packages/libp2p-daemon-server/package.json
@@ -29,7 +29,8 @@
   "exports": {
     ".": {
       "types": "./src/index.d.ts",
-      "import": "./dist/src/index.js"
+      "import": "./dist/src/index.js",
+      "module-sync": "./dist/src/index.js"
     }
   },
   "scripts": {
@@ -42,9 +43,9 @@
     "test:node": "aegir test -t node"
   },
   "dependencies": {
-    "@libp2p/gossipsub": "^15.0.17",
     "@libp2p/crypto": "^5.1.15",
     "@libp2p/daemon-protocol": "^8.0.5",
+    "@libp2p/gossipsub": "^15.0.17",
     "@libp2p/interface": "^3.2.0",
     "@libp2p/kad-dht": "^16.2.0",
     "@libp2p/logger": "^6.2.4",

--- a/packages/libp2p-daemon/package.json
+++ b/packages/libp2p-daemon/package.json
@@ -32,7 +32,8 @@
   "exports": {
     ".": {
       "types": "./src/index.d.ts",
-      "import": "./dist/src/index.js"
+      "import": "./dist/src/index.js",
+      "module-sync": "./dist/src/index.js"
     }
   },
   "scripts": {

--- a/packages/libp2p/package.json
+++ b/packages/libp2p/package.json
@@ -50,16 +50,19 @@
   "exports": {
     ".": {
       "types": "./dist/src/index.d.ts",
-      "import": "./dist/src/index.js"
+      "import": "./dist/src/index.js",
+      "module-sync": "./dist/src/index.js"
     },
     "./user-agent": {
       "types": "./dist/src/user-agent.d.ts",
       "browser": "./dist/src/user-agent.browser.js",
-      "import": "./dist/src/user-agent.js"
+      "import": "./dist/src/user-agent.js",
+      "module-sync": "./dist/src/user-agent.js"
     },
     "./version": {
       "types": "./dist/src/version.d.ts",
-      "import": "./dist/src/version.js"
+      "import": "./dist/src/version.js",
+      "module-sync": "./dist/src/version.js"
     }
   },
   "scripts": {

--- a/packages/logger/package.json
+++ b/packages/logger/package.json
@@ -29,7 +29,8 @@
   "exports": {
     ".": {
       "types": "./dist/src/index.d.ts",
-      "import": "./dist/src/index.js"
+      "import": "./dist/src/index.js",
+      "module-sync": "./dist/src/index.js"
     }
   },
   "scripts": {

--- a/packages/metrics-opentelemetry/package.json
+++ b/packages/metrics-opentelemetry/package.json
@@ -26,7 +26,8 @@
   "exports": {
     ".": {
       "types": "./dist/src/index.d.ts",
-      "import": "./dist/src/index.js"
+      "import": "./dist/src/index.js",
+      "module-sync": "./dist/src/index.js"
     }
   },
   "scripts": {

--- a/packages/metrics-prometheus/package.json
+++ b/packages/metrics-prometheus/package.json
@@ -27,7 +27,8 @@
   "exports": {
     ".": {
       "types": "./dist/src/index.d.ts",
-      "import": "./dist/src/index.js"
+      "import": "./dist/src/index.js",
+      "module-sync": "./dist/src/index.js"
     }
   },
   "scripts": {

--- a/packages/metrics-simple/package.json
+++ b/packages/metrics-simple/package.json
@@ -26,7 +26,8 @@
   "exports": {
     ".": {
       "types": "./dist/src/index.d.ts",
-      "import": "./dist/src/index.js"
+      "import": "./dist/src/index.js",
+      "module-sync": "./dist/src/index.js"
     }
   },
   "scripts": {

--- a/packages/multistream-select/package.json
+++ b/packages/multistream-select/package.json
@@ -33,7 +33,8 @@
   "exports": {
     ".": {
       "types": "./dist/src/index.d.ts",
-      "import": "./dist/src/index.js"
+      "import": "./dist/src/index.js",
+      "module-sync": "./dist/src/index.js"
     }
   },
   "scripts": {

--- a/packages/peer-collections/package.json
+++ b/packages/peer-collections/package.json
@@ -29,7 +29,8 @@
   "exports": {
     ".": {
       "types": "./dist/src/index.d.ts",
-      "import": "./dist/src/index.js"
+      "import": "./dist/src/index.js",
+      "module-sync": "./dist/src/index.js"
     }
   },
   "scripts": {

--- a/packages/peer-discovery-bootstrap/package.json
+++ b/packages/peer-discovery-bootstrap/package.json
@@ -29,7 +29,8 @@
   "exports": {
     ".": {
       "types": "./dist/src/index.d.ts",
-      "import": "./dist/src/index.js"
+      "import": "./dist/src/index.js",
+      "module-sync": "./dist/src/index.js"
     }
   },
   "scripts": {

--- a/packages/peer-discovery-mdns/package.json
+++ b/packages/peer-discovery-mdns/package.json
@@ -29,7 +29,8 @@
   "exports": {
     ".": {
       "types": "./dist/src/index.d.ts",
-      "import": "./dist/src/index.js"
+      "import": "./dist/src/index.js",
+      "module-sync": "./dist/src/index.js"
     }
   },
   "scripts": {

--- a/packages/peer-id/package.json
+++ b/packages/peer-id/package.json
@@ -29,7 +29,8 @@
   "exports": {
     ".": {
       "types": "./dist/src/index.d.ts",
-      "import": "./dist/src/index.js"
+      "import": "./dist/src/index.js",
+      "module-sync": "./dist/src/index.js"
     }
   },
   "scripts": {

--- a/packages/peer-record/package.json
+++ b/packages/peer-record/package.json
@@ -29,7 +29,8 @@
   "exports": {
     ".": {
       "types": "./dist/src/index.d.ts",
-      "import": "./dist/src/index.js"
+      "import": "./dist/src/index.js",
+      "module-sync": "./dist/src/index.js"
     }
   },
   "scripts": {

--- a/packages/peer-store/package.json
+++ b/packages/peer-store/package.json
@@ -29,7 +29,8 @@
   "exports": {
     ".": {
       "types": "./dist/src/index.d.ts",
-      "import": "./dist/src/index.js"
+      "import": "./dist/src/index.js",
+      "module-sync": "./dist/src/index.js"
     }
   },
   "scripts": {

--- a/packages/pnet/package.json
+++ b/packages/pnet/package.json
@@ -26,7 +26,8 @@
   "exports": {
     ".": {
       "types": "./dist/src/index.d.ts",
-      "import": "./dist/src/index.js"
+      "import": "./dist/src/index.js",
+      "module-sync": "./dist/src/index.js"
     }
   },
   "scripts": {

--- a/packages/protocol-autonat-v2/package.json
+++ b/packages/protocol-autonat-v2/package.json
@@ -26,7 +26,8 @@
   "exports": {
     ".": {
       "types": "./dist/src/index.d.ts",
-      "import": "./dist/src/index.js"
+      "import": "./dist/src/index.js",
+      "module-sync": "./dist/src/index.js"
     }
   },
   "scripts": {

--- a/packages/protocol-autonat/package.json
+++ b/packages/protocol-autonat/package.json
@@ -26,7 +26,8 @@
   "exports": {
     ".": {
       "types": "./dist/src/index.d.ts",
-      "import": "./dist/src/index.js"
+      "import": "./dist/src/index.js",
+      "module-sync": "./dist/src/index.js"
     }
   },
   "scripts": {

--- a/packages/protocol-dcutr/package.json
+++ b/packages/protocol-dcutr/package.json
@@ -26,7 +26,8 @@
   "exports": {
     ".": {
       "types": "./dist/src/index.d.ts",
-      "import": "./dist/src/index.js"
+      "import": "./dist/src/index.js",
+      "module-sync": "./dist/src/index.js"
     }
   },
   "scripts": {

--- a/packages/protocol-echo/package.json
+++ b/packages/protocol-echo/package.json
@@ -26,7 +26,8 @@
   "exports": {
     ".": {
       "types": "./dist/src/index.d.ts",
-      "import": "./dist/src/index.js"
+      "import": "./dist/src/index.js",
+      "module-sync": "./dist/src/index.js"
     }
   },
   "scripts": {

--- a/packages/protocol-fetch/package.json
+++ b/packages/protocol-fetch/package.json
@@ -26,7 +26,8 @@
   "exports": {
     ".": {
       "types": "./dist/src/index.d.ts",
-      "import": "./dist/src/index.js"
+      "import": "./dist/src/index.js",
+      "module-sync": "./dist/src/index.js"
     }
   },
   "scripts": {

--- a/packages/protocol-identify/package.json
+++ b/packages/protocol-identify/package.json
@@ -26,7 +26,8 @@
   "exports": {
     ".": {
       "types": "./dist/src/index.d.ts",
-      "import": "./dist/src/index.js"
+      "import": "./dist/src/index.js",
+      "module-sync": "./dist/src/index.js"
     }
   },
   "scripts": {

--- a/packages/protocol-perf/package.json
+++ b/packages/protocol-perf/package.json
@@ -27,7 +27,8 @@
   "exports": {
     ".": {
       "types": "./dist/src/index.d.ts",
-      "import": "./dist/src/index.js"
+      "import": "./dist/src/index.js",
+      "module-sync": "./dist/src/index.js"
     }
   },
   "scripts": {

--- a/packages/protocol-ping/package.json
+++ b/packages/protocol-ping/package.json
@@ -26,7 +26,8 @@
   "exports": {
     ".": {
       "types": "./dist/src/index.d.ts",
-      "import": "./dist/src/index.js"
+      "import": "./dist/src/index.js",
+      "module-sync": "./dist/src/index.js"
     }
   },
   "scripts": {

--- a/packages/record/package.json
+++ b/packages/record/package.json
@@ -29,7 +29,8 @@
   "exports": {
     ".": {
       "types": "./dist/src/index.d.ts",
-      "import": "./dist/src/index.js"
+      "import": "./dist/src/index.js",
+      "module-sync": "./dist/src/index.js"
     }
   },
   "scripts": {

--- a/packages/stream-multiplexer-mplex/package.json
+++ b/packages/stream-multiplexer-mplex/package.json
@@ -36,7 +36,8 @@
   "exports": {
     ".": {
       "types": "./dist/src/index.d.ts",
-      "import": "./dist/src/index.js"
+      "import": "./dist/src/index.js",
+      "module-sync": "./dist/src/index.js"
     }
   },
   "scripts": {

--- a/packages/transport-circuit-relay-v2/package.json
+++ b/packages/transport-circuit-relay-v2/package.json
@@ -26,7 +26,8 @@
   "exports": {
     ".": {
       "types": "./dist/src/index.d.ts",
-      "import": "./dist/src/index.js"
+      "import": "./dist/src/index.js",
+      "module-sync": "./dist/src/index.js"
     }
   },
   "scripts": {

--- a/packages/transport-memory/package.json
+++ b/packages/transport-memory/package.json
@@ -26,7 +26,8 @@
   "exports": {
     ".": {
       "types": "./dist/src/index.d.ts",
-      "import": "./dist/src/index.js"
+      "import": "./dist/src/index.js",
+      "module-sync": "./dist/src/index.js"
     }
   },
   "scripts": {

--- a/packages/transport-tcp/package.json
+++ b/packages/transport-tcp/package.json
@@ -35,7 +35,8 @@
   "exports": {
     ".": {
       "types": "./dist/src/index.d.ts",
-      "import": "./dist/src/index.js"
+      "import": "./dist/src/index.js",
+      "module-sync": "./dist/src/index.js"
     }
   },
   "scripts": {

--- a/packages/transport-webrtc/package.json
+++ b/packages/transport-webrtc/package.json
@@ -26,7 +26,8 @@
   "exports": {
     ".": {
       "types": "./dist/src/index.d.ts",
-      "import": "./dist/src/index.js"
+      "import": "./dist/src/index.js",
+      "module-sync": "./dist/src/index.js"
     }
   },
   "scripts": {
@@ -45,11 +46,11 @@
   },
   "dependencies": {
     "@chainsafe/is-ip": "^2.1.0",
+    "@chainsafe/libp2p-noise": "^17.0.0",
     "@libp2p/crypto": "^5.1.15",
     "@libp2p/interface": "^3.2.0",
     "@libp2p/interface-internal": "^3.1.0",
     "@libp2p/keychain": "^6.0.12",
-    "@chainsafe/libp2p-noise": "^17.0.0",
     "@libp2p/peer-id": "^6.0.6",
     "@libp2p/utils": "^7.0.15",
     "@multiformats/multiaddr": "^13.0.1",

--- a/packages/transport-websockets/package.json
+++ b/packages/transport-websockets/package.json
@@ -45,11 +45,13 @@
   "exports": {
     ".": {
       "types": "./dist/src/index.d.ts",
-      "import": "./dist/src/index.js"
+      "import": "./dist/src/index.js",
+      "module-sync": "./dist/src/index.js"
     },
     "./filters": {
       "types": "./dist/src/filters.d.ts",
-      "import": "./dist/src/filters.js"
+      "import": "./dist/src/filters.js",
+      "module-sync": "./dist/src/filters.js"
     }
   },
   "scripts": {

--- a/packages/transport-webtransport/package.json
+++ b/packages/transport-webtransport/package.json
@@ -29,7 +29,8 @@
   "exports": {
     ".": {
       "types": "./dist/src/index.d.ts",
-      "import": "./dist/src/index.js"
+      "import": "./dist/src/index.js",
+      "module-sync": "./dist/src/index.js"
     }
   },
   "scripts": {
@@ -44,8 +45,8 @@
     "test:firefox": "aegir test -t browser -- --browser firefox"
   },
   "dependencies": {
-    "@libp2p/interface": "^3.2.0",
     "@chainsafe/libp2p-noise": "^17.0.0",
+    "@libp2p/interface": "^3.2.0",
     "@libp2p/peer-id": "^6.0.6",
     "@libp2p/utils": "^7.0.15",
     "@multiformats/multiaddr": "^13.0.1",

--- a/packages/upnp-nat/package.json
+++ b/packages/upnp-nat/package.json
@@ -29,7 +29,8 @@
   "exports": {
     ".": {
       "types": "./dist/src/index.d.ts",
-      "import": "./dist/src/index.js"
+      "import": "./dist/src/index.js",
+      "module-sync": "./dist/src/index.js"
     }
   },
   "scripts": {

--- a/packages/utils/package.json
+++ b/packages/utils/package.json
@@ -26,7 +26,8 @@
   "exports": {
     ".": {
       "types": "./dist/src/index.d.ts",
-      "import": "./dist/src/index.js"
+      "import": "./dist/src/index.js",
+      "module-sync": "./dist/src/index.js"
     }
   },
   "scripts": {


### PR DESCRIPTION
Add the `module-sync` field to the exports map for each module to support synchronous loading from CJS environments using `require`.

This allows use by older projects that cannot or do not want to upgrade to ESM, or in TypeScript projects that compile to CJS knowingly or unknowingly.

See:

 - https://nodejs.org/en/blog/release/v22.10.0#2024-10-16-version-22100-current-aduh95
 - https://nodejs.org/api/packages.html#conditional-exports

## Change checklist

- [x] I have performed a self-review of my own code
- [ ] I have made corresponding changes to the documentation if necessary (this includes comments as well)
- [ ] I have added tests that prove my fix is effective or that my feature works