### PR TITLE
fix(transport-webrtc): abort stream when datachannel send throws

### DIFF
--- a/.github/dictionary.txt
+++ b/.github/dictionary.txt
@@ -10,7 +10,6 @@ dout
 getbit
 hopr
 incrby
-libdatachannel
 microtask
 nothrow
 peerStore

--- a/.github/dictionary.txt
+++ b/.github/dictionary.txt
@@ -10,6 +10,7 @@ dout
 getbit
 hopr
 incrby
+libdatachannel
 microtask
 nothrow
 peerStore

--- a/packages/transport-webrtc/src/stream.ts
+++ b/packages/transport-webrtc/src/stream.ts
@@ -139,9 +139,19 @@ export class WebRTCStream extends AbstractStream {
 
     this.log.trace('sending message, channel state "%s"', this.channel.readyState)
 
-    // send message without copying data
-    for (const buf of data) {
-      this.channel.send(buf)
+    try {
+      // send message without copying data
+      for (const buf of data) {
+        this.channel.send(buf)
+      }
+    } catch (err: any) {
+      // channel.send can throw synchronously when the underlying datachannel
+      // is closed (e.g. because the native libdatachannel state diverged from
+      // the polyfill's cached readyState). Treat as a transport failure and
+      // abort the stream so the error surfaces to consumers instead of going
+      // uncaught.
+      this.log.error('error sending datachannel message - %e', err)
+      this.abort(err)
     }
   }
 

--- a/packages/transport-webrtc/src/stream.ts
+++ b/packages/transport-webrtc/src/stream.ts
@@ -145,11 +145,7 @@ export class WebRTCStream extends AbstractStream {
         this.channel.send(buf)
       }
     } catch (err: any) {
-      // channel.send can throw synchronously when the underlying datachannel
-      // is closed (e.g. because the native libdatachannel state diverged from
-      // the polyfill's cached readyState). Treat as a transport failure and
-      // abort the stream so the error surfaces to consumers instead of going
-      // uncaught.
+      // channel.send can throw synchronously if the polyfill's cached readyState is stale
       this.log.error('error sending datachannel message - %e', err)
       this.abort(err)
     }

--- a/packages/transport-webrtc/test/stream.spec.ts
+++ b/packages/transport-webrtc/test/stream.spec.ts
@@ -5,6 +5,7 @@ import * as lengthPrefixed from 'it-length-prefixed'
 import { bytes } from 'multiformats'
 import { pEvent } from 'p-event'
 import { stubInterface } from 'sinon-ts'
+import { isNode, isElectronMain } from 'wherearewe'
 import { MAX_MESSAGE_SIZE, PROTOBUF_OVERHEAD } from '../src/constants.js'
 import { Message } from '../src/private-to-public/pb/message.js'
 import { createStream } from '../src/stream.js'
@@ -81,7 +82,13 @@ describe('Datachannel send errors', () => {
     pcB?.close()
   })
 
