### PR TITLE
fix(kad-dht): run the periodic routing table refresh

### DIFF
--- a/packages/kad-dht/src/routing-table/refresh.ts
+++ b/packages/kad-dht/src/routing-table/refresh.ts
@@ -149,6 +149,8 @@ export class RoutingTableRefresh {
 
       this.log(`found ${peers} peers that were close to imaginary peer %p`, peerId)
       this.log('finished refreshing cpl %s with key %p (routing table size is now %s)', cpl, peerId, this.routingTable.size)
+
+      this.commonPrefixLengthRefreshedAt[cpl] = new Date()
     } finally {
       signal.clear()
     }
@@ -163,7 +165,7 @@ export class RoutingTableRefresh {
 
     for (let i = 0; i <= maxCommonPrefix; i++) {
       // defaults to the zero value if we haven't refreshed it yet.
-      dates[i] = this.commonPrefixLengthRefreshedAt[i] ?? new Date()
+      dates[i] = this.commonPrefixLengthRefreshedAt[i] ?? new Date(0)
     }
 
     return dates

--- a/packages/kad-dht/test/routing-table.spec.ts
+++ b/packages/kad-dht/test/routing-table.spec.ts
@@ -17,9 +17,12 @@ import { MessageType } from '../src/message/dht.ts'
 import { peerResponseEvent } from '../src/query/events.ts'
 import { KAD_PEER_TAG_NAME, KAD_PEER_TAG_VALUE, RoutingTable } from '../src/routing-table/index.ts'
 import { isLeafBucket } from '../src/routing-table/k-bucket.ts'
+import { RoutingTableRefresh } from '../src/routing-table/refresh.ts'
 import * as kadUtils from '../src/utils.ts'
 import { createPeerIdWithPrivateKey, createPeerIdsWithPrivateKey } from './utils/create-peer-id.ts'
+import type { QueryEvent } from '../src/index.ts'
 import type { Network } from '../src/network.ts'
+import type { PeerRouting } from '../src/peer-routing/index.ts'
 import type { RoutingTableComponents } from '../src/routing-table/index.ts'
 import type { Bucket } from '../src/routing-table/k-bucket.ts'
 import type { Libp2pEvents, PeerId, PeerStore, Peer } from '@libp2p/interface'
@@ -570,6 +573,51 @@ describe('Routing Table', () => {
     expect(table.kb.root).to.have.property('depth', 0)
     expect(table.kb.root).to.have.property('prefix', '')
     expect(table.kb.root).to.have.property('peers').that.is.empty()
+  })
+
+  describe('refresh', () => {
+    let peerRouting: StubbedInstance<PeerRouting>
+    let refresh: RoutingTableRefresh
+    let queriedKeys: Uint8Array[]
+
+    beforeEach(() => {
+      queriedKeys = []
+      peerRouting = stubInterface<PeerRouting>()
+      peerRouting.getClosestPeers.callsFake((key: Uint8Array) => {
+        queriedKeys.push(key)
+        return (async function * (): AsyncGenerator<QueryEvent> {})()
+      })
+
+      refresh = new RoutingTableRefresh({ logger: defaultLogger() }, {
+        peerRouting,
+        routingTable: table,
+        logPrefix: ''
+      })
+    })
+
+    afterEach(async () => {
+      await refresh.stop()
+    })
+
+    it('issues refresh queries when run without force (the periodic refresh path)', async () => {
+      refresh.refreshTable(false)
+      await delay(200)
+
+      expect(queriedKeys.length).to.be.greaterThan(0)
+    })
+
+    it('does not re-query a common prefix length that was just refreshed', async () => {
+      refresh.refreshTable(false)
+      await delay(200)
+
+      const afterFirstRefresh = queriedKeys.length
+      expect(afterFirstRefresh).to.be.greaterThan(0)
+
+      refresh.refreshTable(false)
+      await delay(200)
+
+      expect(queriedKeys.length).to.equal(afterFirstRefresh)
+    })
   })
 
   describe('max size', () => {


### PR DESCRIPTION
## Description

The routing table refreshes once at startup, but the periodic refresh on the
interval timer never does any work. When a common-prefix-length has never been
refreshed, `_getTrackedCommonPrefixLengthsForRefresh` defaults its last-refresh
time to *now*, so the throttle (`!force && lastRefresh > Date.now() - interval`)
always treats it as just-refreshed and skips it - only the forced startup
refresh gets through.

Fix: default an unrefreshed common-prefix-length to the epoch so the throttle
lets it through, and record the refresh time on success. The interval refresh
then actually runs, keeping the table populated as peers churn.

Part of #3536.

## Change checklist

- [x] I have performed a self-review of my own code
- [x] I have made corresponding changes to the documentation if necessary (this includes comments as well)
- [x] I have added tests that prove my fix is effective or that my feature works
