### PR TITLE
fix(pnet): abort the connection when the inbound cipher throws

### DIFF
--- a/packages/pnet/src/crypto.ts
+++ b/packages/pnet/src/crypto.ts
@@ -34,12 +34,19 @@ export class BoxMessageStream extends AbstractMultiaddrConnection {
     this.maConn.addEventListener('message', (evt) => {
       const data = evt.data
 
-      if (data instanceof Uint8Array) {
-        this.onData(this.inboundXor.update(data))
-      } else {
-        for (const buf of data) {
-          this.onData(this.inboundXor.update(buf))
+      try {
+        if (data instanceof Uint8Array) {
+          this.onData(this.inboundXor.update(data))
+        } else {
+          for (const buf of data) {
+            this.onData(this.inboundXor.update(buf))
+          }
         }
+      } catch (err: any) {
+        // any bytes we fail to process leave the cipher permanently out of
+        // step with the remote so tear the connection down
+        this.log.error('error decrypting inbound data - %e', err)
+        this.abort(err)
       }
     })
 

--- a/packages/pnet/test/index.spec.ts
+++ b/packages/pnet/test/index.spec.ts
@@ -1,6 +1,8 @@
+import { StreamMessageEvent } from '@libp2p/interface'
 import { multiaddrConnectionPair } from '@libp2p/utils'
 import { expect } from 'aegir/chai'
 import { pEvent } from 'p-event'
+import { Uint8ArrayList } from 'uint8arraylist'
 import { fromString as uint8ArrayFromString } from 'uint8arrays/from-string'
 import { INVALID_PSK } from '../src/errors.ts'
 import { preSharedKey, generateKey } from '../src/index.ts'
@@ -79,20 +81,79 @@ describe('private network', () => {
       finalize: () => {}
     }
 
-    // @ts-expect-error inboundXor is a private field
+    // @ts-expect-error inboundXor is not on the MultiaddrConnection interface
     inbound.inboundXor = cipher
 
-    outbound.send(uint8ArrayFromString('hello world'))
-
-    const [evt] = await Promise.all([
+    // attach before sending, the abort can be dispatched synchronously
+    const closed = Promise.all([
       pEvent<'close', StreamCloseEvent>(inbound, 'close'),
       pEvent(outbound, 'close')
     ])
+
+    outbound.send(uint8ArrayFromString('hello world'))
+
+    const [evt] = await closed
 
     expect(evt.error).to.equal(err)
     expect(inbound).to.have.property('status', 'aborted')
     expect(inboundConnection).to.have.property('status', 'aborted')
     expect(outbound).to.have.property('status', 'reset')
+  })
+
+  it('should pass on data decrypted before the cipher throws mid-message', async () => {
+    const [outboundConnection, inboundConnection] = multiaddrConnectionPair({
+      delay: 10
+    })
+
+    const protector = preSharedKey({
+      psk: swarmKeyBuffer
+    })()
+
+    const [, inbound] = await Promise.all([
+      protector.protect(outboundConnection),
+      protector.protect(inboundConnection)
+    ])
+
+    const err = new Error('cipher failed')
+    let updates = 0
+
+    // throw on the second buffer of the message so the first has already been
+    // emitted
+    const cipher: xsalsa20.Xor = {
+      update: (input) => {
+        if (++updates > 1) {
+          throw err
+        }
+
+        return input as any
+      },
+      finalize: () => {}
+    }
+
+    // @ts-expect-error inboundXor is not on the MultiaddrConnection interface
+    inbound.inboundXor = cipher
+
+    const received: Uint8Array[] = []
+
+    inbound.addEventListener('message', (evt) => {
+      received.push(evt.data.subarray())
+    })
+
+    // dispatching directly is synchronous, so attach first
+    const closed = pEvent<'close', StreamCloseEvent>(inbound, 'close')
+
+    inboundConnection.dispatchEvent(new StreamMessageEvent(new Uint8ArrayList(
+      uint8ArrayFromString('hello world'),
+      uint8ArrayFromString('doo dah')
+    )))
+
+    const evt = await closed
+
+    expect(received).to.deep.equal([uint8ArrayFromString('hello world')])
+    expect(updates).to.equal(2)
+    expect(evt.error).to.equal(err)
+    expect(inbound).to.have.property('status', 'aborted')
+    expect(inboundConnection).to.have.property('status', 'aborted')
   })
 
   it('should forward drain events from the underlying connection', async () => {

--- a/packages/pnet/test/index.spec.ts
+++ b/packages/pnet/test/index.spec.ts
@@ -4,6 +4,8 @@ import { pEvent } from 'p-event'
 import { fromString as uint8ArrayFromString } from 'uint8arrays/from-string'
 import { INVALID_PSK } from '../src/errors.ts'
 import { preSharedKey, generateKey } from '../src/index.ts'
+import type { StreamCloseEvent } from '@libp2p/interface'
+import type xsalsa20 from 'xsalsa20'
 
 const swarmKeyBuffer = new Uint8Array(95)
 const wrongSwarmKeyBuffer = new Uint8Array(95)
@@ -50,6 +52,47 @@ describe('private network', () => {
     ])
 
     expect(output).to.deep.equal([uint8ArrayFromString('hello world'), uint8ArrayFromString('doo dah')])
+  })
+
+  it('should abort the connection when the cipher throws on inbound data', async () => {
+    const [outboundConnection, inboundConnection] = multiaddrConnectionPair({
+      delay: 10
+    })
+
+    const protector = preSharedKey({
+      psk: swarmKeyBuffer
+    })()
+
+    const [outbound, inbound] = await Promise.all([
+      protector.protect(outboundConnection),
+      protector.protect(inboundConnection)
+    ])
+
+    const err = new Error('cipher failed')
+
+    // stub the cipher to throw, as it does when the xsalsa20 wasm memory limit
+    // is reached
+    const cipher: xsalsa20.Xor = {
+      update: () => {
+        throw err
+      },
+      finalize: () => {}
+    }
+
+    // @ts-expect-error inboundXor is a private field
+    inbound.inboundXor = cipher
+
+    outbound.send(uint8ArrayFromString('hello world'))
+
+    const [evt] = await Promise.all([
+      pEvent<'close', StreamCloseEvent>(inbound, 'close'),
+      pEvent(outbound, 'close')
+    ])
+
+    expect(evt.error).to.equal(err)
+    expect(inbound).to.have.property('status', 'aborted')
+    expect(inboundConnection).to.have.property('status', 'aborted')
+    expect(outbound).to.have.property('status', 'reset')
   })
 
   it('should forward drain events from the underlying connection', async () => {


### PR DESCRIPTION
## Description

Inbound data is decrypted in a listener on the underlying connection's `message` event. When the cipher throws, the exception escapes that listener: `EventTarget` reports errors rather than propagating them, so Node rethrows on the next tick as an uncaught exception, or a process-level `uncaughtException` handler swallows it entirely. Either way the connection stays open, and the bytes it failed to process leave the cipher permanently out of step with the remote, so nothing the peer sends afterwards decrypts correctly. pnet provides confidentiality only, there is no MAC, so the resulting corruption is undetectable downstream.

The outbound direction already fails safely: a throw from `sendData()` propagates into `processSendQueue()`, which aborts the connection. The inbound listener was the one path bypassing that, so this makes it behave the same way.

## Notes & open questions

Touches the same call sites as #3585, so whichever lands second needs a trivial rebase.

## Change checklist

- [x] I have performed a self-review of my own code
- [x] I have made corresponding changes to the documentation if necessary (this includes comments as well)
- [x] I have added tests that prove my fix is effective or that my feature works
