### PR TITLE
refactor(kad-dht): only check dialability for closer peers

### DIFF
--- a/packages/kad-dht/src/query/query-path.ts
+++ b/packages/kad-dht/src/query/query-path.ts
@@ -159,13 +159,6 @@ export async function * queryPath (options: QueryPathOptions): AsyncGenerator<Qu
                   continue
                 }
 
-                if (!(await connectionManager.isDialable(closerPeer.multiaddrs, { // eslint-disable-line max-depth
-                  signal
-                }))) {
-                  log('not querying undialable peer')
-                  continue
-                }
-
                 const closerPeerKadId = await convertPeerId(closerPeer.id, {
                   signal
                 })
@@ -174,6 +167,15 @@ export async function * queryPath (options: QueryPathOptions): AsyncGenerator<Qu
                 // only continue query if closer peer is actually closer
                 if (uint8ArrayXorCompare(closerPeerXor, peerXor) !== -1) { // eslint-disable-line max-depth
                   log('skipping %p as they are not closer to %b than %p', closerPeer.id, key, peer.id)
+                  continue
+                }
+
+                // dialability is the most expensive check so only run it for
+                // peers we would actually query
+                if (!(await connectionManager.isDialable(closerPeer.multiaddrs, { // eslint-disable-line max-depth
+                  signal
+                }))) {
+                  log('not querying undialable peer')
                   continue
                 }
 


### PR DESCRIPTION
## Description

In the iterative query path, `connectionManager.isDialable()` was called for **every** peer returned in a `FIND_NODE` response, *before* checking whether that peer is actually closer to the target than the peer that returned it.

`isDialable()` is the heaviest of the per-peer checks — it resolves the addresses (including DNS lookups for `/dnsaddr`, `/dns4`, `/dns6`), runs them through the connection gater, and filters/sorts them. Many of the returned peers are no closer to the target and are discarded immediately, so this work was being spent on peers we never query.

This reorders the closer-peer handling so the cheap XOR-distance comparison runs first, and `isDialable()` is only evaluated for peers we would actually query. **The set of queried peers is unchanged** — purely a reordering to avoid unnecessary work.

## Notes & open questions

A quick microbenchmark of `isDialable()` on typical peer addresses, so the trade-off isn't oversold:

| address type | cost per call |
| --- | --- |
| `/ip4`, `/ip6` (warm) | ~15 µs |
| DNS-based (warm/cached) | ~475 µs |
| DNS-based (cold) | ~520 ms (one-time network DNS) |

## Change checklist

- [x] I have performed a self-review of my own code
- [x] I have made corresponding changes to the documentation if necessary (this includes comments as well)
- [ ] I have added tests that prove my fix is effective or that my feature works
