### PR TITLE
deps: upgrade aegir to 48.1.1

### DIFF
--- a/doc/package.json
+++ b/doc/package.json
@@ -17,7 +17,7 @@
     "doc-check": "aegir doc-check"
   },
   "devDependencies": {
-    "aegir": "^48.0.11"
+    "aegir": "^48.1.1"
   },
   "private": true
 }

--- a/interop/package.json
+++ b/interop/package.json
@@ -24,7 +24,7 @@
     "@libp2p/websockets": "^10.1.15",
     "@libp2p/webtransport": "^6.0.30",
     "@multiformats/multiaddr": "^13.0.3",
-    "aegir": "^48.0.11",
+    "aegir": "^48.1.1",
     "libp2p": "^3.3.4",
     "p-event": "^7.0.0",
     "redis": "^4.7.1"

--- a/package.json
+++ b/package.json
@@ -39,7 +39,7 @@
     "docs:no-publish": "aegir docs --publish false -- --exclude interop --exclude doc"
   },
   "devDependencies": {
-    "aegir": "^48.0.11",
+    "aegir": "^48.1.1",
     "npm-run-all": "^4.1.5"
   },
   "workspaces": [

--- a/packages/config/package.json
+++ b/packages/config/package.json
@@ -47,7 +47,7 @@
     "interface-datastore": "^10.0.1"
   },
   "devDependencies": {
-    "aegir": "^48.0.11",
+    "aegir": "^48.1.1",
     "datastore-core": "^12.0.1"
   },
   "sideEffects": false

--- a/packages/connection-encrypter-plaintext/package.json
+++ b/packages/connection-encrypter-plaintext/package.json
@@ -57,7 +57,7 @@
   "devDependencies": {
     "@libp2p/crypto": "^5.1.20",
     "@libp2p/logger": "^6.2.9",
-    "aegir": "^48.0.11",
+    "aegir": "^48.1.1",
     "protons": "^9.0.1",
     "sinon": "^21.0.0"
   },

--- a/packages/connection-encrypter-tls/package.json
+++ b/packages/connection-encrypter-tls/package.json
@@ -80,7 +80,7 @@
   },
   "devDependencies": {
     "@libp2p/logger": "^6.2.9",
-    "aegir": "^48.0.11",
+    "aegir": "^48.1.1",
     "protons": "^9.0.1",
     "sinon": "^21.0.0",
     "sinon-ts": "^2.0.0"

--- a/packages/crypto/package.json
+++ b/packages/crypto/package.json
@@ -100,7 +100,7 @@
   },
   "devDependencies": {
     "@types/mocha": "^10.0.10",
-    "aegir": "^48.0.11",
+    "aegir": "^48.1.1",
     "asn1js": "^3.0.6",
     "benchmark": "^2.1.4",
     "protons": "^9.0.1"

--- a/packages/floodsub/package.json
+++ b/packages/floodsub/package.json
@@ -72,7 +72,7 @@
     "@libp2p/logger": "^6.2.9",
     "@multiformats/multiaddr": "^13.0.3",
     "@types/sinon": "^21.0.1",
-    "aegir": "^48.0.11",
+    "aegir": "^48.1.1",
     "delay": "^7.0.0",
     "p-wait-for": "^6.0.0",
     "protons": "^9.0.1",

--- a/packages/gossipsub/package.json
+++ b/packages/gossipsub/package.json
@@ -102,7 +102,7 @@
     "@types/benchmark": "^2.1.5",
     "@types/sinon": "^21.0.1",
     "abortable-iterator": "^5.1.0",
-    "aegir": "^48.0.11",
+    "aegir": "^48.1.1",
     "benchmark": "^2.1.4",
     "datastore-core": "^12.0.1",
     "delay": "^7.0.0",

--- a/packages/integration-tests/package.json
+++ b/packages/integration-tests/package.json
@@ -53,7 +53,7 @@
     "@multiformats/dns": "^1.0.6",
     "@multiformats/multiaddr": "^13.0.3",
     "@multiformats/multiaddr-matcher": "^3.0.2",
-    "aegir": "^48.0.11",
+    "aegir": "^48.1.1",
     "delay": "^7.0.0",
     "detect-browser": "^5.3.0",
     "execa": "^9.6.0",

--- a/packages/interface-compliance-tests/package.json
+++ b/packages/interface-compliance-tests/package.json
@@ -97,7 +97,7 @@
     "@libp2p/utils": "^7.2.3",
     "@multiformats/multiaddr": "^13.0.3",
     "@multiformats/multiaddr-matcher": "^3.0.2",
-    "aegir": "^48.0.11",
+    "aegir": "^48.1.1",
     "delay": "^7.0.0",
     "it-all": "^3.0.9",
     "it-drain": "^3.0.10",

--- a/packages/interface-internal/package.json
+++ b/packages/interface-internal/package.json
@@ -48,7 +48,7 @@
     "progress-events": "^1.0.1"
   },
   "devDependencies": {
-    "aegir": "^48.0.11"
+    "aegir": "^48.1.1"
   },
   "sideEffects": false
 }

