### PR TITLE
test(floodsub): harden decode-limit and topic-cleanup coverage

### DIFF
--- a/packages/floodsub/src/decodeRpc.ts
+++ b/packages/floodsub/src/decodeRpc.ts
@@ -3,10 +3,11 @@ import type { DecodeOptions } from 'protons-runtime'
 
 /**
  * Limits applied when decoding incoming RPC messages. A single RPC frame is
- * already byte-capped by the length-prefixed stream (see `maxDataLength`), but
- * that bounds bytes, not element counts - protobuf packs many small repeated
- * entries into a few bytes. These caps bound the number of decoded elements so
- * a single frame cannot expand into millions of objects.
+ * already byte-capped by the underlying byte stream (`maxBufferSize`, which
+ * defaults to 4 MiB), but that bounds bytes, not element counts - protobuf
+ * packs many small repeated entries into a few bytes. These caps bound the
+ * number of decoded elements so a single frame cannot expand into millions of
+ * objects.
  */
 export interface DecodeRPCLimits {
   maxSubscriptions: number

--- a/packages/floodsub/test/decode-rpc-limits.spec.ts
+++ b/packages/floodsub/test/decode-rpc-limits.spec.ts
@@ -19,10 +19,11 @@ import type { Connection, PeerId, Stream } from '@libp2p/interface'
 import type { Registrar } from '@libp2p/interface-internal'
 import type { StubbedInstance } from 'sinon-ts'
 
-// small limits so the crafted frames stay tiny
+// small limits so the crafted frames stay tiny. the two caps use distinct
+// values so a transposed subscriptions/messages mapping cannot pass the tests
 const limits = createRPCDecodeLimits({
   maxSubscriptions: 4,
-  maxMessages: 4
+  maxMessages: 2
 })
 
 function subscriptions (n: number): RPC {
@@ -46,11 +47,15 @@ describe('decode rpc limits', () => {
     })
 
     it('rejects an RPC with more messages than the limit', () => {
-      expect(() => RPC.decode(RPC.encode(messages(5)), { limits })).to.throw(MaxLengthError)
+      expect(() => RPC.decode(RPC.encode(messages(3)), { limits })).to.throw(MaxLengthError)
     })
 
-    it('accepts an RPC within the limits', () => {
+    it('accepts subscriptions at the limit', () => {
       expect(() => RPC.decode(RPC.encode(subscriptions(4)), { limits })).to.not.throw()
+    })
+
+    it('accepts messages at the limit', () => {
+      expect(() => RPC.decode(RPC.encode(messages(2)), { limits })).to.not.throw()
     })
 
     it('skips an unknown control block (field 3) instead of decoding it', () => {
@@ -138,8 +143,11 @@ describe('floodsub decode-limits integration', () => {
     const remotePeer = peerIdFromPrivateKey(await generateKeyPair('Ed25519'))
     const [outbound, inbound] = await streamPair()
 
-    let dispatched = 0
-    pubsub.addEventListener('message', () => { dispatched++ })
+    // subscription-change is the honest signal that the frame was decoded: it
+    // fires from processRpc, and unlike pubsub.topics it survives _removePeer's
+    // topic cleanup, so it still reads as non-zero after the peer is torn down
+    let subChanges = 0
+    pubsub.addEventListener('subscription-change', () => { subChanges++ })
 
     const connection = stubInterface<Connection>({ remotePeer })
     ;(pubsub as unknown as { _onIncomingStream(stream: Stream, connection: Connection): void })
@@ -151,12 +159,15 @@ describe('floodsub decode-limits integration', () => {
       subscriptions: Array.from({ length: 5001 }, (_, i) => ({ subscribe: true, topic: `t${i}` })),
       messages: []
     }
+    // the outbound stream is intentionally left open: the only thing that can
+    // tear the peer down here is the decode limit firing, not an EOF from close
     outbound.send(lp.encode.single(RPC.encode(oversized)))
-    await outbound.close()
 
     // the over-limit frame is rejected at decode and the peer is torn down,
     // not left half-open with a dead inbound stream
     await pWaitFor(() => !pubsub.getPeers().some(p => p.equals(remotePeer)))
-    expect(dispatched, 'over-limit frame was dispatched').to.equal(0)
+    // decode threw before processRpc ran, so none of the 5001 subscriptions
+    // were processed
+    expect(subChanges, 'over-limit frame was decoded and its subscriptions processed').to.equal(0)
   })
 })

--- a/packages/floodsub/test/topics-cleanup.spec.ts
+++ b/packages/floodsub/test/topics-cleanup.spec.ts
@@ -70,6 +70,38 @@ describe('topics cleanup', () => {
     expect(pubsub.topics.has('t1'), 'empty topic set left behind after peer removal').to.be.false()
   })
 
+  it('keeps the topic when a peer is removed but another remains subscribed', async () => {
+    const peerA = peerIdFromPrivateKey(await generateKeyPair('Ed25519'))
+    const peerB = peerIdFromPrivateKey(await generateKeyPair('Ed25519'))
+
+    pubsub.peers.set(peerA, new PeerStreams(peerA))
+    pubsub.peers.set(peerB, new PeerStreams(peerB))
+    pubsub.processRpcSubOpt(peerA, { subscribe: true, topic: 't1' })
+    pubsub.processRpcSubOpt(peerB, { subscribe: true, topic: 't1' })
+    expect(pubsub.topics.get('t1')?.size).to.equal(2)
+
+    ;(pubsub as unknown as { _removePeer(peerId: PeerId): void })._removePeer(peerA)
+
+    // removing one subscriber must not wipe the topic for the others
+    expect(pubsub.topics.has('t1'), 'topic dropped while another peer still subscribed').to.be.true()
+    expect(pubsub.topics.get('t1')?.has(peerB), 'remaining subscriber lost').to.be.true()
+  })
+
+  it('keeps the topic when a peer unsubscribes but another remains subscribed', async () => {
+    const peerA = peerIdFromPrivateKey(await generateKeyPair('Ed25519'))
+    const peerB = peerIdFromPrivateKey(await generateKeyPair('Ed25519'))
+
+    pubsub.processRpcSubOpt(peerA, { subscribe: true, topic: 't1' })
+    pubsub.processRpcSubOpt(peerB, { subscribe: true, topic: 't1' })
+    expect(pubsub.topics.get('t1')?.size).to.equal(2)
+
+    pubsub.processRpcSubOpt(peerA, { subscribe: false, topic: 't1' })
+
+    // one peer unsubscribing must not wipe the topic for the others
+    expect(pubsub.topics.has('t1'), 'topic dropped while another peer still subscribed').to.be.true()
+    expect(pubsub.topics.get('t1')?.has(peerB), 'remaining subscriber lost').to.be.true()
+  })
+
   it('clears the topics map on stop', async () => {
     const peer = peerIdFromPrivateKey(await generateKeyPair('Ed25519'))
 


### PR DESCRIPTION
## Description

Several floodsub decode-limit and topic-cleanup tests passed even when the behaviour they cover was broken:

- The default-limit integration test passed with the limits disabled. It asserted on message dispatch (structurally zero for a subscription-only frame) and let stream EOF, not the limit, tear the peer down. It now asserts on `subscription-change`, which fires only if the frame decoded and survives the peer cleanup, and leaves the stream open so only the limit can drop the peer.
- The enforcement fixture used equal subscription/message caps, so a transposed field mapping was undetectable. The caps are now distinct, with at-limit accept cases for each field.
- The `peers.size === 0` cleanup guard was only exercised with a single peer, so an unconditional delete would still pass. Two-peer cases now cover the peer-removal and unsubscribe paths.

Also corrects the `decodeRpc` doc comment, which referenced `maxDataLength` (never set on this path); the actual byte cap is `byteStream`'s `maxBufferSize`.

## Change checklist

- [x] I have performed a self-review of my own code
- [x] I have made corresponding changes to the documentation if necessary (this includes comments as well)
- [x] I have added tests that prove my fix is effective or that my feature works
