### PR TITLE
fix(circuit-relay-v2): avoid leaking abort listeners on refresh

### DIFF
--- a/packages/transport-circuit-relay-v2/src/server/reservation-store.ts
+++ b/packages/transport-circuit-relay-v2/src/server/reservation-store.ts
@@ -66,13 +66,16 @@ export class ReservationStore {
         limit: checkedLimit,
         signal: retimeableSignal(this.reservationTtl)
       }
+
+      // only register the abort listener when a new signal is created:
+      // refreshing an existing reservation reuses the same signal, so attaching
+      // a listener on every refresh would leak one listener per refresh
+      reservation.signal.addEventListener('abort', () => {
+        this.reservations.delete(peer)
+      })
     }
 
     this.reservations.set(peer, reservation)
-
-    reservation.signal.addEventListener('abort', () => {
-      this.reservations.delete(peer)
-    })
 
     // return expiry time in seconds
     return { status: Status.OK, expire: Math.round(expiry.getTime() / 1000) }

--- a/packages/transport-circuit-relay-v2/test/reservation-store.spec.ts
+++ b/packages/transport-circuit-relay-v2/test/reservation-store.spec.ts
@@ -3,6 +3,7 @@ import { defaultLogger } from '@libp2p/logger'
 import { peerIdFromPrivateKey } from '@libp2p/peer-id'
 import { multiaddr } from '@multiformats/multiaddr'
 import { expect } from 'aegir/chai'
+import Sinon from 'sinon'
 import { DEFAULT_DATA_LIMIT, DEFAULT_DURATION_LIMIT } from '../src/constants.ts'
 import { Status } from '../src/pb/index.ts'
 import { ReservationStore } from '../src/server/reservation-store.ts'
@@ -27,6 +28,32 @@ describe('circuit-relay server reservation store', function () {
     expect(result.status).to.equal(Status.OK)
     expect(result.expire).to.not.be.undefined()
     expect(store.get(peer)).to.be.ok()
+  })
+
+  it('should not attach a new abort listener when refreshing a reservation', async function () {
+    const store = new ReservationStore({ logger: defaultLogger() }, { maxReservations: 1 })
+    const privateKey = await generateKeyPair('Ed25519')
+    const peer = peerIdFromPrivateKey(privateKey)
+
+    expect(store.reserve(peer, multiaddr()).status).to.equal(Status.OK)
+
+    const reservation = store.get(peer)
+
+    if (reservation == null) {
+      throw new Error('reservation was not created')
+    }
+
+    // refreshing a reservation reuses the same signal, so spy on it to ensure
+    // no further listeners are attached
+    const signal = reservation.signal
+    const addEventListener = Sinon.spy(signal, 'addEventListener')
+
+    for (let i = 0; i < 10; i++) {
+      expect(store.reserve(peer, multiaddr()).status).to.equal(Status.OK)
+      expect(store.get(peer)?.signal).to.equal(signal)
+    }
+
+    expect(addEventListener.called).to.be.false()
   })
 
   it('should fail to add reservation on exceeding limit', async function () {


### PR DESCRIPTION
## Description

When a relay reservation is refreshed, `ReservationStore.reserve()` attaches another `abort` listener to the reservation's signal. A refresh reuses the same `retimeableSignal` (it only resets the internal timeout via `signal.reset()`), so the earlier listeners are never removed and accumulate on the same signal across refreshes.

The fix registers the `abort` listener only in the branch that creates a new signal, so a single listener is attached per signal lifetime. Refreshing a reservation then just resets the timer.

## Notes & open questions

Opening as a draft with the failing regression test first; the fix commit follows.

## Change checklist

- [x] I have performed a self-review of my own code
- [x] I have made corresponding changes to the documentation if necessary (this includes comments as well)
- [x] I have added tests that prove my fix is effective or that my feature works
