### PR TITLE
fix(peer-store): copy observation times from the matching address

### DIFF
--- a/packages/peer-store/src/utils/to-peer-pb.ts
+++ b/packages/peer-store/src/utils/to-peer-pb.ts
@@ -162,7 +162,7 @@ export async function toPeerPB (peerId: PeerId, data: Partial<PeerData>, strateg
 
   // add observed addresses to multiaddrs
   output.addresses.forEach(addr => {
-    addr.observed = options.existingPeer?.peerPB.addresses?.find(addr => uint8ArrayEquals(addr.multiaddr, addr.multiaddr))?.observed ?? Date.now()
+    addr.observed = options.existingPeer?.peerPB.addresses?.find(existingAddr => uint8ArrayEquals(existingAddr.multiaddr, addr.multiaddr))?.observed ?? Date.now()
   })
 
   // Ed25519 and secp256k1 have their public key embedded in them so no need to duplicate it

--- a/packages/peer-store/test/index.spec.ts
+++ b/packages/peer-store/test/index.spec.ts
@@ -321,7 +321,7 @@ describe('PersistentPeerStore', () => {
 
     it('should not expire a newly added multiaddr early', async () => {
       const peerStore = persistentPeerStore(components, {
-        maxAddressAge: 1000
+        maxAddressAge: 1500
       })
 
       await peerStore.merge(otherPeerId, {
@@ -330,8 +330,9 @@ describe('PersistentPeerStore', () => {
         ]
       })
 
-      // let the first multiaddr age, but not expire
-      await delay(800)
+      // age the first multiaddr but keep it alive, so it is still present
+      // when the second is added
+      await delay(1000)
 
       // the second multiaddr is observed now, so should outlive the first
       await peerStore.merge(otherPeerId, {
@@ -341,7 +342,7 @@ describe('PersistentPeerStore', () => {
       })
 
       // enough to expire the first multiaddr, but not the second
-      await delay(400)
+      await delay(1000)
 
       const peer = await peerStore.get(otherPeerId)
       expect(peer.addresses.map(({ multiaddr }) => multiaddr.toString())).to.deep.equal([

--- a/packages/peer-store/test/index.spec.ts
+++ b/packages/peer-store/test/index.spec.ts
@@ -319,6 +319,36 @@ describe('PersistentPeerStore', () => {
         .with.lengthOf(0, 'did not expire multiaddrs')
     })
 
+    it('should not expire a newly added multiaddr early', async () => {
+      const peerStore = persistentPeerStore(components, {
+        maxAddressAge: 1000
+      })
+
+      await peerStore.merge(otherPeerId, {
+        multiaddrs: [
+          multiaddr('/ip4/123.123.123.123/tcp/1234')
+        ]
+      })
+
+      // let the first multiaddr age, but not expire
+      await delay(800)
+
+      // the second multiaddr is observed now, so should outlive the first
+      await peerStore.merge(otherPeerId, {
+        multiaddrs: [
+          multiaddr('/ip4/123.123.123.123/tcp/5678')
+        ]
+      })
+
+      // enough to expire the first multiaddr, but not the second
+      await delay(400)
+
+      const peer = await peerStore.get(otherPeerId)
+      expect(peer.addresses.map(({ multiaddr }) => multiaddr.toString())).to.deep.equal([
+        '/ip4/123.123.123.123/tcp/5678'
+      ], 'expired a newly added multiaddr')
+    })
+
     it('should not expire self peer multiaddrs', async () => {
       const peerStore = persistentPeerStore(components, {
         maxAddressAge: 100


### PR DESCRIPTION
## Description

Each stored address is stamped with an `observed` timestamp, copied from the
matching existing address so a re-stored address keeps its original time. The
lookup for the matching address named its callback parameter `addr`, shadowing
the address being stamped, so it compared an address to itself and always
matched the first stored address. Every address therefore inherited the first
stored address's `observed` time instead of its own, so a newly added multiaddr
could be expired early by `maxAddressAge` despite having just been observed.

Rename the callback parameter so the lookup matches by multiaddr.

## Change checklist

- [x] I have performed a self-review of my own code
- [x] I have made corresponding changes to the documentation if necessary (this includes comments as well)
- [x] I have added tests that prove my fix is effective or that my feature works
