### PR TITLE
fix(tcp): drain pending dials during shutdown

### DIFF
--- a/packages/transport-tcp/src/tcp.ts
+++ b/packages/transport-tcp/src/tcp.ts
@@ -28,27 +28,38 @@
  */
 
 import net from 'net'
-import { AbortError, TimeoutError, serviceCapabilities, transportSymbol } from '@libp2p/interface'
+import { AbortError, NotStartedError, TimeoutError, serviceCapabilities, transportSymbol } from '@libp2p/interface'
 import { TCP as TCPMatcher } from '@multiformats/multiaddr-matcher'
 import { CustomProgressEvent } from 'progress-events'
 import { TCPListener } from './listener.ts'
 import { toMultiaddrConnection } from './socket-to-conn.ts'
 import { multiaddrToNetConfig } from './utils.ts'
 import type { TCPComponents, TCPCreateListenerOptions, TCPDialEvents, TCPDialOptions, TCPMetrics, TCPOptions } from './index.ts'
-import type { Logger, Connection, Transport, Listener, MultiaddrConnection } from '@libp2p/interface'
+import type { Logger, Connection, Transport, Listener, MultiaddrConnection, Startable } from '@libp2p/interface'
 import type { Multiaddr } from '@multiformats/multiaddr'
 import type { Socket, IpcSocketConnectOpts, TcpSocketConnectOpts } from 'net'
 
