### PR TITLE
fix(pnet): forward drain events from the underlying connection

### DIFF
--- a/packages/pnet/src/crypto.ts
+++ b/packages/pnet/src/crypto.ts
@@ -43,6 +43,11 @@ export class BoxMessageStream extends AbstractMultiaddrConnection {
       }
     })
 
+    // resume sending when the underlying connection can accept more data
+    this.maConn.addEventListener('drain', () => {
+      this.onMuxerDrain()
+    })
+
     this.maConn.addEventListener('close', (evt) => {
       if (evt.error != null) {
         if (evt.local) {

--- a/packages/pnet/test/index.spec.ts
+++ b/packages/pnet/test/index.spec.ts
@@ -52,6 +52,50 @@ describe('private network', () => {
     expect(output).to.deep.equal([uint8ArrayFromString('hello world'), uint8ArrayFromString('doo dah')])
   })
 
+  it('should forward drain events from the underlying connection', async () => {
+    const [outboundConnection, inboundConnection] = multiaddrConnectionPair({
+      delay: 10
+    })
+
+    const protector = preSharedKey({
+      psk: swarmKeyBuffer
+    })()
+
+    const [outbound, inbound] = await Promise.all([
+      protector.protect(outboundConnection),
+      protector.protect(inboundConnection)
+    ])
+
+    let received = 0
+
+    inbound.addEventListener('message', (evt) => {
+      received += evt.data.byteLength
+    })
+
+    // send data until the underlying connection reports backpressure
+    const chunk = new Uint8Array(1024 * 64)
+    let sent = 0
+    let canSendMore = true
+
+    while (canSendMore) {
+      canSendMore = outbound.send(chunk)
+      sent += chunk.byteLength
+    }
+
+    // the protected connection should emit 'drain' when the underlying
+    // connection drains, otherwise sending never resumes
+    await pEvent(outbound, 'drain', {
+      timeout: 5_000
+    })
+
+    await Promise.all([
+      pEvent(inbound, 'close'),
+      outbound.close()
+    ])
+
+    expect(received).to.equal(sent)
+  })
+
   it('should not be able to share correct data with different keys', async () => {
     const [outboundConnection, inboundConnection] = multiaddrConnectionPair({
       delay: 10

--- a/packages/pnet/test/index.spec.ts
+++ b/packages/pnet/test/index.spec.ts
@@ -72,21 +72,21 @@ describe('private network', () => {
       received += evt.data.byteLength
     })
 
-    // send data until the underlying connection reports backpressure
+    // send more data than the underlying connection can buffer, awaiting a
+    // 'drain' each time it reports backpressure
     const chunk = new Uint8Array(1024 * 64)
     let sent = 0
-    let canSendMore = true
 
-    while (canSendMore) {
-      canSendMore = outbound.send(chunk)
+    for (let i = 0; i < 25; i++) {
+      if (!outbound.send(chunk)) {
+        await pEvent(outbound, 'drain', {
+          timeout: 5_000,
+          rejectionEvents: ['close']
+        })
+      }
+
       sent += chunk.byteLength
     }
-
-    // the protected connection should emit 'drain' when the underlying
-    // connection drains, otherwise sending never resumes
-    await pEvent(outbound, 'drain', {
-      timeout: 5_000
-    })
 
     await Promise.all([
       pEvent(inbound, 'close'),


### PR DESCRIPTION
## Description

`BoxMessageStream` relays `'message'` and `'close'` events from the wrapped `MultiaddrConnection`, but not `'drain'`. When the underlying connection reports write backpressure (`send()` returns `false`), `AbstractMessageStream` pauses sending and buffers writes until a `'drain'` event is dispatched on the stream — which only happens via `onMuxerDrain()`. Since pnet never invoked it, the first backpressure event permanently wedged the outbound direction of every PSK-protected connection while the connection still appeared healthy: a `tcp` + `yamux` + PSK bulk transfer stalls at ~4 MB (the point the socket send buffer first fills) and never recovers, while the inbound direction keeps working.

This PR relays the underlying connection's `'drain'` event to `this.onMuxerDrain()` in the `BoxMessageStream` constructor — the same pattern `AbstractStreamMuxer` uses for its wrapped connection. With the change, the same transfers complete (verified at 4 MB and 128 MB).

Includes a regression test that protects both halves of a `multiaddrConnectionPair()`, sends until the underlying connection reports backpressure, then asserts the protected connection emits `'drain'` and that all queued bytes arrive at the other end. The test times out without the fix and passes with it.

Fixes https://github.com/libp2p/js-libp2p/issues/3551.

## Notes & open questions

None — the change is intentionally minimal (a single event relay plus the regression test). `sendPause()`/`sendResume()` already handle the read side; this addresses the write side only.

## Change checklist

- [x] I have performed a self-review of my own code
- [x] I have made corresponding changes to the documentation if necessary (this includes comments as well)
- [x] I have added tests that prove my fix is effective or that my feature works