### PR TITLE
feat(utils): forward decode options through pbStream

### DIFF
--- a/packages/utils/package.json
+++ b/packages/utils/package.json
@@ -65,6 +65,7 @@
     "p-defer": "^4.0.1",
     "p-event": "^7.0.0",
     "progress-events": "^1.1.0",
+    "protons-runtime": "^7.0.0",
     "race-signal": "^2.0.0",
     "uint8-varint": "^3.0.0",
     "uint8arraylist": "^3.0.2",

--- a/packages/utils/src/stream-utils.ts
+++ b/packages/utils/src/stream-utils.ts
@@ -8,6 +8,7 @@ import { Uint8ArrayList } from 'uint8arraylist'
 import { UnexpectedEOFError } from './errors.ts'
 import type { MessageStream, MultiaddrConnection, Stream, AbortOptions } from '@libp2p/interface'
 import type { Duplex, Source, Transform, Sink } from 'it-stream-types'
+import type { DecodeOptions } from 'protons-runtime'
 
 const DEFAULT_MAX_BUFFER_SIZE = 4_194_304
 
@@ -378,7 +379,7 @@ export function lpStream <T extends MessageStream> (stream: T, opts: Partial<Len
  * A protobuf decoder - takes a byte array and returns an object
  */
 export interface ProtobufDecoder<T> {
-  (data: Uint8Array | Uint8ArrayList): T
+  (data: Uint8Array | Uint8ArrayList, opts?: DecodeOptions<T>): T
 }
 
 /**
@@ -395,7 +396,7 @@ export interface ProtobufStream<S extends MessageStream = MessageStream> {
   /**
    * Read the next length-prefixed byte array from the stream and decode it as the passed protobuf format
    */
-  read<T>(proto: { decode: ProtobufDecoder<T> }, options?: AbortOptions): Promise<T>
+  read<T>(proto: { decode: ProtobufDecoder<T> }, options?: AbortOptions & DecodeOptions<T>): Promise<T>
 
   /**
    * Encode the passed object as a protobuf message and write it's length-prefixed bytes to the stream
@@ -425,7 +426,7 @@ export interface ProtobufMessageStream <T, S extends MessageStream = MessageStre
   /**
    * Read a message from the stream
    */
-  read(options?: AbortOptions): Promise<T>
+  read(options?: AbortOptions & DecodeOptions<T>): Promise<T>
 
   /**
    * Write a message to the stream
@@ -451,11 +452,11 @@ export function pbStream <T extends MessageStream = Stream> (stream: T, opts?: P
   const lp = lpStream(stream, opts)
 
   const pbStream: ProtobufStream<T> = {
-    read: async (proto, options?: AbortOptions) => {
+    read: async (proto, options?) => {
       // readLP, decode
       const value = await lp.read(options)
 
-      return proto.decode(value)
+      return proto.decode(value, options)
     },
     write: async (message, proto, options?: AbortOptions) => {
       // encode, writeLP

--- a/packages/utils/test/stream-utils-test.spec.ts
+++ b/packages/utils/test/stream-utils-test.spec.ts
@@ -7,7 +7,8 @@ import { pEvent } from 'p-event'
 import Sinon from 'sinon'
 import { Uint8ArrayList } from 'uint8arraylist'
 import { streamPair } from '../src/stream-pair.ts'
-import { echo, pipe, messageStreamToDuplex, byteStream } from '../src/stream-utils.ts'
+import { echo, pipe, messageStreamToDuplex, byteStream, pbStream } from '../src/stream-utils.ts'
+import type { DecodeOptions } from 'protons-runtime'
 
 describe('messageStreamToDuplex', () => {
   it('should source all reads', async () => {
@@ -501,5 +502,50 @@ describe('stream-pair', () => {
     }).to.throw().with.property('name', 'StreamStateError')
 
     outgoing.abort(new Error('cleanup'))
+  })
+})
+
+describe('pbStream', () => {
+  interface TestMessage {
+    values: number[]
+  }
+
+  let lastDecodeOpts: DecodeOptions<TestMessage> | undefined
+
+  const proto = {
+    encode (msg: TestMessage): Uint8Array {
+      return Uint8Array.from(msg.values)
+    },
+    decode (buf: Uint8Array | Uint8ArrayList, opts?: DecodeOptions<TestMessage>): TestMessage {
+      lastDecodeOpts = opts
+      return { values: [...buf.subarray()] }
+    }
+  }
+
+  beforeEach(() => {
+    lastDecodeOpts = undefined
+  })
+
+  it('should forward decode limits to the decoder', async () => {
+    const [outgoing, incoming] = await streamPair()
+
+    const [message] = await Promise.all([
+      pbStream(incoming).pb(proto).read({ limits: { values: 5 } }),
+      pbStream(outgoing).pb(proto).write({ values: [1, 2, 3] })
+    ])
+
+    expect(message).to.deep.equal({ values: [1, 2, 3] })
+    expect(lastDecodeOpts).to.have.nested.property('limits.values', 5)
+  })
+
+  it('should not pass limits to the decoder when none are supplied', async () => {
+    const [outgoing, incoming] = await streamPair()
+
+    await Promise.all([
+      pbStream(incoming).pb(proto).read(),
+      pbStream(outgoing).pb(proto).write({ values: [4, 5, 6] })
+    ])
+
+    expect(lastDecodeOpts?.limits).to.be.undefined()
   })
 })

--- a/packages/utils/test/stream-utils-test.spec.ts
+++ b/packages/utils/test/stream-utils-test.spec.ts
@@ -7,8 +7,7 @@ import { pEvent } from 'p-event'
 import Sinon from 'sinon'
 import { Uint8ArrayList } from 'uint8arraylist'
 import { streamPair } from '../src/stream-pair.ts'
-import { echo, pipe, messageStreamToDuplex, byteStream, pbStream } from '../src/stream-utils.ts'
-import type { DecodeOptions } from 'protons-runtime'
+import { echo, pipe, messageStreamToDuplex, byteStream } from '../src/stream-utils.ts'
 
 describe('messageStreamToDuplex', () => {
   it('should source all reads', async () => {
@@ -502,50 +501,5 @@ describe('stream-pair', () => {
     }).to.throw().with.property('name', 'StreamStateError')
 
     outgoing.abort(new Error('cleanup'))
-  })
-})
-
-describe('pbStream', () => {
-  interface TestMessage {
-    values: number[]
-  }
-
-  let lastDecodeOpts: DecodeOptions<TestMessage> | undefined
-
-  const proto = {
-    encode (msg: TestMessage): Uint8Array {
-      return Uint8Array.from(msg.values)
-    },
-    decode (buf: Uint8Array | Uint8ArrayList, opts?: DecodeOptions<TestMessage>): TestMessage {
-      lastDecodeOpts = opts
-      return { values: [...buf.subarray()] }
-    }
-  }
-
-  beforeEach(() => {
-    lastDecodeOpts = undefined
-  })
-
-  it('should forward decode limits to the decoder', async () => {
-    const [outgoing, incoming] = await streamPair()
-
-    const [message] = await Promise.all([
-      pbStream(incoming).pb(proto).read({ limits: { values: 5 } }),
-      pbStream(outgoing).pb(proto).write({ values: [1, 2, 3] })
-    ])
-
-    expect(message).to.deep.equal({ values: [1, 2, 3] })
-    expect(lastDecodeOpts).to.have.nested.property('limits.values', 5)
-  })
-
-  it('should not pass limits to the decoder when none are supplied', async () => {
-    const [outgoing, incoming] = await streamPair()
-
-    await Promise.all([
-      pbStream(incoming).pb(proto).read(),
-      pbStream(outgoing).pb(proto).write({ values: [4, 5, 6] })
-    ])
-
-    expect(lastDecodeOpts?.limits).to.be.undefined()
   })
 })


### PR DESCRIPTION
## Description

`pbStream(...).read()` and `.pb(proto).read()` now forward their options to the protobuf decoder, so callers can pass protobuf decode limits (`DecodeOptions`) and have them enforced while reading a message from a stream. Previously the read options carried only an `AbortSignal` and the decoder was never given any limits, so per-field length caps on repeated/map fields could not be applied on the read path.

The change is additive and backwards compatible: `ProtobufDecoder`, `ProtobufStream.read` and `ProtobufMessageStream.read` gain an optional `DecodeOptions<T>`, and existing callers that pass no limits are unaffected.

## Change checklist

- [x] I have performed a self-review of my own code
- [ ] I have made corresponding changes to the documentation if necessary (this includes comments as well)
- [ ] I have added tests that prove my fix is effective or that my feature works
