### PR TITLE
fix(kad-dht): only keep peers that responded in getClosestPeers

### DIFF
--- a/packages/kad-dht/src/peer-routing/index.ts
+++ b/packages/kad-dht/src/peer-routing/index.ts
@@ -263,12 +263,8 @@ export class PeerRouting {
         yield event
       }
 
-      // only add the peer to the closest set if it actually responded - a peer
-      // we could not contact is a dead or stale routing-table entry, and
-      // including it both wastes a PUT_VALUE and lets dead peers fill the
-      // closest-K so the lookup stops before finding live peers slightly
-      // further out
       if (responded) {
+        // add the peer to the list if we've managed to contact it successfully
         peers.addWithKadId(peer, peerKadId, path)
       }
     }

--- a/packages/kad-dht/src/peer-routing/index.ts
+++ b/packages/kad-dht/src/peer-routing/index.ts
@@ -249,14 +249,28 @@ export class PeerRouting {
         key
       }
 
-      yield * self.network.sendRequest(peer.id, request, {
+      let responded = false
+
+      for await (const event of self.network.sendRequest(peer.id, request, {
         ...options,
         signal,
         path
-      })
+      })) {
+        if (event.name === 'PEER_RESPONSE') {
+          responded = true
+        }
 
-      // add the peer to the list if we've managed to contact it successfully
-      peers.addWithKadId(peer, peerKadId, path)
+        yield event
+      }
+
+      // only add the peer to the closest set if it actually responded - a peer
+      // we could not contact is a dead or stale routing-table entry, and
+      // including it both wastes a PUT_VALUE and lets dead peers fill the
+      // closest-K so the lookup stops before finding live peers slightly
+      // further out
+      if (responded) {
+        peers.addWithKadId(peer, peerKadId, path)
+      }
     }
 
     yield * this.queryManager.run(key, getCloserPeersQuery, options)

--- a/packages/kad-dht/test/peer-routing.spec.ts
+++ b/packages/kad-dht/test/peer-routing.spec.ts
@@ -5,14 +5,17 @@ import { multiaddr } from '@multiformats/multiaddr'
 import { expect } from 'aegir/chai'
 import { stubInterface } from 'sinon-ts'
 import { K } from '../src/constants.ts'
+import { MessageType } from '../src/message/dht.ts'
 import { PeerRouting } from '../src/peer-routing/index.ts'
-import { convertBuffer } from '../src/utils.ts'
+import { peerResponseEvent, queryErrorEvent } from '../src/query/events.ts'
+import { convertBuffer, convertPeerId } from '../src/utils.ts'
 import { createPeerIdsWithPrivateKey } from './utils/create-peer-id.ts'
 import { sortClosestPeers } from './utils/sort-closest-peers.ts'
 import type { PeerAndKey } from './utils/create-peer-id.ts'
-import type { Validators } from '../src/index.ts'
+import type { QueryEvent, Validators } from '../src/index.ts'
 import type { Network } from '../src/network.ts'
 import type { QueryManager } from '../src/query/manager.ts'
+import type { QueryFunc } from '../src/query/types.ts'
 import type { RoutingTable } from '../src/routing-table/index.ts'
 import type { Peer, ComponentLogger, PeerId, PeerStore } from '@libp2p/interface'
 import type { ConnectionManager } from '@libp2p/interface-internal'
@@ -133,6 +136,50 @@ describe('peer-routing', () => {
       expect(closer).to.have.lengthOf(2)
       expect(closer[0].id).to.equal(clientPeer.id)
       expect(closer[1].id).to.equal(serverPeer.id)
+    })
+  })
+
+  describe('getClosestPeers', () => {
+    it('only adds peers to the closest set if they responded to the query', async () => {
+      const key = Uint8Array.from([0, 1, 2, 3, 4])
+      const [livePeer, deadPeer] = await getSortedPeers(key, 2)
+      const path = { index: 0, queued: 0, running: 0, total: 1 }
+
+      // the QueryManager is stubbed, so drive the query function ourselves for
+      // both peers and re-yield whatever the network produces for each
+      const run = async function * (_key: Uint8Array, query: QueryFunc): AsyncGenerator<QueryEvent> {
+        for (const { peerId } of [livePeer, deadPeer]) {
+          yield * query({
+            key,
+            peer: { id: peerId, multiaddrs: [] },
+            peerKadId: await convertPeerId(peerId),
+            path,
+            numPaths: 1
+          })
+        }
+      }
+      init.queryManager.run.callsFake(run)
+
+      // the live peer answers; the dead peer only errors, never sending a
+      // PEER_RESPONSE
+      const sendRequest = async function * (to: PeerId): AsyncGenerator<QueryEvent> {
+        if (to.equals(livePeer.peerId)) {
+          yield peerResponseEvent({ from: to, messageType: MessageType.FIND_NODE, path })
+        } else {
+          yield queryErrorEvent({ from: to, error: new Error('could not dial peer'), path })
+        }
+      }
+      init.network.sendRequest.callsFake(sendRequest)
+
+      const finalPeerIds: PeerId[] = []
+      for await (const event of peerRouting.getClosestPeers(key)) {
+        if (event.name === 'FINAL_PEER') {
+          finalPeerIds.push(event.peer.id)
+        }
+      }
+
+      expect(finalPeerIds).to.have.lengthOf(1)
+      expect(finalPeerIds[0].equals(livePeer.peerId)).to.be.true()
     })
   })
 })


### PR DESCRIPTION
## Description

`getClosestPeers` adds every queried peer to the closest-K set even when it never
answered the `FIND_NODE`, so the set is padded with dead or stale routing-table
entries. `PUT_VALUE` writes to that set, so each dead peer is a wasted write and
can crowd out reachable peers slightly further out.

This adds a peer to the closest set only if it sent a `PEER_RESPONSE` during the
lookup, matching go-libp2p, which excludes `PeerUnreachable` peers from the set a
lookup converges on.

Writing IPNS records to the public Amino DHT, of the 20 closest peers a lookup returns:

| | before | after |
| --- | --- | --- |
| reachable on a fresh dial | ~3-16 | ~18-20 |
| stored the record (write reach) | ~4-18, varies per run | 18-20, consistent |

Part of #3536.

## Change checklist

- [x] I have performed a self-review of my own code
- [x] I have made corresponding changes to the documentation if necessary (this includes comments as well)
- [x] I have added tests that prove my fix is effective or that my feature works
