### PR TITLE
fix: drain outbound connections during shutdown

### DIFF
--- a/packages/libp2p/src/connection-manager/dial-queue.ts
+++ b/packages/libp2p/src/connection-manager/dial-queue.ts
@@ -81,6 +81,7 @@ export class DialQueue {
   private readonly connections: PeerMap<Connection[]>
   private readonly log: Logger
   private readonly resolvers: Record<string, MultiaddrResolver>
+  private readonly activeDials: Set<Promise<Connection>>
 
   constructor (components: DialQueueComponents, init: DialerInit = {}) {
     this.addressSorter = init.addressSorter
@@ -91,6 +92,7 @@ export class DialQueue {
     this.log = components.logger.forComponent('libp2p:connection-manager:dial-queue')
     this.components = components
     this.resolvers = init.resolvers ?? defaultOptions.resolvers
+    this.activeDials = new Set()
 
     this.shutDownController = new AbortController()
     setMaxListeners(Infinity, this.shutDownController.signal)
@@ -117,9 +119,10 @@ export class DialQueue {
   /**
    * Clears any pending dials
    */
-  stop (): void {
+  async stop (): Promise<void> {
     this.shutDownController.abort()
     this.queue.abort()
+    await Promise.allSettled(this.activeDials)
   }
 
   /**
@@ -199,9 +202,13 @@ export class DialQueue {
       ])
       setMaxListeners(Infinity, signal)
 
+      const dialPromise = this.dialPeer(options, signal)
+      this.activeDials.add(dialPromise)
+
       try {
-        return await this.dialPeer(options, signal)
+        return await dialPromise
       } finally {
+        this.activeDials.delete(dialPromise)
         // clean up abort signals/controllers
         signal.clear()
       }

--- a/packages/libp2p/src/connection-manager/index.ts
+++ b/packages/libp2p/src/connection-manager/index.ts
@@ -376,12 +376,15 @@ export class DefaultConnectionManager implements ConnectionManager, Startable {
     this.log('started')
   }
 
+  beforeStop (): void {
+    this.started = false
+  }
+
   /**
    * Stops the Connection Manager
    */
   async stop (): Promise<void> {
-    this.events.removeEventListener('connection:open', this.onConnect)
-    this.events.removeEventListener('connection:close', this.onDisconnect)
+    this.started = false
 
     await stop(
       this.reconnectQueue,
@@ -412,6 +415,9 @@ export class DefaultConnectionManager implements ConnectionManager, Startable {
     this.log('closing %d connections', tasks.length)
     await Promise.all(tasks)
     this.connections.clear()
+
+    this.events.removeEventListener('connection:open', this.onConnect)
+    this.events.removeEventListener('connection:close', this.onDisconnect)
 
     this.log('stopped')
   }

--- a/packages/libp2p/test/connection-manager/dial-queue.spec.ts
+++ b/packages/libp2p/test/connection-manager/dial-queue.spec.ts
@@ -39,10 +39,45 @@ describe('dial queue', () => {
     }
   })
 
-  afterEach(() => {
+  afterEach(async () => {
     if (dialer != null) {
-      dialer.stop()
+      await dialer.stop()
     }
+  })
+
+  it('should wait for active dials to finish when stopped', async () => {
+    const dialStarted = pDefer<void>()
+    const dialCleanup = pDefer<void>()
+
+    components.transportManager.dialTransportForMultiaddr.returns(stubInterface<Transport>())
+    components.transportManager.dial.callsFake(async (_ma, options) => {
+      dialStarted.resolve()
+
+      await new Promise<void>(resolve => {
+        options?.signal?.addEventListener('abort', () => { resolve() }, { once: true })
+      })
+      await dialCleanup.promise
+
+      throw new Error('dial aborted')
+    })
+
+    dialer = new DialQueue(components)
+    const dialPromise = dialer.dial(multiaddr('/ip4/127.0.0.1/tcp/1234'))
+    const dialResult = expect(dialPromise).to.eventually.be.rejected()
+
+    await dialStarted.promise
+
+    let stopped = false
+    const stopPromise = dialer.stop().then(() => {
+      stopped = true
+    })
+
+    await Promise.resolve()
+    expect(stopped).to.be.false()
+
+    dialCleanup.resolve()
+    await stopPromise
+    await dialResult
   })
 
   it('should end when a single multiaddr dials succeeds', async () => {

--- a/packages/libp2p/test/connection-manager/index.spec.ts
+++ b/packages/libp2p/test/connection-manager/index.spec.ts
@@ -525,4 +525,22 @@ describe('Connection Manager', () => {
 
     expect(connectionManager.getConnections(remotePeer)).to.have.lengthOf(0)
   })
+
+  it('should close connections opened after shutdown starts', async () => {
+    const connectionManager = new DefaultConnectionManager(components)
+    await connectionManager.start()
+
+    const connection = stubInterface<Connection>({
+      remotePeer: peerIdFromPrivateKey(await generateKeyPair('Ed25519')),
+      status: 'open'
+    })
+
+    connectionManager.beforeStop()
+    components.events.safeDispatchEvent('connection:open', { detail: connection })
+
+    await pWaitFor(() => connection.close.called)
+    expect(connectionManager.getConnections()).to.have.lengthOf(0)
+
+    await connectionManager.stop()
+  })
 })

--- a/packages/transport-tcp/src/listener.ts
+++ b/packages/transport-tcp/src/listener.ts
@@ -217,8 +217,10 @@ export class TCPListener extends TypedEventEmitter<ListenerEvents> implements Li
       .catch(async err => {
         this.log.error('inbound connection upgrade failed - %e', err)
         this.metrics.errors?.increment({ [`${this.addr} inbound_upgrade`]: true })
-        this.sockets.delete(socket)
+        const socketClosed = socket.closed ? undefined : pEvent(socket, 'close', { rejectionEvents: [] })
         maConn.abort(err)
+        await socketClosed
+        this.sockets.delete(socket)
       })
   }
 
@@ -281,9 +283,12 @@ export class TCPListener extends TypedEventEmitter<ListenerEvents> implements Li
     // synchronously close any open connections - should be done after closing
     // the server socket in case new sockets are opened during the shutdown
     this.sockets.forEach(socket => {
-      if (socket.readable) {
+      if (!socket.closed) {
         events.push(pEvent(socket, 'close', options))
-        socket.destroy()
+
+        if (!socket.destroyed) {
+          socket.destroy()
+        }
       }
     })
 

--- a/packages/transport-tcp/src/socket-to-conn.ts
+++ b/packages/transport-tcp/src/socket-to-conn.ts
@@ -123,6 +123,12 @@ class TCPSocketMultiaddrConnection extends AbstractMultiaddrConnection {
   }
 
   sendReset (): void {
+    // Node.js cannot reset a socket while a graceful shutdown request is pending
+    if (this.socket.writableEnded) {
+      this.socket.destroy()
+      return
+    }
+
     this.socket.resetAndDestroy()
   }
 

--- a/packages/transport-tcp/src/tcp.ts
+++ b/packages/transport-tcp/src/tcp.ts
@@ -175,8 +175,15 @@ export class TCP implements Transport<TCPDialEvents> {
 
       options.signal.addEventListener('abort', onAbort)
     })
-      .catch(err => {
-        rawSocket?.destroy()
+      .catch(async err => {
+        if (rawSocket != null && !rawSocket.closed) {
+          const socketClosed = new Promise<void>(resolve => {
+            rawSocket.once('close', resolve)
+          })
+          rawSocket.destroy()
+          await socketClosed
+        }
+
         throw err
       })
   }

--- a/packages/transport-tcp/src/tcp.ts
+++ b/packages/transport-tcp/src/tcp.ts
@@ -83,12 +83,11 @@ export class TCP implements Transport<TCPDialEvents>, Startable {
     const socketClosedPromises: Array<Promise<unknown>> = []
 
     for (const socket of this.outboundSockets) {
-      if (socket.closed) {
-        continue
-      }
-
       socketClosedPromises.push(pEvent(socket, 'close', { rejectionEvents: [] }))
-      socket.destroy()
+
+      if (!socket.destroyed) {
+        socket.destroy()
+      }
     }
 
     await Promise.all(socketClosedPromises)

--- a/packages/transport-tcp/src/tcp.ts
+++ b/packages/transport-tcp/src/tcp.ts
@@ -36,20 +36,22 @@ import { TCPListener } from './listener.js'
 import { toMultiaddrConnection } from './socket-to-conn.js'
 import { multiaddrToNetConfig } from './utils.js'
 import type { TCPComponents, TCPCreateListenerOptions, TCPDialEvents, TCPDialOptions, TCPMetrics, TCPOptions } from './index.js'
-import type { Logger, Connection, Transport, Listener, MultiaddrConnection } from '@libp2p/interface'
+import type { Logger, Connection, Transport, Listener, MultiaddrConnection, Startable } from '@libp2p/interface'
 import type { Multiaddr } from '@multiformats/multiaddr'
 import type { Socket, IpcSocketConnectOpts, TcpSocketConnectOpts } from 'net'
 
-export class TCP implements Transport<TCPDialEvents> {
+export class TCP implements Transport<TCPDialEvents>, Startable {
   private readonly opts: TCPOptions
   private readonly metrics?: TCPMetrics
   private readonly components: TCPComponents
   private readonly log: Logger
+  private readonly outboundSockets: Set<Socket>
 
   constructor (components: TCPComponents, options: TCPOptions = {}) {
     this.log = components.logger.forComponent('libp2p:tcp')
     this.opts = options
     this.components = components
+    this.outboundSockets = new Set()
 
     if (components.metrics != null) {
       this.metrics = {
@@ -72,6 +74,25 @@ export class TCP implements Transport<TCPDialEvents> {
   readonly [serviceCapabilities]: string[] = [
     '@libp2p/transport'
   ]
+
+  start (): void {}
+
+  stop (): void {}
+
+  async afterStop (): Promise<void> {
+    const socketClosedPromises: Array<Promise<unknown>> = []
+
+    for (const socket of this.outboundSockets) {
+      if (socket.closed) {
+        continue
+      }
+
+      socketClosedPromises.push(pEvent(socket, 'close', { rejectionEvents: [] }))
+      socket.destroy()
+    }
+
+    await Promise.all(socketClosedPromises)
+  }
 
   async dial (ma: Multiaddr, options: TCPDialOptions): Promise<Connection> {
     options.keepAlive = options.keepAlive ?? true
@@ -128,6 +149,10 @@ export class TCP implements Transport<TCPDialEvents> {
 
       this.log('dialing %a with opts %o', ma, cOpts)
       rawSocket = net.connect(cOpts)
+      this.outboundSockets.add(rawSocket)
+      rawSocket.once('close', () => {
+        this.outboundSockets.delete(rawSocket)
+      })
 
       const onError = (err: Error): void => {
         this.log.error('dial to %a errored - %e', ma, err)

--- a/packages/transport-tcp/src/tcp.ts
+++ b/packages/transport-tcp/src/tcp.ts
@@ -30,6 +30,7 @@
 import net from 'net'
 import { AbortError, TimeoutError, serviceCapabilities, transportSymbol } from '@libp2p/interface'
 import { TCP as TCPMatcher } from '@multiformats/multiaddr-matcher'
+import { pEvent } from 'p-event'
 import { CustomProgressEvent } from 'progress-events'
 import { TCPListener } from './listener.js'
 import { toMultiaddrConnection } from './socket-to-conn.js'
@@ -93,7 +94,9 @@ export class TCP implements Transport<TCPDialEvents> {
       })
     } catch (err: any) {
       this.metrics?.errors.increment({ outbound_to_connection: true })
+      const socketClosed = socket.closed ? undefined : pEvent(socket, 'close', { rejectionEvents: [] })
       socket.destroy(err)
+      await socketClosed
       throw err
     }
 
@@ -103,7 +106,9 @@ export class TCP implements Transport<TCPDialEvents> {
     } catch (err: any) {
       this.metrics?.errors.increment({ outbound_upgrade: true })
       this.log.error('error upgrading outbound connection - %e', err)
+      const socketClosed = socket.closed ? undefined : pEvent(socket, 'close', { rejectionEvents: [] })
       maConn.abort(err)
+      await socketClosed
       throw err
     }
   }

--- a/packages/transport-tcp/test/listen-dial.spec.ts
+++ b/packages/transport-tcp/test/listen-dial.spec.ts
@@ -10,7 +10,7 @@ import pDefer from 'p-defer'
 import Sinon from 'sinon'
 import { stubInterface } from 'sinon-ts'
 import { tcp } from '../src/index.js'
-import type { Connection, Listener, Transport, Upgrader } from '@libp2p/interface'
+import type { Connection, Listener, MultiaddrConnection, Transport, Upgrader } from '@libp2p/interface'
 
 const isCI = process.env.CI
 
@@ -282,6 +282,118 @@ describe('dial', () => {
 
       expect(socket.closed).to.be.false()
       await stop(transport)
+      expect(socket.closed).to.be.true()
+    } finally {
+      connectSpy.restore()
+      await new Promise<void>(resolve => {
+        server.close(() => { resolve() })
+      })
+    }
+  })
+
+  it('waits for reset outbound sockets to emit close when stopped', async () => {
+    const server = net.createServer(socket => {
+      socket.on('error', () => {})
+    })
+    await new Promise<void>((resolve, reject) => {
+      server.once('error', reject)
+      server.listen(0, '127.0.0.1', resolve)
+    })
+
+    const address = server.address()
+    if (address == null || typeof address === 'string') {
+      throw new Error('TCP server did not bind to an IP port')
+    }
+
+    const connectSpy = Sinon.spy(net, 'connect')
+    const tcpTransport = tcp()({ logger: defaultLogger() })
+    let maConn: MultiaddrConnection | undefined
+
+    try {
+      await tcpTransport.dial(multiaddr(`/ip4/127.0.0.1/tcp/${address.port}`), {
+        upgrader: stubInterface<Upgrader>({
+          upgradeOutbound: async (connection) => {
+            maConn = connection
+
+            return stubInterface<Connection>({
+              remoteAddr: connection.remoteAddr
+            })
+          }
+        }),
+        signal: AbortSignal.timeout(5_000)
+      })
+
+      const socket = connectSpy.returnValues[0]
+      if (socket == null || maConn == null) {
+        throw new Error('TCP transport did not open a socket')
+      }
+
+      let socketClosed = false
+      socket.once('close', () => {
+        socketClosed = true
+      })
+
+      maConn.abort(new Error('connection aborted'))
+
+      expect(socket.closed).to.be.true()
+      expect(socketClosed).to.be.false()
+
+      await stop(tcpTransport)
+
+      expect(socketClosed).to.be.true()
+    } finally {
+      connectSpy.restore()
+      await new Promise<void>(resolve => {
+        server.close(() => { resolve() })
+      })
+    }
+  })
+
+  it('closes an outbound socket when abort races graceful close', async () => {
+    const server = net.createServer(socket => {
+      socket.on('error', () => {})
+    })
+    await new Promise<void>((resolve, reject) => {
+      server.once('error', reject)
+      server.listen(0, '127.0.0.1', resolve)
+    })
+
+    const address = server.address()
+    if (address == null || typeof address === 'string') {
+      throw new Error('TCP server did not bind to an IP port')
+    }
+
+    const connectSpy = Sinon.spy(net, 'connect')
+    const tcpTransport = tcp()({ logger: defaultLogger() })
+    let maConn: MultiaddrConnection | undefined
+
+    try {
+      await tcpTransport.dial(multiaddr(`/ip4/127.0.0.1/tcp/${address.port}`), {
+        upgrader: stubInterface<Upgrader>({
+          upgradeOutbound: async (connection) => {
+            maConn = connection
+
+            return stubInterface<Connection>({
+              remoteAddr: connection.remoteAddr
+            })
+          }
+        }),
+        signal: AbortSignal.timeout(5_000)
+      })
+
+      const socket = connectSpy.returnValues[0]
+      if (socket == null || maConn == null) {
+        throw new Error('TCP transport did not open a socket')
+      }
+
+      const closePromise = maConn.close()
+      expect(socket.writableEnded).to.be.true()
+
+      maConn.abort(new Error('connection aborted while closing'))
+
+      await closePromise
+      await stop(tcpTransport)
+
       expect(socket.closed).to.be.true()
     } finally {
       connectSpy.restore()

--- a/packages/transport-tcp/test/listen-dial.spec.ts
+++ b/packages/transport-tcp/test/listen-dial.spec.ts
@@ -211,6 +211,47 @@ describe('dial', () => {
     }
   })
 
+  it('waits for the socket to close when an outbound upgrade fails', async () => {
+    const server = net.createServer(socket => {
+      socket.on('error', () => {})
+    })
+    await new Promise<void>((resolve, reject) => {
+      server.once('error', reject)
+      server.listen(0, '127.0.0.1', resolve)
+    })
+
+    const address = server.address()
+    if (address == null || typeof address === 'string') {
+      throw new Error('TCP server did not bind to an IP port')
+    }
+
+    const connectSpy = Sinon.spy(net, 'connect')
+    const upgradeError = new Error('upgrade failed')
+
+    try {
+      const dialPromise = transport.dial(multiaddr(`/ip4/127.0.0.1/tcp/${address.port}`), {
+        upgrader: stubInterface<Upgrader>({
+          upgradeOutbound: Sinon.stub().rejects(upgradeError)
+        }),
+        signal: AbortSignal.timeout(5_000)
+      })
+
+      await expect(dialPromise).to.eventually.be.rejectedWith(upgradeError)
+
+      const socket = connectSpy.returnValues[0]
+      if (socket == null) {
+        throw new Error('TCP transport did not open a socket')
+      }
+
+      expect(socket.closed).to.be.true()
+    } finally {
+      connectSpy.restore()
+      await new Promise<void>(resolve => {
+        server.close(() => { resolve() })
+      })
+    }
+  })
+
   it('dial IPv4', async () => {
     const ma = multiaddr('/ip4/127.0.0.1/tcp/9090')
     const listener = transport.createListener({
@@ -317,6 +358,8 @@ describe('dial', () => {
     // create a Promise that resolves when the upgrade starts
     const upgradeStarted = pDefer()
     const abortedUpgrade = pDefer()
+    const createServerSpy = Sinon.spy(net, 'createServer')
+    let inboundSocket: net.Socket | undefined
 
     // create a listener with the handler
     const listener = transport.createListener({
@@ -336,6 +379,10 @@ describe('dial', () => {
           return new Promise(() => {})
         }
       })
+    })
+    const server = createServerSpy.returnValues[0]
+    server?.once('connection', socket => {
+      inboundSocket = socket
     })
 
     // listen on a multiaddr
@@ -358,5 +405,7 @@ describe('dial', () => {
 
     // should abort the upgrade
     await abortedUpgrade.promise
+    expect(inboundSocket?.closed).to.be.true()
+    createServerSpy.restore()
   })
 })

--- a/packages/transport-tcp/test/listen-dial.spec.ts
+++ b/packages/transport-tcp/test/listen-dial.spec.ts
@@ -1,6 +1,7 @@
 import net from 'net'
 import os from 'os'
 import path from 'path'
+import { stop } from '@libp2p/interface'
 import { defaultLogger } from '@libp2p/logger'
 import { getNetConfig } from '@libp2p/utils'
 import { multiaddr } from '@multiformats/multiaddr'
@@ -243,6 +244,44 @@ describe('dial', () => {
         throw new Error('TCP transport did not open a socket')
       }
 
+      expect(socket.closed).to.be.true()
+    } finally {
+      connectSpy.restore()
+      await new Promise<void>(resolve => {
+        server.close(() => { resolve() })
+      })
+    }
+  })
+
+  it('waits for established outbound sockets to close when stopped', async () => {
+    const server = net.createServer(socket => {
+      socket.on('error', () => {})
+    })
+    await new Promise<void>((resolve, reject) => {
+      server.once('error', reject)
+      server.listen(0, '127.0.0.1', resolve)
+    })
+
+    const address = server.address()
+    if (address == null || typeof address === 'string') {
+      throw new Error('TCP server did not bind to an IP port')
+    }
+
+    const connectSpy = Sinon.spy(net, 'connect')
+
+    try {
+      await transport.dial(multiaddr(`/ip4/127.0.0.1/tcp/${address.port}`), {
+        upgrader,
+        signal: AbortSignal.timeout(5_000)
+      })
+
+      const socket = connectSpy.returnValues[0]
+      if (socket == null) {
+        throw new Error('TCP transport did not open a socket')
+      }
+
+      expect(socket.closed).to.be.false()
+      await stop(transport)
       expect(socket.closed).to.be.true()
     } finally {
       connectSpy.restore()

--- a/packages/transport-tcp/test/listen-dial.spec.ts
+++ b/packages/transport-tcp/test/listen-dial.spec.ts
@@ -1,3 +1,4 @@
+import net from 'net'
 import os from 'os'
 import path from 'path'
 import { defaultLogger } from '@libp2p/logger'
@@ -170,6 +171,44 @@ describe('dial', () => {
     transport = tcp()({
       logger: defaultLogger()
     })
+  })
+
+  it('waits for the socket to close when a dial is aborted', async () => {
+    const server = net.createServer()
+    await new Promise<void>((resolve, reject) => {
+      server.once('error', reject)
+      server.listen(0, '127.0.0.1', resolve)
+    })
+
+    const address = server.address()
+    if (address == null || typeof address === 'string') {
+      throw new Error('TCP server did not bind to an IP port')
+    }
+
+    const connectSpy = Sinon.spy(net, 'connect')
+
+    try {
+      const controller = new AbortController()
+      const dialPromise = transport.dial(multiaddr(`/ip4/127.0.0.1/tcp/${address.port}`), {
+        upgrader,
+        signal: controller.signal
+      })
+      const socket = connectSpy.returnValues[0]
+
+      if (socket == null) {
+        throw new Error('TCP transport did not open a socket')
+      }
+
+      controller.abort()
+
+      await expect(dialPromise).to.eventually.be.rejected()
+      expect(socket.closed).to.be.true()
+    } finally {
+      connectSpy.restore()
+      await new Promise<void>(resolve => {
+        server.close(() => { resolve() })
+      })
+    }
   })
 
   it('dial IPv4', async () => {


### PR DESCRIPTION
## Description

Prevent shutdown from finishing while outbound dial jobs or TCP sockets still own referenced native handles.

- mark the connection manager stopped before service teardown
- abort and await active dial jobs
- track outbound TCP sockets and wait for their close events
- avoid resetAndDestroy after graceful socket shutdown has started, since libuv does not allow mixing uv_shutdown with uv_tcp_close_reset

This was observed while investigating a Lodestar shutdown hang: https://gist.github.com/nflaig/5f41cfc50f38baf5046a034162943dc3

## Tested version

This draft intentionally points to commit c20c70314f5328ef240f6b061242a313eb38d860, the exact js-libp2p source used to build Lodestar image sha256:2c2bcfbe1a9adf72cb9f73dfc605fb3a149e283d8aeae6b0325bbefd5e1b13f9.

The affected compiled libp2p and TCP files in the running image were compared byte-for-byte with the artifacts built from this commit. All hashes match.

The image has completed 44 consecutive effective mainnet shutdown cycles without a hang so far. The 50-cycle soak is still running.

This branch is intentionally not merged with newer main commits yet, so the PR head remains identical to the tested version.

## Verification

- Added real TCP regression coverage for outbound socket close and the reset/graceful-close race.
- At this exact commit, the affected package lint, doc check, build, and 39 Node.js tests passed.
- No tests were rerun while opening this draft PR.

## Change checklist

- [x] I have performed a self-review of my own code
- [x] I have made corresponding changes to the documentation if necessary (this includes comments as well)
- [x] I have added tests that prove my fix is effective or that my feature works