### PR TITLE
fix(crypto): reject invalid DER element lengths

### DIFF
--- a/packages/crypto/src/keys/rsa/der.ts
+++ b/packages/crypto/src/keys/rsa/der.ts
@@ -46,6 +46,10 @@ function readLength (buf: Uint8Array, context: Context): number {
     context.offset++
 
     for (let i = 0; i < count; i++, context.offset++) {
+      if (context.offset >= buf.byteLength) {
+        throw new Error('invalid DER element length')
+      }
+
       str += buf[context.offset].toString(16).padStart(2, '0')
     }
 
@@ -53,6 +57,12 @@ function readLength (buf: Uint8Array, context: Context): number {
   } else {
     length = buf[context.offset]
     context.offset++
+  }
+
+  // length can be NaN (indefinite-form 0x80), negative, or larger than the
+  // bytes that remain; reject all three
+  if (!Number.isInteger(length) || length < 0 || length > buf.byteLength - context.offset) {
+    throw new Error('invalid DER element length')
   }
 
   return length

--- a/packages/crypto/test/keys/der.spec.ts
+++ b/packages/crypto/test/keys/der.spec.ts
@@ -1,0 +1,48 @@
+/* eslint-env mocha */
+import { expect } from 'aegir/chai'
+import { decodeDer } from '../../src/keys/rsa/der.ts'
+
+describe('der', () => {
+  it('rejects an integer whose length exceeds the buffer', () => {
+    // INTEGER (0x02) with a long-form length claiming 1,000,000 bytes, but only
+    // a single content byte present. Without a bound on the claimed length the
+    // decoder loops ~1,000,000 times reading past the end of the buffer, so a
+    // ~7-byte blob triggers large synchronous work. A crafted key like this
+    // reaches decodeDer pre-verification via the Identify publicKey field.
+    const malformed = Uint8Array.from([0x02, 0x84, 0x00, 0x0f, 0x42, 0x40, 0x01])
+
+    expect(() => decodeDer(malformed)).to.throw(/invalid DER element length/)
+  })
+
+  it('rejects an object identifier whose length exceeds the buffer', () => {
+    // OBJECT IDENTIFIER (0x06) is the other reader that loops on the claimed
+    // length, so it must be bounded by the same guard.
+    const malformed = Uint8Array.from([0x06, 0x84, 0x00, 0x0f, 0x42, 0x40, 0x01])
+
+    expect(() => decodeDer(malformed)).to.throw(/invalid DER element length/)
+  })
+
+  it('rejects an indefinite-form length', () => {
+    // 0x80 is a long-form length with zero length bytes (BER indefinite length);
+    // parseInt yields NaN, which must be rejected rather than used as a length.
+    const malformed = Uint8Array.from([0x02, 0x80])
+
+    expect(() => decodeDer(malformed)).to.throw(/invalid DER element length/)
+  })
+
+  it('rejects a truncated long-form length header', () => {
+    // 0x88 claims eight length bytes but only one is present, so the header
+    // itself overruns the buffer.
+    const malformed = Uint8Array.from([0x02, 0x88, 0x00])
+
+    expect(() => decodeDer(malformed)).to.throw(/invalid DER element length/)
+  })
+
+  it('accepts an element whose length exactly fills the buffer', () => {
+    // OCTET STRING (0x04) of two bytes with exactly two content bytes: the
+    // boundary case that must NOT be rejected (guards against a >= off-by-one).
+    const valid = Uint8Array.from([0x04, 0x02, 0xaa, 0xbb])
+
+    expect(() => decodeDer(valid)).to.not.throw()
+  })
+})


### PR DESCRIPTION
## Description

Validate DER element lengths in the RSA key decoder before using them.
`readLength` previously returned a long-form length without checking it against
the input, so the readers that consume it could run past the end of the buffer.

It now rejects a length that is not a whole number of bytes fitting within the
remaining input, and bounds the long-form length header against the buffer. All
readers go through `readLength`, so `readInteger`, `readObjectIdentifier`,
`readBitString` and `readOctetString` are covered in one place. Well-formed keys
are unaffected; a length that exactly fills the buffer is still accepted.

## Change checklist

- [x] I have performed a self-review of my own code
- [ ] I have made corresponding changes to the documentation if necessary
- [x] I have added tests that prove my fix is effective or that my feature works
