### PR TITLE
fix: use the same peer id to load and store peer records

### DIFF
--- a/packages/peer-store/src/index.ts
+++ b/packages/peer-store/src/index.ts
@@ -185,7 +185,7 @@ class PersistentPeerStore implements PeerStore {
     const peerRecord = PeerRecord.createFromProtobuf(envelope.payload)
 
     if (!peerRecord.peerId.equals(peerId)) {
-      this.log('signing key did not match peer id in the peer record - expected: %p received: %p', peerId, peerRecord.peerId)
+      this.log('signing key did not match peer id in the peer record - signer: %p record: %p', peerId, peerRecord.peerId)
       return false
     }
 

--- a/packages/peer-store/src/index.ts
+++ b/packages/peer-store/src/index.ts
@@ -183,6 +183,12 @@ class PersistentPeerStore implements PeerStore {
     }
 
     const peerRecord = PeerRecord.createFromProtobuf(envelope.payload)
+
+    if (!peerRecord.peerId.equals(peerId)) {
+      this.log('signing key did not match peer id in the peer record - expected: %p received: %p', peerId, peerRecord.peerId)
+      return false
+    }
+
     let peer: Peer | undefined
 
     try {

--- a/packages/peer-store/test/index.spec.ts
+++ b/packages/peer-store/test/index.spec.ts
@@ -19,6 +19,7 @@ const addr1 = multiaddr('/ip4/127.0.0.1/tcp/8000')
 
 describe('PersistentPeerStore', () => {
   let key: PrivateKey
+  let otherKey: PrivateKey
   let peerId: PeerId
   let otherPeerId: PeerId
   let peerStore: PeerStore
@@ -28,7 +29,8 @@ describe('PersistentPeerStore', () => {
   beforeEach(async () => {
     key = await generateKeyPair('Ed25519')
     peerId = peerIdFromPrivateKey(key)
-    otherPeerId = peerIdFromPrivateKey(await generateKeyPair('Ed25519'))
+    otherKey = await generateKeyPair('Ed25519')
+    otherPeerId = peerIdFromPrivateKey(otherKey)
     events = new TypedEventEmitter()
     components = {
       peerId,
@@ -289,6 +291,43 @@ describe('PersistentPeerStore', () => {
         expectedPeer: signingPeerId
       })).to.eventually.equal(false)
       await expect(peerStore.has(otherPeerId)).to.eventually.be.false()
+    })
+
+    it('does not overwrite addresses with a record signed by another peer', async () => {
+      const signingKey = await generateKeyPair('Ed25519')
+
+      const signedPeerRecord = await RecordEnvelope.seal(new PeerRecord({
+        peerId: otherPeerId,
+        multiaddrs: [
+          multiaddr('/ip4/127.0.0.1/tcp/1234')
+        ],
+        seqNumber: 2n
+      }), otherKey)
+
+      await expect(peerStore.consumePeerRecord(signedPeerRecord.marshal())).to.eventually.equal(true)
+
+      // the record names `otherPeerId` but is signed by `signingKey` - the sequence
+      // number is higher than the stored one so it cannot be what rejects the record
+      const mismatchedSignedPeerRecord = await RecordEnvelope.seal(new PeerRecord({
+        peerId: otherPeerId,
+        multiaddrs: [
+          multiaddr('/ip4/127.0.0.1/tcp/4567')
+        ],
+        seqNumber: 10n
+      }), signingKey)
+
+      await expect(peerStore.consumePeerRecord(mismatchedSignedPeerRecord.marshal())).to.eventually.equal(false)
+
+      const peer = await peerStore.get(otherPeerId)
+      expect(peer.addresses.map(({ multiaddr, isCertified }) => ({
+        isCertified,
+        multiaddr: multiaddr.toString()
+      }))).to.deep.equal([{
+        isCertified: true,
+        multiaddr: '/ip4/127.0.0.1/tcp/1234'
+      }])
+      expect(peer).to.have.property('peerRecordEnvelope')
+        .that.deep.equals(signedPeerRecord.marshal())
     })
 
     it('allows queries', async () => {

--- a/packages/peer-store/test/index.spec.ts
+++ b/packages/peer-store/test/index.spec.ts
@@ -273,6 +273,24 @@ describe('PersistentPeerStore', () => {
       await expect(peerStore.has(peerId)).to.eventually.be.false()
     })
 
+    it('ignores record where the signing key does not match the peer in the record', async () => {
+      const signingKey = await generateKeyPair('Ed25519')
+      const signingPeerId = peerIdFromPrivateKey(signingKey)
+
+      // the record names `otherPeerId` but is signed by `signingPeerId`
+      const signedPeerRecord = await RecordEnvelope.seal(new PeerRecord({
+        peerId: otherPeerId,
+        multiaddrs: [
+          multiaddr('/ip4/127.0.0.1/tcp/4567')
+        ]
+      }), signingKey)
+
+      await expect(peerStore.consumePeerRecord(signedPeerRecord.marshal(), {
+        expectedPeer: signingPeerId
+      })).to.eventually.equal(false)
+      await expect(peerStore.has(otherPeerId)).to.eventually.be.false()
+    })
+
     it('allows queries', async () => {
       await peerStore.save(otherPeerId, {
         multiaddrs: [


### PR DESCRIPTION
## Description

`consumePeerRecord()` uses two different peer ids. It derives one from the
envelope public key and uses it to load the stored peer and compare sequence
numbers, then stores the addresses under the peer id from the record payload.

A `PeerRecord` names the peer it describes, so for anything produced by
`RecordEnvelope.seal()` the two agree and this is invisible. Nothing checks it
though, and when they differ the sequence number comparison is made against a
different peer to the one being written, so it no longer orders that peer's
records and an older record can replace a newer one.

Ignore records where the two do not match.

## Notes & open questions

Returns `false` like the neighbouring `expectedPeer` check rather than throwing.

## Change checklist

- [x] I have performed a self-review of my own code
- [x] I have made corresponding changes to the documentation if necessary (this includes comments as well)
- [x] I have added tests that prove my fix is effective or that my feature works
