### PR TITLE
feat: allow creating nodes synchronously

### DIFF
--- a/packages/connection-encrypter-plaintext/src/index.ts
+++ b/packages/connection-encrypter-plaintext/src/index.ts
@@ -38,11 +38,11 @@ export interface PlaintextComponents {
 
 class Plaintext implements ConnectionEncrypter {
   public protocol: string = PROTOCOL
-  private readonly privateKey: PrivateKey
+  private readonly components: PlaintextComponents
   private readonly log: Logger
 
   constructor (components: PlaintextComponents) {
-    this.privateKey = components.privateKey
+    this.components = components
     this.log = components.logger.forComponent('libp2p:plaintext')
   }
 
@@ -69,7 +69,7 @@ class Plaintext implements ConnectionEncrypter {
 
     log('write pubkey exchange to peer %p', options?.remotePeer)
 
-    const publicKey = this.privateKey.publicKey
+    const publicKey = this.components.privateKey.publicKey
 
     // Encode the public key and write it to the remote peer
     await pb.write({

--- a/packages/integration-tests/test/listening.spec.ts
+++ b/packages/integration-tests/test/listening.spec.ts
@@ -2,7 +2,7 @@ import { FaultTolerance, stop } from '@libp2p/interface'
 import { memory } from '@libp2p/memory'
 import { plaintext } from '@libp2p/plaintext'
 import { expect } from 'aegir/chai'
-import { createLibp2p } from 'libp2p'
+import { createLibp2p, createLibp2pSync } from 'libp2p'
 import type { Libp2p } from '@libp2p/interface'
 
 describe('Listening', () => {
@@ -41,13 +41,12 @@ describe('Listening', () => {
   })
 
   it('fails to start if multiaddr fails to listen', async () => {
-    libp2p = await createLibp2p({
+    libp2p = createLibp2pSync({
       addresses: {
         listen: ['/ip4/127.0.0.1/tcp/0']
       },
       transports: [memory()],
-      connectionEncrypters: [plaintext()],
-      start: false
+      connectionEncrypters: [plaintext()]
     })
 
     await expect(libp2p.start()).to.eventually.be.rejected
@@ -55,7 +54,7 @@ describe('Listening', () => {
   })
 
   it('does not fail to start if provided listen multiaddr are not compatible to configured transports (when supporting dial only mode)', async () => {
-    libp2p = await createLibp2p({
+    libp2p = createLibp2pSync({
       addresses: {
         listen: ['/ip4/127.0.0.1/tcp/0']
       },
@@ -67,15 +66,14 @@ describe('Listening', () => {
       ],
       connectionEncrypters: [
         plaintext()
-      ],
-      start: false
+      ]
     })
 
     await expect(libp2p.start()).to.eventually.be.undefined()
   })
 
   it('does not fail to start if provided listen multiaddr fail to listen on configured transports (when supporting dial only mode)', async () => {
-    libp2p = await createLibp2p({
+    libp2p = createLibp2pSync({
       addresses: {
         listen: ['/ip4/127.0.0.1/tcp/12345/p2p/QmWDn2LY8nannvSWJzruUYoLZ4vV83vfCBwd8DipvdgQc3/p2p-circuit']
       },
@@ -87,8 +85,7 @@ describe('Listening', () => {
       ],
       connectionEncrypters: [
         plaintext()
-      ],
-      start: false
+      ]
     })
 
     await expect(libp2p.start()).to.eventually.be.undefined()

--- a/packages/integration-tests/test/mdns.node.ts
+++ b/packages/integration-tests/test/mdns.node.ts
@@ -1,6 +1,8 @@
 import { randomBytes } from '@libp2p/crypto'
+import { generateKeyPair } from '@libp2p/crypto/keys'
 import { start, stop } from '@libp2p/interface'
 import { mdns } from '@libp2p/mdns'
+import { peerIdFromPrivateKey } from '@libp2p/peer-id'
 import { tcp } from '@libp2p/tcp'
 import { multiaddr } from '@multiformats/multiaddr'
 import { createLibp2p } from 'libp2p'
@@ -31,7 +33,7 @@ describe('mdns', () => {
     // use a random tag to prevent CI collision
     const serviceTag = `libp2p-test-${uint8ArrayToString(randomBytes(4), 'base16')}.local`
 
-    const getConfig = (): Libp2pOptions => ({
+    const getConfig = (opts?: Libp2pOptions): Libp2pOptions => ({
       start: false,
       addresses: {
         listen: [
@@ -46,16 +48,25 @@ describe('mdns', () => {
           interval: 200, // discover quickly
           serviceTag
         })
-      ]
+      ],
+      ...opts
     })
 
     libp2p = await createLibp2p(getConfig())
-    const remoteLibp2p1 = await createLibp2p(getConfig())
-    const remoteLibp2p2 = await createLibp2p(getConfig())
+
+    const remotePeer1 = await generateKeyPair('Ed25519')
+    const remotePeer2 = await generateKeyPair('Ed25519')
+
+    const remoteLibp2p1 = await createLibp2p(getConfig({
+      privateKey: remotePeer1
+    }))
+    const remoteLibp2p2 = await createLibp2p(getConfig({
+      privateKey: remotePeer2
+    }))
 
     const expectedPeers = new Set([
-      remoteLibp2p1.peerId.toString(),
-      remoteLibp2p2.peerId.toString()
+      peerIdFromPrivateKey(remotePeer1).toString(),
+      peerIdFromPrivateKey(remotePeer2).toString()
     ])
 
     libp2p.addEventListener('peer:discovery', (evt) => {

--- a/packages/kad-dht/src/query-self.ts
+++ b/packages/kad-dht/src/query-self.ts
@@ -34,9 +34,8 @@ export interface QuerySelfComponents {
  */
 export class QuerySelf implements Startable {
   private readonly log: Logger
-  private readonly peerId: PeerId
+  private readonly components: QuerySelfComponents
   private readonly peerRouting: PeerRouting
-  private readonly events: EventTarget
   private readonly count: number
   private readonly interval: number
   private readonly initialInterval: number
@@ -48,9 +47,8 @@ export class QuerySelf implements Startable {
   private querySelfPromise?: DeferredPromise<void>
 
   constructor (components: QuerySelfComponents, init: QuerySelfInit) {
-    this.peerId = components.peerId
     this.log = components.logger.forComponent(`${init.logPrefix}:query-self`)
-    this.events = components.events
+    this.components = components
     this.running = false
     this.peerRouting = init.peerRouting
     this.count = init.count ?? K
@@ -125,7 +123,7 @@ export class QuerySelf implements Startable {
         const start = Date.now()
 
         const peers = await pipe(
-          this.peerRouting.getClosestPeers(this.peerId.toMultihash().bytes, {
+          this.peerRouting.getClosestPeers(this.components.peerId.toMultihash().bytes, {
             signal,
             isSelfQuery: true
           }),
@@ -139,7 +137,7 @@ export class QuerySelf implements Startable {
 
         this.log('self-query found %d peers in %dms', peers, duration)
 
-        this.events.dispatchEvent(new CustomEvent('kad-dht:query:self', {
+        this.components.events.dispatchEvent(new CustomEvent('kad-dht:query:self', {
           detail: {
             peers,
             duration

--- a/packages/kad-dht/src/query/manager.ts
+++ b/packages/kad-dht/src/query/manager.ts
@@ -51,8 +51,7 @@ export class QueryManager implements Startable {
   private shutDownController: AbortController
   private running: boolean
   private readonly logger: ComponentLogger
-  private readonly peerId: PeerId
-  private readonly connectionManager: ConnectionManager
+  private readonly components: QueryManagerComponents
   private readonly routingTable: RoutingTable
   private initialQuerySelfHasRun?: DeferredPromise<void>
   private readonly logPrefix: string
@@ -65,8 +64,7 @@ export class QueryManager implements Startable {
     this.initialQuerySelfHasRun = init.initialQuerySelfHasRun
     this.routingTable = init.routingTable
     this.logger = components.logger
-    this.peerId = components.peerId
-    this.connectionManager = components.connectionManager
+    this.components = components
     this.allowQueryWithZeroPeers = init.allowQueryWithZeroPeers ?? false
 
     // allow us to stop queries on shut down
@@ -149,7 +147,7 @@ export class QueryManager implements Startable {
         // wait to discover at least one DHT peer that isn't us
         await pEvent(this.routingTable, 'peer:add', {
           signal,
-          filter: (event) => !this.peerId.equals(event.detail)
+          filter: (event) => !this.components.peerId.equals(event.detail)
         })
         log('routing table has peers, continuing with%s query', options.isSelfQuery === true ? ' self' : '')
       }
@@ -200,7 +198,7 @@ export class QueryManager implements Startable {
           ...options,
           key,
           startingPeers: peer,
-          ourPeerId: this.peerId,
+          ourPeerId: this.components.peerId,
           signal,
           query: queryFunc,
           path: index,
@@ -209,7 +207,7 @@ export class QueryManager implements Startable {
           log,
           peersSeen,
           onProgress: options.onProgress,
-          connectionManager: this.connectionManager
+          connectionManager: this.components.connectionManager
         })
       })
 

--- a/packages/kad-dht/src/reprovider.ts
+++ b/packages/kad-dht/src/reprovider.ts
@@ -46,7 +46,6 @@ export class Reprovider extends TypedEventEmitter<ReprovideEvents> {
   private readonly log: Logger
   private readonly reprovideQueue: Queue<void, QueueJobOptions>
   private readonly maxQueueSize: number
-  private readonly datastore: Datastore
   private timeout?: ReturnType<typeof setTimeout>
   private readonly reprovideTimeout: AdaptiveTimeout
   private running: boolean
@@ -54,16 +53,15 @@ export class Reprovider extends TypedEventEmitter<ReprovideEvents> {
   private readonly reprovideThreshold: number
   private readonly contentRouting: ContentRouting
   private readonly datastorePrefix: string
-  private readonly addressManager: AddressManager
   private readonly validity: number
   private readonly interval: number
-  private readonly peerId: PeerId
+  private readonly components: ReproviderComponents
 
   constructor (components: ReproviderComponents, init: ReproviderInit) {
     super()
 
     this.log = components.logger.forComponent(`${init.logPrefix}:reprovider`)
-    this.peerId = components.peerId
+    this.components = components
     this.reprovideQueue = new Queue({
       concurrency: init.concurrency ?? REPROVIDE_CONCURRENCY,
       metrics: components.metrics,
@@ -74,8 +72,6 @@ export class Reprovider extends TypedEventEmitter<ReprovideEvents> {
       metrics: components.metrics,
       metricName: `${init.metricsPrefix}_reprovide_timeout_milliseconds`
     })
-    this.datastore = components.datastore
-    this.addressManager = components.addressManager
     this.datastorePrefix = `${init.datastorePrefix}/provider`
     this.reprovideThreshold = init.threshold ?? REPROVIDE_THRESHOLD
     this.maxQueueSize = init.maxQueueSize ?? REPROVIDE_MAX_QUEUE_SIZE
@@ -122,7 +118,7 @@ export class Reprovider extends TypedEventEmitter<ReprovideEvents> {
       this.safeDispatchEvent('reprovide:start')
       this.log('starting reprovide/cleanup')
       // Get all provider entries from the datastore
-      for await (const entry of this.datastore.query({
+      for await (const entry of this.components.datastore.query({
         prefix: this.datastorePrefix
       }, options)) {
         try {
@@ -132,14 +128,14 @@ export class Reprovider extends TypedEventEmitter<ReprovideEvents> {
           const expires = created + this.validity
           const now = Date.now()
           const expired = now > expires
-          const isSelf = this.peerId.equals(peerId)
+          const isSelf = this.components.peerId.equals(peerId)
 
           this.log.trace('comparing: %d (now) < %d (expires) = %s %s', now, expires, expired, expired ? '(expired)' : '(valid)')
 
           // delete the record if it has expired and isn't us
           // so that if user node is down for a while, we still persist provide intent
           if (expired && !isSelf) {
-            await this.datastore.delete(entry.key, options)
+            await this.components.datastore.delete(entry.key, options)
           }
 
           // if the provider is us and we are within the reprovide threshold,
@@ -239,6 +235,6 @@ export class Reprovider extends TypedEventEmitter<ReprovideEvents> {
 
   private async reprovide (cid: CID, options?: AbortOptions): Promise<void> {
     // reprovide
-    await drain(this.contentRouting.provide(cid, this.addressManager.getAddresses(), options))
+    await drain(this.contentRouting.provide(cid, this.components.addressManager.getAddresses(), options))
   }
 }

--- a/packages/kad-dht/src/routing-table/k-bucket.ts
+++ b/packages/kad-dht/src/routing-table/k-bucket.ts
@@ -140,7 +140,7 @@ export interface GetClosestPeersOptions extends AbortOptions {
  * configurable prefix length, bucket split threshold and size.
  */
 export class KBucket {
-  private readonly peerId: PeerId
+  private readonly components: KBucketComponents
   public root: Bucket
   public localPeer?: Peer
   private readonly prefixLength: number
@@ -156,7 +156,7 @@ export class KBucket {
   private readonly addingPeerMap: PeerMap<Promise<void>>
 
   constructor (components: KBucketComponents, options: KBucketOptions) {
-    this.peerId = components.peerId
+    this.components = components
     this.prefixLength = options.prefixLength ?? PREFIX_LENGTH
     this.kBucketSize = options.kBucketSize ?? KBUCKET_SIZE
     this.splitThreshold = options.splitThreshold ?? this.kBucketSize
@@ -179,7 +179,7 @@ export class KBucket {
   }
 
   async start (): Promise<void> {
-    await this.addSelfPeer(this.peerId)
+    await this.addSelfPeer(this.components.peerId)
   }
 
   stop (): void {

--- a/packages/kad-dht/src/rpc/handlers/add-provider.ts
+++ b/packages/kad-dht/src/rpc/handlers/add-provider.ts
@@ -20,16 +20,14 @@ export interface AddProviderHandlerInit {
 }
 
 export class AddProviderHandler implements DHTMessageHandler {
-  private readonly peerId: PeerId
+  private readonly components: AddProviderComponents
   private readonly providers: Providers
-  private readonly peerStore: PeerStore
   private readonly log: Logger
 
   constructor (components: AddProviderComponents, init: AddProviderHandlerInit) {
     this.log = components.logger.forComponent(`${init.logPrefix}:rpc:handlers:add-provider`)
-    this.peerId = components.peerId
+    this.components = components
     this.providers = init.providers
-    this.peerStore = components.peerStore
   }
 
   async handle (peerId: PeerId, msg: Message): Promise<Message | undefined> {
@@ -49,7 +47,7 @@ export class AddProviderHandler implements DHTMessageHandler {
       this.log.error('no providers found in message')
     }
 
-    this.log('%p asked us, %p to store provider record for for %c', peerId, this.peerId, cid)
+    this.log('%p asked us, %p to store provider record for for %c', peerId, this.components.peerId, cid)
 
     await Promise.all(
       msg.providers.map(async (pi) => {
@@ -71,7 +69,7 @@ export class AddProviderHandler implements DHTMessageHandler {
         this.log.trace('received provider %p for %s (addrs %s)', peerId, cid, providerMultiaddrs)
 
         await this.providers.addProvider(cid, providerId)
-        await this.peerStore.merge(providerId, {
+        await this.components.peerStore.merge(providerId, {
           multiaddrs: providerMultiaddrs
         })
       })

--- a/packages/kad-dht/src/rpc/handlers/find-node.ts
+++ b/packages/kad-dht/src/rpc/handlers/find-node.ts
@@ -24,16 +24,14 @@ export interface FindNodeHandlerComponents {
 export class FindNodeHandler implements DHTMessageHandler {
   private readonly peerRouting: PeerRouting
   private readonly peerInfoMapper: PeerInfoMapper
-  private readonly peerId: PeerId
-  private readonly addressManager: AddressManager
+  private readonly components: FindNodeHandlerComponents
   private readonly log: Logger
 
   constructor (components: FindNodeHandlerComponents, init: FindNodeHandlerInit) {
     const { peerRouting, logPrefix } = init
 
     this.log = components.logger.forComponent(`${logPrefix}:rpc:handlers:find-node`)
-    this.peerId = components.peerId
-    this.addressManager = components.addressManager
+    this.components = components
     this.peerRouting = peerRouting
     this.peerInfoMapper = init.peerInfoMapper
   }
@@ -54,14 +52,14 @@ export class FindNodeHandler implements DHTMessageHandler {
           peerId,
 
           // do not include the server in the results
-          this.peerId
+          this.components.peerId
         ]
       })
 
-      if (uint8ArrayEquals(this.peerId.toMultihash().bytes, msg.key)) {
+      if (uint8ArrayEquals(this.components.peerId.toMultihash().bytes, msg.key)) {
         closer.push({
-          id: this.peerId,
-          multiaddrs: this.addressManager.getAddresses().map(ma => ma.decapsulateCode(CODE_P2P))
+          id: this.components.peerId,
+          multiaddrs: this.components.addressManager.getAddresses().map(ma => ma.decapsulateCode(CODE_P2P))
         })
       }
 

--- a/packages/kad-dht/src/rpc/handlers/get-providers.ts
+++ b/packages/kad-dht/src/rpc/handlers/get-providers.ts
@@ -25,10 +25,9 @@ export interface GetProvidersHandlerComponents {
 }
 
 export class GetProvidersHandler implements DHTMessageHandler {
-  private readonly peerId: PeerId
   private readonly peerRouting: PeerRouting
   private readonly providers: Providers
-  private readonly peerStore: PeerStore
+  private readonly components: GetProvidersHandlerComponents
   private readonly peerInfoMapper: PeerInfoMapper
   private readonly log: Logger
 
@@ -36,8 +35,7 @@ export class GetProvidersHandler implements DHTMessageHandler {
     const { peerRouting, providers, logPrefix } = init
 
     this.log = components.logger.forComponent(`${logPrefix}:rpc:handlers:get-providers`)
-    this.peerId = components.peerId
-    this.peerStore = components.peerStore
+    this.components = components
     this.peerRouting = peerRouting
     this.providers = providers
     this.peerInfoMapper = init.peerInfoMapper
@@ -59,7 +57,7 @@ export class GetProvidersHandler implements DHTMessageHandler {
 
     const [providerPeers, closerPeers] = await Promise.all([
       all(map(await this.providers.getProviders(cid), async (peerId) => {
-        const peer = await this.peerStore.get(peerId)
+        const peer = await this.components.peerStore.get(peerId)
         const info: PeerInfo = {
           id: peer.id,
           multiaddrs: peer.addresses.map(({ multiaddr }) => multiaddr)

--- a/packages/kad-dht/src/rpc/handlers/get-value.ts
+++ b/packages/kad-dht/src/rpc/handlers/get-value.ts
@@ -25,8 +25,7 @@ export interface GetValueHandlerComponents {
 }
 
 export class GetValueHandler implements DHTMessageHandler {
-  private readonly peerStore: PeerStore
-  private readonly datastore: Datastore
+  private readonly components: GetValueHandlerComponents
   private readonly peerRouting: PeerRouting
   private readonly log: Logger
   private readonly datastorePrefix: string
@@ -34,8 +33,7 @@ export class GetValueHandler implements DHTMessageHandler {
   constructor (components: GetValueHandlerComponents, init: GetValueHandlerInit) {
     this.log = components.logger.forComponent(`${init.logPrefix}:rpc:handlers:get-value`)
     this.datastorePrefix = `${init.datastorePrefix}/record`
-    this.peerStore = components.peerStore
-    this.datastore = components.datastore
+    this.components = components
     this.peerRouting = init.peerRouting
   }
 
@@ -62,7 +60,7 @@ export class GetValueHandler implements DHTMessageHandler {
       let pubKey: Uint8Array | undefined
 
       try {
-        const peer = await this.peerStore.get(idFromKey)
+        const peer = await this.components.peerStore.get(idFromKey)
 
         if (peer.id.publicKey == null) {
           throw new NotFoundError('No public key found in key book')
@@ -116,7 +114,7 @@ export class GetValueHandler implements DHTMessageHandler {
     // Fetch value from ds
     let rawRecord
     try {
-      rawRecord = await this.datastore.get(dsKey)
+      rawRecord = await this.components.datastore.get(dsKey)
     } catch (err: any) {
       if (err.name === 'NotFoundError') {
         return undefined
@@ -131,7 +129,7 @@ export class GetValueHandler implements DHTMessageHandler {
     if (record.timeReceived == null ||
       Date.now() - record.timeReceived.getTime() > PROVIDERS_VALIDITY) {
       // If record is bad delete it and return
-      await this.datastore.delete(dsKey)
+      await this.components.datastore.delete(dsKey)
       return undefined
     }
 

--- a/packages/libp2p/src/config.ts
+++ b/packages/libp2p/src/config.ts
@@ -2,7 +2,7 @@ import { InvalidParametersError } from '@libp2p/interface'
 import type { Libp2pInit } from './index.ts'
 import type { ServiceMap } from '@libp2p/interface'
 
-export async function validateConfig <T extends ServiceMap = Record<string, unknown>> (opts: Libp2pInit<T>): Promise<Libp2pInit<T>> {
+export function validateConfig <T extends ServiceMap = Record<string, unknown>> (opts: Libp2pInit<T>): Libp2pInit<T> {
   if (opts.connectionProtector === null && globalThis.process?.env?.LIBP2P_FORCE_PNET != null) {
     throw new InvalidParametersError('Private network is enforced, but no protector was provided')
   }

--- a/packages/libp2p/src/connection-manager/index.ts
+++ b/packages/libp2p/src/connection-manager/index.ts
@@ -213,11 +213,9 @@ export class DefaultConnectionManager implements ConnectionManager, Startable {
   public readonly reconnectQueue: ReconnectQueue
   public readonly connectionPruner: ConnectionPruner
   private readonly inboundConnectionRateLimiter: RateLimiter
-  private readonly peerStore: PeerStore
   private readonly metrics?: Metrics
-  private readonly events: TypedEventTarget<Libp2pEvents>
   private readonly log: Logger
-  private readonly peerId: PeerId
+  private readonly components: DefaultConnectionManagerComponents
 
   constructor (components: DefaultConnectionManagerComponents, init: ConnectionManagerInit = {}) {
     this.maxConnections = init.maxConnections ?? defaultOptions.maxConnections
@@ -232,11 +230,9 @@ export class DefaultConnectionManager implements ConnectionManager, Startable {
     this.connections = new PeerMap()
 
     this.started = false
-    this.peerId = components.peerId
-    this.peerStore = components.peerStore
-    this.metrics = components.metrics
-    this.events = components.events
     this.log = components.logger.forComponent('libp2p:connection-manager')
+    this.components = components
+    this.metrics = components.metrics
 
     this.onConnect = this.onConnect.bind(this)
     this.onDisconnect = this.onDisconnect.bind(this)
@@ -374,8 +370,8 @@ export class DefaultConnectionManager implements ConnectionManager, Startable {
       }
     })
 
-    this.events.addEventListener('connection:open', this.onConnect)
-    this.events.addEventListener('connection:close', this.onDisconnect)
+    this.components.events.addEventListener('connection:open', this.onConnect)
+    this.components.events.addEventListener('connection:close', this.onDisconnect)
 
     await start(
       this.dialQueue,
@@ -391,8 +387,8 @@ export class DefaultConnectionManager implements ConnectionManager, Startable {
    * Stops the Connection Manager
    */
   async stop (): Promise<void> {
-    this.events.removeEventListener('connection:open', this.onConnect)
-    this.events.removeEventListener('connection:close', this.onDisconnect)
+    this.components.events.removeEventListener('connection:open', this.onConnect)
+    this.components.events.removeEventListener('connection:close', this.onDisconnect)
 
     await stop(
       this.reconnectQueue,
@@ -482,13 +478,13 @@ export class DefaultConnectionManager implements ConnectionManager, Startable {
 
     // only need to store RSA public keys, all other types are embedded in the peer id
     if (peerId.publicKey != null && peerId.type === 'RSA') {
-      await this.peerStore.patch(peerId, {
+      await this.components.peerStore.patch(peerId, {
         publicKey: peerId.publicKey
       })
     }
 
     if (isNewPeer) {
-      this.events.safeDispatchEvent('peer:connect', { detail: connection.remotePeer })
+      this.components.events.safeDispatchEvent('peer:connect', { detail: connection.remotePeer })
     }
   }
 
@@ -512,7 +508,7 @@ export class DefaultConnectionManager implements ConnectionManager, Startable {
       this.connections.delete(peerId)
 
       // broadcast disconnect event
-      this.events.safeDispatchEvent('peer:disconnect', { detail: peerId })
+      this.components.events.safeDispatchEvent('peer:disconnect', { detail: peerId })
     }
   }
 
@@ -547,7 +543,7 @@ export class DefaultConnectionManager implements ConnectionManager, Startable {
 
       const { peerId, multiaddrs } = getPeerAddress(peerIdOrMultiaddr)
 
-      if (this.peerId.equals(peerId)) {
+      if (this.components.peerId.equals(peerId)) {
         throw new InvalidPeerIdError('Can not dial self')
       }
 

--- a/packages/libp2p/src/index.ts
+++ b/packages/libp2p/src/index.ts
@@ -14,8 +14,6 @@
  * ```
  */
 
-import { generateKeyPair } from '@libp2p/crypto/keys'
-import { peerIdFromPrivateKey } from '@libp2p/peer-id'
 import { validateConfig } from './config.ts'
 import { Libp2p as Libp2pClass } from './libp2p.ts'
 import type { AddressManagerInit, AddressFilter } from './address-manager/index.ts'
@@ -199,11 +197,8 @@ export type Libp2pOptions<T extends ServiceMap = ServiceMap> = Libp2pInit<T> & {
  * ```
  */
 export async function createLibp2p <T extends ServiceMap = ServiceMap> (options: Libp2pOptions<T> = {}): Promise<Libp2p<T>> {
-  options.privateKey ??= await generateKeyPair('Ed25519')
-
   const node = new Libp2pClass({
-    ...await validateConfig(options),
-    peerId: peerIdFromPrivateKey(options.privateKey)
+    ...validateConfig(options)
   })
 
   if (options.start !== false) {
@@ -211,6 +206,39 @@ export async function createLibp2p <T extends ServiceMap = ServiceMap> (options:
   }
 
   return node
+}
+
+/**
+ * If you wish more control over the lifecycle of the node, use this function
+ * to synchronously return a `Libp2p` instance.
+ *
+ * All async work will then be deferred until the `.start()` method is invoked.
+ *
+ * This is the same as passing `{ start: false }` to `createLibp2p()` except the
+ * returned libp2p node is not wrapped in a promise.
+ *
+ * Note that if no private key is passed to `createLibp2p`, the peer id of the
+ * node will not be available until the node is started.
+ *
+ * @example
+ *
+ * ```TypeScript
+ * import { createLibp2pSync } from 'libp2p'
+ *
+ * // create libp2p
+ * const libp2p = createLibp2pSync({
+ *   start: false,
+ *   // ...other options
+ * })
+ *
+ * // some time later
+ * await libp2p.start()
+ * ```
+ */
+export function createLibp2pSync <T extends ServiceMap = ServiceMap> (options: Libp2pOptions<T> = {}): Libp2p<T> {
+  return new Libp2pClass({
+    ...validateConfig(options)
+  })
 }
 
 // a non-exhaustive list of methods found on the libp2p object

--- a/packages/libp2p/src/libp2p.ts
+++ b/packages/libp2p/src/libp2p.ts
@@ -1,8 +1,8 @@
-import { publicKeyFromProtobuf } from '@libp2p/crypto/keys'
-import { contentRoutingSymbol, peerDiscoverySymbol, peerRoutingSymbol, InvalidParametersError } from '@libp2p/interface'
+import { generateKeyPair, publicKeyFromProtobuf } from '@libp2p/crypto/keys'
+import { contentRoutingSymbol, peerDiscoverySymbol, peerRoutingSymbol, InvalidParametersError, NotStartedError } from '@libp2p/interface'
 import { defaultLogger } from '@libp2p/logger'
 import { PeerSet } from '@libp2p/peer-collections'
-import { peerIdFromString } from '@libp2p/peer-id'
+import { peerIdFromPrivateKey, peerIdFromString } from '@libp2p/peer-id'
 import { persistentPeerStore } from '@libp2p/peer-store'
 import { CODE_P2P, isMultiaddr } from '@multiformats/multiaddr'
 import { MemoryDatastore } from 'datastore-core/memory'
@@ -28,7 +28,6 @@ import type { PeerRouting, ContentRouting, Libp2pEvents, PendingDial, ServiceMap
 import type { Multiaddr } from '@multiformats/multiaddr'
 
 export class Libp2p<T extends ServiceMap = ServiceMap> extends TypedEventEmitter<Libp2pEvents> implements Libp2pInterface<T> {
-  public peerId: PeerId
   public peerStore: PeerStore
   public contentRouting: ContentRouting
   public peerRouting: PeerRouting
@@ -39,9 +38,10 @@ export class Libp2p<T extends ServiceMap = ServiceMap> extends TypedEventEmitter
 
   public components: Components & T
   private readonly log: Logger
+  private _peerId?: PeerId
 
   // eslint-disable-next-line complexity
-  constructor (init: Libp2pInit<T> & { peerId: PeerId }) {
+  constructor (init: Libp2pInit<T>) {
     super()
 
     this.status = 'stopped'
@@ -62,7 +62,6 @@ export class Libp2p<T extends ServiceMap = ServiceMap> extends TypedEventEmitter
     // This emitter gets listened to a lot
     setMaxListeners(Infinity, events)
 
-    this.peerId = init.peerId
     this.logger = init.logger ?? defaultLogger()
     this.log = this.logger.forComponent('libp2p')
     // @ts-expect-error {} may not be of type T
@@ -73,7 +72,6 @@ export class Libp2p<T extends ServiceMap = ServiceMap> extends TypedEventEmitter
 
     // @ts-expect-error defaultComponents is missing component types added later
     const components = this.components = defaultComponents({
-      peerId: init.peerId,
       privateKey: init.privateKey,
       nodeInfo: {
         name: nodeInfoName,
@@ -86,6 +84,11 @@ export class Libp2p<T extends ServiceMap = ServiceMap> extends TypedEventEmitter
       connectionGater: connectionGater(init.connectionGater),
       dns: init.dns
     })
+
+    // can make the peer id available immediately if a private key was supplied
+    if (init.privateKey != null) {
+      this.components.components.peerId = this._peerId = peerIdFromPrivateKey(init.privateKey)
+    }
 
     // Create Metrics
     if (init.metrics != null) {
@@ -207,6 +210,14 @@ export class Libp2p<T extends ServiceMap = ServiceMap> extends TypedEventEmitter
     checkServiceDependencies(components)
   }
 
+  get peerId (): PeerId {
+    if (this._peerId == null) {
+      throw new NotStartedError()
+    }
+
+    return this._peerId
+  }
+
   private configureComponent <T> (name: string, component: T): T {
     if (component == null) {
       this.log.error('component %s was null or undefined', name)
@@ -229,6 +240,12 @@ export class Libp2p<T extends ServiceMap = ServiceMap> extends TypedEventEmitter
     this.status = 'starting'
 
     this.log('libp2p is starting')
+
+    this.components.components.privateKey = this.components.components.privateKey ?? await generateKeyPair('Ed25519')
+
+    if (this._peerId == null) {
+      this.components.components.peerId = this._peerId = peerIdFromPrivateKey(this.components.privateKey)
+    }
 
     try {
       await this.components.beforeStart?.()

--- a/packages/libp2p/src/peer-routing.ts
+++ b/packages/libp2p/src/peer-routing.ts
@@ -20,14 +20,12 @@ export interface DefaultPeerRoutingComponents {
 
 export class DefaultPeerRouting implements PeerRouting {
   private readonly log: Logger
-  private readonly peerId: PeerId
-  private readonly peerStore: PeerStore
+  private readonly components: DefaultPeerRoutingComponents
   private readonly routers: PeerRouting[]
 
   constructor (components: DefaultPeerRoutingComponents, init: PeerRoutingInit = {}) {
     this.log = components.logger.forComponent('libp2p:peer-routing')
-    this.peerId = components.peerId
-    this.peerStore = components.peerStore
+    this.components = components
     this.routers = init.routers ?? []
 
     this.findPeer = components.metrics?.traceFunction('libp2p.peerRouting.findPeer', this.findPeer.bind(this), {
@@ -66,7 +64,7 @@ export class DefaultPeerRouting implements PeerRouting {
       throw new NoPeerRoutersError('No peer routers available')
     }
 
-    if (id.toString() === this.peerId.toString()) {
+    if (id.toString() === this.components.peerId.toString()) {
       throw new QueriedForSelfError('Should not try to find self')
     }
 
@@ -90,7 +88,7 @@ export class DefaultPeerRouting implements PeerRouting {
 
       // store the addresses for the peer if found
       if (peer.multiaddrs.length > 0) {
-        await this.peerStore.merge(peer.id, {
+        await this.components.peerStore.merge(peer.id, {
           multiaddrs: peer.multiaddrs
         }, options)
       }
@@ -146,7 +144,7 @@ export class DefaultPeerRouting implements PeerRouting {
 
       // store the addresses for the peer if found
       if (peer.multiaddrs.length > 0) {
-        await this.peerStore.merge(peer.id, {
+        await this.components.peerStore.merge(peer.id, {
           multiaddrs: peer.multiaddrs
         }, options)
       }

--- a/packages/libp2p/test/connection-manager/index.spec.ts
+++ b/packages/libp2p/test/connection-manager/index.spec.ts
@@ -75,12 +75,11 @@ describe('Connection Manager', () => {
   })
 
   it('should fail if the connection manager has mismatched connection limit options', async () => {
-    await expect(
-      createLibp2p({
-        connectionManager: {
-          maxConnections: -1
-        }
-      })
+    await expect(createLibp2p({
+      connectionManager: {
+        maxConnections: -1
+      }
+    })
     ).to.eventually.rejected('maxConnections must be greater')
   })
 

--- a/packages/libp2p/test/core/core.spec.ts
+++ b/packages/libp2p/test/core/core.spec.ts
@@ -1,7 +1,8 @@
+import { generateKeyPair } from '@libp2p/crypto/keys'
 import { multiaddr } from '@multiformats/multiaddr'
 import { expect } from 'aegir/chai'
 import { stubInterface } from 'sinon-ts'
-import { createLibp2p, isLibp2p } from '../../src/index.ts'
+import { createLibp2p, createLibp2pSync, isLibp2p } from '../../src/index.ts'
 import type { Libp2p, Transport } from '@libp2p/interface'
 
 describe('core', () => {
@@ -15,6 +16,30 @@ describe('core', () => {
     libp2p = await createLibp2p()
 
     expect(libp2p).to.have.property('status', 'started')
+  })
+
+  it('should synchronously create a node', async () => {
+    libp2p = createLibp2pSync({
+      start: false
+    })
+
+    expect(() => libp2p.peerId).to.throw()
+      .with.property('name', 'NotStartedError')
+
+    await libp2p.start()
+
+    expect(libp2p.peerId).to.be.ok()
+  })
+
+  it('should make a peer id available immediately if a private key is passed', async () => {
+    const privateKey = await generateKeyPair('Ed25519')
+
+    libp2p = createLibp2pSync({
+      privateKey,
+      start: false
+    })
+
+    expect(libp2p.peerId).to.be.ok()
   })
 
   it('should detect the libp2p type', async () => {

--- a/packages/libp2p/test/core/events.spec.ts
+++ b/packages/libp2p/test/core/events.spec.ts
@@ -1,6 +1,6 @@
 import { expect } from 'aegir/chai'
 import { pEvent } from 'p-event'
-import { createLibp2p } from '../../src/index.ts'
+import { createLibp2p, createLibp2pSync } from '../../src/index.ts'
 import type { Libp2p } from '@libp2p/interface'
 
 describe('events', () => {
@@ -13,7 +13,7 @@ describe('events', () => {
   })
 
   it('should emit a start event', async () => {
-    node = await createLibp2p({
+    node = createLibp2pSync({
       start: false
     })
 

--- a/packages/libp2p/test/core/status.spec.ts
+++ b/packages/libp2p/test/core/status.spec.ts
@@ -1,6 +1,6 @@
 import { stop } from '@libp2p/interface'
 import { expect } from 'aegir/chai'
-import { createLibp2p } from '../../src/index.ts'
+import { createLibp2pSync } from '../../src/index.ts'
 import type { Libp2p } from '@libp2p/interface'
 
 describe('status', () => {
@@ -11,9 +11,7 @@ describe('status', () => {
   })
 
   it('should have status', async () => {
-    libp2p = await createLibp2p({
-      start: false
-    })
+    libp2p = createLibp2pSync()
 
     expect(libp2p).to.have.property('status', 'stopped')
 

--- a/packages/peer-store/src/index.ts
+++ b/packages/peer-store/src/index.ts
@@ -63,14 +63,12 @@ export interface PersistentPeerStoreInit {
  */
 class PersistentPeerStore implements PeerStore {
   private readonly store: PersistentStore
-  private readonly events: TypedEventTarget<Libp2pEvents>
-  private readonly peerId: PeerId
   private readonly log: Logger
+  private readonly components: PersistentPeerStoreComponents
 
   constructor (components: PersistentPeerStoreComponents, init: PersistentPeerStoreInit = {}) {
     this.log = components.logger.forComponent('libp2p:peer-store')
-    this.events = components.events
-    this.peerId = components.peerId
+    this.components = components
     this.store = new PersistentStore(components, init)
   }
 
@@ -220,10 +218,10 @@ class PersistentPeerStore implements PeerStore {
       return
     }
 
-    if (this.peerId.equals(id)) {
-      this.events.safeDispatchEvent('self:peer:update', { detail: result })
+    if (this.components.peerId.equals(id)) {
+      this.components.events.safeDispatchEvent('self:peer:update', { detail: result })
     } else {
-      this.events.safeDispatchEvent('peer:update', { detail: result })
+      this.components.events.safeDispatchEvent('peer:update', { detail: result })
     }
   }
 }

--- a/packages/peer-store/src/store.ts
+++ b/packages/peer-store/src/store.ts
@@ -12,7 +12,7 @@ import { NAMESPACE_COMMON, peerIdToDatastoreKey } from './utils/peer-id-to-datas
 import { toPeerPB } from './utils/to-peer-pb.ts'
 import type { AddressFilter, PersistentPeerStoreComponents, PersistentPeerStoreInit } from './index.ts'
 import type { PeerUpdate as PeerUpdateExternal, PeerId, Peer, PeerData, PeerQuery, Logger, AbortOptions } from '@libp2p/interface'
-import type { Datastore, Key, Query } from 'interface-datastore'
+import type { Key, Query } from 'interface-datastore'
 import type { Mortice, Release } from 'mortice'
 
 /**
@@ -59,8 +59,7 @@ export interface Lock {
 }
 
 export class PersistentStore {
-  private readonly peerId: PeerId
-  private readonly datastore: Datastore
+  private readonly components: PersistentPeerStoreComponents
   private locks: PeerMap<Lock>
   private readonly addressFilter?: AddressFilter
   private readonly log: Logger
@@ -69,8 +68,7 @@ export class PersistentStore {
 
   constructor (components: PersistentPeerStoreComponents, init: PersistentPeerStoreInit = {}) {
     this.log = components.logger.forComponent('libp2p:peer-store')
-    this.peerId = components.peerId
-    this.datastore = components.datastore
+    this.components = components
     this.addressFilter = init.addressFilter
     this.locks = trackedPeerMap({
       name: 'libp2p_peer_store_locks',
@@ -158,24 +156,24 @@ export class PersistentStore {
   }
 
   async delete (peerId: PeerId, options?: AbortOptions): Promise<void> {
-    if (this.peerId.equals(peerId)) {
+    if (this.components.peerId.equals(peerId)) {
       return
     }
 
-    await this.datastore.delete(peerIdToDatastoreKey(peerId), options)
+    await this.components.datastore.delete(peerIdToDatastoreKey(peerId), options)
   }
 
   async load (peerId: PeerId, options?: AbortOptions): Promise<Peer> {
     const key = peerIdToDatastoreKey(peerId)
-    const buf = await this.datastore.get(key, options)
+    const buf = await this.components.datastore.get(key, options)
     const peer = PeerPB.decode(buf)
 
     if (this.#peerIsExpired(peerId, peer)) {
-      await this.datastore.delete(key, options)
+      await this.components.datastore.delete(key, options)
       throw new NotFoundError()
     }
 
-    return pbToPeer(peerId, peer, this.peerId.equals(peerId) ? Infinity : this.maxAddressAge)
+    return pbToPeer(peerId, peer, this.components.peerId.equals(peerId) ? Infinity : this.maxAddressAge)
   }
 
   async save (peerId: PeerId, data: PeerData, options?: AbortOptions): Promise<PeerUpdate> {
@@ -213,11 +211,11 @@ export class PersistentStore {
   }
 
   async * all (options?: PeerQuery): AsyncGenerator<Peer, void, unknown> {
-    for await (const { key, value } of this.datastore.query(mapQuery(options ?? {}, this.maxAddressAge), options)) {
+    for await (const { key, value } of this.components.datastore.query(mapQuery(options ?? {}, this.maxAddressAge), options)) {
       const peerId = keyToPeerId(key)
 
       // skip self peer if present
-      if (peerId.equals(this.peerId)) {
+      if (peerId.equals(this.components.peerId)) {
         continue
       }
 
@@ -225,23 +223,23 @@ export class PersistentStore {
 
       // remove expired peer
       if (this.#peerIsExpired(peerId, peer)) {
-        await this.datastore.delete(key, options)
+        await this.components.datastore.delete(key, options)
         continue
       }
 
-      yield pbToPeer(peerId, peer, this.peerId.equals(peerId) ? Infinity : this.maxAddressAge)
+      yield pbToPeer(peerId, peer, this.components.peerId.equals(peerId) ? Infinity : this.maxAddressAge)
     }
   }
 
   async #findExistingPeer (peerId: PeerId, options?: AbortOptions): Promise<ExistingPeer | undefined> {
     try {
       const key = peerIdToDatastoreKey(peerId)
-      const buf = await this.datastore.get(key, options)
+      const buf = await this.components.datastore.get(key, options)
       const peerPB = PeerPB.decode(buf)
 
       // remove expired peer
       if (this.#peerIsExpired(peerId, peerPB)) {
-        await this.datastore.delete(key, options)
+        await this.components.datastore.delete(key, options)
         throw new NotFoundError()
       }
 
@@ -261,7 +259,7 @@ export class PersistentStore {
     peer.updated = Date.now()
     const buf = PeerPB.encode(peer)
 
-    await this.datastore.put(peerIdToDatastoreKey(peerId), buf, options)
+    await this.components.datastore.put(peerIdToDatastoreKey(peerId), buf, options)
 
     return {
       peer: pbToPeer(peerId, peer, this.maxAddressAge),
@@ -275,7 +273,7 @@ export class PersistentStore {
       return true
     }
 
-    if (this.peerId.equals(peerId)) {
+    if (this.components.peerId.equals(peerId)) {
       return false
     }
 

--- a/packages/peer-store/test/save.spec.ts
+++ b/packages/peer-store/test/save.spec.ts
@@ -187,7 +187,7 @@ describe('save', () => {
 
   it('should not store a public key if part of peer id', async () => {
     // @ts-expect-error private fields
-    const spy = sinon.spy(peerStore.store.datastore, 'put')
+    const spy = sinon.spy(peerStore.store.components.datastore, 'put')
 
     if (otherPeerId.publicKey == null) {
       throw new Error('Public key was missing')

--- a/packages/transport-circuit-relay-v2/src/transport/reservation-store.ts
+++ b/packages/transport-circuit-relay-v2/src/transport/reservation-store.ts
@@ -11,10 +11,8 @@ import { HopMessage, Status } from '../pb/index.ts'
 import { getExpirationMilliseconds } from '../utils.ts'
 import type { TransportReservationStoreComponents, TransportReservationStoreInit } from '../index.ts'
 import type { Reservation } from '../pb/index.ts'
-import type { AbortOptions, Libp2pEvents, Logger, PeerId, PeerStore, Startable, Peer, Connection } from '@libp2p/interface'
-import type { ConnectionManager } from '@libp2p/interface-internal'
+import type { AbortOptions, Logger, PeerId, Startable, Peer, Connection } from '@libp2p/interface'
 import type { Filter } from '@libp2p/utils'
-import type { TypedEventTarget } from 'main-event'
 
 // allow refreshing a relay reservation if it will expire in the next 10 minutes
 const REFRESH_WINDOW = (60 * 1000) * 10
@@ -69,10 +67,7 @@ export interface ReservationStoreEvents {
 }
 
 export class ReservationStore extends TypedEventEmitter<ReservationStoreEvents> implements Startable {
-  private readonly peerId: PeerId
-  private readonly connectionManager: ConnectionManager
-  private readonly peerStore: PeerStore
-  private readonly events: TypedEventTarget<Libp2pEvents>
+  private readonly components: TransportReservationStoreComponents
   private readonly reserveQueue: PeerQueue<RelayReservation>
   private readonly reservations: PeerMap<RelayEntry>
   private readonly pendingReservations: string[]
@@ -86,10 +81,7 @@ export class ReservationStore extends TypedEventEmitter<ReservationStoreEvents> 
     super()
 
     this.log = components.logger.forComponent('libp2p:circuit-relay:transport:reservation-store')
-    this.peerId = components.peerId
-    this.connectionManager = components.connectionManager
-    this.peerStore = components.peerStore
-    this.events = components.events
+    this.components = components
     this.reservations = new PeerMap()
     this.pendingReservations = []
     this.maxReservationQueueLength = init?.maxReservationQueueLength ?? DEFAULT_MAX_RESERVATION_QUEUE_LENGTH
@@ -107,7 +99,7 @@ export class ReservationStore extends TypedEventEmitter<ReservationStoreEvents> 
     // reservations are only valid while we are still connected to the relay.
     // if we had a reservation opened via that connection, remove it and maybe
     // trigger a search for new relays
-    this.events.addEventListener('connection:close', (evt) => {
+    this.components.events.addEventListener('connection:close', (evt) => {
       const reservation = [...this.reservations.values()]
         .find(reservation => reservation.connection === evt.detail.id)
 
@@ -134,7 +126,7 @@ export class ReservationStore extends TypedEventEmitter<ReservationStoreEvents> 
     // remove old relay tags
     void Promise.resolve()
       .then(async () => {
-        const relayPeers: Peer[] = await this.peerStore.all({
+        const relayPeers: Peer[] = await this.components.peerStore.all({
           filters: [(peer) => {
             return peer.tags.has(KEEP_ALIVE_TAG)
           }]
@@ -145,7 +137,7 @@ export class ReservationStore extends TypedEventEmitter<ReservationStoreEvents> 
         // remove old relay tag and redial
         await Promise.all(
           relayPeers.map(async peer => {
-            await this.peerStore.merge(peer.id, {
+            await this.components.peerStore.merge(peer.id, {
               tags: {
                 [KEEP_ALIVE_TAG]: undefined
               }
@@ -191,7 +183,7 @@ export class ReservationStore extends TypedEventEmitter<ReservationStoreEvents> 
    * to reserve a slot on the remote peer
    */
   async addRelay (peerId: PeerId, type: RelayType): Promise<RelayReservation> {
-    if (this.peerId.equals(peerId)) {
+    if (this.components.peerId.equals(peerId)) {
       this.log.trace('not trying to use self as relay')
       throw new ListenError('Cannot use self as relay')
     }
@@ -221,7 +213,7 @@ export class ReservationStore extends TypedEventEmitter<ReservationStoreEvents> 
         const existingReservation = this.reservations.get(peerId)
 
         if (existingReservation != null) {
-          const connections = this.connectionManager.getConnections(peerId)
+          const connections = this.components.connectionManager.getConnections(peerId)
           let connected = false
 
           if (connections.length === 0) {
@@ -251,7 +243,7 @@ export class ReservationStore extends TypedEventEmitter<ReservationStoreEvents> 
         const signal = AbortSignal.timeout(this.reservationCompletionTimeout)
         setMaxListeners(Infinity, signal)
 
-        const connection = await this.connectionManager.openConnection(peerId, {
+        const connection = await this.components.connectionManager.openConnection(peerId, {
           signal
         })
 
@@ -314,7 +306,7 @@ export class ReservationStore extends TypedEventEmitter<ReservationStoreEvents> 
         this.reservations.set(peerId, res)
 
         // ensure we don't close the connection to the relay
-        await this.peerStore.merge(peerId, {
+        await this.components.peerStore.merge(peerId, {
           tags: {
             [KEEP_ALIVE_TAG]: {
               value: 1,
@@ -473,7 +465,7 @@ export class ReservationStore extends TypedEventEmitter<ReservationStoreEvents> 
     }
 
     // untag the relay
-    await this.peerStore.merge(peerId, {
+    await this.components.peerStore.merge(peerId, {
       tags: {
         [KEEP_ALIVE_TAG]: undefined
       }


### PR DESCRIPTION
Adds a `createLibp2pSync` function that returns the libp2p instance without wrapping it in a promise.

Gives the user full control over the lifecycle of the node, e.g. they must then call `.start()` themselves.

When no private key was supplied to `createLibp2p()` the `.peerId` component was created using async - this has been moved to the `.start()` function, and the `.peerId` accessor will now throw a `NotStartedError` if accessed before it is set.

Monorepo modules that accessed the `.peerId` or `.privateKey` component before the node is started have been updated to not do that.

## Change checklist

- [x] I have performed a self-review of my own code
- [x] I have made corresponding changes to the documentation if necessary (this includes comments as well)
- [x] I have added tests that prove my fix is effective or that my feature works