### PR TITLE
fix: treat empty dnsaddr answer as no addresses

### DIFF
--- a/packages/libp2p/src/connection-manager/resolvers/dnsaddr.ts
+++ b/packages/libp2p/src/connection-manager/resolvers/dnsaddr.ts
@@ -32,10 +32,6 @@ class DNSAddrResolver implements MultiaddrResolver {
         ]
       })
     } catch (err: any) {
-      // @multiformats/dns >= 1.0.15 throws when a query returns no answers
-      // instead of returning an empty result. Treat "no DNS records" as "no
-      // addresses to dial" so the dial fails with NoValidAddressesError rather
-      // than surfacing a DNSQueryFailedError.
       const noAnswers = err.name === 'DNSQueryFailedError' &&
         Array.isArray(err.errors) &&
         err.errors.length > 0 &&

--- a/packages/libp2p/src/connection-manager/resolvers/dnsaddr.ts
+++ b/packages/libp2p/src/connection-manager/resolvers/dnsaddr.ts
@@ -1,7 +1,7 @@
 import { dns, RecordType } from '@multiformats/dns'
 import { multiaddr } from '@multiformats/multiaddr'
 import type { MultiaddrResolver, MultiaddrResolveOptions } from '@libp2p/interface'
-import type { DNS } from '@multiformats/dns'
+import type { DNS, DNSResponse } from '@multiformats/dns'
 import type { Multiaddr } from '@multiformats/multiaddr'
 
 class DNSAddrResolver implements MultiaddrResolver {
@@ -21,12 +21,32 @@ class DNSAddrResolver implements MultiaddrResolver {
     }
 
     const resolver = this.getDNS(options)
-    const result = await resolver.query(`_dnsaddr.${hostname}`, {
-      signal: options?.signal,
-      types: [
-        RecordType.TXT
-      ]
-    })
+
+    let result: DNSResponse
+
+    try {
+      result = await resolver.query(`_dnsaddr.${hostname}`, {
+        signal: options?.signal,
+        types: [
+          RecordType.TXT
+        ]
+      })
+    } catch (err: any) {
+      // @multiformats/dns >= 1.0.15 throws when a query returns no answers
+      // instead of returning an empty result. Treat "no DNS records" as "no
+      // addresses to dial" so the dial fails with NoValidAddressesError rather
+      // than surfacing a DNSQueryFailedError.
+      const noAnswers = err.name === 'DNSQueryFailedError' &&
+        Array.isArray(err.errors) &&
+        err.errors.length > 0 &&
+        err.errors.every((e: Error) => e.name === 'EmptyDNSAnswerError')
+
+      if (noAnswers) {
+        return []
+      }
+
+      throw err
+    }
 
     const peerId = ma.getComponents()
       .find(component => component.name === 'p2p')


### PR DESCRIPTION
## Description

`@multiformats/dns` 1.0.15 changed `query()` to throw an empty-answer error (so it can fall through to other resolvers) instead of returning an empty result. As a side effect, dialing a `/dnsaddr/` that resolves to no records started rejecting with `DNSQueryFailedError` instead of `NoValidAddressesError`.

This catches the empty-answer case in the dnsaddr resolver so those dials fail with `NoValidAddressesError` again, while genuine DNS failures still surface as `DNSQueryFailedError`.

## Notes & open questions

Root cause is multiformats/js-dns#34 (released in `@multiformats/dns` 1.0.15). No new test needed: the existing `connections.spec.ts` "should fail to dial if resolve fails and there are no addresses to dial" test exercises this path (it was failing on 1.0.15, passes with this change).

## Change checklist

- [x] I have performed a self-review of my own code
- [x] I have added tests that prove my fix is effective or that my feature works
