### PR TITLE
fix(kad-dht): reset stream on RPC handler error

### DIFF
--- a/packages/kad-dht/src/rpc/index.ts
+++ b/packages/kad-dht/src/rpc/index.ts
@@ -1,4 +1,4 @@
-import { TimeoutError } from '@libp2p/interface'
+import { InvalidMessageError, TimeoutError } from '@libp2p/interface'
 import { pbStream } from '@libp2p/utils'
 import { Message, MessageType } from '../message/dht.js'
 import { AddProviderHandler } from './handlers/add-provider.ts'
@@ -76,7 +76,7 @@ export class RPC {
 
     if (handler == null) {
       this.log.error(`no handler found for message type: ${msg.type}`)
-      return
+      throw new InvalidMessageError(`No handler found for message type: ${msg.type}`)
     }
 
     try {
@@ -85,10 +85,12 @@ export class RPC {
       })
 
       return await handler.handle(peerId, msg)
-    } catch {
+    } catch (err) {
       this.metrics.errors?.increment({
         [msg.type]: true
       })
+
+      throw err
     }
   }
 
@@ -134,11 +136,13 @@ export class RPC {
             signal
           })
         }
-      } catch (err) {
+      } catch (err: any) {
         errored = true
         stopErrorTimer?.()
 
-        throw err
+        stream.abort(err)
+
+        return
       } finally {
         if (!errored) {
           stopSuccessTimer?.()

--- a/packages/kad-dht/src/rpc/index.ts
+++ b/packages/kad-dht/src/rpc/index.ts
@@ -75,7 +75,6 @@ export class RPC {
     const handler = this.handlers[msg.type]
 
     if (handler == null) {
-      this.log.error(`no handler found for message type: ${msg.type}`)
       throw new InvalidMessageError(`No handler found for message type: ${msg.type}`)
     }
 
@@ -140,6 +139,7 @@ export class RPC {
         errored = true
         stopErrorTimer?.()
 
+        this.log.error('error handling incoming message - %e', err)
         stream.abort(err)
 
         return

--- a/packages/kad-dht/test/rpc/index.spec.ts
+++ b/packages/kad-dht/test/rpc/index.spec.ts
@@ -109,4 +109,27 @@ describe('rpc', () => {
 
     await defer.promise
   })
+
+  it('resets the stream when a handler throws', async function () {
+    this.timeout(5000)
+
+    const [outboundStream, incomingStream] = await streamPair()
+
+    // a PUT_VALUE message with no record makes PutValueHandler.handle throw
+    const msg: Partial<Message> = {
+      type: MessageType.PUT_VALUE,
+      key: uint8ArrayFromString('hello')
+    }
+
+    queueMicrotask(() => {
+      outboundStream.send(lp.encode.single(Message.encode(msg)))
+    })
+
+    await rpc.onIncomingStream(
+      incomingStream,
+      stubInterface<Connection>()
+    )
+
+    expect(incomingStream.status).to.equal('aborted')
+  })
 })


### PR DESCRIPTION
## Description

When an incoming DHT message handler throws, `RPC.handleMessage` swallowed the error and returned no response, leaving the stream open. The requesting peer then waited for a response until its request timed out (~10s) before the stream was torn down.

The stream is now reset as soon as a handler throws. `handleMessage` re-throws handler errors — and throws on an unknown message type — instead of swallowing them, and `onIncomingStream` aborts the stream, so the remote peer sees the failure immediately.

## Notes & open questions

The kad-dht spec doesn't define how a node should respond to a request it can't fulfil — it only specifies echoing the request back on success. This follows go-libp2p, which resets the stream on any handler error. Before this change js-libp2p left the stream open and the requesting peer timed out.

`test/rpc/index.node.ts` is renamed to `index.spec.ts` — the test runner only matches `*.spec.*js`, so as `index.node.ts` neither its existing test nor the new one would run.

## Change checklist

- [x] I have performed a self-review of my own code
- [ ] I have made corresponding changes to the documentation if necessary (this includes comments as well)
- [x] I have added tests that prove my fix is effective or that my feature works