### PR TITLE
docs(kad-dht): correct the alpha option default in the JSDoc

### DIFF
--- a/packages/kad-dht/src/index.ts
+++ b/packages/kad-dht/src/index.ts
@@ -501,7 +501,7 @@ export interface KadDHTInit {
   /**
    * How many peers are queried in parallel during a query.
    *
-   * @default 3
+   * @default 10
    */
   alpha?: number
 


### PR DESCRIPTION
## Description

The `alpha` option's JSDoc says `@default 3`, but the code uses `ALPHA = 10`.

Part of #3536.

## Change checklist

- [x] I have performed a self-review of my own code
- [x] I have made corresponding changes to the documentation if necessary (this includes comments as well)
- [ ] I have added tests that prove my fix is effective or that my feature works
