### PR TITLE
deps: pin @multiformats/multiaddr to 13.0.1

### DIFF
--- a/package.json
+++ b/package.json
@@ -48,6 +48,7 @@
     "packages/*"
   ],
   "overrides": {
-    "playwright-core": "1.58.0"
+    "playwright-core": "1.58.0",
+    "@multiformats/multiaddr": "13.0.1"
   }
 }


### PR DESCRIPTION
## Description

`@multiformats/multiaddr@13.0.2` silently bumped peer-deps:

- `multiformats`: `^13.4` → `^14`
- `uint8arrays`: `^5` → `^6`

npm now installs both `multiformats` versions side-by-side, esbuild ships
duplicates in browser bundles, and class-mangling breaks sinon's
`withArgs(peerId)` matcher (`constructor.name` mismatch) → dial-queue
browser tests fail.

Pin multiaddr to 13.0.1 via root `overrides` until we do the coordinated
`multiformats@^14` / `uint8arrays@^6` bump across libp2p packages.

## Change checklist

- [x] I have performed a self-review of my own code
- [x] I have made corresponding changes to the documentation if necessary (this includes comments as well)
- [x] I have added tests that prove my fix is effective or that my feature works