--- a/packages/interface/package.json
+++ b/packages/interface/package.json
@@ -50,7 +50,7 @@
     "uint8arraylist": "^3.0.2"
   },
   "devDependencies": {
-    "aegir": "^48.0.11"
+    "aegir": "^48.1.1"
   },
   "sideEffects": false
 }

--- a/packages/interop/package.json
+++ b/packages/interop/package.json
@@ -58,10 +58,10 @@
     "uint8arrays": "^6.1.1"
   },
   "devDependencies": {
-    "aegir": "^48.0.11",
+    "aegir": "^48.1.1",
     "protons": "^9.0.1"
   },
   "peerDependencies": {
-    "aegir": "^48.0.11"
+    "aegir": "^48.1.1"
   }
 }

--- a/packages/kad-dht/package.json
+++ b/packages/kad-dht/package.json
@@ -87,7 +87,7 @@
     "@types/lodash.range": "^3.2.9",
     "@types/sinon": "^21.0.1",
     "@types/which": "^3.0.4",
-    "aegir": "^48.0.11",
+    "aegir": "^48.1.1",
     "benchmark": "^2.1.4",
     "datastore-core": "^12.0.1",
     "delay": "^7.0.0",

--- a/packages/keychain/package.json
+++ b/packages/keychain/package.json
@@ -64,7 +64,7 @@
   },
   "devDependencies": {
     "@libp2p/logger": "^6.2.9",
-    "aegir": "^48.0.11",
+    "aegir": "^48.1.1",
     "datastore-core": "^12.0.1"
   },
   "sideEffects": false

--- a/packages/libp2p-daemon-client/package.json
+++ b/packages/libp2p-daemon-client/package.json
@@ -56,7 +56,7 @@
     "@libp2p/daemon-server": "^9.0.30",
     "@libp2p/gossipsub": "^16.0.3",
     "@libp2p/kad-dht": "^16.3.3",
-    "aegir": "^48.0.11",
+    "aegir": "^48.1.1",
     "it-all": "^3.0.9",
     "p-event": "^7.0.0",
     "sinon": "^21.0.0",

--- a/packages/libp2p-daemon-protocol/package.json
+++ b/packages/libp2p-daemon-protocol/package.json
@@ -72,7 +72,7 @@
     "uint8arrays": "^6.1.1"
   },
   "devDependencies": {
-    "aegir": "^48.0.11",
+    "aegir": "^48.1.1",
     "protons": "^9.0.1"
   }
 }

--- a/packages/libp2p-daemon-server/package.json
+++ b/packages/libp2p-daemon-server/package.json
@@ -61,7 +61,7 @@
     "uint8arrays": "^6.1.1"
   },
   "devDependencies": {
-    "aegir": "^48.0.11",
+    "aegir": "^48.1.1",
     "sinon-ts": "^2.0.0"
   }
 }

--- a/packages/libp2p-daemon/package.json
+++ b/packages/libp2p-daemon/package.json
@@ -53,7 +53,7 @@
   },
   "devDependencies": {
     "@types/yargs": "^17.0.33",
-    "aegir": "^48.0.11",
+    "aegir": "^48.1.1",
     "sinon": "^21.0.0"
   }
 }

--- a/packages/libp2p/package.json
+++ b/packages/libp2p/package.json
@@ -110,7 +110,7 @@
     "uint8arrays": "^6.1.1"
   },
   "devDependencies": {
-    "aegir": "^48.0.11",
+    "aegir": "^48.1.1",
     "delay": "^7.0.0",
     "it-all": "^3.0.9",
     "it-drain": "^3.0.10",

--- a/packages/logger/package.json
+++ b/packages/logger/package.json
@@ -56,7 +56,7 @@
   },
   "devDependencies": {
     "@libp2p/peer-id": "^6.0.11",
-    "aegir": "^48.0.11",
+    "aegir": "^48.1.1",
     "sinon": "^21.0.0",
     "uint8arrays": "^6.1.1"
   },

