### PR TITLE
fix(circuit-relay-v2): keep relay address across reservation refresh

### DIFF
--- a/packages/transport-circuit-relay-v2/src/transport/listener.ts
+++ b/packages/transport-circuit-relay-v2/src/transport/listener.ts
@@ -150,20 +150,22 @@ class CircuitRelayTransportListener extends TypedEventEmitter<ListenerEvents> im
     this.listeningAddrs = reservation.details.reservation.addrs
       .map(buf => multiaddr(buf).encapsulate('/p2p-circuit'))
 
-    // withdraw any previously advertised address the refresh no longer includes,
-    // otherwise a changed relay address leaves the stale one advertised
-    previousAddrs
-      .filter(ma => !this.listeningAddrs.some(current => current.equals(ma)))
-      .forEach(ma => {
-        this.addressManager.removeObservedAddr(ma)
-      })
-
+    // confirm the refreshed addresses first so that failing to withdraw a stale
+    // one below cannot leave us with nothing advertised
     this.listeningAddrs.forEach(ma => {
       // mark as externally dialable
       this.addressManager.confirmObservedAddr(ma, {
         type: 'transport'
       })
     })
+
+    // then withdraw any previously advertised address the refresh no longer
+    // includes, otherwise a changed relay address leaves the stale one advertised
+    previousAddrs
+      .filter(ma => !this.listeningAddrs.some(current => current.equals(ma)))
+      .forEach(ma => {
+        this.addressManager.removeObservedAddr(ma)
+      })
 
     // if that succeeded announce listen addresses change
     queueMicrotask(() => {

--- a/packages/transport-circuit-relay-v2/src/transport/listener.ts
+++ b/packages/transport-circuit-relay-v2/src/transport/listener.ts
@@ -71,6 +71,14 @@ class CircuitRelayTransportListener extends TypedEventEmitter<ListenerEvents> im
     } = evt.detail
 
     if (details.type === 'configured') {
+      // listen() applies a configured relay's initial reservation directly.
+      // This handler also fires for that initial event, but this.relay is not
+      // set yet so the guard below skips it. A later refresh fires with
+      // this.relay set, so re-apply it for our relay to pick up a changed address.
+      if (this.relay?.equals(evt.detail.relay) === true) {
+        this.addedRelay(evt.detail)
+      }
+
       return
     }
 
@@ -136,9 +144,19 @@ class CircuitRelayTransportListener extends TypedEventEmitter<ListenerEvents> im
 
     this.relay = reservation.relay
 
+    const previousAddrs = this.listeningAddrs
+
     // add all addresses from the relay reservation
     this.listeningAddrs = reservation.details.reservation.addrs
       .map(buf => multiaddr(buf).encapsulate('/p2p-circuit'))
+
+    // withdraw any previously advertised address the refresh no longer includes,
+    // otherwise a changed relay address leaves the stale one advertised
+    previousAddrs
+      .filter(ma => !this.listeningAddrs.some(current => current.equals(ma)))
+      .forEach(ma => {
+        this.addressManager.removeObservedAddr(ma)
+      })
 
     this.listeningAddrs.forEach(ma => {
       // mark as externally dialable

--- a/packages/transport-circuit-relay-v2/src/transport/reservation-store.ts
+++ b/packages/transport-circuit-relay-v2/src/transport/reservation-store.ts
@@ -293,17 +293,14 @@ export class ReservationStore extends TypedEventEmitter<ReservationStoreEvents> 
 
         let res: RelayEntry
 
-        // assign a reservation id if one was requested - a refresh reuses the id
-        // its reservation already holds, but only while that reservation is
-        // still the live entry. if it was removed up front (disconnected
-        // refresh) or by a concurrent connection:close, its id was returned to
-        // the pool, so reclaim from the pool instead of duplicating the id.
         if (type === 'discovered') {
-          const isLiveDiscoveredRefresh = existingReservation?.type === 'discovered' &&
-            this.reservations.get(peerId) === existingReservation
-
-          const id = isLiveDiscoveredRefresh
-            ? existingReservation.id
+          // a live refresh reuses the slot id its reservation still holds. if
+          // that entry was removed while we were refreshing (a disconnected
+          // refresh, or a concurrent connection:close) its id went back to the
+          // pool, so claim a fresh one - an id is never both live and pending
+          const live = this.reservations.get(peerId)
+          const id = live?.type === 'discovered'
+            ? live.id
             : this.pendingReservations.pop()
 
           if (id == null) {

--- a/packages/transport-circuit-relay-v2/src/transport/reservation-store.ts
+++ b/packages/transport-circuit-relay-v2/src/transport/reservation-store.ts
@@ -241,10 +241,17 @@ export class ReservationStore extends TypedEventEmitter<ReservationStoreEvents> 
             } satisfies RelayReservation
           }
 
-          await this.#removeReservation(peerId)
+          // keep a still-connected reservation advertised while we refresh it in
+          // place - the catch path below removes it if the refresh fails. only
+          // drop it up front when the relay connection is already gone.
+          if (!connected) {
+            await this.#removeReservation(peerId)
+          }
         }
 
-        if (type === 'discovered' && this.pendingReservations.length === 0) {
+        // a refresh keeps the slot it already holds; only a brand new discovered
+        // reservation needs a free pending slot
+        if (type === 'discovered' && existingReservation == null && this.pendingReservations.length === 0) {
           throw new HadEnoughRelaysError('Not making reservation on discovered relay because we do not need any more relays')
         }
 
@@ -286,9 +293,18 @@ export class ReservationStore extends TypedEventEmitter<ReservationStoreEvents> 
 
         let res: RelayEntry
 
-        // assign a reservation id if one was requested
+        // assign a reservation id if one was requested - a refresh reuses the id
+        // its reservation already holds, but only while that reservation is
+        // still the live entry. if it was removed up front (disconnected
+        // refresh) or by a concurrent connection:close, its id was returned to
+        // the pool, so reclaim from the pool instead of duplicating the id.
         if (type === 'discovered') {
-          const id = this.pendingReservations.pop()
+          const isLiveDiscoveredRefresh = existingReservation?.type === 'discovered' &&
+            this.reservations.get(peerId) === existingReservation
+
+          const id = isLiveDiscoveredRefresh
+            ? existingReservation.id
+            : this.pendingReservations.pop()
 
           if (id == null) {
             throw new HadEnoughRelaysError('Made reservation on relay but did not need any more discovered relays')
@@ -308,6 +324,12 @@ export class ReservationStore extends TypedEventEmitter<ReservationStoreEvents> 
             type,
             connection: connection.id
           }
+        }
+
+        // clear the previous reservation's refresh timer before replacing it,
+        // otherwise it stays armed and later fires against the new reservation
+        if (existingReservation != null) {
+          clearTimeout(existingReservation.timeout)
         }
 
         // we've managed to create a reservation successfully
@@ -472,13 +494,9 @@ export class ReservationStore extends TypedEventEmitter<ReservationStoreEvents> 
       )
     }
 
-    // untag the relay
-    await this.peerStore.merge(peerId, {
-      tags: {
-        [KEEP_ALIVE_TAG]: undefined
-      }
-    })
-
+    // withdraw the address and re-check the relay count from the in-memory
+    // state updated above, independent of the tag write below, so a datastore
+    // failure cannot strand the advertised address or stall rediscovery
     this.safeDispatchEvent('relay:removed', {
       detail: {
         relay: peerId,
@@ -488,6 +506,13 @@ export class ReservationStore extends TypedEventEmitter<ReservationStoreEvents> 
 
     // maybe trigger discovery of new relays
     this.#checkReservationCount()
+
+    // untag the relay so the connection manager may reap the connection
+    await this.peerStore.merge(peerId, {
+      tags: {
+        [KEEP_ALIVE_TAG]: undefined
+      }
+    })
   }
 
   #checkReservationCount (): void {

--- a/packages/transport-circuit-relay-v2/src/transport/reservation-store.ts
+++ b/packages/transport-circuit-relay-v2/src/transport/reservation-store.ts
@@ -117,7 +117,7 @@ export class ReservationStore extends TypedEventEmitter<ReservationStoreEvents> 
 
       this.#removeReservation(evt.detail.remotePeer)
         .catch(err => {
-          this.log('could not remove relay %p - %e', evt.detail, err)
+          this.log.error('could not remove relay %p - %e', evt.detail.remotePeer, err)
         })
     })
   }
