### PR TITLE
docs: update helper module names in migration guide

### DIFF
--- a/doc/migrations/v2.0.0-v3.0.0.md
+++ b/doc/migrations/v2.0.0-v3.0.0.md
@@ -9,9 +9,9 @@ A migration guide for refactoring your application code from libp2p `v2.0.0` to 
   - [Stream closing](#stream-closing)
   - [Write backpressure](#write-backpressure)
   - [Imperative streams](#imperative-streams)
-    - [byteStream](#bytestream)
-    - [lengthPrefixedStream](#lengthprefixedstream)
-    - [protobufStream](#protobufstream)
+    - [Byte Streams](#byte-streams)
+    - [Length Prefixed Streams](#length-prefixed-streams)
+    - [Protobuf Streams](#protobuf-streams)
 - [Protocol handlers now accept a stream and a connection](#protocol-handlers-now-accept-a-stream-and-a-connection)
 - [Protocol handlers can now be async](#protocol-handlers-can-now-be-async)
 - [Stream middleware](#stream-middleware)
@@ -245,7 +245,7 @@ for (const buf of bufs) {
 
 The `@libp2p/utils` module now exports some functions to make imperative stream programming simpler.  These are largely ported from the [it-protobuf-stream](https://www.npmjs.com/package/it-protobuf-stream), [it-length-prefixed-stream](https://www.npmjs.com/package/it-length-prefixed-stream) and [it-byte-stream](https://www.npmjs.com/package/it-byte-stream) modules.
 
-#### byteStream
+#### Byte Streams
 
 The `byteStream` module lets you read/write arbitrary amounts of bytes to/from the stream in an imperative style. The `read` method accepts a `bytes`
 option which will resolve the returned promise once that number of bytes have
@@ -279,9 +279,9 @@ const output = await bytes.read({
 console.info(output) // Uint8Array([0, 1, 2, 3])
 ```
 
-#### lengthPrefixedStream
+#### Length Prefixed Streams
 
-The `lengthPrefixedStream` module lets you read/write arbitrary amounts of bytes
+The `lpStream` module lets you read/write arbitrary amounts of bytes
 to/from the stream in an imperative style.
 
 All data written to the stream is prefixed with a [varint](https://protobuf.dev/programming-guides/encoding/#varints)
@@ -290,7 +290,7 @@ that contains the number of bytes in the following message.
 ```ts
 import { createLibp2p } from 'libp2p'
 import { peerIdFromString } from '@libp2p/peer-id'
-import { lengthPrefixedStream } from '@libp2p/utils'
+import { lpStream } from '@libp2p/utils'
 
 const node = createLibp2p({
   // libp2p config here
@@ -301,7 +301,7 @@ const stream = await node.dialProtocol(remotePeer, '/echo/1.0.0', {
   signal: AbortSignal.timeout(5_000)
 })
 
-const lp = lengthPrefixedStream(stream)
+const lp = lpStream(stream)
 
 await lp.write(Uint8Array.from([0, 1, 2, 3]), {
   signal: AbortSignal.timeout(5_000)
@@ -314,9 +314,9 @@ const output = await lp.read({
 console.info(output) // Uint8Array([0, 1, 2, 3])
 ```
 
-#### protobufStream
+#### Protobuf Streams
 
-The `protobufStream` module lets you read/write [protobuf](https://protobuf.dev)
+The `pbStream` module lets you read/write [protobuf](https://protobuf.dev)
 messages to/from the stream in an imperative style.
 
 In the example below the `Message` class is generated from a `.proto`
@@ -326,7 +326,7 @@ encoders/decoders are available.
 ```ts
 import { createLibp2p } from 'libp2p'
 import { peerIdFromString } from '@libp2p/peer-id'
-import { protobufStream } from '@libp2p/utils'
+import { pbStream } from '@libp2p/utils'
 import { Message } from './hello-world.js'
 
 const node = createLibp2p({
@@ -338,7 +338,7 @@ const stream = await node.dialProtocol(remotePeer, '/echo/1.0.0', {
   signal: AbortSignal.timeout(5_000)
 })
 
-const pb = protobufStream(stream)
+const pb = pbStream(stream)
 
 await pb.write({
   hello: 'world'


### PR DESCRIPTION
The names were wrong.  The doc linter should have caught this.

## Change checklist

- [ ] I have performed a self-review of my own code
- [x] I have made corresponding changes to the documentation if necessary (this includes comments as well)
- [ ] I have added tests that prove my fix is effective or that my feature works