### PR TITLE
fix(echo): avoid unhandled rejection when the connection closes early

### DIFF
--- a/packages/protocol-echo/package.json
+++ b/packages/protocol-echo/package.json
@@ -55,6 +55,7 @@
     "@multiformats/multiaddr": "^13.0.1",
     "aegir": "^47.0.22",
     "it-all": "^3.0.9",
+    "p-wait-for": "^6.0.0",
     "sinon": "^21.0.0",
     "sinon-ts": "^2.0.0"
   },

--- a/packages/protocol-echo/src/echo.ts
+++ b/packages/protocol-echo/src/echo.ts
@@ -118,7 +118,9 @@ export class Echo implements Startable, EchoInterface {
     log('sending %d bytes', buf.byteLength)
     stream.send(buf)
 
-    await stream.close(options)
+    await stream.close(options).catch(err => {
+      output.reject(err)
+    })
 
     return output.promise
   }

--- a/packages/protocol-echo/test/index.spec.ts
+++ b/packages/protocol-echo/test/index.spec.ts
@@ -1,5 +1,5 @@
 import { start, stop } from '@libp2p/interface'
-import { streamPair } from '@libp2p/utils'
+import { streamPair, UnexpectedEOFError } from '@libp2p/utils'
 import { multiaddr } from '@multiformats/multiaddr'
 import { expect } from 'aegir/chai'
 import all from 'it-all'
@@ -9,6 +9,7 @@ import { Uint8ArrayList } from 'uint8arraylist'
 import { Echo } from '../src/echo.js'
 import type { Connection } from '@libp2p/interface'
 import type { ConnectionManager, Registrar } from '@libp2p/interface-internal'
+import type { AbstractStream } from '@libp2p/utils'
 import type { StubbedInstance } from 'sinon-ts'
 
 interface StubbedFetchComponents {
@@ -76,5 +77,36 @@ describe('echo', () => {
     const output = await echo.echo(ma, input)
 
     expect(output.subarray()).to.equalBytes(input)
+  })
+
+  it('rejects with the underread error when the stream closes before the data is echoed back', async () => {
+    const [outgoingStream] = await streamPair()
+    const stream = outgoingStream as AbstractStream
+
+    // stop queued bytes being flushed so the stream's writable end is still
+    // closing when the transport closes - this reproduces a connection dropping
+    // part-way through a transfer
+    stream.sendData = () => ({ sentBytes: 0, canSendMore: false })
+
+    const ma = multiaddr('/ip4/123.123.123.123/tcp/1234')
+    components.connectionManager.openStream.withArgs(ma).resolves(stream)
+
+    const input = Uint8Array.from([0, 1, 2, 3])
+    const echoPromise = echo.echo(ma, input)
+
+    // wait for echo() to send the data and begin closing the stream
+    while (stream.writeStatus !== 'closing') {
+      await new Promise<void>(resolve => { setTimeout(resolve, 1) })
+    }
+
+    // attach the rejection handler before the transport closes
+    const assertion = expect(echoPromise).to.eventually.be.rejectedWith(UnexpectedEOFError)
+
+    // the transport closes before the data is echoed back - this must surface as
+    // an underread rather than throwing the transport-close error and leaving
+    // the result promise unhandled
+    stream.onTransportClosed()
+
+    await assertion
   })
 })

--- a/packages/protocol-echo/test/index.spec.ts
+++ b/packages/protocol-echo/test/index.spec.ts
@@ -3,6 +3,7 @@ import { streamPair, UnexpectedEOFError } from '@libp2p/utils'
 import { multiaddr } from '@multiformats/multiaddr'
 import { expect } from 'aegir/chai'
 import all from 'it-all'
+import pWaitFor from 'p-wait-for'
 import sinon from 'sinon'
 import { stubInterface } from 'sinon-ts'
 import { Uint8ArrayList } from 'uint8arraylist'
@@ -79,34 +80,19 @@ describe('echo', () => {
     expect(output.subarray()).to.equalBytes(input)
   })
 
-  it('rejects with the underread error when the stream closes before the data is echoed back', async () => {
+  it('should handle the stream closing mid-echo', async () => {
     const [outgoingStream] = await streamPair()
     const stream = outgoingStream as AbstractStream
-
-    // stop queued bytes being flushed so the stream's writable end is still
-    // closing when the transport closes - this reproduces a connection dropping
-    // part-way through a transfer
     stream.sendData = () => ({ sentBytes: 0, canSendMore: false })
 
     const ma = multiaddr('/ip4/123.123.123.123/tcp/1234')
     components.connectionManager.openStream.withArgs(ma).resolves(stream)
 
-    const input = Uint8Array.from([0, 1, 2, 3])
-    const echoPromise = echo.echo(ma, input)
+    const echoPromise = echo.echo(ma, Uint8Array.from([0, 1, 2, 3]))
 
-    // wait for echo() to send the data and begin closing the stream
-    while (stream.writeStatus !== 'closing') {
-      await new Promise<void>(resolve => { setTimeout(resolve, 1) })
-    }
-
-    // attach the rejection handler before the transport closes
-    const assertion = expect(echoPromise).to.eventually.be.rejectedWith(UnexpectedEOFError)
-
-    // the transport closes before the data is echoed back - this must surface as
-    // an underread rather than throwing the transport-close error and leaving
-    // the result promise unhandled
+    await pWaitFor(() => stream.writeStatus === 'closing')
     stream.onTransportClosed()
 
-    await assertion
+    await expect(echoPromise).to.eventually.be.rejectedWith(UnexpectedEOFError)
   })
 })


### PR DESCRIPTION
## Description

`echo()` awaits `stream.close()` before returning its result promise. If the connection closes mid-transfer, `close()` rejects and `echo()` throws — leaving the result promise (already rejected with the underread by the `close` listener) unhandled, which crashes the process. This routes the close error onto the result promise instead of throwing it.

## Change checklist

- [x] I have performed a self-review of my own code
- [x] I have made corresponding changes to the documentation if necessary (this includes comments as well)
- [x] I have added tests that prove my fix is effective or that my feature works
