### PR TITLE
fix: log datastore key as string

### DIFF
--- a/packages/kad-dht/src/content-fetching/index.ts
+++ b/packages/kad-dht/src/content-fetching/index.ts
@@ -73,10 +73,10 @@ export class ContentFetching {
 
     const dsKey = bufferToRecordKey(this.datastorePrefix, key)
 
-    this.log('fetching record for key %k', dsKey)
+    this.log('fetching record for key %s', dsKey)
 
     const raw = await this.components.datastore.get(dsKey, options)
-    this.log('found %k in local datastore', dsKey)
+    this.log('found %s in local datastore', dsKey)
 
     const rec = Libp2pRecord.deserialize(raw)
 

--- a/packages/kad-dht/src/rpc/handlers/put-value.ts
+++ b/packages/kad-dht/src/rpc/handlers/put-value.ts
@@ -52,7 +52,7 @@ export class PutValueHandler implements DHTMessageHandler {
       const recordKey = bufferToRecordKey(this.datastorePrefix, deserializedRecord.key)
       await this.components.datastore.put(recordKey, deserializedRecord.serialize().subarray())
 
-      this.log('accepted put for key %b under %k', key, recordKey)
+      this.log('accepted put for key %b under %s', key, recordKey)
 
       return msg
     } catch (err: any) {


### PR DESCRIPTION
No need to use custom formatter, can just stringify the key.

Fixes runtime exceptions with other loggers that have removed several redundant custom formatters.

## Change checklist

- [x] I have performed a self-review of my own code
- [ ] I have made corresponding changes to the documentation if necessary (this includes comments as well)
- [ ] I have added tests that prove my fix is effective or that my feature works