--- a/packages/metrics-opentelemetry/package.json
+++ b/packages/metrics-opentelemetry/package.json
@@ -47,7 +47,7 @@
   },
   "devDependencies": {
     "@libp2p/logger": "^6.2.9",
-    "aegir": "^48.0.11"
+    "aegir": "^48.1.1"
   },
   "browser": {
     "./dist/src/system-metrics.js": "./dist/src/system-metrics.browser.js"

--- a/packages/metrics-prometheus/package.json
+++ b/packages/metrics-prometheus/package.json
@@ -48,7 +48,7 @@
   "devDependencies": {
     "@libp2p/logger": "^6.2.9",
     "@libp2p/utils": "^7.2.3",
-    "aegir": "^48.0.11",
+    "aegir": "^48.1.1",
     "p-event": "^7.0.0"
   },
   "sideEffects": false

--- a/packages/metrics-simple/package.json
+++ b/packages/metrics-simple/package.json
@@ -49,7 +49,7 @@
   },
   "devDependencies": {
     "@types/tdigest": "^0.1.5",
-    "aegir": "^48.0.11",
+    "aegir": "^48.1.1",
     "p-defer": "^4.0.1"
   },
   "sideEffects": false

--- a/packages/multistream-select/package.json
+++ b/packages/multistream-select/package.json
@@ -59,7 +59,7 @@
     "uint8arrays": "^6.1.1"
   },
   "devDependencies": {
-    "aegir": "^48.0.11",
+    "aegir": "^48.1.1",
     "it-all": "^3.0.9",
     "it-drain": "^3.0.10",
     "it-pipe": "^3.0.1",

--- a/packages/peer-collections/package.json
+++ b/packages/peer-collections/package.json
@@ -56,7 +56,7 @@
   "devDependencies": {
     "@libp2p/crypto": "^5.1.20",
     "@types/sinon": "^21.0.1",
-    "aegir": "^48.0.11",
+    "aegir": "^48.1.1",
     "sinon": "^21.0.0",
     "sinon-ts": "^2.0.0"
   },

--- a/packages/peer-discovery-bootstrap/package.json
+++ b/packages/peer-discovery-bootstrap/package.json
@@ -58,7 +58,7 @@
   "devDependencies": {
     "@libp2p/interface-compliance-tests": "^7.0.25",
     "@libp2p/logger": "^6.2.9",
-    "aegir": "^48.0.11",
+    "aegir": "^48.1.1",
     "sinon-ts": "^2.0.0"
   },
   "sideEffects": false

--- a/packages/peer-discovery-mdns/package.json
+++ b/packages/peer-discovery-mdns/package.json
@@ -58,7 +58,7 @@
     "@libp2p/crypto": "^5.1.20",
     "@libp2p/interface-compliance-tests": "^7.0.25",
     "@libp2p/logger": "^6.2.9",
-    "aegir": "^48.0.11",
+    "aegir": "^48.1.1",
     "p-event": "^7.0.0",
     "p-wait-for": "^6.0.0",
     "sinon-ts": "^2.0.0"

--- a/packages/peer-id/package.json
+++ b/packages/peer-id/package.json
@@ -54,7 +54,7 @@
     "uint8arrays": "^6.1.1"
   },
   "devDependencies": {
-    "aegir": "^48.0.11",
+    "aegir": "^48.1.1",
     "sinon": "^21.0.0"
   },
   "sideEffects": false

--- a/packages/peer-record/package.json
+++ b/packages/peer-record/package.json
@@ -60,7 +60,7 @@
     "uint8arrays": "^6.1.1"
   },
   "devDependencies": {
-    "aegir": "^48.0.11",
+    "aegir": "^48.1.1",
     "protons": "^9.0.1"
   },
   "sideEffects": false

--- a/packages/peer-store/package.json
+++ b/packages/peer-store/package.json
@@ -67,7 +67,7 @@
   "devDependencies": {
     "@libp2p/logger": "^6.2.9",
     "@types/sinon": "^21.0.1",
-    "aegir": "^48.0.11",
+    "aegir": "^48.1.1",
     "benchmark": "^2.1.4",
     "datastore-core": "^12.0.1",
     "delay": "^7.0.0",

--- a/packages/pnet/package.json
+++ b/packages/pnet/package.json
@@ -52,7 +52,7 @@
   },
   "devDependencies": {
     "@types/xsalsa20": "^1.1.3",
-    "aegir": "^48.0.11",
+    "aegir": "^48.1.1",
     "p-event": "^7.0.0"
   },
   "sideEffects": false

