### PR TITLE
fix(transport-webrtc): fix EOF race in readCandidatesUntilConnected

### DIFF
--- a/packages/transport-webrtc/src/private-to-private/util.ts
+++ b/packages/transport-webrtc/src/private-to-private/util.ts
@@ -16,10 +16,10 @@ export interface ReadCandidatesOptions extends AbortOptions, LoggerOptions, Prog
 }
 
 export const readCandidatesUntilConnected = async (pc: RTCPeerConnection, stream: MessageStream<Message, Stream>, options: ReadCandidatesOptions): Promise<void> => {
-  try {
-    const connectedPromise = Promise.withResolvers<void>()
-    resolveOnConnected(pc, connectedPromise)
+  const connectedPromise = Promise.withResolvers<void>()
+  resolveOnConnected(pc, connectedPromise)
 
+  try {
     // read candidates until we are connected or we reach the end of the stream
     while (true) {
       // if we connect, stop trying to read from the stream
@@ -66,10 +66,19 @@ export const readCandidatesUntilConnected = async (pc: RTCPeerConnection, stream
       }
     }
   } catch (err) {
-    options.log.error('%s error parsing ICE candidate - %e', options.direction, err)
+    options.log.error('%s error reading ICE candidates - %e', options.direction, err)
 
-    if (options.signal?.aborted === true && pc.connectionState !== 'connected') {
-      throw err
+    // If the peer connection is not connected, the error may still be
+    // recoverable — the signaling stream can close just before the
+    // connectionstatechange event fires. Wait for the connected promise to
+    // settle: if the PC connects we can ignore the stream error; if it fails
+    // or was never going to connect, re-throw.
+    if (pc.connectionState !== 'connected') {
+      try {
+        await connectedPromise.promise
+      } catch {
+        throw err
+      }
     }
   }
 }

--- a/packages/transport-webrtc/test/maconn.spec.ts
+++ b/packages/transport-webrtc/test/maconn.spec.ts
@@ -1,9 +1,13 @@
 /* eslint-disable @typescript-eslint/no-unused-expressions */
 
+import { ConnectionFailedError } from '@libp2p/interface'
 import { defaultLogger } from '@libp2p/logger'
+import { pbStream, streamPair } from '@libp2p/utils'
 import { multiaddr } from '@multiformats/multiaddr'
 import { expect } from 'aegir/chai'
 import { stubObject } from 'sinon-ts'
+import { Message } from '../src/private-to-private/pb/message.js'
+import { readCandidatesUntilConnected } from '../src/private-to-private/util.js'
 import { toMultiaddrConnection } from '../src/rtcpeerconnection-to-conn.ts'
 import { RTCPeerConnection } from '../src/webrtc/index.js'
 import type { CounterGroup } from '@libp2p/interface'
@@ -32,5 +36,119 @@ describe('Multiaddr Connection', () => {
 
     expect(maConn.timeline.close).to.not.be.undefined
     expect(metrics.increment.calledWith({ close: true })).to.be.true
+  })
+})
+
+describe('readCandidatesUntilConnected', () => {
+  it('throws ConnectionFailedError when the peer connection enters failed state', async () => {
+    const [localStream, remoteStream] = await streamPair()
+
+    const pc: any = {
+      connectionState: 'checking' as RTCPeerConnectionState,
+      onconnectionstatechange: null as any
+    }
+
+    // Schedule ICE failure after a short delay
+    setTimeout(() => {
+      pc.connectionState = 'failed'
+      pc.onconnectionstatechange?.(new Event('connectionstatechange'))
+    }, 50)
+
+    const messageStream = pbStream(localStream).pb(Message)
+
+    await expect(
+      readCandidatesUntilConnected(pc, messageStream, {
+        direction: 'initiator',
+        signal: AbortSignal.timeout(5000),
+        log: defaultLogger().forComponent('test:webrtc')
+      })
+    ).to.eventually.be.rejectedWith(ConnectionFailedError)
+
+    await remoteStream.close()
+  })
+
+  it('does not fail when peer connection is temporarily disconnected then recovers to connected', async () => {
+    const [localStream, remoteStream] = await streamPair()
+
+    const pc: any = {
+      connectionState: 'checking' as RTCPeerConnectionState,
+      onconnectionstatechange: null as any
+    }
+
+    // ICE briefly goes disconnected at t=30ms, then recovers at t=60ms
+    setTimeout(() => {
+      pc.connectionState = 'disconnected'
+      pc.onconnectionstatechange?.(new Event('connectionstatechange'))
+    }, 30)
+
+    setTimeout(() => {
+      pc.connectionState = 'connected'
+      pc.onconnectionstatechange?.(new Event('connectionstatechange'))
+    }, 60)
+
+    const messageStream = pbStream(localStream).pb(Message)
+
+    await expect(
+      readCandidatesUntilConnected(pc, messageStream, {
+        direction: 'recipient',
+        signal: AbortSignal.timeout(5000),
+        log: defaultLogger().forComponent('test:webrtc')
+      })
+    ).to.eventually.be.undefined
+
+    await remoteStream.close()
+  })
+
+  it('throws ConnectionFailedError when peer connection goes disconnected then failed', async () => {
+    const [localStream, remoteStream] = await streamPair()
+
+    const pc: any = {
+      connectionState: 'checking' as RTCPeerConnectionState,
+      onconnectionstatechange: null as any
+    }
+
+    // ICE goes disconnected at t=30ms, then fails at t=60ms
+    setTimeout(() => {
+      pc.connectionState = 'disconnected'
+      pc.onconnectionstatechange?.(new Event('connectionstatechange'))
+    }, 30)
+
+    setTimeout(() => {
+      pc.connectionState = 'failed'
+      pc.onconnectionstatechange?.(new Event('connectionstatechange'))
+    }, 60)
+
+    const messageStream = pbStream(localStream).pb(Message)
+
+    await expect(
+      readCandidatesUntilConnected(pc, messageStream, {
+        direction: 'recipient',
+        signal: AbortSignal.timeout(5000),
+        log: defaultLogger().forComponent('test:webrtc')
+      })
+    ).to.eventually.be.rejectedWith(ConnectionFailedError)
+
+    await remoteStream.close()
+  })
+
+  it('returns without error when peer connection reaches connected state', async () => {
+    const [localStream, remoteStream] = await streamPair()
+
+    const pc: any = {
+      connectionState: 'connected' as RTCPeerConnectionState,
+      onconnectionstatechange: null as any
+    }
+
+    const messageStream = pbStream(localStream).pb(Message)
+
+    void remoteStream.close()
+
+    await expect(
+      readCandidatesUntilConnected(pc, messageStream, {
+        direction: 'initiator',
+        signal: AbortSignal.timeout(5000),
+        log: defaultLogger().forComponent('test:webrtc')
+      })
+    ).to.eventually.be.undefined
   })
 })


