### PR TITLE
fix(gossipsub): reject malformed key and signature during validation

### DIFF
--- a/packages/gossipsub/src/utils/buildRawMessage.ts
+++ b/packages/gossipsub/src/utils/buildRawMessage.ts
@@ -138,7 +138,13 @@ export async function validateToRawMessage (
 
       let publicKey: PublicKey
       if (msg.key != null) {
-        publicKey = publicKeyFromProtobuf(msg.key)
+        // malformed key bytes must reject rather than throw, so an attacker
+        // sending them is still scored as delivering an invalid message
+        try {
+          publicKey = publicKeyFromProtobuf(msg.key)
+        } catch {
+          return { valid: false, error: ValidateError.InvalidPeerId }
+        }
 
         // the message key must derive to the `from` peer id
         if (!fromPeerId.equals(publicKey.toMultihash().bytes)) {
@@ -164,7 +170,17 @@ export async function validateToRawMessage (
       // the signature is over the bytes "libp2p-pubsub:<protobuf-message>"
       const bytes = uint8ArrayConcat([SignPrefix, RPC.Message.encode(rpcMsgPreSign)])
 
-      if (!(await publicKey.verify(bytes, msg.signature))) {
+      // a malformed signature (e.g. the wrong length) makes verify throw for
+      // some key types; treat that as an invalid signature so the peer is still
+      // scored rather than the message escaping to the unscored error path
+      let validSignature: boolean
+      try {
+        validSignature = await publicKey.verify(bytes, msg.signature)
+      } catch {
+        validSignature = false
+      }
+
+      if (!validSignature) {
         return { valid: false, error: ValidateError.InvalidSignature }
       }
 

--- a/packages/gossipsub/test/unit/buildRawMessage.spec.ts
+++ b/packages/gossipsub/test/unit/buildRawMessage.spec.ts
@@ -68,4 +68,28 @@ describe('buildRawMessage', () => {
       expect(result).to.deep.equal({ valid: false, error: ValidateError.InvalidPeerId })
     })
   })
+
+  describe('malformed message fields', () => {
+    const topic = 'test-topic'
+    const data = uint8ArrayFromString('hello')
+
+    it('rejects a malformed key rather than throwing, so the peer is still scored', async () => {
+      const key = await generateKeyPair('Ed25519')
+      const id = peerIdFromPrivateKey(key)
+      const { raw } = await buildRawMessage(getPublishConfigFromPeerId(StrictSign, id, key), topic, data, data)
+      raw.key = uint8ArrayFromString('not a valid protobuf key')
+
+      await expect(validateToRawMessage(StrictSign, raw)).to.eventually.deep.equal({ valid: false, error: ValidateError.InvalidPeerId })
+    })
+
+    it('rejects a malformed signature rather than throwing, so the peer is still scored', async () => {
+      const key = await generateKeyPair('Ed25519')
+      const id = peerIdFromPrivateKey(key)
+      const { raw } = await buildRawMessage(getPublishConfigFromPeerId(StrictSign, id, key), topic, data, data)
+      // a wrong-length signature makes the Ed25519 verify throw rather than return false
+      raw.signature = uint8ArrayFromString('too-short')
+
+      await expect(validateToRawMessage(StrictSign, raw)).to.eventually.deep.equal({ valid: false, error: ValidateError.InvalidSignature })
+    })
+  })
 })


### PR DESCRIPTION
## Description

Under the `StrictSign` signature policy, `validateToRawMessage` threw when a
message carried malformed key bytes (`publicKeyFromProtobuf`) or a wrong-length
signature (`verify` throws for Ed25519/secp256k1). The throw escaped validation
and was handled as an internal error rather than as an invalid message, unlike a
well-formed-but-wrong signature, which is already rejected cleanly.

Wrap both calls so malformed input returns `{ valid: false }` and is handled on
the same invalid-message path as any other failed validation. This matches
go-libp2p-pubsub and rust-libp2p, whose signature verification treats malformed
key/signature bytes as an invalid message rather than an error.

## Change checklist

- [x] I have performed a self-review of my own code
- [x] I have made corresponding changes to the documentation if necessary (this includes comments as well)
- [x] I have added tests that prove my fix is effective or that my feature works
