### PR TITLE
fix: destroy sockets that resetAndDestroy() cannot reset

### DIFF
--- a/packages/connection-encrypter-tls/src/utils.ts
+++ b/packages/connection-encrypter-tls/src/utils.ts
@@ -1,5 +1,4 @@
 import 'reflect-metadata'
-import net from 'node:net'
 import { Duplex } from 'node:stream'
 import tls from 'node:tls'
 import { publicKeyFromProtobuf } from '@libp2p/crypto/keys'
@@ -267,7 +266,9 @@ export function toNodeDuplex (stream: MessageStream): Duplex {
 }
 
 class EncryptedMultiaddrConnection extends AbstractMessageStream {
-  private socket: net.Socket
+  private socket: tls.TLSSocket
+  private stream: MessageStream
+  private closing?: Promise<void>
 
   /**
    * @param stream - The maConn that encrypted data is transferred over
@@ -282,6 +283,13 @@ class EncryptedMultiaddrConnection extends AbstractMessageStream {
     })
 
     this.socket = socket
+    this.stream = stream
+
+    // the socket closed before this stream was created, so there is nothing
+    // left to tear down
+    if (socket.closed) {
+      this.closing = Promise.resolve()
+    }
 
     // accept decrypted data
     this.socket.on('data', (buf) => {
@@ -291,7 +299,7 @@ class EncryptedMultiaddrConnection extends AbstractMessageStream {
       stream.abort(err)
     })
     this.socket.on('close', () => {
-      stream.close()
+      this.closing = stream.close()
         .catch(err => {
           stream.abort(err)
         })
@@ -302,16 +310,35 @@ class EncryptedMultiaddrConnection extends AbstractMessageStream {
       this.safeDispatchEvent('drain')
     })
 
-    stream.addEventListener('close', () => {
+    stream.addEventListener('close', (evt) => {
       socket.destroy()
-      this.onTransportClosed()
+
+      // mirror the transport's close reason, otherwise a local failure, a
+      // remote reset and a clean close all reach the application as a clean
+      // close
+      if (evt.error != null) {
+        if (evt.local) {
+          this.abort(evt.error)
+        } else {
+          this.onRemoteReset()
+        }
+      } else {
+        this.onTransportClosed()
+      }
     })
   }
 
   async close (options?: AbortOptions): Promise<void> {
-    this.socket.destroySoon()
+    // the socket only emits 'close' once, so if it has already been emitted
+    // wait for the teardown it started instead of for the event itself
+    if (this.closing == null) {
+      this.socket.destroySoon()
 
-    await pEvent(this.socket, 'close', options)
+      await pEvent(this.socket, 'close', options)
+    }
+
+    // the socket closing does not mean the transport has finished closing
+    await this.closing
   }
 
   sendPause (): void {
@@ -322,13 +349,15 @@ class EncryptedMultiaddrConnection extends AbstractMessageStream {
     this.socket.resume()
   }
 
-  async sendClose (options?: AbortOptions): Promise<void> {
-    this.socket.destroySoon()
-    options?.signal?.throwIfAborted()
-  }
+  sendReset (err: Error): void {
+    // a TLSSocket's handle is a TLSWrap and not a TCP handle, so
+    // resetAndDestroy() throws ERR_INVALID_HANDLE_TYPE here
+    // https://nodejs.org/api/net.html#socketresetanddestroy
+    this.socket.destroy()
 
-  sendReset (): void {
-    this.socket.resetAndDestroy()
+    // destroying the socket only closes the transport gracefully, so reset the
+    // transport too
+    this.stream.abort(err)
   }
 
   sendData (data: Uint8ArrayList): SendResult {

--- a/packages/connection-encrypter-tls/test/utils.spec.ts
+++ b/packages/connection-encrypter-tls/test/utils.spec.ts
@@ -1,7 +1,8 @@
 import 'reflect-metadata'
 import { EventEmitter } from 'node:events'
+import tls from 'node:tls'
 import { logger } from '@libp2p/logger'
-import { streamPair } from '@libp2p/utils'
+import { multiaddrConnectionPair, streamPair } from '@libp2p/utils'
 import { Crypto } from '@peculiar/webcrypto'
 import * as x509 from '@peculiar/x509'
 import { expect } from 'aegir/chai'
@@ -10,6 +11,7 @@ import { stubInterface } from 'sinon-ts'
 import { Uint8ArrayList } from 'uint8arraylist'
 import { toMessageStream, toNodeDuplex, verifyPeerCertificate } from '../src/utils.ts'
 import * as testVectors from './fixtures/test-vectors.ts'
+import type { StreamCloseEvent } from '@libp2p/interface'
 
 const crypto = new Crypto()
 x509.cryptoProvider.set(crypto)
@@ -151,5 +153,212 @@ describe('utils', () => {
     await pEvent(outboundStream, 'close')
 
     expect(new Uint8ArrayList(...received).subarray()).to.equalBytes(new Uint8ArrayList(...sent).subarray())
+  })
+
+  it('should destroy the socket and reset the connection when the stream is aborted', async () => {
+    // a stubbed socket cannot reproduce the bug, only a real TLSSocket has the
+    // TLSWrap handle that makes resetAndDestroy() throw
+    const [connection, remoteConnection] = multiaddrConnectionPair()
+    const socket = new tls.TLSSocket(toNodeDuplex(connection))
+
+    try {
+      const stream = toMessageStream(connection, socket)
+      const socketClosed = pEvent(socket, 'close', {
+        signal: AbortSignal.timeout(2_000)
+      })
+      const remoteClosed = pEvent(remoteConnection, 'close', {
+        signal: AbortSignal.timeout(2_000)
+      })
+
+      // nothing has torn the connection down yet, so the assertions below can
+      // only pass because of the abort
+      expect(stream.status).to.equal('open')
+      expect(connection.status).to.equal('open')
+
+      stream.abort(new Error('Oh no!'))
+
+      // resetAndDestroy() threw before it could destroy the socket, and abort()
+      // swallows the error
+      expect(socket.destroyed).to.be.true()
+
+      // destroying the socket alone would only close the transport gracefully
+      expect(connection.status).to.equal('aborted')
+
+      await socketClosed
+      await remoteClosed
+
+      // the remote has to see a reset and not a graceful close
+      expect(remoteConnection.status).to.equal('reset')
+    } finally {
+      socket.destroy()
+      connection.abort(new Error('Test over'))
+    }
+  })
+
+  it('should destroy the socket when the stream is closed', async () => {
+    const [connection] = multiaddrConnectionPair()
+    const socket = new tls.TLSSocket(toNodeDuplex(connection))
+
+    try {
+      const stream = toMessageStream(connection, socket)
+
+      await stream.close({
+        signal: AbortSignal.timeout(2_000)
+      })
+
+      expect(socket.destroyed).to.be.true()
+      expect(stream.status).to.equal('closed')
+      expect(connection.status).to.equal('closed')
+    } finally {
+      socket.destroy()
+      connection.abort(new Error('Test over'))
+    }
+  })
+
+  it('should wait for a socket that is already being destroyed to close', async () => {
+    const [connection] = multiaddrConnectionPair()
+    const socket = new tls.TLSSocket(toNodeDuplex(connection))
+
+    try {
+      const stream = toMessageStream(connection, socket)
+
+      // destroy() is synchronous but 'close' is emitted on a later turn of the
+      // event loop, so the teardown is still in flight here
+      socket.destroy()
+
+      await stream.close({
+        signal: AbortSignal.timeout(2_000)
+      })
+
+      // close() has to wait for the teardown that was already running, the
+      // socket closing on its own does not mean the transport has finished
+      expect(stream.status).to.equal('closed')
+      expect(connection.status).to.equal('closed')
+    } finally {
+      socket.destroy()
+      connection.abort(new Error('Test over'))
+    }
+  })
+
+  it('should not hang when the socket closed before the stream was created', async () => {
+    const [connection] = multiaddrConnectionPair()
+    const socket = new tls.TLSSocket(toNodeDuplex(connection))
+
+    try {
+      socket.destroy()
+      await pEvent(socket, 'close', {
+        signal: AbortSignal.timeout(2_000)
+      })
+
+      // the socket will never emit 'close' again, so close() cannot wait for it
+      const stream = toMessageStream(connection, socket)
+
+      await expect(stream.close({
+        signal: AbortSignal.timeout(2_000)
+      })).to.eventually.be.fulfilled()
+    } finally {
+      socket.destroy()
+      connection.abort(new Error('Test over'))
+    }
+  })
+
+  it('should not hang when the stream is closed after being aborted', async () => {
+    const [connection] = multiaddrConnectionPair()
+    const socket = new tls.TLSSocket(toNodeDuplex(connection))
+
+    try {
+      const stream = toMessageStream(connection, socket)
+
+      stream.abort(new Error('Oh no!'))
+
+      // wait for the abort's 'close' to be emitted, otherwise an unguarded
+      // close() would resolve on it and this test could never fail
+      await pEvent(socket, 'close', {
+        signal: AbortSignal.timeout(2_000)
+      })
+
+      // the socket cannot emit 'close' again, so close() has to return early
+      await expect(stream.close({
+        signal: AbortSignal.timeout(2_000)
+      })).to.eventually.be.fulfilled()
+
+      expect(connection.status).to.equal('aborted')
+    } finally {
+      socket.destroy()
+      connection.abort(new Error('Test over'))
+    }
+  })
+
+  it('should surface a transport error to the application', async () => {
+    const [connection] = multiaddrConnectionPair()
+    const socket = new tls.TLSSocket(toNodeDuplex(connection))
+
+    try {
+      const stream = toMessageStream(connection, socket)
+      const closed = pEvent<'close', StreamCloseEvent>(stream, 'close', {
+        signal: AbortSignal.timeout(2_000)
+      })
+
+      const err = new Error('Bad record MAC')
+      err.name = 'SSLError'
+      socket.emit('error', err)
+
+      const evt = await closed
+      expect(stream.status).to.equal('aborted')
+      expect(evt.error).to.have.property('name', 'SSLError')
+      expect(evt.local).to.be.true()
+    } finally {
+      socket.destroy()
+      connection.abort(new Error('Test over'))
+    }
+  })
+
+  it('should surface a remote reset to the application', async () => {
+    const [connection, remoteConnection] = multiaddrConnectionPair()
+    const socket = new tls.TLSSocket(toNodeDuplex(connection))
+
+    try {
+      const stream = toMessageStream(connection, socket)
+      const closed = pEvent<'close', StreamCloseEvent>(stream, 'close', {
+        signal: AbortSignal.timeout(2_000)
+      })
+
+      remoteConnection.abort(new Error('Remote went away'))
+
+      const evt = await closed
+      expect(stream.status).to.equal('reset')
+      expect(evt.error).to.have.property('name', 'StreamResetError')
+      expect(evt.local).to.be.false()
+
+      // nothing else tears the socket down on this branch
+      expect(socket.destroyed).to.be.true()
+    } finally {
+      socket.destroy()
+      connection.abort(new Error('Test over'))
+    }
+  })
+
+  it('should not report an error when the connection closes cleanly', async () => {
+    const [connection, remoteConnection] = multiaddrConnectionPair()
+    const socket = new tls.TLSSocket(toNodeDuplex(connection))
+
+    try {
+      const stream = toMessageStream(connection, socket)
+      const closed = pEvent<'close', StreamCloseEvent>(stream, 'close', {
+        signal: AbortSignal.timeout(2_000)
+      })
+
+      await remoteConnection.close()
+
+      const evt = await closed
+      expect(evt.error).to.be.undefined()
+      expect(stream.status).to.equal('closed')
+
+      // nothing else tears the socket down on this branch
+      expect(socket.destroyed).to.be.true()
+    } finally {
+      socket.destroy()
+      connection.abort(new Error('Test over'))
+    }
   })
 })

--- a/packages/interface/src/events.ts
+++ b/packages/interface/src/events.ts
@@ -16,7 +16,7 @@ export class StreamMessageEvent extends Event {
 
 /**
  * An event dispatched when the stream is closed. The `error` property can be
- * inspected to discover if the closing was graceful or not, and the `remote`
+ * inspected to discover if the closing was graceful or not, and the `local`
  * property shows which end of the stream initiated the closure
  */
 export class StreamCloseEvent extends Event {

--- a/packages/transport-tcp/src/socket-to-conn.ts
+++ b/packages/transport-tcp/src/socket-to-conn.ts
@@ -123,6 +123,16 @@ class TCPSocketMultiaddrConnection extends AbstractMultiaddrConnection {
   }
 
   sendReset (): void {
+    // resetAndDestroy() throws ERR_INVALID_HANDLE_TYPE for unix sockets because
+    // their handle is a Pipe and not a TCP handle. there is no RST at AF_UNIX
+    // so the peer sees a clean EOF rather than a reset
+    // https://nodejs.org/api/net.html#socketresetanddestroy
+    if (Unix.matches(this.remoteAddr)) {
+      this.socket.destroy()
+
+      return
+    }
+
     this.socket.resetAndDestroy()
   }
 

--- a/packages/transport-tcp/test/socket-to-conn.spec.ts
+++ b/packages/transport-tcp/test/socket-to-conn.spec.ts
@@ -1,10 +1,15 @@
 import { createServer, Socket } from 'net'
+import fs from 'node:fs'
+import os from 'node:os'
+import path from 'node:path'
 import { defaultLogger } from '@libp2p/logger'
 import { multiaddr } from '@multiformats/multiaddr'
 import { expect } from 'aegir/chai'
 import delay from 'delay'
 import { pEvent } from 'p-event'
 import { toMultiaddrConnection } from '../src/socket-to-conn.ts'
+import { multiaddrToNetConfig } from '../src/utils.ts'
+import type { Multiaddr } from '@multiformats/multiaddr'
 import type { Server, ServerOpts, SocketConstructorOpts } from 'node:net'
 
 interface TestOptions {
@@ -42,6 +47,50 @@ async function setup (opts?: TestOptions): Promise<TestFixture> {
     server,
     serverSocket,
     clientSocket: client
+  }
+}
+
+async function setupUnix (): Promise<TestFixture & { listenAddr: Multiaddr, cleanup(): void }> {
+  const dir = fs.mkdtempSync(path.join(os.tmpdir(), 'libp2p-tcp-test-'))
+  const listenAddr = multiaddr(`/unix/${encodeURIComponent(path.join(dir, 'test.sock'))}`)
+  const cleanup = (): void => {
+    fs.rmSync(dir, { recursive: true, force: true })
+  }
+
+  // on Windows a unix multiaddr binds a named pipe rather than a filesystem
+  // path, so go through the same mapping the listener uses
+  const config = multiaddrToNetConfig(listenAddr)
+
+  if (!('path' in config) || typeof config.path !== 'string') {
+    cleanup()
+    throw new Error('Expected a unix socket path')
+  }
+
+  try {
+    const server = createServer()
+    server.listen(config.path)
+    await pEvent(server, 'listening', { rejectionEvents: ['error'] })
+
+    const client = new Socket()
+    client.connect(config.path)
+
+    const [
+      serverSocket
+    ] = await Promise.all([
+      pEvent<'connection', Socket>(server, 'connection', { rejectionEvents: ['error'] }),
+      pEvent(client, 'connect', { rejectionEvents: ['error'] })
+    ])
+
+    return {
+      server,
+      serverSocket,
+      clientSocket: client,
+      listenAddr,
+      cleanup
+    }
+  } catch (err) {
+    cleanup()
+    throw err
   }
 }
 
@@ -508,5 +557,65 @@ describe('socket-to-conn', () => {
 
     // server socket is destroyed
     expect(serverSocket.destroyed).to.be.true()
+  })
+
+  it('should destroy a unix socket when the MultiaddrConnection is aborted', async () => {
+    let listenAddr: Multiaddr
+    let cleanup: () => void
+    ({ server, clientSocket, serverSocket, listenAddr, cleanup } = await setupUnix())
+
+    try {
+      // the shape the listener creates
+      const maConn = toMultiaddrConnection({
+        socket: serverSocket,
+        direction: 'inbound',
+        localAddr: listenAddr,
+        log: defaultLogger().forComponent('libp2p:test-maconn')
+      })
+
+      const socketClosed = pEvent(serverSocket, 'close', {
+        signal: AbortSignal.timeout(2_000)
+      })
+
+      maConn.abort(new Error('Oh no!'))
+
+      // resetAndDestroy() would throw ERR_INVALID_HANDLE_TYPE on the Pipe
+      // handle and abort() would swallow it, leaving the socket open
+      expect(serverSocket.destroyed).to.be.true()
+
+      await socketClosed
+    } finally {
+      cleanup()
+    }
+  })
+
+  it('should destroy an outbound unix socket when the MultiaddrConnection is aborted', async () => {
+    let listenAddr: Multiaddr
+    let cleanup: () => void
+    ({ server, clientSocket, serverSocket, listenAddr, cleanup } = await setupUnix())
+
+    try {
+      // the shape the dialler creates - remoteAddr is passed directly instead
+      // of being derived from localAddr, which is the other half of the
+      // Unix.matches() discriminator
+      const maConn = toMultiaddrConnection({
+        socket: clientSocket,
+        direction: 'outbound',
+        remoteAddr: listenAddr,
+        log: defaultLogger().forComponent('libp2p:test-maconn')
+      })
+
+      const socketClosed = pEvent(clientSocket, 'close', {
+        signal: AbortSignal.timeout(2_000)
+      })
+
+      maConn.abort(new Error('Oh no!'))
+
+      expect(clientSocket.destroyed).to.be.true()
+
+      await socketClosed
+    } finally {
+      cleanup()
+    }
   })
 })