@@ -297,7 +297,10 @@ export class ReservationStore extends TypedEventEmitter<ReservationStoreEvents> 
           // a live refresh reuses the slot id its reservation still holds. if
           // that entry was removed while we were refreshing (a disconnected
           // refresh, or a concurrent connection:close) its id went back to the
-          // pool, so claim a fresh one - an id is never both live and pending
+          // pool, so claim a fresh one - an id is never both live and pending.
+          // this re-reads instead of trusting existingReservation because only
+          // one addRelay runs per peer at a time, so the entry here is only ever
+          // our own (removed or not), never another reservation's
           const live = this.reservations.get(peerId)
           const id = live?.type === 'discovered'
             ? live.id

--- a/packages/transport-circuit-relay-v2/test/listener.spec.ts
+++ b/packages/transport-circuit-relay-v2/test/listener.spec.ts
@@ -197,6 +197,9 @@ describe('listener', () => {
       throw new Error('did not register a relay:created-reservation listener')
     }
 
+    // only observe confirmations from the refresh, not the initial listen()
+    components.addressManager.confirmObservedAddr.resetHistory()
+
     // a refresh returning the SAME address must not withdraw it
     createdReservationListener(
       new CustomEvent('relay:created-reservation', {

--- a/packages/transport-circuit-relay-v2/test/listener.spec.ts
+++ b/packages/transport-circuit-relay-v2/test/listener.spec.ts
@@ -98,4 +98,193 @@ describe('listener', () => {
       relayAddr.encapsulate('/p2p-circuit')
     )).to.be.true()
   })
+
+  it('should re-confirm a configured relay reservation when it is refreshed', async () => {
+    const relayPeer = peerIdFromPrivateKey(await generateKeyPair('Ed25519'))
+    const relayAddr = multiaddr(`/ip4/123.123.123.123/tcp/1234/p2p/${relayPeer}/p2p-circuit`)
+    const conn = stubInterface<Connection>({
+      id: 'connection-id-1234',
+      remotePeer: relayPeer
+    })
+
+    components.connectionManager.openConnection.withArgs(relayAddr.decapsulate('/p2p-circuit')).resolves(conn)
+
+    components.reservationStore.addRelay.withArgs(relayPeer).resolves({
+      relay: relayPeer,
+      details: {
+        type: 'configured',
+        reservation: {
+          addrs: [
+            relayAddr.bytes
+          ],
+          expire: 100n
+        },
+        timeout: 0 as any,
+        connection: conn.id
+      }
+    })
+
+    // establish the configured relay
+    await listener.listen(relayAddr)
+
+    // the relay reservation is refreshed with a new address for the same relay
+    const refreshedAddr = multiaddr(`/ip4/124.124.124.124/tcp/4321/p2p/${relayPeer}/p2p-circuit`)
+    const createdReservationListener = components.reservationStore.addEventListener.getCall(1).args[1]
+
+    if (typeof createdReservationListener !== 'function') {
+      throw new Error('did not register a relay:created-reservation listener')
+    }
+
+    createdReservationListener(
+      new CustomEvent('relay:created-reservation', {
+        detail: {
+          relay: relayPeer,
+          details: {
+            type: 'configured',
+            reservation: {
+              addrs: [
+                refreshedAddr.bytes
+              ],
+              expire: 200n
+            },
+            timeout: 0 as any,
+            connection: conn.id
+          }
+        }
+      })
+    )
+
+    const confirmedAddrs = components.addressManager.confirmObservedAddr.getCalls()
+      .map(call => call.args[0].toString())
+
+    expect(confirmedAddrs).to.include(refreshedAddr.encapsulate('/p2p-circuit').toString())
+
+    // the previous, now-stale address is withdrawn, not left advertised
+    const withdrawnAddrs = components.addressManager.removeObservedAddr.getCalls()
+      .map(call => call.args[0].toString())
+    expect(withdrawnAddrs).to.include(relayAddr.encapsulate('/p2p-circuit').toString())
+  })
+
+  it('should not withdraw an unchanged configured relay address on refresh', async () => {
+    const relayPeer = peerIdFromPrivateKey(await generateKeyPair('Ed25519'))
+    const relayAddr = multiaddr(`/ip4/123.123.123.123/tcp/1234/p2p/${relayPeer}/p2p-circuit`)
+    const conn = stubInterface<Connection>({
+      id: 'connection-id-1234',
+      remotePeer: relayPeer
+    })
+
+    components.connectionManager.openConnection.withArgs(relayAddr.decapsulate('/p2p-circuit')).resolves(conn)
+    components.reservationStore.addRelay.withArgs(relayPeer).resolves({
+      relay: relayPeer,
+      details: {
+        type: 'configured',
+        reservation: {
+          addrs: [
+            relayAddr.bytes
+          ],
+          expire: 100n
+        },
+        timeout: 0 as any,
+        connection: conn.id
+      }
+    })
+
+    await listener.listen(relayAddr)
+
+    const createdReservationListener = components.reservationStore.addEventListener.getCall(1).args[1]
+
+    if (typeof createdReservationListener !== 'function') {
+      throw new Error('did not register a relay:created-reservation listener')
+    }
+
+    // a refresh returning the SAME address must not withdraw it
+    createdReservationListener(
+      new CustomEvent('relay:created-reservation', {
+        detail: {
+          relay: relayPeer,
+          details: {
+            type: 'configured',
+            reservation: {
+              addrs: [
+                relayAddr.bytes
+              ],
+              expire: 200n
+            },
+            timeout: 0 as any,
+            connection: conn.id
+          }
+        }
+      })
+    )
+
+    const withdrawnAddrs = components.addressManager.removeObservedAddr.getCalls()
+      .map(call => call.args[0].toString())
+    expect(withdrawnAddrs).to.not.include(relayAddr.encapsulate('/p2p-circuit').toString())
+
+    // and it stays confirmed
+    const confirmedAddrs = components.addressManager.confirmObservedAddr.getCalls()
+      .map(call => call.args[0].toString())
+    expect(confirmedAddrs).to.include(relayAddr.encapsulate('/p2p-circuit').toString())
+  })
+
+  it('should ignore a configured reservation refresh for a different relay', async () => {
+    const relayPeer = peerIdFromPrivateKey(await generateKeyPair('Ed25519'))
+    const relayAddr = multiaddr(`/ip4/123.123.123.123/tcp/1234/p2p/${relayPeer}/p2p-circuit`)
+    const conn = stubInterface<Connection>({
+      id: 'connection-id-1234',
+      remotePeer: relayPeer
+    })
+
+    components.connectionManager.openConnection.withArgs(relayAddr.decapsulate('/p2p-circuit')).resolves(conn)
+
+    components.reservationStore.addRelay.withArgs(relayPeer).resolves({
+      relay: relayPeer,
+      details: {
+        type: 'configured',
+        reservation: {
+          addrs: [
+            relayAddr.bytes
+          ],
+          expire: 100n
+        },
+        timeout: 0 as any,
+        connection: conn.id
+      }
+    })
+
+    await listener.listen(relayAddr)
+
+    // a configured refresh for a different relay must not be applied as ours
+    const otherPeer = peerIdFromPrivateKey(await generateKeyPair('Ed25519'))
+    const otherAddr = multiaddr(`/ip4/124.124.124.124/tcp/4321/p2p/${otherPeer}/p2p-circuit`)
+    const createdReservationListener = components.reservationStore.addEventListener.getCall(1).args[1]
+
+    if (typeof createdReservationListener !== 'function') {
+      throw new Error('did not register a relay:created-reservation listener')
+    }
+
+    createdReservationListener(
+      new CustomEvent('relay:created-reservation', {
+        detail: {
+          relay: otherPeer,
+          details: {
+            type: 'configured',
+            reservation: {
+              addrs: [
+                otherAddr.bytes
+              ],
+              expire: 200n
+            },
+            timeout: 0 as any,
+            connection: 'connection-id-5678'
+          }
+        }
+      })
+    )
+
+    const confirmedAddrs = components.addressManager.confirmObservedAddr.getCalls()
+      .map(call => call.args[0].toString())
+
+    expect(confirmedAddrs).to.not.include(otherAddr.encapsulate('/p2p-circuit').toString())
+  })
 })

