### PR TITLE
feat: export TLS utils

### DIFF
--- a/packages/connection-encrypter-tls/package.json
+++ b/packages/connection-encrypter-tls/package.json
@@ -17,6 +17,22 @@
   },
   "type": "module",
   "types": "./dist/src/index.d.ts",
+  "typesVersions": {
+    "*": {
+      "*": [
+        "*",
+        "dist/*",
+        "dist/src/*",
+        "dist/src/*/index"
+      ],
+      "src/*": [
+        "*",
+        "dist/*",
+        "dist/src/*",
+        "dist/src/*/index"
+      ]
+    }
+  },
   "files": [
     "src",
     "dist",
@@ -28,6 +44,11 @@
       "types": "./dist/src/index.d.ts",
       "import": "./dist/src/index.js",
       "module-sync": "./dist/src/index.js"
+    },
+    "./utils": {
+      "types": "./dist/src/utils.d.ts",
+      "import": "./dist/src/utils.js",
+      "module-sync": "./dist/src/utils.js"
     }
   },
   "scripts": {

--- a/packages/connection-encrypter-tls/typedoc.json
+++ b/packages/connection-encrypter-tls/typedoc.json
@@ -1,6 +1,7 @@
 {
   "readme": "none",
   "entryPoints": [
-    "./src/index.ts"
+    "./src/index.ts",
+    "./src/utils.ts"
   ]
 }


### PR DESCRIPTION
Exports the utils needed by the QUIC transport to derive the remote peer id from the TLS certificate.

## Change checklist

- [x] I have performed a self-review of my own code
- [ ] I have made corresponding changes to the documentation if necessary (this includes comments as well)
- [ ] I have added tests that prove my fix is effective or that my feature works