--- a/packages/utils/src/abstract-message-stream.ts
+++ b/packages/utils/src/abstract-message-stream.ts
@@ -218,7 +218,7 @@ export abstract class AbstractMessageStream<Timeline extends MessageStreamTimeli
     try {
       this.sendReset(err)
     } catch (err: any) {
-      this.log('failed to send reset to remote - %e', err)
+      this.log.error('failed to send reset to remote - %e', err)
     }
 
     this.dispatchEvent(new StreamAbortEvent(err))


### PR DESCRIPTION
## Description

`Socket.prototype.resetAndDestroy()` throws `ERR_INVALID_HANDLE_TYPE` unless the
socket's handle is a `TCP`, and `AbstractMessageStream.abort()` catches whatever
`sendReset()` throws. Two `sendReset()` implementations call it on sockets that
never have a TCP handle, so every abort threw, the error was swallowed and the
socket was left open.

- `@libp2p/tls`: a `TLSSocket`'s handle is a `TLSWrap`. This could never have
  worked, the socket always wraps a `Duplex` so there is no TCP handle beneath
  it at all.
- `@libp2p/tcp`: a unix socket's handle is a `Pipe`, so aborting any `/unix/`
  connection leaked the socket. Regular TCP sockets keep `resetAndDestroy()` and
  its RST semantics. AF_UNIX has no RST, so a unix peer now sees a clean EOF.

