### PR TITLE
fix(floodsub): bind the message key to the author peer id

### DIFF
--- a/packages/floodsub/src/sign.ts
+++ b/packages/floodsub/src/sign.ts
@@ -80,12 +80,16 @@ export function messagePublicKey (message: SignedMessage): PublicKey {
     throw new Error('Could not get the public key from the originator id')
   }
 
-  if (message.key != null) {
-    return message.key
-  }
-
+  // an Ed25519/secp256k1 peer id embeds its own public key, so a key recovered
+  // from `from` is provably the author's; trust it over the supplied message.key
   if (message.from.publicKey != null) {
     return message.from.publicKey
+  }
+
+  // otherwise the supplied key must derive to the from peer id, else a message
+  // could be signed by one key while claiming a different author
+  if (message.key != null && message.from.equals(message.key.toMultihash().bytes)) {
+    return message.key
   }
 
   // We couldn't validate pubkey is from the originator, error

--- a/packages/floodsub/test/message.spec.ts
+++ b/packages/floodsub/test/message.spec.ts
@@ -5,10 +5,13 @@ import { peerIdFromPrivateKey } from '@libp2p/peer-id'
 import { expect } from 'aegir/chai'
 import sinon from 'sinon'
 import { stubInterface } from 'sinon-ts'
+import { concat as uint8ArrayConcat } from 'uint8arrays/concat'
 import { fromString as uint8ArrayFromString } from 'uint8arrays/from-string'
 import { floodsub } from '../src/index.ts'
-import { randomSeqno } from '../src/utils.ts'
-import type { FloodSub } from '../src/index.ts'
+import { RPC } from '../src/message/rpc.ts'
+import { SignPrefix } from '../src/sign.ts'
+import { randomSeqno, toMessage, toRpcMessage } from '../src/utils.ts'
+import type { FloodSub, SignedMessage } from '../src/index.ts'
 import type { PeerId } from '@libp2p/interface'
 import type { Registrar } from '@libp2p/interface-internal'
 import type { StubbedInstance } from 'sinon-ts'
@@ -110,5 +113,31 @@ describe('pubsub base messages', () => {
 
     // @ts-expect-error private method
     await expect(pubsub['validate'](peerId, message)).to.be.rejectedWith(Error, 'Signing required and no signature was present')
+  })
+
+  it('validate with StrictSign rejects a forged message whose key does not derive to the author', async () => {
+    const victim = peerIdFromPrivateKey(await generateKeyPair('Ed25519'))
+    const attackerKey = await generateKeyPair('Ed25519')
+
+    // a message claiming the victim as author but signed with, and carrying,
+    // the attacker's key
+    // @ts-expect-error signature and key are added below
+    const forged: SignedMessage = {
+      type: 'signed',
+      from: victim,
+      data: uint8ArrayFromString('hello'),
+      topic: 'test-topic',
+      sequenceNumber: randomSeqno()
+    }
+    const bytes = uint8ArrayConcat([SignPrefix, RPC.Message.encode(toRpcMessage(forged)).subarray()])
+    forged.signature = await attackerKey.sign(bytes)
+    forged.key = attackerKey.publicKey
+
+    // decode through the wire form the way an inbound message is received
+    const received = await toMessage(toRpcMessage(forged))
+    expect(received.type).to.equal('signed')
+
+    // @ts-expect-error private method
+    await expect(pubsub['validate'](victim, received)).to.be.rejectedWith(Error, 'Invalid message signature')
   })
 })

--- a/packages/floodsub/test/sign.spec.ts
+++ b/packages/floodsub/test/sign.spec.ts
@@ -1,5 +1,5 @@
 import { generateKeyPair } from '@libp2p/crypto/keys'
-import { peerIdFromPrivateKey } from '@libp2p/peer-id'
+import { peerIdFromMultihash, peerIdFromPrivateKey } from '@libp2p/peer-id'
 import { expect } from 'aegir/chai'
 import { concat as uint8ArrayConcat } from 'uint8arrays/concat'
 import { fromString as uint8ArrayFromString } from 'uint8arrays/from-string'
