### PR TITLE
chore: pin macos CI runner to macos-15

### DIFF
--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -48,7 +48,10 @@ jobs:
     runs-on: ${{ matrix.os }}
     strategy:
       matrix:
-        os: [windows-latest, ubuntu-latest, macos-latest]
+        # macos-latest migrated from macos-15 to macos-26 in June 2026
+        # (actions/runner-images#14167), which stalls the go-libp2p p2pd binary
+        # download during install. Pin to macos-15 until that is resolved.
+        os: [windows-latest, ubuntu-latest, macos-15]
         node: [lts/*]
       fail-fast: false
     steps:


### PR DESCRIPTION
## Description

`macos-latest` migrated from macos-15 to macos-26 in June 2026 (actions/runner-images#14167). On macos-26 the `go-libp2p` postinstall that downloads the p2pd binary stalls (the fetch returns `200 OK`, then the response body read never completes and times out after 60s, retrying 11 times), so `test-node (macos-latest)` fails at the install step before any tests run. It only surfaces on a node_modules cache miss, which re-triggers the p2pd download, so it hits any deps-changing PR.

Pin the macOS runner to `macos-15` until the download works on macos-26.

## Notes & open questions

Stopgap. The underlying issue is go-libp2p's fetch-based p2pd download not completing on macos-26 (libp2p/npm-go-libp2p); unpin once that is fixed.

## Change checklist

- [x] I have performed a self-review of my own code
