### PR TITLE
fix: emit self:peer:update on observed address removal

### DIFF
--- a/packages/libp2p/src/address-manager/index.ts
+++ b/packages/libp2p/src/address-manager/index.ts
@@ -312,12 +312,12 @@ export class AddressManager implements AddressManagerInterface {
   removeObservedAddr (addr: Multiaddr, options?: ConfirmAddressOptions): void {
     addr = stripPeerId(addr, this.components.peerId)
 
-    let startingConfidence = false
+    let startingConfidence = true
 
     if (this.observed.has(addr)) {
       const observedStartingConfidence = this.observed.remove(addr)
 
-      if (!observedStartingConfidence && startingConfidence) {
+      if (observedStartingConfidence && startingConfidence) {
         startingConfidence = false
       }
     }
@@ -325,7 +325,7 @@ export class AddressManager implements AddressManagerInterface {
     if (this.transportAddresses.has(addr)) {
       const transportStartingConfidence = this.transportAddresses.unconfirm(addr, options?.ttl ?? this.addressVerificationRetry)
 
-      if (!transportStartingConfidence && startingConfidence) {
+      if (transportStartingConfidence && startingConfidence) {
         startingConfidence = false
       }
     }
@@ -333,7 +333,7 @@ export class AddressManager implements AddressManagerInterface {
     if (this.dnsMappings.has(addr)) {
       const dnsMappingStartingConfidence = this.dnsMappings.unconfirm(addr, options?.ttl ?? this.addressVerificationRetry)
 
-      if (!dnsMappingStartingConfidence && startingConfidence) {
+      if (dnsMappingStartingConfidence && startingConfidence) {
         startingConfidence = false
       }
     }
@@ -341,13 +341,13 @@ export class AddressManager implements AddressManagerInterface {
     if (this.ipMappings.has(addr)) {
       const ipMappingStartingConfidence = this.ipMappings.unconfirm(addr, options?.ttl ?? this.addressVerificationRetry)
 
-      if (!ipMappingStartingConfidence && startingConfidence) {
+      if (ipMappingStartingConfidence && startingConfidence) {
         startingConfidence = false
       }
     }
 
     // only trigger the 'self:peer:update' event if our confidence in an address has changed
-    if (startingConfidence) {
+    if (!startingConfidence) {
       this._updatePeerStoreAddresses()
     }
   }

--- a/packages/libp2p/test/addresses/address-manager.spec.ts
+++ b/packages/libp2p/test/addresses/address-manager.spec.ts
@@ -226,6 +226,33 @@ describe('Address Manager', () => {
     expect(peerStore.patch).to.have.property('callCount', 1)
   })
 
+  it('should update the peer store when a verified observed address is removed', async () => {
+    const ma = '/ip4/123.123.123.123/tcp/39201'
+    const am = new AddressManager({
+      peerId,
+      transportManager: stubInterface<TransportManager>({
+        getAddrs: Sinon.stub().returns([]),
+        getListeners: Sinon.stub().returns([])
+      }),
+      peerStore,
+      events,
+      logger: defaultLogger()
+    })
+
+    am.addObservedAddr(multiaddr(ma))
+    am.confirmObservedAddr(multiaddr(ma))
+
+    await delay(1500)
+
+    expect(peerStore.patch).to.have.property('callCount', 1)
+
+    am.removeObservedAddr(multiaddr(ma))
+
+    await delay(1500)
+
+    expect(peerStore.patch).to.have.property('callCount', 2)
+  })
+
   it('should strip our peer address from added observed addresses', () => {
     const ma = multiaddr('/ip4/123.123.123.123/tcp/39201')
     const am = new AddressManager({

--- a/packages/libp2p/test/addresses/address-manager.spec.ts
+++ b/packages/libp2p/test/addresses/address-manager.spec.ts
@@ -5,6 +5,7 @@ import { multiaddr } from '@multiformats/multiaddr'
 import { expect } from 'aegir/chai'
 import delay from 'delay'
 import { TypedEventEmitter } from 'main-event'
+import pWaitFor from 'p-wait-for'
 import Sinon from 'sinon'
 import { stubInterface } from 'sinon-ts'
 import { AddressManager } from '../../src/address-manager/index.js'
@@ -242,15 +243,11 @@ describe('Address Manager', () => {
     am.addObservedAddr(multiaddr(ma))
     am.confirmObservedAddr(multiaddr(ma))
 
-    await delay(1500)
-
-    expect(peerStore.patch).to.have.property('callCount', 1)
+    await pWaitFor(() => peerStore.patch.callCount === 1)
 
     am.removeObservedAddr(multiaddr(ma))
 
-    await delay(1500)
-
-    expect(peerStore.patch).to.have.property('callCount', 2)
+    await pWaitFor(() => peerStore.patch.callCount === 2)
   })
 
   it('should strip our peer address from added observed addresses', () => {

--- a/packages/libp2p/test/addresses/address-manager.spec.ts
+++ b/packages/libp2p/test/addresses/address-manager.spec.ts
@@ -243,11 +243,11 @@ describe('Address Manager', () => {
     am.addObservedAddr(multiaddr(ma))
     am.confirmObservedAddr(multiaddr(ma))
 
-    await pWaitFor(() => peerStore.patch.callCount === 1)
+    await pWaitFor(() => peerStore.patch.callCount === 1, { timeout: 2000 })
 
     am.removeObservedAddr(multiaddr(ma))
 
-    await pWaitFor(() => peerStore.patch.callCount === 2)
+    await pWaitFor(() => peerStore.patch.callCount === 2, { timeout: 2000 })
   })
 
   it('should strip our peer address from added observed addresses', () => {


### PR DESCRIPTION
## Description

`AddressManager.removeObservedAddr` had inverted polarity vs.
`confirmObservedAddr`: `startingConfidence` was initialised to `false`,
the inner guards used the wrong sign, and the final check was negated.
`_updatePeerStoreAddresses()` was never invoked from the removal path.

Effect: callers that mark an address unreachable —
`packages/protocol-autonat-v2/src/client.ts`,
`packages/protocol-autonat/src/autonat.ts`,
`packages/transport-circuit-relay-v2/src/transport/listener.ts` —
removed the address from internal state but never patched the peer
store, so `self:peer:update` did not fire and downstream consumers
(DHT mode switching, identify-push, application subscribers) could not
react.

Fix mirrors the polarity used by `confirmObservedAddr`.

## Notes & open questions

## Change checklist

- [x] I have performed a self-review of my own code
- [ ] I have made corresponding changes to the documentation if necessary (this includes comments as well)
- [x] I have added tests that prove my fix is effective or that my feature works