### PR TITLE
chore(transport-webrtc): remove firefox detection and workarounds

### DIFF
--- a/packages/transport-webrtc/package.json
+++ b/packages/transport-webrtc/package.json
@@ -57,7 +57,6 @@
     "@multiformats/multiaddr-matcher": "^3.0.1",
     "@peculiar/webcrypto": "^1.5.0",
     "@peculiar/x509": "^2.0.0",
-    "detect-browser": "^5.3.0",
     "get-port": "^7.1.0",
     "interface-datastore": "^9.0.1",
     "it-length-prefixed": "^10.0.1",

--- a/packages/transport-webrtc/src/private-to-public/utils/connect.ts
+++ b/packages/transport-webrtc/src/private-to-public/utils/connect.ts
@@ -4,7 +4,6 @@ import { WebRTCTransportError } from '../../error.js'
 import { DataChannelMuxerFactory } from '../../muxer.js'
 import { toMultiaddrConnection } from '../../rtcpeerconnection-to-conn.ts'
 import { createStream } from '../../stream.js'
-import { isFirefox } from '../../util.js'
 import { generateNoisePrologue } from './generate-noise-prologue.ts'
 import * as sdp from './sdp.ts'
 import type { DirectRTCPeerConnection } from './get-rtcpeerconnection.ts'