--- a/packages/protocol-autonat-v2/package.json
+++ b/packages/protocol-autonat-v2/package.json
@@ -61,7 +61,7 @@
     "@libp2p/crypto": "^5.1.20",
     "@libp2p/logger": "^6.2.9",
     "@libp2p/peer-id": "^6.0.11",
-    "aegir": "^48.0.11",
+    "aegir": "^48.1.1",
     "delay": "^7.0.0",
     "it-all": "^3.0.9",
     "it-length-prefixed": "^11.0.1",

--- a/packages/protocol-autonat/package.json
+++ b/packages/protocol-autonat/package.json
@@ -61,7 +61,7 @@
   "devDependencies": {
     "@libp2p/crypto": "^5.1.20",
     "@libp2p/logger": "^6.2.9",
-    "aegir": "^48.0.11",
+    "aegir": "^48.1.1",
     "delay": "^7.0.0",
     "it-all": "^3.0.9",
     "it-length-prefixed": "^11.0.1",

--- a/packages/protocol-dcutr/package.json
+++ b/packages/protocol-dcutr/package.json
@@ -56,7 +56,7 @@
     "uint8arraylist": "^3.0.2"
   },
   "devDependencies": {
-    "aegir": "^48.0.11",
+    "aegir": "^48.1.1",
     "protons": "^9.0.1",
     "sinon": "^21.0.0",
     "sinon-ts": "^2.0.0"

--- a/packages/protocol-echo/package.json
+++ b/packages/protocol-echo/package.json
@@ -53,7 +53,7 @@
   },
   "devDependencies": {
     "@multiformats/multiaddr": "^13.0.3",
-    "aegir": "^48.0.11",
+    "aegir": "^48.1.1",
     "it-all": "^3.0.9",
     "p-wait-for": "^6.0.0",
     "sinon": "^21.0.0",

--- a/packages/protocol-fetch/package.json
+++ b/packages/protocol-fetch/package.json
@@ -57,7 +57,7 @@
   "devDependencies": {
     "@libp2p/crypto": "^5.1.20",
     "@libp2p/peer-id": "^6.0.11",
-    "aegir": "^48.0.11",
+    "aegir": "^48.1.1",
     "protons": "^9.0.1",
     "sinon": "^21.0.0",
     "sinon-ts": "^2.0.0"

--- a/packages/protocol-identify/package.json
+++ b/packages/protocol-identify/package.json
@@ -63,7 +63,7 @@
   },
   "devDependencies": {
     "@libp2p/logger": "^6.2.9",
-    "aegir": "^48.0.11",
+    "aegir": "^48.1.1",
     "delay": "^7.0.0",
     "it-length-prefixed": "^11.0.1",
     "protons": "^9.0.1",

--- a/packages/protocol-perf/package.json
+++ b/packages/protocol-perf/package.json
@@ -56,7 +56,7 @@
   "devDependencies": {
     "@libp2p/logger": "^6.2.9",
     "@libp2p/utils": "^7.2.3",
-    "aegir": "^48.0.11",
+    "aegir": "^48.1.1",
     "it-last": "^3.0.9",
     "sinon-ts": "^2.0.0"
   },

--- a/packages/protocol-ping/package.json
+++ b/packages/protocol-ping/package.json
@@ -55,7 +55,7 @@
     "@libp2p/crypto": "^5.1.20",
     "@libp2p/peer-id": "^6.0.11",
     "@libp2p/utils": "^7.2.3",
-    "aegir": "^48.0.11",
+    "aegir": "^48.1.1",
     "delay": "^7.0.0",
     "sinon": "^21.0.0",
     "sinon-ts": "^2.0.0"

--- a/packages/record/package.json
+++ b/packages/record/package.json
@@ -56,7 +56,7 @@
     "@types/lodash.random": "^3.2.9",
     "@types/lodash.range": "^3.2.9",
     "@types/which": "^3.0.4",
-    "aegir": "^48.0.11",
+    "aegir": "^48.1.1",
     "multiformats": "^14.0.0",
     "protons": "^9.0.1"
   },

--- a/packages/stream-multiplexer-mplex/package.json
+++ b/packages/stream-multiplexer-mplex/package.json
@@ -66,7 +66,7 @@
   "devDependencies": {
     "@libp2p/interface-compliance-tests": "^7.0.25",
     "@libp2p/logger": "^6.2.9",
-    "aegir": "^48.0.11",
+    "aegir": "^48.1.1",
     "benchmark": "^2.1.4",
     "it-all": "^3.0.9",
     "it-drain": "^3.0.10",

--- a/packages/transport-circuit-relay-v2/package.json
+++ b/packages/transport-circuit-relay-v2/package.json
@@ -67,7 +67,7 @@
   },
   "devDependencies": {
     "@libp2p/logger": "^6.2.9",
-    "aegir": "^48.0.11",
+    "aegir": "^48.1.1",
     "delay": "^7.0.0",
     "it-all": "^3.0.9",
     "it-protobuf-stream": "^3.0.0",

--- a/packages/transport-memory/package.json
+++ b/packages/transport-memory/package.json
@@ -61,7 +61,7 @@
   "devDependencies": {
     "@libp2p/logger": "^6.2.9",
     "@libp2p/peer-id": "^6.0.11",
-    "aegir": "^48.0.11",
+    "aegir": "^48.1.1",
     "sinon": "^21.0.0",
     "sinon-ts": "^2.0.0"
   },

--- a/packages/transport-tcp/package.json
+++ b/packages/transport-tcp/package.json
@@ -66,7 +66,7 @@
   "devDependencies": {
     "@libp2p/logger": "^6.2.9",
     "@types/sinon": "^21.0.1",
-    "aegir": "^48.0.11",
+    "aegir": "^48.1.1",
     "delay": "^7.0.0",
     "p-defer": "^4.0.1",
     "p-wait-for": "^6.0.0",

--- a/packages/transport-webrtc/package.json
+++ b/packages/transport-webrtc/package.json
@@ -82,7 +82,7 @@
   "devDependencies": {
     "@libp2p/logger": "^6.2.9",
     "@types/sinon": "^21.0.1",
-    "aegir": "^48.0.11",
+    "aegir": "^48.1.1",
     "any-signal": "^4.1.1",
     "datastore-core": "^12.0.1",
     "delay": "^7.0.0",

--- a/packages/transport-websockets/package.json
+++ b/packages/transport-websockets/package.json
@@ -84,7 +84,7 @@
   "devDependencies": {
     "@libp2p/logger": "^6.2.9",
     "@types/ws": "^8.18.1",
-    "aegir": "^48.0.11",
+    "aegir": "^48.1.1",
     "is-loopback-addr": "^2.0.2",
     "p-wait-for": "^6.0.0",
     "sinon": "^21.0.0",

--- a/packages/transport-webtransport/package.json
+++ b/packages/transport-webtransport/package.json
@@ -62,7 +62,7 @@
     "@libp2p/daemon-client": "^10.0.30",
     "@libp2p/logger": "^6.2.9",
     "@libp2p/ping": "^3.1.7",
-    "aegir": "^48.0.11",
+    "aegir": "^48.1.1",
     "execa": "^9.6.0",
     "go-libp2p": "^1.6.0",
     "it-all": "^3.0.9",

--- a/packages/upnp-nat/package.json
+++ b/packages/upnp-nat/package.json
@@ -63,7 +63,7 @@
     "@libp2p/crypto": "^5.1.20",
     "@libp2p/logger": "^6.2.9",
     "@libp2p/peer-id": "^6.0.11",
-    "aegir": "^48.0.11",
+    "aegir": "^48.1.1",
     "sinon-ts": "^2.0.0",
     "wherearewe": "^2.0.1"
   },

--- a/packages/utils/package.json
+++ b/packages/utils/package.json
@@ -74,7 +74,7 @@
     "@libp2p/crypto": "^5.1.20",
     "@libp2p/peer-id": "^6.0.11",
     "@types/netmask": "^2.0.5",
-    "aegir": "^48.0.11",
+    "aegir": "^48.1.1",
     "benchmark": "^2.1.4",
     "it-all": "^3.0.9",
     "it-drain": "^3.0.10",


### PR DESCRIPTION
## Description

Bumps the `aegir` devDependency to 48.1.1 across the monorepo. This adopts the new lint rule requiring relative imports in TypeScript sources to use the `.ts` extension; existing sources already comply, so no source changes are needed.

## Change checklist

- [x] I have performed a self-review of my own code
