### PR TITLE
feat(utils): add tryGetNetConfig helper

### DIFF
--- a/packages/utils/src/multiaddr/get-net-config.ts
+++ b/packages/utils/src/multiaddr/get-net-config.ts
@@ -110,3 +110,15 @@ export function getNetConfig (ma: Multiaddr): NetConfig {
 
   return config
 }
+
+/**
+ * Like `getNetConfig` but returns `null` instead of throwing when the
+ * multiaddr does not start with a network address.
+ */
+export function tryGetNetConfig (ma: Multiaddr): NetConfig | null {
+  try {
+    return getNetConfig(ma)
+  } catch {
+    return null
+  }
+}

--- a/packages/utils/src/multiaddr/get-net-config.ts
+++ b/packages/utils/src/multiaddr/get-net-config.ts
@@ -55,12 +55,10 @@ export interface DNSAddrNetConfig {
 export type NetConfig = IP4NetConfig | IP6NetConfig | DNSNetConfig | DNS4NetConfig | DNS6NetConfig | DNSAddrNetConfig
 
 /**
- * Returns host/port/etc information for multiaddrs, if it is available.
- *
- * It will throw if the passed multiaddr does not start with a network address,
- * e.g. a IPv4, IPv6, DNS, DNS4, DNS6 or DNSADDR address
+ * Returns host/port/etc information for a multiaddr if it starts with a
+ * network address (IPv4, IPv6, DNS, DNS4, DNS6 or DNSADDR), or null otherwise.
  */
-export function getNetConfig (ma: Multiaddr): NetConfig {
+export function tryGetNetConfig (ma: Multiaddr): NetConfig | null {
   const components = ma.getComponents()
   const config: any = {}
   let index = 0
@@ -70,15 +68,15 @@ export function getNetConfig (ma: Multiaddr): NetConfig {
     index++
   }
 
-  if (components[index].name === 'ip4' || components[index].name === 'ip6') {
+  if (components[index]?.name === 'ip4' || components[index]?.name === 'ip6') {
     config.type = components[index].name
     config.host = components[index].value
     index++
-  } else if (components[index].name === 'dns' || components[index].name === 'dns4' || components[index].name === 'dns6') {
+  } else if (components[index]?.name === 'dns' || components[index]?.name === 'dns4' || components[index]?.name === 'dns6') {
     config.type = components[index].name
     config.host = components[index].value
     index++
-  } else if (components[index].name === 'dnsaddr') {
+  } else if (components[index]?.name === 'dnsaddr') {
     config.type = components[index].name
     config.host = `_dnsaddr.${components[index].value}`
     index++
@@ -100,7 +98,7 @@ export function getNetConfig (ma: Multiaddr): NetConfig {
   }
 
   if (config.type == null || config.host == null) {
-    throw new InvalidParametersError(`Multiaddr ${ma} was not an IPv4, IPv6, DNS, DNS4, DNS6 or DNSADDR address`)
+    return null
   }
 
   if (components[index]?.name === 'tls' && components[index + 1]?.name === 'sni') {
@@ -112,13 +110,15 @@ export function getNetConfig (ma: Multiaddr): NetConfig {
 }
 
 /**
- * Like `getNetConfig` but returns `null` instead of throwing when the
- * multiaddr does not start with a network address.
+ * Like `tryGetNetConfig` but throws `InvalidParametersError` when the multiaddr
+ * does not start with a network address.
  */
-export function tryGetNetConfig (ma: Multiaddr): NetConfig | null {
-  try {
-    return getNetConfig(ma)
-  } catch {
-    return null
+export function getNetConfig (ma: Multiaddr): NetConfig {
+  const config = tryGetNetConfig(ma)
+
+  if (config == null) {
+    throw new InvalidParametersError(`Multiaddr ${ma} was not an IPv4, IPv6, DNS, DNS4, DNS6 or DNSADDR address`)
   }
+
+  return config
 }

--- a/packages/utils/src/multiaddr/is-network-address.ts
+++ b/packages/utils/src/multiaddr/is-network-address.ts
@@ -1,15 +1,9 @@
-import { getNetConfig } from './get-net-config.ts'
+import { tryGetNetConfig } from './get-net-config.ts'
 import type { Multiaddr } from '@multiformats/multiaddr'
 
 /**
  * Check if a given multiaddr is a network address
  */
 export function isNetworkAddress (ma: Multiaddr): boolean {
-  try {
-    getNetConfig(ma)
-
-    return true
-  } catch {
-    return false
-  }
+  return tryGetNetConfig(ma) !== null
 }

--- a/packages/utils/test/multiaddr/get-net-config.spec.ts
+++ b/packages/utils/test/multiaddr/get-net-config.spec.ts
@@ -1,6 +1,6 @@
 import { multiaddr } from '@multiformats/multiaddr'
 import { expect } from 'aegir/chai'
-import { getNetConfig } from '../../src/index.ts'
+import { getNetConfig, tryGetNetConfig } from '../../src/index.ts'
 
 describe('multiaddr getNetConfig', () => {
   it('throws on empty multiaddr', () => {
@@ -31,5 +31,24 @@ describe('multiaddr getNetConfig', () => {
       protocol: 'tcp',
       port: 1000
     })
+  })
+})
+
+describe('multiaddr tryGetNetConfig', () => {
+  it('returns config for a network multiaddr', () => {
+    expect(tryGetNetConfig(multiaddr('/ip4/127.0.0.1/tcp/1000'))).to.deep.equal({
+      type: 'ip4',
+      host: '127.0.0.1',
+      protocol: 'tcp',
+      port: 1000
+    })
+  })
+
+  it('returns null for an empty multiaddr', () => {
+    expect(tryGetNetConfig(multiaddr())).to.be.null()
+  })
+
+  it('returns null for a non-network multiaddr', () => {
+    expect(tryGetNetConfig(multiaddr('/p2p/12D3KooWK43NgYJKLv3Rerrac9YQ5gz7tpFnmreLYH3AdEAa3PhW'))).to.be.null()
   })
 })


### PR DESCRIPTION
## Description

Adds `tryGetNetConfig(ma)` that returns the `NetConfig` for a network multiaddr or `null` otherwise, as a non-throwing alternative to `getNetConfig`.

Callers that need to skip non-network multiaddrs (e.g. `/p2p-circuit`, `/p2p/...`, or empty multiaddrs) can avoid wrapping `getNetConfig` in their own try/catch and the cost of thrown exceptions.

A companion PR will migrate `@libp2p/autonat-v2` to use this helper, replacing `isNetworkAddress(ma)` + `getNetConfig(ma)` pairs with a single call per site.

## Notes & open questions

Opening this for use in https://github.com/libp2p/js-libp2p/pull/3400 as isNetworkAddress calls getNetConfig itself.

## Change checklist

- [x] I have performed a self-review of my own code
- [ ] I have made corresponding changes to the documentation if necessary (this includes comments as well)
- [x] I have added tests that prove my fix is effective or that my feature works