-export class TCP implements Transport<TCPDialEvents> {
+interface PendingDial {
+  socket?: Socket
+  promise: Promise<void>
+  complete(): void
+}
+
+export class TCP implements Transport<TCPDialEvents>, Startable {
   private readonly opts: TCPOptions
   private readonly metrics?: TCPMetrics
   private readonly components: TCPComponents
   private readonly log: Logger
+  private readonly pendingDials: Set<PendingDial>
+  private acceptingDials: boolean
+  private shutdownPromise?: Promise<void>
 
   constructor (components: TCPComponents, options: TCPOptions = {}) {
     this.log = components.logger.forComponent('libp2p:tcp')
     this.opts = options
     this.components = components
+    this.pendingDials = new Set()
+    this.acceptingDials = true
 
     if (components.metrics != null) {
       this.metrics = {
@@ -72,13 +83,59 @@ export class TCP implements Transport<TCPDialEvents> {
     '@libp2p/transport'
   ]
 
+  start (): void {
+    this.acceptingDials = true
+    this.shutdownPromise = undefined
+  }
+
+  async beforeStop (): Promise<void> {
+    if (this.shutdownPromise != null) {
+      return this.shutdownPromise
+    }
+
+    this.acceptingDials = false
+
+    // Dials register before invoking user callbacks so closing admission makes
+    // this a stable set that cannot grow during shutdown.
+    const pendingDials = [...this.pendingDials]
+    this.shutdownPromise = Promise.all(pendingDials.map(pendingDial => pendingDial.promise)).then(() => undefined)
+
+    for (const pendingDial of pendingDials) {
+      pendingDial.socket?.destroy(new AbortError('TCP transport is stopping'))
+    }
+
+    await this.shutdownPromise
+  }
+
+  async stop (): Promise<void> {
+    await this.beforeStop()
+  }
+
   async dial (ma: Multiaddr, options: TCPDialOptions): Promise<Connection> {
+    if (!this.acceptingDials) {
+      throw new NotStartedError('TCP transport is not started')
+    }
+
+    // Register before onProgress or net.connect can invoke user-controlled
+    // code that re-enters the transport lifecycle.
+    const pendingDial = this.createPendingDial()
+
     options.keepAlive = options.keepAlive ?? true
     options.noDelay = options.noDelay ?? true
     options.allowHalfOpen = options.allowHalfOpen ?? false
 
     // options.signal destroys the socket before 'connect' event
-    const socket = await this._connect(ma, options)
+    let socket: Socket
+
+    try {
+      socket = await this._connect(ma, options, pendingDial)
+    } catch (err) {
+      if (pendingDial.socket == null) {
+        pendingDial.complete()
+      }
+
+      throw err
+    }
 
     let maConn: MultiaddrConnection
 
@@ -99,7 +156,10 @@ export class TCP implements Transport<TCPDialEvents> {
 
     try {
       this.log('new outbound connection %s', maConn.remoteAddr)
-      return await options.upgrader.upgradeOutbound(maConn, options)
+      const connection = await options.upgrader.upgradeOutbound(maConn, options)
+      pendingDial.complete()
+
+      return connection
     } catch (err: any) {
       this.metrics?.errors.increment({ outbound_upgrade: true })
       this.log.error('error upgrading outbound connection - %e', err)
@@ -108,7 +168,7 @@ export class TCP implements Transport<TCPDialEvents> {
     }
   }
 
-  async _connect (ma: Multiaddr, options: TCPDialOptions): Promise<Socket> {
+  async _connect (ma: Multiaddr, options: TCPDialOptions, pendingDial: PendingDial): Promise<Socket> {
     options.signal.throwIfAborted()
     options.onProgress?.(new CustomProgressEvent('tcp:open-connection'))
 
@@ -123,6 +183,8 @@ export class TCP implements Transport<TCPDialEvents> {
 
       this.log('dialing %a with opts %o', ma, cOpts)
       rawSocket = net.connect(cOpts)
+      pendingDial.socket = rawSocket
+      rawSocket.once('close', pendingDial.complete)
 
       const onError = (err: Error): void => {
         this.log.error('dial to %a errored - %e', ma, err)
@@ -174,11 +236,40 @@ export class TCP implements Transport<TCPDialEvents> {
       rawSocket.on('connect', onConnect)
 
       options.signal.addEventListener('abort', onAbort)
+
+      if (!this.acceptingDials || options.signal.aborted) {
+        onAbort()
+      }
     })
       .catch(err => {
         rawSocket?.destroy()
         throw err
       })
+  }
+
+  private createPendingDial (): PendingDial {
+    let resolve = (): void => {}
+    let completed = false
+    const promise = new Promise<void>((_resolve) => {
+      resolve = _resolve
+    })
+    const pendingDial: PendingDial = {
+      promise,
+      complete: () => {
+        if (completed) {
+          return
+        }
+
+        completed = true
+        pendingDial.socket?.removeListener('close', pendingDial.complete)
+        this.pendingDials.delete(pendingDial)
+        resolve()
+      }
+    }
+
+    this.pendingDials.add(pendingDial)
+
+    return pendingDial
   }
 
   /**

--- a/packages/transport-tcp/src/tcp.ts
+++ b/packages/transport-tcp/src/tcp.ts
@@ -40,9 +40,11 @@ import type { Multiaddr } from '@multiformats/multiaddr'
 import type { Socket, IpcSocketConnectOpts, TcpSocketConnectOpts } from 'net'
 
 interface PendingDial {
-  socket?: Socket
-  promise: Promise<void>
-  complete(): void
+  readonly done: Promise<void>
+  attach(socket: Socket): void
+  abort(err: Error): void
+  releaseIfUnattached(): void
+  handoff(): void
 }
 
 export class TCP implements Transport<TCPDialEvents>, Startable {
@@ -98,10 +100,10 @@ export class TCP implements Transport<TCPDialEvents>, Startable {
     // Dials register before invoking user callbacks so closing admission makes
     // this a stable set that cannot grow during shutdown.
     const pendingDials = [...this.pendingDials]
-    this.shutdownPromise = Promise.all(pendingDials.map(pendingDial => pendingDial.promise)).then(() => undefined)
+    this.shutdownPromise = Promise.all(pendingDials.map(pendingDial => pendingDial.done)).then(() => undefined)
 
     for (const pendingDial of pendingDials) {
-      pendingDial.socket?.destroy(new AbortError('TCP transport is stopping'))
+      pendingDial.abort(new AbortError('TCP transport is stopping'))
     }
 
     await this.shutdownPromise
@@ -120,51 +122,45 @@ export class TCP implements Transport<TCPDialEvents>, Startable {
     // code that re-enters the transport lifecycle.
     const pendingDial = this.createPendingDial()
 
-    options.keepAlive = options.keepAlive ?? true
-    options.noDelay = options.noDelay ?? true
-    options.allowHalfOpen = options.allowHalfOpen ?? false
-
-    // options.signal destroys the socket before 'connect' event
-    let socket: Socket
-
     try {
-      socket = await this._connect(ma, options, pendingDial)
-    } catch (err) {
-      if (pendingDial.socket == null) {
-        pendingDial.complete()
+      options.keepAlive = options.keepAlive ?? true
+      options.noDelay = options.noDelay ?? true
+      options.allowHalfOpen = options.allowHalfOpen ?? false
+
+      // options.signal destroys the socket before 'connect' event
+      const socket = await this._connect(ma, options, pendingDial)
+
+      let maConn: MultiaddrConnection
+
+      try {
+        maConn = toMultiaddrConnection({
+          socket,
+          inactivityTimeout: this.opts.outboundSocketInactivityTimeout,
+          metrics: this.metrics?.events,
+          direction: 'outbound',
+          remoteAddr: ma,
+          log: this.log.newScope('connection')
+        })
+      } catch (err: any) {
+        this.metrics?.errors.increment({ outbound_to_connection: true })
+        socket.destroy(err)
+        throw err
       }
 
-      throw err
-    }
+      try {
+        this.log('new outbound connection %s', maConn.remoteAddr)
+        const connection = await options.upgrader.upgradeOutbound(maConn, options)
+        pendingDial.handoff()
 
-    let maConn: MultiaddrConnection
-
-    try {
-      maConn = toMultiaddrConnection({
-        socket,
-        inactivityTimeout: this.opts.outboundSocketInactivityTimeout,
-        metrics: this.metrics?.events,
-        direction: 'outbound',
-        remoteAddr: ma,
-        log: this.log.newScope('connection')
-      })
-    } catch (err: any) {
-      this.metrics?.errors.increment({ outbound_to_connection: true })
-      socket.destroy(err)
-      throw err
-    }
-
-    try {
-      this.log('new outbound connection %s', maConn.remoteAddr)
-      const connection = await options.upgrader.upgradeOutbound(maConn, options)
-      pendingDial.complete()
-
-      return connection
-    } catch (err: any) {
-      this.metrics?.errors.increment({ outbound_upgrade: true })
-      this.log.error('error upgrading outbound connection - %e', err)
-      maConn.abort(err)
-      throw err
+        return connection
+      } catch (err: any) {
+        this.metrics?.errors.increment({ outbound_upgrade: true })
+        this.log.error('error upgrading outbound connection - %e', err)
+        maConn.abort(err)
+        throw err
+      }
+    } finally {
+      pendingDial.releaseIfUnattached()
     }
   }
 
@@ -183,8 +179,6 @@ export class TCP implements Transport<TCPDialEvents>, Startable {
 
       this.log('dialing %a with opts %o', ma, cOpts)
       rawSocket = net.connect(cOpts)
-      pendingDial.socket = rawSocket
-      rawSocket.once('close', pendingDial.complete)
 
       const onError = (err: Error): void => {
         this.log.error('dial to %a errored - %e', ma, err)
@@ -236,8 +230,9 @@ export class TCP implements Transport<TCPDialEvents>, Startable {
       rawSocket.on('connect', onConnect)
 
       options.signal.addEventListener('abort', onAbort)
+      pendingDial.attach(rawSocket)
 
-      if (!this.acceptingDials || options.signal.aborted) {
+      if (options.signal.aborted) {
         onAbort()
       }
     })
@@ -248,23 +243,36 @@ export class TCP implements Transport<TCPDialEvents>, Startable {
   }
 
   private createPendingDial (): PendingDial {
-    let resolve = (): void => {}
-    let completed = false
-    const promise = new Promise<void>((_resolve) => {
-      resolve = _resolve
-    })
-    const pendingDial: PendingDial = {
-      promise,
-      complete: () => {
-        if (completed) {
-          return
-        }
+    const { promise: done, resolve } = Promise.withResolvers<void>()
+    let socket: Socket | undefined
+    let abortError: Error | undefined
 
-        completed = true
-        pendingDial.socket?.removeListener('close', pendingDial.complete)
-        this.pendingDials.delete(pendingDial)
-        resolve()
-      }
+    const complete = (): void => {
+      socket?.removeListener('close', complete)
+      this.pendingDials.delete(pendingDial)
+      resolve()
+    }
+
+    const pendingDial: PendingDial = {
+      done,
+      attach: (rawSocket) => {
+        rawSocket.once('close', complete)
+        socket = rawSocket
+
+        if (abortError != null) {
+          socket.destroy(abortError)
+        }
+      },
+      abort: (err) => {
+        abortError = err
+        socket?.destroy(err)
+      },
+      releaseIfUnattached: () => {
+        if (socket == null) {
+          complete()
+        }
+      },
+      handoff: complete
     }
 
     this.pendingDials.add(pendingDial)

--- a/packages/transport-tcp/test/shutdown.spec.ts
+++ b/packages/transport-tcp/test/shutdown.spec.ts
@@ -6,7 +6,7 @@ import { expect } from 'aegir/chai'
 import Sinon from 'sinon'
 import { stubInterface } from 'sinon-ts'
 import { tcp } from '../src/index.ts'
-import type { Connection, Upgrader } from '@libp2p/interface'
+import type { Connection, Transport, Upgrader } from '@libp2p/interface'
 
 class TestSocket extends net.Socket {
   destroyCalls = 0
@@ -72,7 +72,7 @@ describe('shutdown', () => {
     expect(connect.calledOnce).to.be.true()
   })
 
-  it('should drain a dial created reentrantly during shutdown', async () => {
+  it('should drain a dial created during reentrant shutdown', async () => {
     const socket = new TestSocket()
     const connect = Sinon.stub(net, 'connect').returns(socket)
     const transport = tcp()({
@@ -119,6 +119,50 @@ describe('shutdown', () => {
       socket.close()
       await dialPromise.catch(() => {})
     }
+  })
+
+  it('should release dials that fail before creating a socket', async () => {
+    const transport = tcp()({
+      logger: defaultLogger()
+    })
+    const options = Object.freeze({
+      upgrader: stubInterface<Upgrader>(),
+      signal: AbortSignal.timeout(5_000)
+    })
+
+    await expect(transport.dial(multiaddr('/ip4/127.0.0.1/tcp/9000'), options))
+      .to.eventually.be.rejected()
+      .and.to.have.property('name', 'TypeError')
+    await stop(transport)
+  })
+
+  it('should drain a dial when shutdown starts during DNS lookup', async () => {
+    let stopPromise: Promise<void> | undefined
+    const dialOpts: Omit<net.TcpSocketConnectOpts, 'port'> & { noDelay: boolean } = {
+      noDelay: true
+    }
+    const transport: Transport = tcp({ dialOpts })({
+      logger: defaultLogger()
+    })
+    dialOpts.lookup = (_hostname, _options, callback) => {
+      stopPromise = stop(transport)
+      callback(null, '127.0.0.1', 4)
+    }
+    const dialPromise = transport.dial(multiaddr('/dns4/example.com/tcp/9000'), {
+      upgrader: stubInterface<Upgrader>(),
+      signal: AbortSignal.timeout(5_000)
+    })
+    const dialErrorPromise = dialPromise.then(
+      () => { throw new Error('dial unexpectedly succeeded') },
+      (err: Error) => err
+    )
+
+    if (stopPromise == null) {
+      throw new Error('DNS lookup did not start transport shutdown')
+    }
+
+    await stopPromise
+    expect(await dialErrorPromise).to.have.property('name', 'AbortError')
   })
 
   it('should not close successfully upgraded sockets', async () => {

--- a/packages/transport-tcp/test/shutdown.spec.ts
+++ b/packages/transport-tcp/test/shutdown.spec.ts
@@ -1,0 +1,146 @@
+import net from 'node:net'
+import { stop } from '@libp2p/interface'
+import { defaultLogger } from '@libp2p/logger'
+import { multiaddr } from '@multiformats/multiaddr'
+import { expect } from 'aegir/chai'
+import Sinon from 'sinon'
+import { stubInterface } from 'sinon-ts'
+import { tcp } from '../src/index.ts'
+import type { Connection, Upgrader } from '@libp2p/interface'
+
+class TestSocket extends net.Socket {
+  destroyCalls = 0
+
+  override destroy (error?: Error): this {
+    this.destroyCalls++
+
+    if (error != null) {
+      this.emit('error', error)
+    }
+
+    return this
+  }
+
+  close (): void {
+    this.emit('close', false)
+  }
+}
+
+describe('shutdown', () => {
+  afterEach(() => {
+    Sinon.restore()
+  })
+
+  it('should destroy pending outbound sockets and await close', async () => {
+    const socket = new TestSocket()
+    const connect = Sinon.stub(net, 'connect').returns(socket)
+    const transport = tcp()({
+      logger: defaultLogger()
+    })
+    const upgrader = stubInterface<Upgrader>()
+    const addr = multiaddr('/ip4/127.0.0.1/tcp/9000')
+    const dialPromise = transport.dial(addr, {
+      upgrader,
+      signal: AbortSignal.timeout(5_000)
+    })
+
+    let stopped = false
+    const stopPromise = stop(transport).then(() => {
+      stopped = true
+    })
+
+    await Promise.resolve()
+
+    expect(connect.calledOnce).to.be.true()
+    expect(socket.destroyCalls).to.be.greaterThan(0)
+    expect(stopped).to.be.false()
+
+    socket.close()
+    await stopPromise
+
+    expect(stopped).to.be.true()
+    await expect(dialPromise)
+      .to.eventually.be.rejected()
+      .and.to.have.property('name', 'AbortError')
+
+    await expect(transport.dial(addr, {
+      upgrader,
+      signal: AbortSignal.timeout(5_000)
+    }))
+      .to.eventually.be.rejected()
+      .and.to.have.property('name', 'NotStartedError')
+    expect(connect.calledOnce).to.be.true()
+  })
+
+  it('should drain a dial created reentrantly during shutdown', async () => {
+    const socket = new TestSocket()
+    const connect = Sinon.stub(net, 'connect').returns(socket)
+    const transport = tcp()({
+      logger: defaultLogger()
+    })
+    const upgrader = stubInterface<Upgrader>()
+    const addr = multiaddr('/ip4/127.0.0.1/tcp/9000')
+    let stopPromise: Promise<void> | undefined
+    let stopped = false
+
+    const dialPromise = transport.dial(addr, {
+      upgrader,
+      signal: AbortSignal.timeout(5_000),
+      onProgress: () => {
+        stopPromise = stop(transport).then(() => {
+          stopped = true
+        })
+      }
+    })
+
+    if (stopPromise == null) {
+      throw new Error('onProgress did not start transport shutdown')
+    }
+
+    try {
+      await Promise.resolve()
+      await Promise.resolve()
+
+      expect(connect.calledOnce).to.be.true()
+      expect(socket.destroyCalls).to.be.greaterThan(0)
+      expect(stopped).to.be.false()
+
+      socket.close()
+      await stopPromise
+
+      expect(stopped).to.be.true()
+      await expect(dialPromise)
+        .to.eventually.be.rejected()
+        .and.to.have.property('name', 'AbortError')
+    } finally {
+      if (socket.destroyCalls === 0) {
+        socket.emit('error', new Error('test cleanup'))
+      }
+      socket.close()
+      await dialPromise.catch(() => {})
+    }
+  })
+
+  it('should not close successfully upgraded sockets', async () => {
+    const socket = new TestSocket()
+    Sinon.stub(net, 'connect').returns(socket)
+    const transport = tcp()({
+      logger: defaultLogger()
+    })
+    const connection = stubInterface<Connection>()
+    const upgrader = stubInterface<Upgrader>({
+      upgradeOutbound: Sinon.stub().resolves(connection)
+    })
+    const dialPromise = transport.dial(multiaddr('/ip4/127.0.0.1/tcp/9000'), {
+      upgrader,
+      signal: AbortSignal.timeout(5_000)
+    })
+
+    socket.emit('connect')
+
+    await expect(dialPromise).to.eventually.equal(connection)
+    await stop(transport)
+
+    expect(socket.destroyCalls).to.equal(0)
+  })
+})


### PR DESCRIPTION
## Description

Make the TCP transport participate in component shutdown and drain outbound dial operations before shutdown completes.

The root cause is a one-time snapshot race. A dial can pass its admission check, invoke caller-controlled code through `onProgress` or DNS lookup, and re-enter shutdown before `net.connect()` returns. If shutdown snapshots only returned sockets, the new socket is registered after the snapshot and is left open.

This change:

- registers each dial operation before any caller-controlled boundary
- closes dial admission before taking a stable shutdown snapshot
- records shutdown on the operation even before its socket exists
- destroys sockets owned by pending operations and awaits their close
- releases operations that fail before socket creation
- retains operation ownership until socket close or successful connection handoff
- rejects new dials after shutdown begins

Related investigation: https://github.com/matthewkeil/js-libp2p/pull/1

## Validation

- `npm run lint --workspace @libp2p/tcp`
- `npm run build --workspace @libp2p/tcp`
- `npm run spell-check`
- shutdown regressions on Node.js 22.23.2 and 24.13.0
- 23 additional TCP tests outside the locally blocked `listen-dial.spec.js`

## Change checklist

- [x] I have performed a self-review of my own code
- [x] Documentation changes are not necessary for this internal lifecycle fix
- [x] I have added tests that prove the fix is effective
