### PR TITLE
fix(crypto): derive ed25519 public key with @noble/curves

### DIFF
--- a/packages/crypto/src/keys/ed25519/index.ts
+++ b/packages/crypto/src/keys/ed25519/index.ts
@@ -1,4 +1,5 @@
 import crypto from 'crypto'
+import { ed25519 as ed } from '@noble/curves/ed25519.js'
 import { concat as uint8arrayConcat } from 'uint8arrays/concat'
 import { fromString as uint8arrayFromString } from 'uint8arrays/from-string'
 import { toString as uint8arrayToString } from 'uint8arrays/to-string'
@@ -16,24 +17,7 @@ export { PUBLIC_KEY_BYTE_LENGTH as publicKeyLength }
 export { PRIVATE_KEY_BYTE_LENGTH as privateKeyLength }
 
 function derivePublicKey (privateKey: Uint8Array): Uint8Array {
-  const keyObject = crypto.createPrivateKey({
-    format: 'jwk',
-    key: {
-      crv: 'Ed25519',
-      x: '',
-      d: uint8arrayToString(privateKey, 'base64url'),
-      kty: 'OKP'
-    }
-  })
-  const jwk = keyObject.export({
-    format: 'jwk'
-  })
-
-  if (jwk.x == null || jwk.x === '') {
-    throw new Error('Could not export JWK public key')
-  }
-
-  return uint8arrayFromString(jwk.x, 'base64url')
+  return ed.getPublicKey(privateKey)
 }
 
 export function generateKey (): Uint8ArrayKeyPair {


### PR DESCRIPTION
## Description

`derivePublicKey()` in the Node entrypoint constructed a JWK with an empty
`x` field and relied on `crypto.createPrivateKey` to silently fill it in.
Node.js 26 tightened JWK validation and now rejects this with
`TypeError: Invalid JWK OKP key` (`ERR_CRYPTO_INVALID_JWK`), breaking
`generateKeyFromSeed()` and the 32-byte branch of `hashAndSign()`.

Replace the JWK roundtrip with `ed25519.getPublicKey()` from `@noble/curves`,
which is already a runtime dependency of `@libp2p/crypto` and is already the
derivation primitive used by the browser entrypoint (`index.browser.ts`).
Node and browser now share the same derivation path; sign and verify still
go through Node's `crypto` module unchanged.

Fixes https://github.com/libp2p/js-libp2p/issues/3491.

## Change checklist

- [x] I have performed a self-review of my own code
- [x] I have made corresponding changes to the documentation if necessary (this includes comments as well)
- [x] I have added tests that prove my fix is effective or that my feature works