### PR TITLE
docs: dial discovered peers by peer id

### DIFF
--- a/doc/CONFIGURATION.md
+++ b/doc/CONFIGURATION.md
@@ -302,7 +302,7 @@ const node = await createLibp2p({
 
 node.addEventListener('peer:discovery', (event) => {
   console.log('Discovered new peer:', event.detail.id.toString())
-  node.dial(event.detail.multiaddrs)
+  node.dial(event.detail.id)
 })
 ```
 

--- a/packages/peer-discovery-mdns/README.md
+++ b/packages/peer-discovery-mdns/README.md
@@ -39,7 +39,7 @@ const libp2p = await createLibp2p({
 })
 
 libp2p.addEventListener('peer:discovery', (evt) => {
-  libp2p.dial(evt.detail.multiaddrs) // dial discovered peers
+  libp2p.dial(evt.detail.id) // dial discovered peers
   console.log('found peer: ', evt.detail.toString())
 })
 ```

--- a/packages/peer-discovery-mdns/src/index.ts
+++ b/packages/peer-discovery-mdns/src/index.ts
@@ -16,7 +16,7 @@
  * })
  *
  * libp2p.addEventListener('peer:discovery', (evt) => {
- *   libp2p.dial(evt.detail.multiaddrs) // dial discovered peers
+ *   libp2p.dial(evt.detail.id) // dial discovered peers
  *   console.log('found peer: ', evt.detail.toString())
  * })
  * ```


### PR DESCRIPTION
## Description

Update examples to dial by peer id instead of mutliaddrs - in regard to comments on https://github.com/libp2p/js-libp2p/pull/3402

## Change checklist

- [x] I have performed a self-review of my own code
- [x] I have made corresponding changes to the documentation if necessary (this includes comments as well)
- [ ] I have added tests that prove my fix is effective or that my feature works