### PR TITLE
fix(libp2p): default abortConnectionOnPingFailure to false

### DIFF
--- a/packages/libp2p/src/connection-monitor.ts
+++ b/packages/libp2p/src/connection-monitor.ts
@@ -11,7 +11,14 @@ const PROTOCOL_VERSION = '1.0.0'
 const PROTOCOL_NAME = 'ping'
 const PROTOCOL_PREFIX = 'ipfs'
 const PING_LENGTH = 32
-const DEFAULT_ABORT_CONNECTION_ON_PING_FAILURE = true
+// Probe failures are not reliable evidence a connection is dead under real
+// WAN conditions — trans-continental RTT, event-loop contention, and transient
+// network jitter routinely cause a single 10s ping exchange to fail. Yamux
+// keepalive detects genuinely dead connections at the muxer layer without
+// tearing down the TCP socket, so aborting on a single probe failure is
+// measurable self-harm at non-trivial scale. Applications that want the
+// aggressive behaviour can still opt in by setting this to true.
+const DEFAULT_ABORT_CONNECTION_ON_PING_FAILURE = false
 
 export interface ConnectionMonitorInit {
   /**
@@ -38,9 +45,12 @@ export interface ConnectionMonitorInit {
   pingTimeout?: Omit<AdaptiveTimeoutInit, 'metricsName' | 'metrics'>
 
   /**
-   * If true, any connection that fails the ping will be aborted
+   * If true, any connection that fails the ping will be aborted. Defaults to
+   * false because a single 10s probe failure is not reliable evidence that
+   * the connection is dead under real WAN conditions. Set to true to restore
+   * the previous aggressive behaviour.
    *
-   * @default true
+   * @default false
    */
   abortConnectionOnPingFailure?: boolean
 

--- a/packages/libp2p/test/connection-monitor/index.spec.ts
+++ b/packages/libp2p/test/connection-monitor/index.spec.ts
@@ -112,7 +112,8 @@ describe('connection monitor', () => {
       pingInterval: 50,
       pingTimeout: {
         maxTimeout: 50
-      }
+      },
+      abortConnectionOnPingFailure: true
     })
 
     await start(monitor)
@@ -133,7 +134,8 @@ describe('connection monitor', () => {
 
   it('should abort a connection that fails', async () => {
     monitor = new ConnectionMonitor(components, {
-      pingInterval: 10
+      pingInterval: 10,
+      abortConnectionOnPingFailure: true
     })
 
     await start(monitor)
@@ -148,6 +150,25 @@ describe('connection monitor', () => {
     await delay(500)
 
     expect(connection.abort).to.have.property('called', true)
+  })
+
+  it('should not abort a connection that fails by default', async () => {
+    monitor = new ConnectionMonitor(components, {
+      pingInterval: 10
+    })
+
+    await start(monitor)
+
+    const connection = stubInterface<Connection>()
+    connection.newStream.withArgs('/ipfs/ping/1.0.0').callsFake(async (protocols, opts) => {
+      throw new ConnectionClosedError('Connection closed')
+    })
+
+    components.connectionManager.getConnections.returns([connection])
+
+    await delay(500)
+
+    expect(connection.abort).to.have.property('called', false)
   })
 
   it('should not abort a connection that fails when abortConnectionOnPingFailure is false', async () => {


### PR DESCRIPTION
## Motivation

`@libp2p/connection-monitor` defaults to `abortConnectionOnPingFailure: true`. On any probe failure this calls `conn.abort(err)`, which cascades through the muxer (GoAway) and every multiplexed stream, and terminates the underlying MA-connection with a TCP RST on `@libp2p/tcp`.

Under normal WAN conditions — trans-continental RTT, intermittent event-loop contention on either peer, transient network jitter — a single 10s probe exchange failing is routine. The current default treats it as evidence the connection is dead and destroys it.

## Evidence

A five-host deployment across three continents (Germany, Australia, New Zealand) on libp2p 3.x with yamux keepalive enabled (`enableKeepAlive: true`, `keepAliveInterval: 10_000`). Baseline measurements per host over a 30-minute window:

| Host | Role | Disconnect rate |
|---|---|---|
| bootstrap (IONOS, DE) | VPS bootstrap | ~36/hr |
| bootstrap-de (Contabo, DE) | VPS bootstrap | ~42/hr |
| station3 (Contabo, AU) | VPS node | ~25/hr |
| station .11 (TrueNAS, NZ) | LAN guardian | ~48/hr |
| station .13 (LAN, NZ) | LAN guardian | ~62/hr |

Packet capture on the AU→NZ link confirmed the Node process itself sends the TCP RST mid-traffic, in the same event-loop tick as a preceding yamux GoAway burst. Instrumenting every abort call site in production produced stack traces rooted overwhelmingly at \`connection-monitor.ts\` → \`conn.abort(err)\`.

Setting \`abortConnectionOnPingFailure: false\` on all five hosts dropped the measured disconnect rate to **0/hr across all hosts** over multi-hour windows — no other change was required. Yamux keepalive handled liveness without the RST cascade. I do have a full writeup available of the hypotheses tested and their results to get to this point, but it's currently an offline copy in StreamResetInvestigation.md.  Please advise if required.

## Change

Flips \`DEFAULT_ABORT_CONNECTION_ON_PING_FAILURE\` from \`true\` to \`false\`. The option is still honoured when set explicitly. Applications that want the aggressive behaviour opt in rather than opt out.

## Tests

- Two existing tests that relied on the old default (\`should abort a connection that times out\`, \`should abort a connection that fails\`) now pass \`abortConnectionOnPingFailure: true\` explicitly — their intent was always to test the abort mechanism, not the default.
- New regression test \`should not abort a connection that fails by default\` guards against accidental regression of the new default.
- All 9 connection-monitor tests pass.

## Alternative considered

A more conservative middle-ground would be to require N consecutive probe failures before aborting (with N defaulting to e.g. 3), preserving the dead-connection-detection intent while eliminating the false-positive cascade. Happy to follow up with that if maintainers prefer — but changing the default to \`false\` is the simpler, strictly-safer change and matches what every deployment we're aware of ends up doing manually after hitting this problem.