--- a/packages/transport-circuit-relay-v2/test/transport/reservation-store.spec.ts
+++ b/packages/transport-circuit-relay-v2/test/transport/reservation-store.spec.ts
@@ -167,13 +167,18 @@ describe('transport reservation-store', () => {
     store.reserveRelay()
     await store.addRelay(relayPeer, 'discovered')
 
-    // make the next (refresh) reservation attempt fail
+    // make the next (refresh) reservation attempt fail, recording when it runs
+    const order: string[] = []
     connection.newStream.reset()
-    connection.newStream.rejects(new Error('stream failed'))
+    connection.newStream.callsFake(async () => {
+      order.push('attempt')
+      throw new Error('stream failed')
+    })
 
     const removed: PeerId[] = []
     store.addEventListener('relay:removed', (evt) => {
       removed.push(evt.detail.relay)
+      order.push('removed')
     })
     let notEnough = 0
     store.addEventListener('relay:not-enough-relays', () => { notEnough++ })
@@ -186,6 +191,9 @@ describe('transport reservation-store', () => {
     // the freed slot returns to the pool so rediscovery can replace the relay
     expect((store as any).pendingReservations).to.have.lengthOf(1)
     expect(notEnough).to.be.greaterThan(0)
+    // keep-until-failure: a still-connected reservation is removed only after
+    // the refresh attempt runs, not dropped up front before trying
+    expect(order).to.deep.equal(['attempt', 'removed'])
   })
 
   it('should reclaim the slot when a disconnected discovered reservation refreshes', async () => {
@@ -240,11 +248,16 @@ describe('transport reservation-store', () => {
     await store.addRelay(relayPeer, 'discovered')
     expect((store as any).pendingReservations).to.have.lengthOf(1)
 
-    // refreshing must not touch the other still-pending slot
+    // a live refresh must not withdraw the address...
+    const removed: string[] = []
+    store.addEventListener('relay:removed', () => { removed.push('removed') })
+
+    // ...nor touch the other still-pending slot
     await store.addRelay(relayPeer, 'discovered')
 
     expect((store as any).pendingReservations).to.have.lengthOf(1)
     expect(store.hasReservation(relayPeer)).to.equal(true)
+    expect(removed).to.have.lengthOf(0)
   })
 
   it('should clear the previous refresh timer when a reservation is refreshed', async () => {
@@ -278,13 +291,18 @@ describe('transport reservation-store', () => {
     const connection = addConnectedRelay(relayPeer, 300)
     await store.addRelay(relayPeer, 'configured')
 
-    // make the next (refresh) reservation attempt fail
+    // make the next (refresh) reservation attempt fail, recording when it runs
+    const order: string[] = []
     connection.newStream.reset()
-    connection.newStream.rejects(new Error('stream failed'))
+    connection.newStream.callsFake(async () => {
+      order.push('attempt')
+      throw new Error('stream failed')
+    })
 
     const removed: PeerId[] = []
     store.addEventListener('relay:removed', (evt) => {
       removed.push(evt.detail.relay)
+      order.push('removed')
     })
 
     // the refresh rejects; the catch path must clean up the stale reservation
@@ -295,5 +313,37 @@ describe('transport reservation-store', () => {
 
     expect(removed).to.have.lengthOf(1)
     expect(store.hasReservation(relayPeer)).to.equal(false)
+    // keep-until-failure: the still-connected reservation is removed only after
+    // the refresh attempt runs, not dropped up front before trying
+    expect(order).to.deep.equal(['attempt', 'removed'])
+  })
+
+  it('should withdraw the address and re-check the count even when the datastore untag fails', async () => {
+    const relayPeer = peerIdFromPrivateKey(await generateKeyPair('Ed25519'))
+    const connection = addConnectedRelay(relayPeer, 300)
+    store.reserveRelay()
+    await store.addRelay(relayPeer, 'discovered')
+    expect((store as any).pendingReservations).to.have.lengthOf(0)
+
+    // the datastore rejects the untag write performed during removal
+    components.peerStore.merge.rejects(new Error('datastore down'))
+
+    const removed: PeerId[] = []
+    store.addEventListener('relay:removed', (evt) => {
+      removed.push(evt.detail.relay)
+    })
+    let notEnough = 0
+    store.addEventListener('relay:not-enough-relays', () => { notEnough++ })
+
+    // the relay connection closes, triggering removal; the untag rejection must
+    // not prevent withdrawing the address or freeing the slot for rediscovery
+    components.events.dispatchEvent(new CustomEvent('connection:close', { detail: connection }))
+    await delay(0)
+
+    expect(removed).to.have.lengthOf(1)
+    expect(store.hasReservation(relayPeer)).to.equal(false)
+    // the freed slot returns to the pool despite the failed datastore write
+    expect((store as any).pendingReservations).to.have.lengthOf(1)
+    expect(notEnough).to.be.greaterThan(0)
   })
 })

--- a/packages/transport-circuit-relay-v2/test/transport/reservation-store.spec.ts
+++ b/packages/transport-circuit-relay-v2/test/transport/reservation-store.spec.ts
@@ -2,13 +2,17 @@ import { generateKeyPair } from '@libp2p/crypto/keys'
 import { start } from '@libp2p/interface'
 import { defaultLogger } from '@libp2p/logger'
 import { peerIdFromPrivateKey } from '@libp2p/peer-id'
+import { pbStream, streamPair } from '@libp2p/utils'
+import { multiaddr } from '@multiformats/multiaddr'
 import { expect } from 'aegir/chai'
 import delay from 'delay'
 import { TypedEventEmitter } from 'main-event'
+import Sinon from 'sinon'
 import { stubInterface } from 'sinon-ts'
-import { KEEP_ALIVE_TAG } from '../../src/constants.ts'
+import { KEEP_ALIVE_TAG, RELAY_V2_HOP_CODEC } from '../../src/constants.ts'
+import { HopMessage, Status } from '../../src/pb/index.ts'
 import { ReservationStore } from '../../src/transport/reservation-store.ts'
-import type { ComponentLogger, Libp2pEvents, Peer, PeerId, PeerStore } from '@libp2p/interface'
+import type { ComponentLogger, Connection, Libp2pEvents, Peer, PeerId, PeerStore, Stream } from '@libp2p/interface'
 import type { ConnectionManager, TransportManager } from '@libp2p/interface-internal'
 import type { TypedEventTarget } from 'main-event'
 import type { StubbedInstance } from 'sinon-ts'
@@ -41,6 +45,56 @@ describe('transport reservation-store', () => {
     store = new ReservationStore(components)
   })
 
+  afterEach(() => {
+    if (store != null) {
+      // clears the real refresh timers armed by addRelay
+      store.stop()
+    }
+
+    Sinon.restore()
+  })
+
+  const RELAY_ADDR = multiaddr('/ip4/223.223.223.223/tcp/2345')
+
+  // acts as the relay server end of a hop stream: reads the RESERVE and replies
+  // with an OK reservation that expires `expireSeconds` from now
+  function respondToReserve (relayPeer: PeerId, expireSeconds: number): () => Promise<Stream> {
+    return async () => {
+      const [outbound, inbound] = await streamPair({ protocol: RELAY_V2_HOP_CODEC })
+
+      void Promise.resolve().then(async () => {
+        const relay = pbStream(inbound).pb(HopMessage)
+        await relay.read()
+        await relay.write({
+          type: HopMessage.Type.STATUS,
+          status: Status.OK,
+          reservation: {
+            addrs: [RELAY_ADDR.encapsulate(`/p2p/${relayPeer}`).bytes],
+            expire: BigInt(Math.round(Date.now() / 1000) + expireSeconds)
+          }
+        })
+      }).catch(() => {})
+
+      return outbound
+    }
+  }
+
+  // wires up an open, still-connected relay whose reservation expires soon, so a
+  // subsequent addRelay call takes the refresh path
+  function addConnectedRelay (relayPeer: PeerId, expireSeconds: number): StubbedInstance<Connection> {
+    const connection = stubInterface<Connection>({
+      id: `conn-${relayPeer.toString()}`,
+      remotePeer: relayPeer,
+      remoteAddr: RELAY_ADDR.encapsulate(`/p2p/${relayPeer}`)
+    })
+    connection.newStream.callsFake(respondToReserve(relayPeer, expireSeconds))
+
+    components.connectionManager.openConnection.withArgs(relayPeer).resolves(connection)
+    components.connectionManager.getConnections.withArgs(relayPeer).returns([connection])
+
+    return connection
+  }
+
   it('should remove relay tags on start', async () => {
     const peer: Peer = {
       id: peerIdFromPrivateKey(await generateKeyPair('Ed25519')),
@@ -61,5 +115,185 @@ describe('transport reservation-store', () => {
         [KEEP_ALIVE_TAG]: undefined
       }
     })).to.be.true()
+  })
+
+  it('should not drop a still-connected reservation while refreshing it', async () => {
+    const relayPeer = peerIdFromPrivateKey(await generateKeyPair('Ed25519'))
+    addConnectedRelay(relayPeer, 300)
+
+    // create the initial reservation
+    await store.addRelay(relayPeer, 'configured')
+
+    // observe any relay:removed emitted while refreshing
+    const removed: PeerId[] = []
+    store.addEventListener('relay:removed', (evt) => {
+      removed.push(evt.detail.relay)
+    })
+
+    // refresh the still-connected, soon-to-expire reservation
+    await store.addRelay(relayPeer, 'configured')
+
+    expect(removed).to.have.lengthOf(0)
+  })
+
+  it('should refresh a still-connected discovered reservation in place', async () => {
+    const relayPeer = peerIdFromPrivateKey(await generateKeyPair('Ed25519'))
+    addConnectedRelay(relayPeer, 300)
+
+    // a discovered relay fills a pending reservation slot
+    store.reserveRelay()
+    await store.addRelay(relayPeer, 'discovered')
+    expect(store.hasReservation(relayPeer)).to.equal(true)
+    const idBefore = (store as any).reservations.get(relayPeer).id
+
+    // a refresh must not withdraw the address or free the slot for rediscovery
+    const events: string[] = []
+    store.addEventListener('relay:removed', () => { events.push('removed') })
+    store.addEventListener('relay:not-enough-relays', () => { events.push('not-enough') })
+
+    await store.addRelay(relayPeer, 'discovered')
+
+    expect(store.hasReservation(relayPeer)).to.equal(true)
+    expect(events).to.have.lengthOf(0)
+    // the same slot stays pinned to the relay, not leaked or double-counted
+    expect((store as any).reservations.get(relayPeer).id).to.equal(idBefore)
+    expect((store as any).pendingReservations).to.have.lengthOf(0)
+    expect(store.reservationCount('discovered')).to.equal(1)
+  })
+
+  it('should remove a discovered reservation when its refresh fails', async () => {
+    const relayPeer = peerIdFromPrivateKey(await generateKeyPair('Ed25519'))
+    const connection = addConnectedRelay(relayPeer, 300)
+    store.reserveRelay()
+    await store.addRelay(relayPeer, 'discovered')
+
+    // make the next (refresh) reservation attempt fail
+    connection.newStream.reset()
+    connection.newStream.rejects(new Error('stream failed'))
+
+    const removed: PeerId[] = []
+    store.addEventListener('relay:removed', (evt) => {
+      removed.push(evt.detail.relay)
+    })
+    let notEnough = 0
+    store.addEventListener('relay:not-enough-relays', () => { notEnough++ })
+
+    await store.addRelay(relayPeer, 'discovered').catch(() => {})
+    await delay(0)
+
+    expect(removed).to.have.lengthOf(1)
+    expect(store.hasReservation(relayPeer)).to.equal(false)
+    // the freed slot returns to the pool so rediscovery can replace the relay
+    expect((store as any).pendingReservations).to.have.lengthOf(1)
+    expect(notEnough).to.be.greaterThan(0)
+  })
+
+  it('should reclaim the slot when a disconnected discovered reservation refreshes', async () => {
+    const relayPeer = peerIdFromPrivateKey(await generateKeyPair('Ed25519'))
+    addConnectedRelay(relayPeer, 300)
+    store.reserveRelay()
+    await store.addRelay(relayPeer, 'discovered')
+    expect((store as any).pendingReservations).to.have.lengthOf(0)
+
+    // the reservation's original connection is gone by the time it refreshes, so
+    // it is removed up front (returning its slot to the pool) and must be
+    // re-reserved from the pool, not have its id duplicated back in
+    components.connectionManager.getConnections.withArgs(relayPeer).returns([])
+
+    await store.addRelay(relayPeer, 'discovered')
+
+    expect(store.hasReservation(relayPeer)).to.equal(true)
+    // the slot id must not be live and pending at the same time
+    expect((store as any).pendingReservations).to.have.lengthOf(0)
+  })
+
+  it('should reclaim the slot when connection:close removes a discovered reservation mid-refresh', async () => {
+    const relayPeer = peerIdFromPrivateKey(await generateKeyPair('Ed25519'))
+    const connection = addConnectedRelay(relayPeer, 300)
+    store.reserveRelay()
+    await store.addRelay(relayPeer, 'discovered')
+    expect((store as any).pendingReservations).to.have.lengthOf(0)
+
+    // connected is true at the top so nothing is removed up front, but a
+    // connection:close during the refresh await removes the reservation and
+    // returns its id to the pool. the id must be reclaimed, not duplicated.
+    connection.newStream.reset()
+    connection.newStream.callsFake(() => {
+      components.events.dispatchEvent(new CustomEvent('connection:close', { detail: connection }))
+      return respondToReserve(relayPeer, 300)()
+    })
+
+    await store.addRelay(relayPeer, 'discovered')
+
+    expect(store.hasReservation(relayPeer)).to.equal(true)
+    expect((store as any).pendingReservations).to.have.lengthOf(0)
+    expect(store.reservationCount('discovered')).to.equal(1)
+  })
+
+  it('should not consume an unrelated pending slot when refreshing', async () => {
+    const relayPeer = peerIdFromPrivateKey(await generateKeyPair('Ed25519'))
+    addConnectedRelay(relayPeer, 300)
+
+    // two discovery slots are outstanding, the reserved relay holds one
+    store.reserveRelay()
+    store.reserveRelay()
+    await store.addRelay(relayPeer, 'discovered')
+    expect((store as any).pendingReservations).to.have.lengthOf(1)
+
+    // refreshing must not touch the other still-pending slot
+    await store.addRelay(relayPeer, 'discovered')
+
+    expect((store as any).pendingReservations).to.have.lengthOf(1)
+    expect(store.hasReservation(relayPeer)).to.equal(true)
+  })
+
+  it('should clear the previous refresh timer when a reservation is refreshed', async () => {
+    const relayPeer = peerIdFromPrivateKey(await generateKeyPair('Ed25519'))
+    const connection = addConnectedRelay(relayPeer, 450)
+
+    const clearTimeoutSpy = Sinon.spy(globalThis, 'clearTimeout')
+
+    // create the initial reservation and capture the exact refresh timer it arms
+    await store.addRelay(relayPeer, 'configured')
+    const previousTimer = (store as any).reservations.get(relayPeer)?.timeout
+
+    // refresh it - the previous refresh timer must be cleared, not left armed
+    await store.addRelay(relayPeer, 'configured')
+
+    // the refresh path must have been taken, not the return-existing branch
+    expect(connection.newStream.callCount).to.equal(2)
+
+    const clearedRefreshTimer = clearTimeoutSpy.getCalls()
+      .some(call => call.args[0] === previousTimer)
+
+    // defensively clear the old timer in case a regression left it armed
+    // (afterEach -> store.stop() clears the new one)
+    clearTimeout(previousTimer)
+
+    expect(clearedRefreshTimer).to.equal(true)
+  })
+
+  it('should remove a still-connected reservation when its refresh fails', async () => {
+    const relayPeer = peerIdFromPrivateKey(await generateKeyPair('Ed25519'))
+    const connection = addConnectedRelay(relayPeer, 300)
+    await store.addRelay(relayPeer, 'configured')
+
+    // make the next (refresh) reservation attempt fail
+    connection.newStream.reset()
+    connection.newStream.rejects(new Error('stream failed'))
+
+    const removed: PeerId[] = []
+    store.addEventListener('relay:removed', (evt) => {
+      removed.push(evt.detail.relay)
+    })
+
+    // the refresh rejects; the catch path must clean up the stale reservation
+    await store.addRelay(relayPeer, 'configured').catch(() => {})
+
+    // the catch removes via a fire-and-forget call, so let it settle
+    await delay(0)
+
+    expect(removed).to.have.lengthOf(1)
+    expect(store.hasReservation(relayPeer)).to.equal(false)
   })
 })


### PR DESCRIPTION
## Description

When a circuit relay v2 client refreshed a reservation before it expired, it
removed the existing reservation and created a new one. Removing the reservation
dispatched `relay:removed`, which made the transport listener withdraw the
advertised `/p2p-circuit` address. For a configured relay the address was then
never re-advertised (the listener ignored the re-creation event), so the first
refresh permanently dropped the relay address even though the relay was still
connected.

This keeps a still-connected reservation in place across a refresh and withdraws
the address only if the refresh fails, matching how go-libp2p and rust-libp2p
renew reservations.

The change:

- Keeps a still-connected reservation while it is refreshed (both configured and
  discovered relays), removing it only if the refresh fails or the relay
  connection is already gone.
- Clears the previous refresh timer before replacing the reservation, so the
  keep-in-place path does not leave a stale timer armed to fire against the new
  reservation.
- Re-applies a refreshed configured reservation in the listener (previously
  ignored), so a changed relay address is picked up and only addresses the
  refresh no longer includes are withdrawn.

Fixes #3571.

## Notes & open questions

- Keeping a discovered reservation in place means its pending slot is no longer
  returned to the pool on refresh, so the refresh reuses the id it already holds.
  A liveness check (`this.reservations.get(peerId) === existingReservation`)
  prevents reusing an id that a concurrent `connection:close` already returned to
  the pool, so a slot is never both live and pending.
- Thanks to @emin93 for reporting and investigating in #3571.

## Change checklist

- [x] I have performed a self-review of my own code
- [x] I have made corresponding changes to the documentation if necessary (this includes comments as well)
- [x] I have added tests that prove my fix is effective or that my feature works