The swallowed error was logged on the debug channel, while the abort that
triggers it is logged on the error channel. That is why this stayed invisible on
every TLS abort and every unix TCP abort, so it is now logged at error level.

Fixing the TLS leak exposed three more problems in the same class:

- Destroying the `TLSSocket` only closed the underlying connection gracefully,
  so the peer was never told the connection had been reset, and under write
  backpressure the connection stalled in `closing` while the remote stayed
  `open`. `sendReset(err)` now also resets the transport, as `@libp2p/pnet` and
  `@libp2p/circuit-relay-v2` do.
- `close()` waited for a socket `'close'` event that may already have been
  emitted, which never resolved, and otherwise resolved before the transport
  teardown that event starts had finished. It now tracks that teardown and
  awaits it.
- The transport's `'close'` listener discarded `evt.error`, so a TLS failure
  (certificate verification, bad record MAC) and a remote reset both reached the
  application as a clean disconnect. It now branches on `evt.error` and
  `evt.local` the way `@libp2p/pnet` does.

`sendClose()` is removed from the TLS encrypter, `AbstractMessageStream`
declares no such member and nothing called it.

## Notes & open questions

`EncryptedMultiaddrConnection` is the only connection-shaped class that extends
`AbstractMessageStream` instead of `AbstractMultiaddrConnection`, which is why
it hand-rolls `close()`. Reparenting it would drop that override and restore the
write-buffer drain the override skips. Left for a separate PR.

## Change checklist

- [x] I have performed a self-review of my own code
- [x] I have made corresponding changes to the documentation if necessary (this includes comments as well)
- [x] I have added tests that prove my fix is effective or that my feature works
