### PR TITLE
fix(gossipsub): validate the message key for all peer id types

### DIFF
--- a/packages/gossipsub/src/utils/buildRawMessage.ts
+++ b/packages/gossipsub/src/utils/buildRawMessage.ts
@@ -177,7 +177,7 @@ export async function validateToRawMessage (
           sequenceNumber: BigInt(`0x${uint8ArrayToString(msg.seqno, 'base16')}`),
           topic: msg.topic,
           signature: msg.signature,
-          key: msg.key != null ? publicKeyFromProtobuf(msg.key) : publicKey
+          key: publicKey
         }
       }
     }

--- a/packages/gossipsub/src/utils/buildRawMessage.ts
+++ b/packages/gossipsub/src/utils/buildRawMessage.ts
@@ -1,5 +1,5 @@
 import { publicKeyFromProtobuf } from '@libp2p/crypto/keys'
-import { peerIdFromMultihash, peerIdFromPublicKey } from '@libp2p/peer-id'
+import { peerIdFromMultihash } from '@libp2p/peer-id'
 import * as Digest from 'multiformats/hashes/digest'
 import { concat as uint8ArrayConcat } from 'uint8arrays/concat'
 import { fromString as uint8ArrayFromString } from 'uint8arrays/from-string'
@@ -139,9 +139,9 @@ export async function validateToRawMessage (
       let publicKey: PublicKey
       if (msg.key != null) {
         publicKey = publicKeyFromProtobuf(msg.key)
-        // derive the peer id from the key and compare, so this applies to peer
-        // ids that do not inline their public key (RSA) as well as those that do
-        if (!peerIdFromPublicKey(publicKey).equals(fromPeerId)) {
+
+        // the message key must derive to the `from` peer id
+        if (!fromPeerId.equals(publicKey.toMultihash().bytes)) {
           return { valid: false, error: ValidateError.InvalidPeerId }
         }
       } else {

--- a/packages/gossipsub/src/utils/buildRawMessage.ts
+++ b/packages/gossipsub/src/utils/buildRawMessage.ts
@@ -1,5 +1,5 @@
 import { publicKeyFromProtobuf } from '@libp2p/crypto/keys'
-import { peerIdFromMultihash } from '@libp2p/peer-id'
+import { peerIdFromMultihash, peerIdFromPublicKey } from '@libp2p/peer-id'
 import * as Digest from 'multiformats/hashes/digest'
 import { concat as uint8ArrayConcat } from 'uint8arrays/concat'
 import { fromString as uint8ArrayFromString } from 'uint8arrays/from-string'
@@ -139,8 +139,9 @@ export async function validateToRawMessage (
       let publicKey: PublicKey
       if (msg.key != null) {
         publicKey = publicKeyFromProtobuf(msg.key)
-        // TODO: Should `fromPeerId.pubKey` be optional?
-        if (fromPeerId.publicKey !== undefined && !publicKey.equals(fromPeerId.publicKey)) {
+        // derive the peer id from the key and compare, so this applies to peer
+        // ids that do not inline their public key (RSA) as well as those that do
+        if (!peerIdFromPublicKey(publicKey).equals(fromPeerId)) {
           return { valid: false, error: ValidateError.InvalidPeerId }
         }
       } else {

--- a/packages/gossipsub/test/unit/buildRawMessage.spec.ts
+++ b/packages/gossipsub/test/unit/buildRawMessage.spec.ts
@@ -3,8 +3,9 @@ import { peerIdFromPrivateKey } from '@libp2p/peer-id'
 import { expect } from 'aegir/chai'
 import { fromString as uint8ArrayFromString } from 'uint8arrays/from-string'
 import { StrictSign } from '../../src/index.ts'
-import { buildRawMessage } from '../../src/utils/buildRawMessage.ts'
+import { buildRawMessage, validateToRawMessage } from '../../src/utils/buildRawMessage.ts'
 import { getPublishConfigFromPeerId } from '../../src/utils/publishConfig.ts'
+import type { PrivateKey } from '@libp2p/interface'
 
 describe('buildRawMessage', () => {
   describe('Signing seqno', () => {
@@ -26,6 +27,44 @@ describe('buildRawMessage', () => {
       for (let i = 1; i < seqnos.length; i++) {
         expect(seqnos[i] > seqnos[i - 1], `seqno ${seqnos[i]} should be > previous ${seqnos[i - 1]} (index ${i})`).to.equal(true)
       }
+    })
+  })
+
+  describe('RSA author key binding', () => {
+    const topic = 'test-topic'
+    const data = uint8ArrayFromString('hello')
+    let victimKey: PrivateKey
+
+    before(async function () {
+      // RSA key generation is slow
+      this.timeout(30_000)
+      victimKey = await generateKeyPair('RSA', 2048)
+    })
+
+    it('accepts a message signed by the genuine RSA author', async () => {
+      const victim = peerIdFromPrivateKey(victimKey)
+      const config = getPublishConfigFromPeerId(StrictSign, victim, victimKey)
+      const { raw } = await buildRawMessage(config, topic, data, data)
+
+      const result = await validateToRawMessage(StrictSign, raw)
+      expect(result.valid).to.equal(true)
+    })
+
+    it('rejects a message whose signing key does not derive to the RSA author', async () => {
+      const victim = peerIdFromPrivateKey(victimKey)
+      const attackerKey = await generateKeyPair('Ed25519')
+
+      // claim the victim RSA peer id as author but sign with the attacker's key.
+      // getPublishConfigFromPeerId does not check that the peer id matches the
+      // private key, so `from` is the victim while the signature and `key` field
+      // are the attacker's
+      const forgedConfig = getPublishConfigFromPeerId(StrictSign, victim, attackerKey)
+      const { raw } = await buildRawMessage(forgedConfig, topic, data, data)
+
+      expect(raw.from).to.deep.equal(victim.toMultihash().bytes)
+
+      const result = await validateToRawMessage(StrictSign, raw)
+      expect(result.valid).to.equal(false)
     })
   })
 })

--- a/packages/gossipsub/test/unit/buildRawMessage.spec.ts
+++ b/packages/gossipsub/test/unit/buildRawMessage.spec.ts
@@ -3,6 +3,7 @@ import { peerIdFromPrivateKey } from '@libp2p/peer-id'
 import { expect } from 'aegir/chai'
 import { fromString as uint8ArrayFromString } from 'uint8arrays/from-string'
 import { StrictSign } from '../../src/index.ts'
+import { ValidateError } from '../../src/types.ts'
 import { buildRawMessage, validateToRawMessage } from '../../src/utils/buildRawMessage.ts'
 import { getPublishConfigFromPeerId } from '../../src/utils/publishConfig.ts'
 import type { PrivateKey } from '@libp2p/interface'
@@ -64,7 +65,7 @@ describe('buildRawMessage', () => {
       expect(raw.from).to.deep.equal(victim.toMultihash().bytes)
 
       const result = await validateToRawMessage(StrictSign, raw)
-      expect(result.valid).to.equal(false)
+      expect(result).to.deep.equal({ valid: false, error: ValidateError.InvalidPeerId })
     })
   })
 })


### PR DESCRIPTION
## Description

When validating a `StrictSign` message that carries a `key`, `@libp2p/gossipsub` checks that key against the message's `from` peer id. That check compared the public keys directly, which only applies when the `from` peer id inlines its public key (Ed25519, secp256k1).

It now derives the peer id from the supplied key and compares that instead, so the check applies to every peer id type, including those that don't inline a public key (RSA).

## Change checklist

- [x] I have performed a self-review of my own code
- [x] I have made corresponding changes to the documentation if necessary (this includes comments as well)
- [x] I have added tests that prove my fix is effective or that my feature works