### PR DESCRIPTION
## Problem

A race condition caused the WebRTC \"simple\" transport compliance test to fail intermittently: the listener closes its signaling stream just before the initiator's `connectionstatechange: connected` event fires. The initiator then received EOF on the signaling stream and threw an `UnexpectedEOFError`, discarding a perfectly good peer connection.

**Root cause:** `connectedPromise` was declared inside the `try` block, making it inaccessible in the `catch` handler for stream read errors.

## Solution

Move `connectedPromise` outside the `try` block. In the `catch` handler, if the peer connection is not yet `'connected'`, await `connectedPromise`:
- If it resolves → the connection succeeded, ignore the stream error
- If it rejects → the connection failed, re-throw the original stream error

Also corrects the log message from \"error parsing ICE candidate\" to \"error reading ICE candidates\" for accuracy.

## Test plan

- [ ] Added `readCandidatesUntilConnected` describe block with 4 tests
- [ ] Test: throws `ConnectionFailedError` when the peer connection enters `'failed'` state
- [ ] Test: does not fail when peer connection is temporarily disconnected then recovers
- [ ] Test: throws `ConnectionFailedError` when peer connection goes disconnected then failed
- [ ] Test: returns without error when peer connection reaches `'connected'` state

## Related PRs

This is one of four focused fixes split from #3406 as requested by @dozyio:
- fix(transport-webrtc): check initial peer connection state at construction time
- **This PR** — `UnexpectedEOFError` race in `readCandidatesUntilConnected`
- fix(transport-webrtc): do not treat `'disconnected'` as a terminal peer connection state
- fix(interface-compliance-tests): increase abort propagation timeout in stream muxer close test