### PR TITLE
fix(kad-dht): only echo PUT_VALUE response on success

### DIFF
--- a/packages/kad-dht/src/rpc/handlers/put-value.ts
+++ b/packages/kad-dht/src/rpc/handlers/put-value.ts
@@ -51,11 +51,13 @@ export class PutValueHandler implements DHTMessageHandler {
       deserializedRecord.timeReceived = new Date()
       const recordKey = bufferToRecordKey(this.datastorePrefix, deserializedRecord.key)
       await this.components.datastore.put(recordKey, deserializedRecord.serialize().subarray())
-      this.log('put record for %b into datastore under key %k', key, recordKey)
-    } catch (err: any) {
-      this.log('did not put record for key %b into datastore %o', key, err)
-    }
 
-    return msg
+      this.log('accepted put for key %b under %k', key, recordKey)
+
+      return msg
+    } catch (err: any) {
+      this.log('failed to accept put for key %b - %e', key, err)
+      throw err
+    }
   }
 }

--- a/packages/kad-dht/test/rpc/handlers/put-value.spec.ts
+++ b/packages/kad-dht/test/rpc/handlers/put-value.spec.ts
@@ -92,4 +92,26 @@ describe('rpc - handlers - PutValue', () => {
     await delay(10)
     expect(rec.timeReceived.getTime()).to.be.lessThan(Date.now())
   })
+
+  it('errors and does not store when validation fails', async () => {
+    const msg: Message = {
+      type: T,
+      key: uint8ArrayFromString('/val/hello'),
+      closer: [],
+      providers: []
+    }
+    const record = new Libp2pRecord(
+      uint8ArrayFromString('/val/hello'),
+      uint8ArrayFromString('world'),
+      new Date()
+    )
+    msg.record = record.serialize()
+    validators.val = async () => { throw new Error('invalid record') }
+
+    await expect(handler.handle(sourcePeer.peerId, msg)).to.eventually.be.rejected
+      .with.property('message', 'invalid record')
+
+    const dsKey = utils.bufferToRecordKey('/dht/record', uint8ArrayFromString('/val/hello'))
+    expect(await datastore.has(dsKey)).to.be.false()
+  })
 })


### PR DESCRIPTION
## Description

The PUT_VALUE handler echoed the request back regardless of whether the record was stored. Per the spec and go-libp2p, the response should only be echoed on successful validation and storage. The handler now throws on failure; `RPC.handleMessage` already catches that to skip the write and increment the error metric.

## Change checklist

- [x] I have performed a self-review of my own code
- [ ] I have made corresponding changes to the documentation if necessary (this includes comments as well)
- [x] I have added tests that prove my fix is effective or that my feature works