### PR TITLE
test: validate go-libp2p p2pd download fix on macos-26

### DIFF
--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -48,10 +48,9 @@ jobs:
     runs-on: ${{ matrix.os }}
     strategy:
       matrix:
-        # macos-latest migrated from macos-15 to macos-26 in June 2026
-        # (actions/runner-images#14167), which stalls the go-libp2p p2pd binary
-        # download during install. Pin to macos-15 until that is resolved.
-        os: [windows-latest, ubuntu-latest, macos-15]
+        # TEST ONLY (do not merge): unpinned back to macos-latest (macos-26) to
+        # validate the go-libp2p p2pd download fix via the overrides below.
+        os: [windows-latest, ubuntu-latest, macos-latest]
         node: [lts/*]
       fail-fast: false
     steps:

--- a/package.json
+++ b/package.json
@@ -43,7 +43,7 @@
     "npm-run-all": "^4.1.5"
   },
   "overrides": {
-    "go-libp2p": "github:tabcat/npm-go-libp2p#fix/download-on-first-use"
+    "go-libp2p": "github:tabcat/npm-go-libp2p#test/download-on-first-use-dist"
   },
   "workspaces": [
     "doc",

--- a/package.json
+++ b/package.json
@@ -42,6 +42,9 @@
     "aegir": "^48.0.11",
     "npm-run-all": "^4.1.5"
   },
+  "overrides": {
+    "go-libp2p": "github:tabcat/npm-go-libp2p#fix/download-on-first-use"
+  },
   "workspaces": [
     "doc",
     "interop",


### PR DESCRIPTION
**Test only, do not merge.**

Validates the go-libp2p p2pd download fix (keep `postinstall` + on-first-use fallback + `got` instead of the global `fetch`) on the macos-26 runner before opening the npm-go-libp2p PR.

- Reverts the macos-15 pin (#3553) back to `macos-latest` so `test-node` runs on macos-26.
- Overrides `go-libp2p` to the fixed branch (`github:tabcat/npm-go-libp2p#fix/download-on-first-use`), which also forces a node_modules cache miss so p2pd is freshly downloaded on macos-26.

Success = the macOS `test-node` install step (`cache-node-modules`) no longer stalls. Mirrors ipfs/ipfs-desktop#3180's validation of ipfs/npm-kubo#83.
