### PR TITLE
fix(transport-webrtc): disconnected is not a terminal state

### DIFF
--- a/packages/transport-webrtc/src/private-to-private/util.ts
+++ b/packages/transport-webrtc/src/private-to-private/util.ts
@@ -86,7 +86,6 @@ function resolveOnConnected (pc: RTCPeerConnection, promise: DeferredPromise<voi
         promise.resolve()
         break
       case 'failed':
-      case 'disconnected':
       case 'closed':
         promise.reject(new ConnectionFailedError(`RTCPeerConnection connection state became "${pc.connectionState}"`))
         break

--- a/packages/transport-webrtc/src/rtcpeerconnection-to-conn.ts
+++ b/packages/transport-webrtc/src/rtcpeerconnection-to-conn.ts
@@ -20,7 +20,7 @@ class RTCPeerConnectionMultiaddrConnection extends AbstractMultiaddrConnection {
     this.peerConnection.onconnectionstatechange = () => {
       this.log.trace('peer connection state change %s initial state %s', this.peerConnection.connectionState, initialState)
 
-      if (this.peerConnection.connectionState === 'disconnected' || this.peerConnection.connectionState === 'failed' || this.peerConnection.connectionState === 'closed') {
+      if (this.peerConnection.connectionState === 'failed' || this.peerConnection.connectionState === 'closed') {
         // nothing else to do but close the connection
         this.onTransportClosed()
 


### PR DESCRIPTION
## Problem

The `onconnectionstatechange` handler and `resolveOnConnected` both treated `'disconnected'` the same as `'failed'` and `'closed'`, immediately tearing down the connection and rejecting the connected promise.

WebRTC's `'disconnected'` state is **transient** — the ICE agent may recover to `'connected'` without any intervention. Treating it as terminal caused two issues:

1. Connections that could have recovered were torn down prematurely.
2. In Firefox, the spurious `DataChannel` close during large data transfers raced against `sendCloseWrite`'s `pEvent(channel, 'close')` listener registration. If the channel closed before the listener was registered, the FIN_ACK was missed, the `finAckTimeout` fired, and all branches of `Promise.any` rejected with an `AggregateError`.

## Solution

Only treat `'failed'` and `'closed'` as terminal states in both:
- `RTCPeerConnectionMultiaddrConnection.onconnectionstatechange`
- `resolveOnConnected` in `util.ts`

## Test plan

- [ ] Existing WebRTC transport tests pass (Chrome, Firefox)
- [ ] No regression in connection teardown on genuine `'failed'` / `'closed'` states

## Related PRs

This is one of four focused fixes split from #3406 as requested by @dozyio:
- fix(transport-webrtc): check initial peer connection state at construction time
- fix(transport-webrtc): fix `UnexpectedEOFError` race in `readCandidatesUntilConnected`
- **This PR** — `'disconnected'` not terminal
- fix(interface-compliance-tests): increase abort propagation timeout in stream muxer close test