### PR TITLE
fix(transport-webrtc): validate ufrag from incoming STUN requests

### DIFF
--- a/packages/transport-webrtc/src/private-to-public/utils/get-rtcpeerconnection.ts
+++ b/packages/transport-webrtc/src/private-to-public/utils/get-rtcpeerconnection.ts
@@ -1,8 +1,10 @@
+import { InvalidParametersError } from '@libp2p/interface'
 import { Crypto } from '@peculiar/webcrypto'
 import { PeerConnection } from 'node-datachannel'
 import { RTCPeerConnection } from 'node-datachannel/polyfill'
 import { DEFAULT_ICE_SERVERS, MAX_MESSAGE_SIZE } from '../../constants.ts'
 import { DataChannelMuxerFactory } from '../../muxer.ts'
+import { isValidUfrag } from '../../util.ts'
 import { generateTransportCertificate } from './generate-certificates.ts'
 import type { DataChannelOptions, TransportCertificate } from '../../index.ts'
 import type { CounterGroup } from '@libp2p/interface'
@@ -40,26 +42,33 @@ export class DirectRTCPeerConnection extends RTCPeerConnection {
 
   async createOffer (): Promise<globalThis.RTCSessionDescriptionInit | any> {
     // have to set ufrag before creating offer
-    if (this.connectionState === 'new') {
-      this.peerConnection?.setLocalDescription('offer', {
-        iceUfrag: this.ufrag,
-        icePwd: this.ufrag
-      })
-    }
+    this.setLocalUfrag('offer')
 
     return super.createOffer()
   }
 
   async createAnswer (): Promise<globalThis.RTCSessionDescriptionInit | any> {
     // have to set ufrag before creating answer
-    if (this.connectionState === 'new') {
-      this.peerConnection?.setLocalDescription('answer', {
-        iceUfrag: this.ufrag,
-        icePwd: this.ufrag
-      })
-    }
+    this.setLocalUfrag('answer')
 
     return super.createAnswer()
+  }
+
+  // this.ufrag is reused as the ICE password; an invalid value aborts the process
+  // inside the native ICE stack, so reject it with a recoverable error first
+  private setLocalUfrag (type: 'offer' | 'answer'): void {
+    if (this.connectionState !== 'new') {
+      return
+    }
+
+    if (!isValidUfrag(this.ufrag)) {
+      throw new InvalidParametersError('ufrag is not a valid ICE credential')
+    }
+
+    this.peerConnection?.setLocalDescription(type, {
+      iceUfrag: this.ufrag,
+      icePwd: this.ufrag
+    })
   }
 
   remoteFingerprint (): CertificateFingerprint {

--- a/packages/transport-webrtc/src/private-to-public/utils/stun-listener.ts
+++ b/packages/transport-webrtc/src/private-to-public/utils/stun-listener.ts
@@ -1,5 +1,6 @@
 import { isIPv4 } from '@chainsafe/is-ip'
 import { IceUdpMuxListener } from 'node-datachannel'
+import { handleStunRequest } from '../../util.ts'
 import type { Logger } from '@libp2p/interface'
 import type { AddressInfo } from 'node:net'
 
@@ -15,13 +16,7 @@ export interface Callback {
 export async function stunListener (host: string, port: number, log: Logger, cb: Callback): Promise<StunServer> {
   const listener = new IceUdpMuxListener(port, host)
   listener.onUnhandledStunRequest(request => {
-    if (request.ufrag == null) {
-      return
-    }
-
-    log.trace('incoming STUN packet from %s:%d %s', request.host, request.port, request.ufrag)
-
-    cb(request.ufrag, request.host, request.port)
+    handleStunRequest(request, log, cb)
   })
 
   return {

--- a/packages/transport-webrtc/src/util.ts
+++ b/packages/transport-webrtc/src/util.ts
@@ -1,9 +1,9 @@
 import pDefer from 'p-defer'
 import pTimeout from 'p-timeout'
 import { DATA_CHANNEL_DRAIN_TIMEOUT, DEFAULT_ICE_SERVERS, UFRAG_ALPHABET, UFRAG_PREFIX } from './constants.ts'
-import type { LoggerOptions } from '@libp2p/interface'
+import type { Logger, LoggerOptions } from '@libp2p/interface'
 import type { Duplex, Source } from 'it-stream-types'
-import type { PeerConnection } from 'node-datachannel'
+import type { IceUdpMuxRequest, PeerConnection } from 'node-datachannel'
 
 export const nopSource = async function * nop (): AsyncGenerator<Uint8Array, any, unknown> {}
 
@@ -104,4 +104,31 @@ export async function getRtcConfiguration (config?: RTCConfiguration | (() => RT
 
 export const genUfrag = (len: number = 32): string => {
   return UFRAG_PREFIX + [...Array(len)].map(() => UFRAG_ALPHABET.at(Math.floor(Math.random() * UFRAG_ALPHABET.length))).join('')
+}
+
+// WebRTC-direct reuses the ufrag as the ICE password, which RFC 8445 requires to
+// be 22-256 chars from the ice-char set [a-zA-Z0-9+/]; other values crash the
+// process during native ICE setup, so reject them beforehand.
+const ICE_CREDENTIAL_REGEX = /^[a-zA-Z0-9+/]{22,256}$/
+
+export const isValidUfrag = (ufrag: string): boolean => {
+  return ICE_CREDENTIAL_REGEX.test(ufrag)
+}
+
+// Validate and forward a STUN request received by the UDP mux listener. The ufrag
+// is attacker-controlled and reused as the ICE password in native setup, where an
+// invalid value aborts the process, so drop anything that is not a valid credential.
+export function handleStunRequest (request: IceUdpMuxRequest, log: Logger, cb: (ufrag: string, host: string, port: number) => void): void {
+  if (request.ufrag == null) {
+    return
+  }
+
+  if (!isValidUfrag(request.ufrag)) {
+    log.trace('dropping incoming STUN packet from %s:%d with invalid ufrag', request.host, request.port)
+    return
+  }
+
+  log.trace('incoming STUN packet from %s:%d %s', request.host, request.port, request.ufrag)
+
+  cb(request.ufrag, request.host, request.port)
 }

--- a/packages/transport-webrtc/test/get-rtcpeerconnection.spec.ts
+++ b/packages/transport-webrtc/test/get-rtcpeerconnection.spec.ts
@@ -1,0 +1,27 @@
+import { expect } from 'aegir/chai'
+import { isNode, isElectronMain } from 'wherearewe'
+import { createDialerRTCPeerConnection } from '../src/private-to-public/utils/get-rtcpeerconnection.ts'
+
+describe('webrtc-direct DirectRTCPeerConnection ufrag backstop', () => {
+  it('rejects createAnswer with an invalid ufrag instead of aborting the process', async function () {
+    // exercises the native node-datachannel answer path, which only runs in node
+    if (!isNode && !isElectronMain) {
+      return this.skip()
+    }
+
+    // 'controlled' is too short to be a valid ICE password. It is reused as the
+    // ICE password during the answer, and without the guard node-datachannel
+    // aborts the whole process with SIGABRT instead of throwing.
+    const { peerConnection } = await createDialerRTCPeerConnection('server', 'controlled')
+
+    try {
+      const err = await peerConnection.createAnswer().then(
+        () => { throw new Error('createAnswer should have rejected for an invalid ufrag') },
+        (err: unknown) => err
+      )
+      expect(err).to.have.property('name', 'InvalidParametersError')
+    } finally {
+      peerConnection.close()
+    }
+  })
+})

--- a/packages/transport-webrtc/test/util.spec.ts
+++ b/packages/transport-webrtc/test/util.spec.ts
@@ -1,0 +1,83 @@
+import { defaultLogger } from '@libp2p/logger'
+import { expect } from 'aegir/chai'
+import Sinon from 'sinon'
+import { genUfrag, handleStunRequest, isValidUfrag } from '../src/util.ts'
+import type { IceUdpMuxRequest } from 'node-datachannel'
+
+describe('isValidUfrag', () => {
+  it('accepts a generated ufrag', () => {
+    expect(isValidUfrag(genUfrag())).to.be.true()
+  })
+
+  it('accepts the full ice-char set [a-zA-Z0-9+/]', () => {
+    expect(isValidUfrag('AZaz09+/AZaz09+/AZaz09+/')).to.be.true()
+  })
+
+  it('accepts the minimum valid length of 22 characters', () => {
+    expect(isValidUfrag('a'.repeat(22))).to.be.true()
+  })
+
+  it('accepts the maximum valid length of 256 characters', () => {
+    expect(isValidUfrag('a'.repeat(256))).to.be.true()
+  })
+
+  it('rejects a ufrag shorter than 22 characters', () => {
+    expect(isValidUfrag('a'.repeat(21))).to.be.false()
+  })
+
+  it('rejects an empty ufrag', () => {
+    expect(isValidUfrag('')).to.be.false()
+  })
+
+  it('rejects a ufrag longer than 256 characters', () => {
+    expect(isValidUfrag('a'.repeat(257))).to.be.false()
+  })
+
+  it('rejects a short, attacker-controlled STUN ufrag', () => {
+    // reused as the ICE password, a value this short is rejected by the native
+    // ICE stack and aborts the process before it can be validated here
+    expect(isValidUfrag('controlled')).to.be.false()
+  })
+
+  it('rejects a ufrag with characters outside the ice-char set', () => {
+    for (const char of [' ', '\t', '\n', ':', '%', '=', '#', 'ü']) {
+      const ufrag = `aaaaaaaaaaaa${char}aaaaaaaaaaaa`
+      expect(isValidUfrag(ufrag), `expected ${JSON.stringify(char)} to be rejected`).to.be.false()
+    }
+  })
+})
+
+describe('handleStunRequest', () => {
+  const log = defaultLogger().forComponent('test')
+
+  function request (ufrag: string | null): IceUdpMuxRequest {
+    return { ufrag: ufrag as string, localUfrag: 'libp2p+webrtc+v1/server', host: '1.2.3.4', port: 1234 }
+  }
+
+  it('forwards a request with a valid ufrag to the callback', () => {
+    const cb = Sinon.stub()
+    const ufrag = genUfrag()
+
+    handleStunRequest(request(ufrag), log, cb)
+
+    expect(cb.calledOnceWithExactly(ufrag, '1.2.3.4', 1234)).to.be.true()
+  })
+
+  it('drops a request with no ufrag', () => {
+    const cb = Sinon.stub()
+
+    handleStunRequest(request(null), log, cb)
+
+    expect(cb.called).to.be.false()
+  })
+
+  it('drops a request whose ufrag is not a valid ICE credential', () => {
+    // a short, attacker-controlled ufrag must never reach the callback - reused
+    // as an ICE password it aborts the process in native code
+    const cb = Sinon.stub()
+
+    handleStunRequest(request('controlled'), log, cb)
+
+    expect(cb.called).to.be.false()
+  })
+})


### PR DESCRIPTION
## Description

WebRTC-direct has no signaling channel, so the listener reads the ICE ufrag
from the `USERNAME` of an incoming STUN request and reuses it as both the ICE
ufrag and the ICE password during connection setup. The native ICE layer
requires these to be valid ICE credentials (RFC 8445: 22-256 characters from
`[A-Za-z0-9+/]`).

Validate the ufrag before it reaches native setup: drop incoming STUN requests
whose ufrag is not a valid ICE credential at the listener, and reject invalid
values in `DirectRTCPeerConnection` before `setLocalDescription` as a backstop.
A working dial already reuses the ufrag as the ICE password, so every legitimate
peer sends a value that passes this check and no valid connection is affected.

## Change checklist

- [x] I have performed a self-review of my own code
- [x] I have made corresponding changes to the documentation if necessary (this includes comments as well)
- [x] I have added tests that prove my fix is effective or that my feature works
