### PR TITLE
chore: Disable fail-fast in CI workflow

### DIFF
--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -50,6 +50,7 @@ jobs:
       matrix:
         os: [windows-latest, ubuntu-latest, macos-latest]
         node: [lts/*]
+      fail-fast: false
     steps:
       - uses: actions/checkout@v6
       - uses: actions/setup-node@v6


### PR DESCRIPTION
## Description

Allow OS tests to continue when one fails

## Change checklist

- [x] I have performed a self-review of my own code
- [ ] I have made corresponding changes to the documentation if necessary (this includes comments as well)
- [ ] I have added tests that prove my fix is effective or that my feature works