@@ -11,7 +11,7 @@ import {
 } from '../src/sign.ts'
 import { randomSeqno, toRpcMessage } from '../src/utils.ts'
 import type { PubSubRPCMessage } from '../src/floodsub.ts'
-import type { Message } from '../src/index.ts'
+import type { Message, SignedMessage } from '../src/index.ts'
 import type { PeerId, PrivateKey } from '@libp2p/interface'
 
 function encodeMessage (message: PubSubRPCMessage): Uint8Array {
@@ -112,5 +112,70 @@ describe('message signing', () => {
       from: peerId
     }, encodeMessage)
     expect(verified).to.eql(true)
+  })
+})
+
+describe('author key binding', () => {
+  const topic = 'test-topic'
+  const data = uint8ArrayFromString('hello')
+
+  // a message whose `from` is the victim but which is signed by, and carries
+  // the public key of, the attacker
+  async function forge (victim: PeerId, attackerKey: PrivateKey): Promise<SignedMessage> {
+    // @ts-expect-error signature and key are added below
+    const message: SignedMessage = {
+      type: 'signed',
+      from: victim,
+      data,
+      sequenceNumber: randomSeqno(),
+      topic
+    }
+    const bytes = uint8ArrayConcat([SignPrefix, encodeMessage(toRpcMessage(message)).subarray()])
+    message.signature = await attackerKey.sign(bytes)
+    message.key = attackerKey.publicKey
+    return message
+  }
+
+  it('rejects a message whose key does not derive to the Ed25519 author', async () => {
+    const victim = peerIdFromPrivateKey(await generateKeyPair('Ed25519'))
+    const forged = await forge(victim, await generateKeyPair('Ed25519'))
+
+    await expect(verifySignature(forged, encodeMessage)).to.eventually.equal(false)
+  })
+
+  it('rejects a message whose key does not derive to the secp256k1 author', async () => {
+    const victim = peerIdFromPrivateKey(await generateKeyPair('secp256k1'))
+    const forged = await forge(victim, await generateKeyPair('Ed25519'))
+
+    await expect(verifySignature(forged, encodeMessage)).to.eventually.equal(false)
+  })
+
+  // an RSA peer id does not carry its public key, so `from.publicKey` is
+  // undefined and verification goes through the derive-to-author check rather
+  // than the authoritative-key branch that the inlined types above exercise
+  describe('peer id without an inline public key (RSA)', () => {
+    let rsaKey: PrivateKey
+    let author: PeerId
+
+    before(async () => {
+      rsaKey = await generateKeyPair('RSA', 2048)
+      // on the wire `from` is rebuilt from its multihash and carries no key
+      author = peerIdFromMultihash(peerIdFromPrivateKey(rsaKey).toMultihash())
+    })
+
+    it('accepts a message whose key derives to the author', async () => {
+      const signed = await signMessage(rsaKey, { from: author, topic, data, sequenceNumber: randomSeqno() }, encodeMessage)
+      // signMessage rebuilds `from` from the private key, so it carries the key;
+      // use the wire form so the derive-to-author check is exercised
+      signed.from = author
+
+      await expect(verifySignature(signed, encodeMessage)).to.eventually.equal(true)
+    })
+
+    it('rejects a message whose key does not derive to the author', async () => {
+      const forged = await forge(author, await generateKeyPair('Ed25519'))
+
+      await expect(verifySignature(forged, encodeMessage)).to.be.rejectedWith('Could not get the public key from the originator id')
+    })
   })
 })


### PR DESCRIPTION
## Description

Under the `StrictSign` signature policy, `messagePublicKey` returned the public
key from a message's `key` field without checking that it corresponds to the
message's `from` peer id. When `from` carries its own public key (Ed25519,
secp256k1), that key is authoritative and should be used instead.

Prefer `from`'s own public key when it is present, and otherwise require the
supplied key to derive to `from`, so a signed message is always verified against
the key its `from` peer id commits to. `@libp2p/gossipsub` performs the
equivalent check.

## Change checklist

- [x] I have performed a self-review of my own code
- [x] I have made corresponding changes to the documentation if necessary (this includes comments as well)
- [x] I have added tests that prove my fix is effective or that my feature works
