### PR TITLE
fix(gossipsub)!: bound subscribed topic bytes per peer

### DIFF
--- a/packages/gossipsub/src/constants.ts
+++ b/packages/gossipsub/src/constants.ts
@@ -264,3 +264,18 @@ export const BACKOFF_SLACK = 1
 
 export const GossipsubIdontwantMinDataSize = 512
 export const GossipsubIdontwantMaxMessages = 512
+
+/**
+ * The default per-peer memory budget for tracking a peer's topic subscriptions,
+ * bounding per-peer memory in the topics map. Each topic costs its string
+ * length plus GossipsubTopicEntryOverhead, so this bounds topic count as well
+ * as bytes (~1000 topics at the 1 MiB default).
+ */
+export const GossipsubMaxTopicBytesPerPeer = 1024 * 1024
+
+/**
+ * Approximate fixed heap cost of one topics-map entry (the Map slot, the Set,
+ * and the subscriber's peer id), charged per subscription on top of the topic
+ * string length so the per-peer budget bounds topic count as well as bytes.
+ */
+export const GossipsubTopicEntryOverhead = 1024

--- a/packages/gossipsub/src/gossipsub.ts
+++ b/packages/gossipsub/src/gossipsub.ts
@@ -273,6 +273,9 @@ export class GossipSub extends TypedEventEmitter<GossipSubEvents> implements Typ
   private readonly maxOutboundStreams?: number
   private readonly runOnLimitedConnection?: boolean
   private readonly allowedTopics: Set<TopicStr> | null
+  private readonly maxTopicBytesPerPeer: number
+  /** Running total of subscribed-topic bytes per peer, to bound the topics map */
+  private readonly peerTopicBytes = new Map<PeerIdStr, number>()
 
   private heartbeatTimer: {
     _intervalId: ReturnType<typeof setInterval> | undefined
@@ -410,6 +413,7 @@ export class GossipSub extends TypedEventEmitter<GossipSubEvents> implements Typ
     this.runOnLimitedConnection = options.runOnLimitedConnection
 
     this.allowedTopics = (opts.allowedTopics != null) ? new Set(opts.allowedTopics) : null
+    this.maxTopicBytesPerPeer = opts.maxTopicBytesPerPeer ?? constants.GossipsubMaxTopicBytesPerPeer
   }
 
   readonly [Symbol.toStringTag] = '@libp2p/gossipsub'
@@ -578,6 +582,7 @@ export class GossipSub extends TypedEventEmitter<GossipSubEvents> implements Typ
     this.peers.clear()
     this.subscriptions.clear()
     this.topics.clear()
+    this.peerTopicBytes.clear()
 
     // Gossipsub
 
@@ -799,6 +804,7 @@ export class GossipSub extends TypedEventEmitter<GossipSubEvents> implements Typ
         this.topics.delete(topic)
       }
     }
+    this.peerTopicBytes.delete(id)
 
     // Remove this peer from the mesh
     for (const [topicStr, peers] of this.mesh) {
@@ -986,7 +992,10 @@ export class GossipSub extends TypedEventEmitter<GossipSubEvents> implements Typ
             return
           }
 
-          this.handleReceivedSubscription(from, topic, subscribe)
+          if (!this.handleReceivedSubscription(from, topic, subscribe)) {
+            // over the per-peer topic-byte budget, so ignore this subscription
+            return
+          }
 
           // graft the peer into the mesh now rather than waiting for the next
           // heartbeat, so a message published right after subscribing is not dropped
@@ -1038,28 +1047,49 @@ export class GossipSub extends TypedEventEmitter<GossipSubEvents> implements Typ
   /**
    * Handles a subscription change from a peer
    */
