### PR TITLE
fix: verify records and public keys match what was requested

### DIFF
--- a/packages/kad-dht/src/peer-routing/index.ts
+++ b/packages/kad-dht/src/peer-routing/index.ts
@@ -3,6 +3,7 @@ import { InvalidPublicKeyError, NotFoundError } from '@libp2p/interface'
 import { peerIdFromPublicKey, peerIdFromMultihash } from '@libp2p/peer-id'
 import { Libp2pRecord } from '@libp2p/record'
 import * as Digest from 'multiformats/hashes/digest'
+import { equals as uint8ArrayEquals } from 'uint8arrays/equals'
 import { QueryError, InvalidRecordError } from '../errors.ts'
 import { MessageType } from '../message/dht.ts'
 import { PeerDistanceList } from '../peer-distance-list.ts'
@@ -299,7 +300,7 @@ export class PeerRouting {
         if (event.record != null) {
           // We have a record
           try {
-            await this._verifyRecordOnline(event.record, options)
+            await this._verifyRecordOnline(event.record, key, options)
           } catch (err: any) {
             const errMsg = 'invalid record received, discarded'
             this.log(errMsg)
@@ -322,9 +323,14 @@ export class PeerRouting {
    * Verify a record, fetching missing public keys from the network.
    * Throws an error if the record is invalid.
    */
-  async _verifyRecordOnline (record: DHTRecord, options?: AbortOptions): Promise<void> {
+  async _verifyRecordOnline (record: DHTRecord, key: Uint8Array, options?: AbortOptions): Promise<void> {
     if (record.timeReceived == null) {
       throw new InvalidRecordError('invalid record received')
+    }
+
+    // the returned record must be for the key that was requested
+    if (!uint8ArrayEquals(record.key, key)) {
+      throw new InvalidRecordError('received record key did not match the requested key')
     }
 
     await verifyRecord(this.validators, new Libp2pRecord(record.key, record.value, record.timeReceived), options)

--- a/packages/kad-dht/test/peer-routing.spec.ts
+++ b/packages/kad-dht/test/peer-routing.spec.ts
@@ -1,9 +1,11 @@
 import { generateKeyPair } from '@libp2p/crypto/keys'
 import { defaultLogger } from '@libp2p/logger'
 import { peerIdFromPrivateKey } from '@libp2p/peer-id'
+import { Libp2pRecord } from '@libp2p/record'
 import { multiaddr } from '@multiformats/multiaddr'
 import { expect } from 'aegir/chai'
 import { stubInterface } from 'sinon-ts'
+import { fromString as uint8ArrayFromString } from 'uint8arrays/from-string'
 import { K } from '../src/constants.ts'
 import { MessageType } from '../src/message/dht.ts'
 import { PeerRouting } from '../src/peer-routing/index.ts'
@@ -180,6 +182,42 @@ describe('peer-routing', () => {
 
       expect(finalPeerIds).to.have.lengthOf(1)
       expect(finalPeerIds[0].equals(livePeer.peerId)).to.be.true()
+    })
+  })
+
+  describe('getValueOrPeers', () => {
+    it('rejects a record whose key does not match the queried key', async () => {
+      const [responder] = await getSortedPeers(Uint8Array.from([0, 1, 2, 3, 4]), 1)
+      const path = { index: 0, queued: 0, running: 0, total: 1 }
+
+      // a permissive validator so the record passes verification - only a
+      // comparison against the queried key should be able to reject it
+      init.validators = {
+        test: async () => {}
+      }
+      peerRouting = new PeerRouting(components, init)
+
+      const queriedKey = uint8ArrayFromString('/test/queried')
+      const record = new Libp2pRecord(
+        uint8ArrayFromString('/test/other'),
+        uint8ArrayFromString('value'),
+        new Date()
+      )
+
+      init.network.sendRequest.callsFake(async function * (): AsyncGenerator<QueryEvent> {
+        yield peerResponseEvent({ from: responder.peerId, messageType: MessageType.GET_VALUE, record, path })
+      })
+
+      const events: QueryEvent[] = []
+      for await (const event of peerRouting.getValueOrPeers(responder.peerId, queriedKey, { path })) {
+        events.push(event)
+      }
+
+      // the record is published under a different key, so it must be discarded
+      // as a query error rather than surfaced as a response to this query
+      expect(events.map(event => event.name)).to.include('QUERY_ERROR')
+      const records = events.filter(event => event.name === 'PEER_RESPONSE' && event.record != null)
+      expect(records).to.have.lengthOf(0)
     })
   })
 })

--- a/packages/libp2p/src/libp2p.ts
+++ b/packages/libp2p/src/libp2p.ts
@@ -1,5 +1,5 @@
 import { publicKeyFromProtobuf } from '@libp2p/crypto/keys'
-import { contentRoutingSymbol, peerDiscoverySymbol, peerRoutingSymbol, InvalidParametersError } from '@libp2p/interface'
+import { contentRoutingSymbol, peerDiscoverySymbol, peerRoutingSymbol, InvalidParametersError, InvalidPublicKeyError } from '@libp2p/interface'
 import { defaultLogger } from '@libp2p/logger'
 import { PeerSet } from '@libp2p/peer-collections'
 import { peerIdFromString } from '@libp2p/peer-id'
@@ -359,8 +359,12 @@ export class Libp2p<T extends ServiceMap = ServiceMap> extends TypedEventEmitter
     // search any available content routing methods
     const bytes = await this.contentRouting.get(peerKey, options)
 
-    // ensure the returned key is valid
     const publicKey = publicKeyFromProtobuf(bytes)
+
+    // ensure the returned key belongs to the requested peer
+    if (!peer.equals(publicKey.toMultihash().bytes)) {
+      throw new InvalidPublicKeyError('public key did not match requested peer')
+    }
 
     await this.peerStore.patch(peer, {
       publicKey

--- a/packages/libp2p/test/core/get-public-key.spec.ts
+++ b/packages/libp2p/test/core/get-public-key.spec.ts
@@ -2,6 +2,7 @@ import { generateKeyPair, publicKeyToProtobuf } from '@libp2p/crypto/keys'
 import { contentRoutingSymbol } from '@libp2p/interface'
 import { peerIdFromMultihash, peerIdFromPrivateKey } from '@libp2p/peer-id'
 import { expect } from 'aegir/chai'
+import sinon from 'sinon'
 import { stubInterface } from 'sinon-ts'
 import { createLibp2p } from '../../src/index.ts'
 import type { ContentRouting, ContentRoutingProvider, Libp2p } from '@libp2p/interface'
@@ -71,5 +72,23 @@ describe('getPublicKey', () => {
 
     expect(otherPeer.publicKey?.equals(key)).to.be.true()
     expect(router.get.called).to.be.true('routing was not queried')
+  })
+
+  it('rejects a public key that does not match the requested peer', async () => {
+    const otherPeer = peerIdFromPrivateKey(await generateKeyPair('RSA', 512))
+    const wrongKey = await generateKeyPair('Ed25519')
+
+    // content routing returns a key for a different peer
+    router.get.callsFake(async () => publicKeyToProtobuf(wrongKey.publicKey))
+
+    // the mismatched key must be rejected before it is stored
+    const patchSpy = sinon.spy(node.peerStore, 'patch')
+
+    // an RSA id resolved from its multihash has no embedded public key, so the
+    // key is fetched from content routing
+    const otherPeerWithoutPublicKey = peerIdFromMultihash(otherPeer.toMultihash())
+
+    await expect(node.getPublicKey(otherPeerWithoutPublicKey)).to.eventually.be.rejectedWith(/did not match requested peer/)
+    expect(patchSpy.called).to.be.false()
   })
 })

--- a/packages/peer-store/src/utils/to-peer-pb.ts
+++ b/packages/peer-store/src/utils/to-peer-pb.ts
@@ -18,8 +18,8 @@ export async function toPeerPB (peerId: PeerId, data: Partial<PeerData>, strateg
     throw new InvalidParametersError('Invalid PeerData')
   }
 
-  if (data.publicKey != null && peerId.publicKey != null && !data.publicKey.equals(peerId.publicKey)) {
-    throw new InvalidParametersError('publicKey bytes do not match peer id publicKey bytes')
+  if (data.publicKey != null && !peerId.equals(data.publicKey.toMultihash().bytes)) {
+    throw new InvalidParametersError('publicKey does not match peer id')
   }
 
   const existingPeer = options.existingPeer?.peer

--- a/packages/peer-store/test/save.spec.ts
+++ b/packages/peer-store/test/save.spec.ts
@@ -3,7 +3,7 @@
 
 import { generateKeyPair, publicKeyToProtobuf } from '@libp2p/crypto/keys'
 import { defaultLogger } from '@libp2p/logger'
-import { peerIdFromPrivateKey } from '@libp2p/peer-id'
+import { peerIdFromMultihash, peerIdFromPrivateKey } from '@libp2p/peer-id'
 import { multiaddr } from '@multiformats/multiaddr'
 import { expect } from 'aegir/chai'
 import { MemoryDatastore } from 'datastore-core/memory'
@@ -161,7 +161,18 @@ describe('save', () => {
 
     await expect(peerStore.save(edKey, {
       publicKey: peerId.publicKey
-    })).to.eventually.be.rejectedWith(/bytes do not match/)
+    })).to.eventually.be.rejectedWith(/does not match peer id/)
+  })
+
+  it('should not set a public key that does not match an RSA peer id', async () => {
+    const rsaPeer = peerIdFromPrivateKey(await generateKeyPair('RSA', 512))
+    // an RSA id resolved from its multihash has no embedded public key
+    const rsaPeerWithoutPublicKey = peerIdFromMultihash(rsaPeer.toMultihash())
+    const wrongKey = await generateKeyPair('Ed25519')
+
+    await expect(peerStore.save(rsaPeerWithoutPublicKey, {
+      publicKey: wrongKey.publicKey
+    })).to.eventually.be.rejectedWith(/does not match peer id/)
   })
 
   it('should not store a public key if already stored', async () => {


### PR DESCRIPTION
## Description

Verify that a fetched or stored value matches what it was requested for:

- **kad-dht**: `getValueOrPeers` verified a returned record against the record's
  own key instead of the key that was requested, so `get(key)` could resolve to
  a record stored under a different key. The record is now checked against the
  requested key.
- **libp2p**: `getPublicKey` stored and returned whatever content routing
  returned without checking it belonged to the requested peer, and now verifies
  the returned key matches.
- **peer-store**: the public key check was skipped for peer ids that do not
  embed their key (e.g. RSA), so any key could be stored under such a peer id.
  Keys are now verified against the peer id for all peer id types.

## Change checklist

- [x] I have performed a self-review of my own code
- [x] I have made corresponding changes to the documentation if necessary (this includes comments as well)
- [x] I have added tests that prove my fix is effective or that my feature works