@@ -33,8 +32,6 @@ export interface ClientOptions extends ConnectOptions {
 export interface ServerOptions extends ConnectOptions {
   role: 'server'
 }
-
-const CONNECTION_STATE_CHANGE_EVENT = isFirefox ? 'iceconnectionstatechange' : 'connectionstatechange'
 
 function isServer (options: ClientOptions | ServerOptions, peerConnection: any): peerConnection is DirectRTCPeerConnection {
   return options.role === 'server'
@@ -135,7 +132,7 @@ export async function connect (peerConnection: RTCPeerConnection | DirectRTCPeer
       log: options.logger.forComponent('libp2p:webrtc-direct:connection')
     })
 
-    peerConnection.addEventListener(CONNECTION_STATE_CHANGE_EVENT, () => {
+    peerConnection.addEventListener('connectionstatechange', () => {
       switch (peerConnection.connectionState) {
         case 'failed':
         case 'disconnected':

--- a/packages/transport-webrtc/src/stream.ts
+++ b/packages/transport-webrtc/src/stream.ts
@@ -7,7 +7,6 @@ import { raceSignal } from 'race-signal'
 import { Uint8ArrayList } from 'uint8arraylist'
 import { DEFAULT_FIN_ACK_TIMEOUT, MAX_BUFFERED_AMOUNT, MAX_MESSAGE_SIZE, PROTOBUF_OVERHEAD } from './constants.ts'
 import { Message } from './private-to-public/pb/message.ts'
-import { isFirefox } from './util.ts'
 import type { DataChannelOptions } from './index.ts'
 import type { AbortOptions, MessageStreamDirection, Logger } from '@libp2p/interface'
 import type { AbstractStreamInit, SendResult } from '@libp2p/utils'
@@ -139,14 +138,6 @@ export class WebRTCStream extends AbstractStream {
     }
 
     this.log.trace('sending message, channel state "%s"', this.channel.readyState)
-
-    if (isFirefox) {
-      // TODO: firefox can deliver small messages out of order - remove once a
-      // browser with https://bugzilla.mozilla.org/show_bug.cgi?id=1983831 is
-      // available in playwright-test
-      this.channel.send(data.subarray())
-      return
-    }
 
     // send message without copying data
     for (const buf of data) {

--- a/packages/transport-webrtc/src/util.ts
+++ b/packages/transport-webrtc/src/util.ts
@@ -1,13 +1,9 @@
-import { detect } from 'detect-browser'
 import pDefer from 'p-defer'
 import pTimeout from 'p-timeout'
 import { DATA_CHANNEL_DRAIN_TIMEOUT, DEFAULT_ICE_SERVERS, UFRAG_ALPHABET, UFRAG_PREFIX } from './constants.ts'
 import type { LoggerOptions } from '@libp2p/interface'
 import type { Duplex, Source } from 'it-stream-types'
 import type { PeerConnection } from 'node-datachannel'
-
-const browser = detect()
-export const isFirefox = ((browser != null) && browser.name === 'firefox')
 
 export const nopSource = async function * nop (): AsyncGenerator<Uint8Array, any, unknown> {}
 

--- a/packages/transport-webrtc/test/peer.spec.ts
+++ b/packages/transport-webrtc/test/peer.spec.ts
@@ -5,7 +5,6 @@ import { streamPair, pbStream } from '@libp2p/utils'
 import { multiaddr } from '@multiformats/multiaddr'
 import { expect } from 'aegir/chai'
 import delay from 'delay'
-import { detect } from 'detect-browser'
 import { TypedEventEmitter } from 'main-event'
 import pRetry from 'p-retry'
 import Sinon from 'sinon'
@@ -20,8 +19,6 @@ import type { Logger, Connection, Stream, ComponentLogger, Upgrader } from '@lib
 import type { ConnectionManager, Registrar, TransportManager } from '@libp2p/interface-internal'
 import type { Multiaddr } from '@multiformats/multiaddr'
 import type { StubbedInstance } from 'sinon-ts'
-
-const browser = detect()
 
 interface Initiator {
   multiaddr: Multiaddr
@@ -80,7 +77,6 @@ async function getComponents (): Promise<PrivateToPrivateComponents> {
 }
 
 describe('webrtc basic', () => {
-  const isFirefox = ((browser != null) && browser.name === 'firefox')
   let initiator: Initiator
   let recipient: Recipient
   let initiatorPeerConnection: RTCPeerConnection
@@ -110,11 +106,6 @@ describe('webrtc basic', () => {
     ).to.eventually.be.fulfilled()
 
     await pRetry(async () => {
-      if (isFirefox) {
-        expect(initiatorPeerConnection.iceConnectionState).eq('connected')
-        expect(recipient.peerConnection.iceConnectionState).eq('connected')
-        return
-      }
       expect(initiatorPeerConnection.connectionState).eq('connected')
       expect(recipient.peerConnection.connectionState).eq('connected')
     })

--- a/packages/transport-webrtc/test/stream.spec.ts
+++ b/packages/transport-webrtc/test/stream.spec.ts
@@ -8,7 +8,6 @@ import { stubInterface } from 'sinon-ts'
 import { MAX_MESSAGE_SIZE, PROTOBUF_OVERHEAD } from '../src/constants.js'
 import { Message } from '../src/private-to-public/pb/message.js'
 import { createStream } from '../src/stream.js'
-import { isFirefox } from '../src/util.ts'
 import { RTCPeerConnection } from '../src/webrtc/index.js'
 import { receiveFinAck, receiveRemoteCloseWrite } from './util.ts'
 import type { WebRTCStream } from '../src/stream.js'
@@ -39,14 +38,7 @@ describe('Max message size', () => {
     const sendMore = webrtcStream.send(data)
     expect(sendMore).to.be.true()
 
-    if (isFirefox) {
-      // TODO: firefox can deliver small messages out of order - remove once a
-      // browser with https://bugzilla.mozilla.org/show_bug.cgi?id=1983831 is
-      // available in playwright-test
-      expect(channel.send).to.have.property('callCount', 1)
-    } else {
-      expect(channel.send).to.have.property('callCount', 2)
-    }
+    expect(channel.send).to.have.property('callCount', 2)
 
     const bytes = channel.send.getCalls().reduce((acc, curr) => {
       return acc + curr.args[0].byteLength
@@ -54,13 +46,8 @@ describe('Max message size', () => {
 
     expect(bytes).to.be.lessThan(MAX_MESSAGE_SIZE)
 
-    if (isFirefox) {
-      // minus 2x bytes because there is no flag field in the protobuf message
-      expect(channel.send.getCall(0).args[0]).to.have.lengthOf(MAX_MESSAGE_SIZE - 2)
-    } else {
-      // minus 2x bytes because there is no flag field in the protobuf message
-      expect(channel.send.getCall(1).args[0]).to.have.lengthOf(MAX_MESSAGE_SIZE - 4)
-    }
+    // minus 2x bytes because there is no flag field in the protobuf message
+    expect(channel.send.getCall(1).args[0]).to.have.lengthOf(MAX_MESSAGE_SIZE - 4)
   })
 
   it(`sends messages greater than ${MAX_MESSAGE_SIZE} bytes in parts`, async () => {


### PR DESCRIPTION
## Title

chore(transport-webrtc): remove firefox detection and workarounds

## Description

Removes all remaining Firefox-specific code paths in the WebRTC transport.

**Stream send workaround** — drops the `isFirefox` branch in
`WebRTCStream._sendMessage` that concatenated `Uint8ArrayList` buffers into
a single `RTCDataChannel.send()` call to work around
https://bugzilla.mozilla.org/show_bug.cgi?id=1983831 (Firefox delivering
small messages out of order). Current Firefox delivers the length-prefix
and payload buffers in order, so the non-Firefox path works for every
browser.

**`connectionstatechange` fallback** — drops the `iceconnectionstatechange`
fallback in `connect.ts`. Firefox 113+ (May 2023) supports
`connectionstatechange`; this fallback was missed when #3279 migrated the
rest of the codebase off `detect-browser`.

With both workarounds gone there are no remaining Firefox-specific code
paths, so this also drops the `isFirefox` export, the `detect-browser`
dependency, and the `isFirefox` branch in the `peer.spec` `should connect`
test. The matching branch in `test/stream.spec.ts` (`Max message size`) is
collapsed to the single expected path.

## Notes & open questions

Verified with:

- \`npm -w @libp2p/webrtc run test:firefox\` — passes
- \`npm -w @libp2p/webrtc run test:chrome\` — passes
- \`npm -w @libp2p/integration-tests run test:firefox -- --grep "WebRTC transport interface compliance.*many small writes"\` — passes (2000 × 1024-byte echoes over real Firefox WebRTC, completes in ~14s with no data loss or framing errors)

The "many small writes" compliance test exercises exactly the send path
being changed, over a real \`RTCPeerConnection\` — framing corruption from
out-of-order delivery would surface as length-prefix decode errors, which
it does not.

One caveat: the echo input is \`new Uint8Array(1024).fill(5)\`, so the test
guards against framing-level ordering and data loss but not within-payload
byte reordering. Happy to strengthen that (random bytes or a counter
pattern) in a separate PR if desired.

## Change checklist

- [x] I have performed a self-review of my own code
- [ ] I have made corresponding changes to the documentation if necessary (this includes comments as well)
- [ ] I have added tests that prove my fix is effective or that my feature works