-  it('aborts the stream when underlying datachannel is closed mid-send', async () => {
+  it('aborts the stream when underlying datachannel is closed mid-send', async function () {
+    // the state divergence reproduced here is specific to the
+    // node-datachannel polyfill; native browser WebRTC does not exhibit it
+    if (!isNode && !isElectronMain) {
+      return this.skip()
+    }
+
     // open a real datachannel pair so we can trigger the JS-vs-native state
     // divergence in the node-datachannel polyfill: peerConnection.close()
     // synchronously closes the native datachannel at the C++ level, but the

--- a/packages/transport-webrtc/test/stream.spec.ts
+++ b/packages/transport-webrtc/test/stream.spec.ts
@@ -12,7 +12,7 @@ import { isFirefox } from '../src/util.ts'
 import { RTCPeerConnection } from '../src/webrtc/index.js'
 import { receiveFinAck, receiveRemoteCloseWrite } from './util.ts'
 import type { WebRTCStream } from '../src/stream.js'
-import type { Stream } from '@libp2p/interface'
+import type { Stream, StreamCloseEvent } from '@libp2p/interface'
 
 describe('Max message size', () => {
   it(`sends messages smaller or equal to ${MAX_MESSAGE_SIZE} bytes in one`, async () => {
@@ -82,6 +82,69 @@ describe('Max message size', () => {
     for (let i = 0; i < channel.send.callCount; i++) {
       expect(channel.send.getCall(i).args[0]).to.have.length.that.is.lessThanOrEqual(MAX_MESSAGE_SIZE)
     }
+  })
+})
+
+describe('Datachannel send errors', () => {
+  let pcA: RTCPeerConnection
+  let pcB: RTCPeerConnection
+
+  afterEach(() => {
+    pcA?.close()
+    pcB?.close()
+  })
+
+  it('aborts the stream when underlying datachannel is closed mid-send', async () => {
+    // open a real datachannel pair so we can trigger the JS-vs-native state
+    // divergence in the node-datachannel polyfill: peerConnection.close()
+    // synchronously closes the native datachannel at the C++ level, but the
+    // polyfill's cached readyState only updates when the onClosed callback
+    // fires on the next event loop tick. Calling send() in that race window
+    // passes the readyState guard and reaches the native binding, which
+    // throws "DataChannel is closed"
+    pcA = new RTCPeerConnection()
+    pcB = new RTCPeerConnection()
+    const channelA = pcA.createDataChannel('test', { negotiated: true, id: 91 })
+    const channelB = pcB.createDataChannel('test', { negotiated: true, id: 91 })
+
+    pcA.onicecandidate = ({ candidate }) => {
+      if (candidate != null) {
+        pcB.addIceCandidate(candidate).catch(() => {})
+      }
+    }
+    pcB.onicecandidate = ({ candidate }) => {
+      if (candidate != null) {
+        pcA.addIceCandidate(candidate).catch(() => {})
+      }
+    }
+
+    await pcA.setLocalDescription(await pcA.createOffer())
+    await pcB.setRemoteDescription(pcA.localDescription as RTCSessionDescriptionInit)
+    await pcB.setLocalDescription(await pcB.createAnswer())
+    await pcA.setRemoteDescription(pcB.localDescription as RTCSessionDescriptionInit)
+
+    await Promise.all([
+      pEvent(channelA, 'open', { rejectionEvents: ['close', 'error'] }),
+      pEvent(channelB, 'open', { rejectionEvents: ['close', 'error'] })
+    ])
+
+    const webrtcStream = createStream({
+      channel: channelA,
+      direction: 'outbound',
+      closeTimeout: 1,
+      log: defaultLogger().forComponent('test')
+    })
+
+    // synchronously close the native peer; polyfill readyState is still 'open'
+    pcA.close()
+    expect(channelA.readyState).to.equal('open')
+
+    const closeEventPromise = pEvent<'close', StreamCloseEvent>(webrtcStream, 'close')
+    webrtcStream.send(new Uint8Array([1, 2, 3, 4]))
+    const closeEvent = await closeEventPromise
+
+    expect(closeEvent.error).to.exist()
+    expect(webrtcStream.status).to.equal('aborted')
   })
 })
 

--- a/packages/transport-webrtc/test/stream.spec.ts
+++ b/packages/transport-webrtc/test/stream.spec.ts
@@ -83,19 +83,14 @@ describe('Datachannel send errors', () => {
   })
 
   it('aborts the stream when underlying datachannel is closed mid-send', async function () {
-    // the state divergence reproduced here is specific to the
-    // node-datachannel polyfill; native browser WebRTC does not exhibit it
+    // polyfill-specific race; native browser WebRTC doesn't exhibit it
     if (!isNode && !isElectronMain) {
       return this.skip()
     }
 
-    // open a real datachannel pair so we can trigger the JS-vs-native state
-    // divergence in the node-datachannel polyfill: peerConnection.close()
-    // synchronously closes the native datachannel at the C++ level, but the
-    // polyfill's cached readyState only updates when the onClosed callback
-    // fires on the next event loop tick. Calling send() in that race window
-    // passes the readyState guard and reaches the native binding, which
-    // throws "DataChannel is closed"
+    // the node-datachannel polyfill's cached readyState updates on the next
+    // tick after onClosed fires, so closing the peer leaves a window where
+    // send() passes the guard and hits an already-closed native channel
     pcA = new RTCPeerConnection()
     pcB = new RTCPeerConnection()
     const channelA = pcA.createDataChannel('test', { negotiated: true, id: 91 })
@@ -129,7 +124,6 @@ describe('Datachannel send errors', () => {
       log: defaultLogger().forComponent('test')
     })
 
-    // synchronously close the native peer; polyfill readyState is still 'open'
     pcA.close()
     expect(channelA.readyState).to.equal('open')
 


### PR DESCRIPTION
## Description

The `node-datachannel` polyfill caches `RTCDataChannel.readyState` and updates it via `setImmediate` when the native channel closes. This creates a window where the cached `readyState` still reports `'open'` while the underlying native channel is already closed. In that window, `channel.send()` passes the `readyState !== 'open'` guard in `WebRTCStream._sendMessage` and calls into the native binding, which throws `"DataChannel is closed"` synchronously.

The throw was uncaught because `_sendMessage` did not wrap the `channel.send` calls, surfacing as an unhandled error in CI (observed in https://github.com/libp2p/js-libp2p/actions/runs/24605305629/job/71950609115?pr=3459).

This PR:

- Adds a test that reproduces the divergence by creating a real datachannel pair, closing the peer connection synchronously, and asserting that `send()` aborts the stream cleanly.
- Wraps `channel.send` in a try/catch and calls `this.abort(err)` on synchronous throw, so the error surfaces as a transport failure on the stream rather than an uncaught exception.

Related https://github.com/libp2p/js-libp2p/pull/3459.

## Notes & open questions

The first commit (test only) is expected to fail CI to demonstrate the error path. The fix commit will be pushed next.

## Change checklist

- [x] I have performed a self-review of my own code
- [ ] I have made corresponding changes to the documentation if necessary (this includes comments as well)
- [x] I have added tests that prove my fix is effective or that my feature works