### PR TITLE
fix(interface-compliance-tests): increase abort timeout

### DIFF
--- a/packages/interface-compliance-tests/src/stream-muxer/close-test.ts
+++ b/packages/interface-compliance-tests/src/stream-muxer/close-test.ts
@@ -195,7 +195,7 @@ export default (common: TestSetup<StreamMuxerFactory>): void => {
               new Promise((resolve, reject) => {
                 setTimeout(() => {
                   reject(timeoutError)
-                }, 70)
+                }, 2000)
               })
             ])
             expect.fail('stream pipe with infinite source should never return')


### PR DESCRIPTION
## Problem

The \"calling abort aborts streams\" test in the stream muxer compliance suite was flaky on loaded CI runners.

The test structure:
- `infiniteRandom` yields values with `await delay(10)` per iteration
- `dialer.abort()` is called at t=50ms
- A `setTimeout` races against the abort with a 70ms deadline

This leaves only a **20ms window** after the abort call for propagation to complete. Node.js timer imprecision on a loaded runner routinely exceeds 15–50ms, causing the timeout to fire before abort propagation finishes.

## Solution

Increase the timeout from 70ms to 2000ms. On success, the test exits well under 100ms. The 2000ms only fires if abort genuinely fails to propagate, making the test a true failure detector rather than a race against the scheduler.

## Test plan

- [ ] \"calling abort aborts streams\" passes reliably on CI
- [ ] On success the test completes in <100ms (no slowdown on happy path)

## Related PRs

This is one of four focused fixes split from #3406 as requested by @dozyio:
- fix(transport-webrtc): check initial peer connection state at construction time
- fix(transport-webrtc): fix `UnexpectedEOFError` race in `readCandidatesUntilConnected`
- fix(transport-webrtc): do not treat `'disconnected'` as a terminal peer connection state
- **This PR** — stream muxer abort timeout