-  private handleReceivedSubscription (from: PeerId, topic: TopicStr, subscribe: boolean): void {
+  private handleReceivedSubscription (from: PeerId, topic: TopicStr, subscribe: boolean): boolean {
     this.log('subscription update from %p topic %s', from, topic)
 
+    const fromStr = from.toString()
     let topicSet = this.topics.get(topic)
 
+    // charge each topic its string length plus a fixed per-entry overhead, so
+    // the budget bounds both topic bytes and topic count (a peer cannot occupy
+    // more than roughly budget / overhead entries regardless of topic length)
+    const cost = topic.length + constants.GossipsubTopicEntryOverhead
+
     if (subscribe) {
+      // a repeat SUBSCRIBE to a topic the peer already has is a no-op
+      if (topicSet?.has(fromStr) === true) {
+        return true
+      }
+
+      // bound the memory a single peer may occupy in the topics map
+      const used = this.peerTopicBytes.get(fromStr) ?? 0
+      if (used + cost > this.maxTopicBytesPerPeer) {
+        // over budget, so drop this subscription; the peer keeps what it has
+        this.log('dropping subscription from %p topic %s, over per-peer topic budget', from, topic)
+        return false
+      }
+      this.peerTopicBytes.set(fromStr, used + cost)
+
       if (topicSet == null) {
         topicSet = new Set()
         this.topics.set(topic, topicSet)
       }
 
       // subscribe peer to new topic
-      topicSet.add(from.toString())
-    } else if (topicSet != null) {
-      // unsubscribe from existing topic
-      topicSet.delete(from.toString())
+      topicSet.add(fromStr)
+    } else if (topicSet?.has(fromStr) === true) {
+      // unsubscribe from existing topic and refund its cost
+      topicSet.delete(fromStr)
+      this.peerTopicBytes.set(fromStr, Math.max(0, (this.peerTopicBytes.get(fromStr) ?? 0) - cost))
       if (topicSet.size === 0) {
         this.topics.delete(topic)
       }
     }
 
-    // TODO: rust-libp2p has A LOT more logic here
+    return true
   }
 
   /**

--- a/packages/gossipsub/src/gossipsub.ts
+++ b/packages/gossipsub/src/gossipsub.ts
@@ -1067,8 +1067,8 @@ export class GossipSub extends TypedEventEmitter<GossipSubEvents> implements Typ
       // bound the memory a single peer may occupy in the topics map
       const used = this.peerTopicBytes.get(fromStr) ?? 0
       if (used + cost > this.maxTopicBytesPerPeer) {
-        // over budget, so drop this subscription; the peer keeps what it has
-        this.log('dropping subscription from %p topic %s, over per-peer topic budget', from, topic)
+        // over budget, so ignore this subscription; the peer keeps what it has
+        this.log('ignoring subscription from %p topic %s, over per-peer topic budget', from, topic)
         return false
       }
       this.peerTopicBytes.set(fromStr, used + cost)
@@ -1089,6 +1089,7 @@ export class GossipSub extends TypedEventEmitter<GossipSubEvents> implements Typ
       }
     }
 
+    // TODO: rust-libp2p has A LOT more logic here
     return true
   }
 

--- a/packages/gossipsub/src/index.ts
+++ b/packages/gossipsub/src/index.ts
@@ -198,6 +198,18 @@ export interface GossipsubOpts extends GossipsubOptsSpec {
   allowedTopics?: string[] | Set<string>
 
   /**
+   * A per-peer memory budget for tracking that peer's topic subscriptions. Each
+   * subscribed topic costs its string length plus a fixed per-entry overhead
+   * (~1 KiB, approximating the Map/Set bookkeeping), so this bounds both the
+   * total topic bytes and the number of topics a single peer may occupy in the
+   * topics map (roughly budget / 1 KiB topics). Subscriptions beyond the budget
+   * are ignored; a peer that reaches it silently stops receiving messages for
+   * further topics, so keep this well above any legitimate peer's needs.
+   * (default 1 MiB, ~1000 topics)
+   */
+  maxTopicBytesPerPeer?: number
+
+  /**
    * Limits to bound protobuf decoding
    */
   decodeRpcLimits?: DecodeRPCLimits

--- a/packages/gossipsub/test/subscription-byte-cap.spec.ts
+++ b/packages/gossipsub/test/subscription-byte-cap.spec.ts
@@ -1,0 +1,110 @@
+import { stop } from '@libp2p/interface'
+import { expect } from 'aegir/chai'
+import { pEvent } from 'p-event'
+import { GossipsubTopicEntryOverhead } from '../src/constants.ts'
+import { connectAllPubSubNodes, createComponents, createComponentsArray } from './utils/create-pubsub.ts'
+import { createPeerId } from './utils/index.ts'
+import type { GossipSubAndComponents } from './utils/create-pubsub.ts'
+import type { PeerId } from '@libp2p/interface'
+
+// each subscribed topic is charged its string length plus a fixed per-entry
+// overhead, so budgets in these tests are expressed in units of that cost
+const topicLength = 10
+const perTopic = topicLength + GossipsubTopicEntryOverhead
+
+describe('gossip / subscription byte cap', () => {
+  let nodes: GossipSubAndComponents[]
+
+  // five 10-byte topics; a budget for exactly three admits three and drops two
+  const topics = Array.from({ length: 5 }, (_, i) => `topic${i}`.padEnd(topicLength, '0'))
+  const maxTopicBytesPerPeer = perTopic * 3
+
+  beforeEach(async () => {
+    nodes = await createComponentsArray({
+      number: 2,
+      connected: false,
+      init: {
+        maxTopicBytesPerPeer
+      }
+    })
+  })
+
+  afterEach(async () => {
+    await stop(...nodes.reduce<any[]>((acc, curr) => acc.concat(curr.pubsub, ...Object.entries(curr.components)), []))
+  })
+
+  it('drops a peer\'s subscriptions once its topic budget is exceeded', async function () {
+    this.timeout(10 * 1000)
+    const [nodeA, nodeB] = nodes
+
+    for (const topic of topics) {
+      nodeA.pubsub.subscribe(topic)
+    }
+
+    await Promise.all([
+      connectAllPubSubNodes(nodes),
+      pEvent(nodeB.pubsub, 'subscription-change')
+    ])
+
+    // nodeB stores only the three topics that fit within the budget, not all five
+    const nodeBTopics = Array.from((nodeB.pubsub)['topics'].keys())
+    expect(nodeBTopics.length).to.equal(3)
+  })
+})
+
+describe('gossip / subscription byte cap accounting', () => {
+  let node: GossipSubAndComponents
+  let peer: PeerId
+  const cap = perTopic * 2 // budget for exactly two topics
+
+  beforeEach(async () => {
+    node = await createComponents({ init: { maxTopicBytesPerPeer: cap } })
+    peer = await createPeerId()
+  })
+
+  afterEach(async () => {
+    await stop(node.pubsub, ...Object.values(node.components))
+  })
+
+  const topic = (i: number): string => `t${i}`.padEnd(topicLength, 'x') // distinct, 10 chars
+  // call the private receive handler directly with a fixed remote peer
+  const sub = (t: string, subscribe = true): boolean =>
+    (node.pubsub as any).handleReceivedSubscription(peer, t, subscribe)
+  const used = (): number => (node.pubsub as any).peerTopicBytes.get(peer.toString()) ?? 0
+  const topicCount = (): number => (node.pubsub as any).topics.size
+
+  it('does not double-charge a repeated subscribe to the same topic', () => {
+    expect(sub(topic(0))).to.equal(true)
+    expect(sub(topic(0))).to.equal(true) // idempotent re-announce
+    expect(used()).to.equal(perTopic)
+    expect(topicCount()).to.equal(1)
+  })
+
+  it('refunds a topic\'s cost on unsubscribe so the budget is freed', () => {
+    expect(sub(topic(0))).to.equal(true) // 1x
+    expect(sub(topic(1))).to.equal(true) // 2x (at cap)
+    expect(sub(topic(2))).to.equal(false) // 3x > cap, rejected
+    expect(used()).to.equal(perTopic * 2)
+
+    expect(sub(topic(0), false)).to.equal(true) // unsubscribe, refund
+    expect(used()).to.equal(perTopic)
+    expect(sub(topic(2))).to.equal(true) // now fits again
+    expect(used()).to.equal(perTopic * 2)
+  })
+
+  it('does not refund a topic the peer was never charged for (no cap bypass)', () => {
+    expect(sub(topic(0))).to.equal(true)
+    // unsubscribe from a never-subscribed topic must be a no-op, otherwise a
+    // peer could erase its charges and exceed the cap
+    expect(sub(topic(99), false)).to.equal(true)
+    expect(used()).to.equal(perTopic)
+  })
+
+  it('accepts a subscription that exactly fills the budget and rejects one over', () => {
+    expect(sub(topic(0))).to.equal(true) // 1x
+    expect(sub(topic(1))).to.equal(true) // 2x, exactly the cap (pins > not >=)
+    expect(used()).to.equal(perTopic * 2)
+    expect(sub(topic(2))).to.equal(false) // one over
+    expect(used()).to.equal(perTopic * 2)
+  })
+})


### PR DESCRIPTION
## Description

Adds a per-peer budget for the topic subscriptions gossipsub tracks in its
`topics` map, which was previously unbounded per peer.

Each tracked topic costs its string length plus a small fixed per-entry
overhead, capped per peer by `maxTopicBytesPerPeer` (default 1 MiB, ~1000
topics). Subscriptions over the budget are ignored (the peer keeps what it
had), refunded on unsubscribe, and cleared when the peer is removed.

Behaviour change from the previous unbounded default: a peer that legitimately
subscribes to more than ~1000 topics will have the excess ignored; raise
`maxTopicBytesPerPeer` to restore the old behaviour.

## Change checklist

- [x] I have performed a self-review of my own code
- [ ] I have made corresponding changes to the documentation if necessary
- [x] I have added tests that prove my fix is effective or that my feature works
