### PR TITLE
handle WebSocket implementations missing bufferedAmount

### DIFF
--- a/packages/transport-websockets/src/websocket-to-conn.ts
+++ b/packages/transport-websockets/src/websocket-to-conn.ts
@@ -62,7 +62,14 @@ class WebSocketMultiaddrConnection extends AbstractMultiaddrConnection {
       this.websocket.send(buf)
     }
 
-    const canSendMore = this.websocket.bufferedAmount < this.maxBufferedAmount
+    // Some WebSocket implementations (notably React Native) don't expose
+    // `bufferedAmount`. When unavailable, treat it as 0; we can't track
+    // backpressure, but at least writes proceed instead of blocking forever
+    // waiting for a 'drain' event, the implementation never emits.
+    const bufferedAmount = typeof this.websocket.bufferedAmount === 'number'
+      ? this.websocket.bufferedAmount
+      : 0
+    const canSendMore = bufferedAmount < this.maxBufferedAmount
 
     if (!canSendMore) {
       this.checkBufferedAmountTask.start()
@@ -92,9 +99,11 @@ class WebSocketMultiaddrConnection extends AbstractMultiaddrConnection {
   }
 
   private checkBufferedAmount (): void {
-    this.log('buffered amount now %d', this.websocket.bufferedAmount)
-
-    if (this.websocket.bufferedAmount === 0) {
+    const bufferedAmount = typeof this.websocket.bufferedAmount === 'number'
+      ? this.websocket.bufferedAmount
+      : 0
+    this.log('buffered amount now %d', bufferedAmount)
+    if (bufferedAmount === 0) {
       this.checkBufferedAmountTask.stop()
       this.safeDispatchEvent('drain')
     }


### PR DESCRIPTION
## Title
<!---
The title of the PR will be the commit message of the merge commit, so please make sure it is descriptive enough.
We utilize the Conventional Commits specification for our commit messages. See <https://www.conventionalcommits.org/en/v1.0.0/#specification> for more information.
The commit tag types can be of one of the following: feat, fix, deps, refactor, chore, docs. See <https://github.com/libp2p/js-libp2p/blob/master/.github/workflows/main.yml#L235-L242>
The title must also be fewer than 72 characters long or it will fail the Semantic PR check. See <https://github.com/libp2p/js-libp2p/blob/master/.github/workflows/semantic-pull-request.yml>
--->

## Description

React Native's WebSocket implementation does not expose bufferedAmount (it's undefined). The current code in WebSocketMultiaddrConnection.sendData compares it directly with a number, which evaluates undefined < 4MB to false, marking every write as needing drain. The eventual 'close' event then makes pEvent reject with undefined, surfacing in Upgrader._encryptOutbound as the cryptic TypeError: Cannot read property 'message' of undefined.

Same guard applied to checkBufferedAmount, which otherwise starts a polling task that never terminates.

Reproducer: a React Native Expo project using @libp2p/websockets to dial a Node.js relay. Before the fix, every dial failed at `mss.select` with an undefined message error. After the fix, dial completes and noise handshake proceeds normally.
 
Refs
- React Native WebSocket source: https://github.com/facebook/react-native/blob/main/packages/react-native/Libraries/WebSocket/WebSocket.js — bufferedAmount is not implemented.
- MDN: bufferedAmount is required for browsers, but not all WebSocket implementations conform.

## Change checklist

- [ ] I have performed a self-review of my own code
- [ ] I have made corresponding changes to the documentation if necessary (this includes comments as well)
- [ ] I have added tests that prove my fix is effective or that my feature works