### PR TITLE
fix(gossipsub): use monotonic seqnos

### DIFF
--- a/packages/gossipsub/src/utils/buildRawMessage.ts
+++ b/packages/gossipsub/src/utils/buildRawMessage.ts
@@ -1,4 +1,3 @@
-import { randomBytes } from '@libp2p/crypto'
 import { publicKeyFromProtobuf } from '@libp2p/crypto/keys'
 import { peerIdFromMultihash } from '@libp2p/peer-id'
 import * as Digest from 'multiformats/hashes/digest'
@@ -13,6 +12,20 @@ import type { PublishConfig, TopicStr } from '../types.js'
 import type { PublicKey, PeerId } from '@libp2p/interface'
 
 export const SignPrefix = uint8ArrayFromString('libp2p-pubsub:')
+
+// Monotonic seqno counter seeded from the wall clock in nanoseconds, matching
+// go-libp2p-pubsub and rust-libp2p. The pubsub spec requires a "linearly
+// increasing 64-bit big-endian uint" seqno, and kubo's BasicSeqnoValidator
+// (default since kubo 0.40) drops messages whose seqno isn't strictly greater
+// than the previously-seen max from that peer.
+let seqnoCounter = BigInt(Date.now()) * 1_000_000n
+
+function nextSeqno (): Uint8Array {
+  const v = ++seqnoCounter
+  const out = new Uint8Array(8)
+  new DataView(out.buffer).setBigUint64(0, v, false)
+  return out
+}
 
 export interface RawMessageAndMessage {
   raw: RPC.Message
@@ -30,7 +43,7 @@ export async function buildRawMessage (
       const rpcMsg: RPC.Message = {
         from: publishConfig.author.toMultihash().bytes,
         data: transformedData,
-        seqno: randomBytes(8),
+        seqno: nextSeqno(),
         topic,
         signature: undefined, // Exclude signature field for signing
         key: undefined // Exclude key field for signing

--- a/packages/gossipsub/test/unit/buildRawMessage.spec.ts
+++ b/packages/gossipsub/test/unit/buildRawMessage.spec.ts
@@ -1,0 +1,31 @@
+import { generateKeyPair } from '@libp2p/crypto/keys'
+import { peerIdFromPrivateKey } from '@libp2p/peer-id'
+import { expect } from 'aegir/chai'
+import { fromString as uint8ArrayFromString } from 'uint8arrays/from-string'
+import { StrictSign } from '../../src/index.ts'
+import { buildRawMessage } from '../../src/utils/buildRawMessage.ts'
+import { getPublishConfigFromPeerId } from '../../src/utils/publishConfig.ts'
+
+describe('buildRawMessage', () => {
+  describe('Signing seqno', () => {
+    it('produces strictly increasing big-endian uint64 seqnos', async () => {
+      const privateKey = await generateKeyPair('Ed25519')
+      const peerId = peerIdFromPrivateKey(privateKey)
+      const publishConfig = getPublishConfigFromPeerId(StrictSign, peerId, privateKey)
+      const topic = 'test-topic'
+      const data = uint8ArrayFromString('hello')
+
+      const seqnos: bigint[] = []
+      for (let i = 0; i < 100; i++) {
+        const { raw } = await buildRawMessage(publishConfig, topic, data, data)
+        expect(raw.seqno).to.be.an.instanceOf(Uint8Array)
+        expect(raw.seqno).to.have.lengthOf(8)
+        seqnos.push(new DataView(raw.seqno!.buffer, raw.seqno!.byteOffset, 8).getBigUint64(0, false))
+      }
+
+      for (let i = 1; i < seqnos.length; i++) {
+        expect(seqnos[i] > seqnos[i - 1], `seqno ${seqnos[i]} should be > previous ${seqnos[i - 1]} (index ${i})`).to.equal(true)
+      }
+    })
+  })
+})


### PR DESCRIPTION
## Summary

- Replace `randomBytes(8)` in the `Signing` branch of `buildRawMessage` with a module-scope counter seeded from `Date.now()` in nanoseconds, written big-endian.
- Mirrors [go-libp2p-pubsub](https://github.com/libp2p/go-libp2p-pubsub/blob/master/pubsub.go) and [rust-libp2p](https://github.com/libp2p/rust-libp2p/blob/master/protocols/gossipsub/src/behaviour.rs), which both seed from a high-res timestamp and atomically increment per message.
- Adds a unit test asserting strictly increasing big-endian uint64 seqnos.

## Why

The [pubsub spec](https://github.com/libp2p/specs/blob/master/pubsub/README.md#the-message) requires `seqno` to be a "linearly increasing 64-bit big-endian uint". `@libp2p/gossipsub` was the last major impl still emitting random seqnos, which made it non-compliant.

This started causing real interop pain: kubo 0.40+ enables `BasicSeqnoValidator` by default, and that validator drops any message whose seqno isn't strictly greater than the previously-seen max from that peer. With random 64-bit seqnos, ~50% of consecutive messages from a JS publisher are dropped at any given kubo peer; over a mesh, the reproducer below sees ~80% end-to-end loss.

- Spec violation analysis (lidel): chainsafe/js-libp2p-gossipsub#545
- Kubo-side investigation: ipfs/kubo#11304
- Reproducer (helia↔kubo loses ~80%, helia↔helia clean): https://github.com/Rinse12/kubo_helia_libp2p_gossipsub_bug_reproductions

## Notes on the seed

`Date.now() * 1_000_000n` gives sub-microsecond headroom seeded from wall clock. Across a process restart this still produces seqnos larger than the previous batch (assuming wall clock doesn't move backwards), matching the go/rust behavior. `performance.now()` was rejected for the seed because it starts near 0 each process — restarts would reset seqnos and trip the validator on the receiver.

The receive/validation path (`validateToRawMessage`) is intentionally untouched — JS already accepts any 8-byte seqno, which is fine. Adding a `BasicSeqnoValidator`-equivalent on the JS side is a separate change.

## Test plan

- [x] New unit test `buildRawMessage > Signing seqno > produces strictly increasing big-endian uint64 seqnos` (publishes 100 messages, asserts strict monotonicity).
- [x] `npm run test:node` in `packages/gossipsub` — 94 passing, 21 pending, no regressions.
- [x] `npm run lint` clean.
- [x] `npm run dep-check` clean.
