### PR TITLE
feat: emit an end event when the readable end closes

### DIFF
--- a/packages/interface/src/connection.ts
+++ b/packages/interface/src/connection.ts
@@ -96,7 +96,7 @@ export interface NewStreamOptions extends AbortOptions, ProgressOptions<NewStrea
  * multiplexed, depending on the configuration of the nodes
  * between which the connection is made.
  */
-export interface Connection extends TypedEventTarget<Omit<MessageStreamEvents, 'drain' | 'message'>> {
+export interface Connection extends TypedEventTarget<Omit<MessageStreamEvents, 'drain' | 'message' | 'end'>> {
   /**
    * The unique identifier for this connection
    */

--- a/packages/interface/src/message-stream.ts
+++ b/packages/interface/src/message-stream.ts
@@ -50,8 +50,8 @@ export interface MessageStreamEvents {
   drain: Event
 
   /**
-   * The underlying resource is closed - no further events will be emitted and
-   * the stream cannot be used to send or receive any more data.
+   * The underlying resource is closed and the stream cannot be used to send any
+   * more data.
    *
    * When the `.error` field is set, the `local` property of the event will be
    * `true` value if the `.abort` was invoked, otherwise it means a remote error
@@ -63,11 +63,24 @@ export interface MessageStreamEvents {
    * Where the stream implementation supports half-closing, it may emit this
    * event when the remote end of the stream closes it's writable end.
    *
-   * After this event is received no further 'message' events will be emitted
-   * though the stream can still be written to, if it has not been closed at
-   * this end.
+   * The stream can still be written to, if it has not been closed at this end.
    */
   remoteCloseWrite: Event
+
+  /**
+   * The remote will send no more data and everything it sent has been read, so
+   * resources tied to reading can be released.
+   *
+   * Emitted at most once, when the read buffer empties after the remote closes
+   * their writable end, or when `.abort` or `Stream.closeRead` close the
+   * readable end, discarding anything unread. Consumers that may attach after
+   * it has fired should read `readableEnded` rather than wait for it.
+   *
+   * Unread data defers it, so a stream with no 'message' listener, or one left
+   * paused, may close without ever emitting it. Use 'close' as the
+   * unconditional signal that a stream is finished.
+   */
+  end: Event
 
   /**
    * The outgoing write queue emptied - there are no more bytes queued for
@@ -133,6 +146,17 @@ export interface MessageStream<Timeline extends MessageStreamTimeline = MessageS
    * again to resume sending.
    */
   writableNeedsDrain: boolean
+
+  /**
+   * True once 'end' has been emitted. Read this instead of waiting for the
+   * event, which fires only once and may already have passed. It is never set
+   * if a stream closes with data left unread.
+   *
+   * It does not mean the readable end is closed, or that the read buffer is
+   * empty: data can be pushed back after 'end', for example by unwrapping a
+   * byte stream that read ahead.
+   */
+  readonly readableEnded: boolean
 
   /**
    * Returns the number of bytes that are queued to be read

--- a/packages/interface/src/message-stream.ts
+++ b/packages/interface/src/message-stream.ts
@@ -68,8 +68,8 @@ export interface MessageStreamEvents {
   remoteCloseWrite: Event
 
   /**
-   * The remote will send no more data and everything it sent has been read, so
-   * resources tied to reading can be released.
+   * No more data from the remote will be delivered, so resources tied to
+   * reading can be released.
    *
    * Emitted at most once, when the read buffer empties after the remote closes
    * their writable end, or when `.abort` or `Stream.closeRead` close the
@@ -149,12 +149,11 @@ export interface MessageStream<Timeline extends MessageStreamTimeline = MessageS
 
   /**
    * True once 'end' has been emitted. Read this instead of waiting for the
-   * event, which fires only once and may already have passed. It is never set
-   * if a stream closes with data left unread.
+   * event, which fires only once and may already have passed.
    *
    * It does not mean the readable end is closed, or that the read buffer is
-   * empty: data can be pushed back after 'end', for example by unwrapping a
-   * byte stream that read ahead.
+   * empty. Where the readable end is still open, data can be pushed back
+   * after 'end', for example by unwrapping a byte stream that read ahead.
    */
   readonly readableEnded: boolean
 

--- a/packages/utils/src/abstract-message-stream.ts
+++ b/packages/utils/src/abstract-message-stream.ts
@@ -65,6 +65,8 @@ export abstract class AbstractMessageStream<Timeline extends MessageStreamTimeli
   protected readonly writeBuffer: Uint8ArrayList
   protected sendingData: boolean
 
+  #readableEnded = false
+
   private onDrainPromise?: PromiseWithResolvers<void>
 
   constructor (init: MessageStreamInit) {
@@ -120,6 +122,10 @@ export abstract class AbstractMessageStream<Timeline extends MessageStreamTimeli
 
   get readBufferLength (): number {
     return this.readBuffer.byteLength
+  }
+
+  get readableEnded (): boolean {
+    return this.#readableEnded
   }
 
   get writeBufferLength (): number {
@@ -214,6 +220,7 @@ export abstract class AbstractMessageStream<Timeline extends MessageStreamTimeli
     this.readStatus = 'closed'
     this.remoteReadStatus = 'closed'
     this.timeline.close = Date.now()
+    this.maybeDispatchEnd()
 
     try {
       this.sendReset(err)
@@ -353,10 +360,10 @@ export abstract class AbstractMessageStream<Timeline extends MessageStreamTimeli
 
     if (this.readBuffer.byteLength === 0) {
       this.readStatus = 'closed'
+      this.maybeDispatchEnd()
     }
 
-    const err = new StreamResetError()
-    this.dispatchEvent(new StreamResetEvent(err))
+    this.dispatchEvent(new StreamResetEvent(new StreamResetError()))
   }
 
   /**
@@ -385,16 +392,15 @@ export abstract class AbstractMessageStream<Timeline extends MessageStreamTimeli
     }
 
     if (err != null) {
+      // abort dispatches 'end' itself, once the stream is fully terminal
       this.abort(err)
-    } else {
-      if (this.status === 'open' || this.status === 'closing') {
-        this.timeline.close = Date.now()
-        this.status = 'closed'
-        this.writeStatus = 'closed'
-        this.remoteWriteStatus = 'closed'
-        this.remoteReadStatus = 'closed'
-        this.dispatchEvent(new StreamCloseEvent())
-      }
+    } else if (this.status === 'open' || this.status === 'closing') {
+      this.timeline.close = Date.now()
+      this.status = 'closed'
+
+      // this may be the end even if the readable end was not closed above
+      this.maybeDispatchEnd()
+      this.dispatchEvent(new StreamCloseEvent())
     }
   }
 
@@ -411,6 +417,8 @@ export abstract class AbstractMessageStream<Timeline extends MessageStreamTimeli
     this.remoteWriteStatus = 'closed'
 
     this.safeDispatchEvent('remoteCloseWrite')
+
+    this.maybeDispatchEnd()
 
     if (this.writeStatus === 'closed') {
       this.onTransportClosed()
@@ -530,6 +538,23 @@ export abstract class AbstractMessageStream<Timeline extends MessageStreamTimeli
     }
   }
 
+  /**
+   * Emit 'end' if nothing is buffered and no more data can arrive. Only the
+   * first call has any effect
+   */
+  protected maybeDispatchEnd (): void {
+    if (this.#readableEnded || this.readBuffer.byteLength > 0) {
+      return
+    }
+
+    if (this.remoteWriteStatus !== 'closed' && this.readStatus !== 'closed') {
+      return
+    }
+
+    this.#readableEnded = true
+    this.safeDispatchEvent('end')
+  }
+
   protected dispatchReadBuffer (): void {
     try {
       if (this.listenerCount('message') === 0) {
@@ -562,6 +587,7 @@ export abstract class AbstractMessageStream<Timeline extends MessageStreamTimeli
       if (this.readBuffer.byteLength === 0 && this.remoteWriteStatus === 'closed') {
         this.log('close readable end after dispatching read buffer and remote writable end is closed')
         this.readStatus = 'closed'
+        this.maybeDispatchEnd()
       }
 
       // abort if we failed to consume the read buffer and it is too large

--- a/packages/utils/src/abstract-message-stream.ts
+++ b/packages/utils/src/abstract-message-stream.ts
@@ -539,8 +539,8 @@ export abstract class AbstractMessageStream<Timeline extends MessageStreamTimeli
   }
 
   /**
-   * Emit 'end' if nothing is buffered and no more data can arrive. Only the
-   * first call has any effect
+   * Emit 'end' if nothing is buffered and no more data will be delivered.
+   * Emits at most once
    */
   protected maybeDispatchEnd (): void {
     if (this.#readableEnded || this.readBuffer.byteLength > 0) {

--- a/packages/utils/src/abstract-stream.ts
+++ b/packages/utils/src/abstract-stream.ts
@@ -84,6 +84,7 @@ export abstract class AbstractStream extends AbstractMessageStream implements St
     await this.sendCloseRead(options)
 
     this.readStatus = 'closed'
+    this.maybeDispatchEnd()
 
     this.log('closed readable end gracefully')
   }

--- a/packages/utils/test/message-stream-end.spec.ts
+++ b/packages/utils/test/message-stream-end.spec.ts
@@ -1,0 +1,362 @@
+import { expect } from 'aegir/chai'
+import delay from 'delay'
+import { pEvent } from 'p-event'
+import { fromString as uint8ArrayFromString } from 'uint8arrays/from-string'
+import { multiaddrConnectionPair } from '../src/multiaddr-connection-pair.ts'
+import { streamPair } from '../src/stream-pair.ts'
+import type { AbstractMultiaddrConnection } from '../src/abstract-multiaddr-connection.ts'
+
+describe('message stream end event', () => {
+  it('should emit end when the transport closes', async () => {
+    const [outbound, inbound] = multiaddrConnectionPair()
+
+    expect(inbound).to.have.property('readableEnded', false)
+
+    const order: string[] = []
+
+    let status: string | undefined
+    let closeTime: number | undefined
+
+    inbound.addEventListener('end', () => {
+      order.push('end')
+      status = inbound.status
+      closeTime = inbound.timeline.close
+    })
+    inbound.addEventListener('close', () => {
+      order.push('close')
+    })
+
+    await Promise.all([
+      pEvent(inbound, 'close'),
+      outbound.close()
+    ])
+
+    expect(order).to.deep.equal(['end', 'close'])
+
+    // the stream must be fully closed before listeners run
+    expect(status).to.equal('closed')
+    expect(closeTime).to.be.a('number')
+
+    // late consumers read this instead of waiting for an event that already fired
+    expect(inbound).to.have.property('readableEnded', true)
+  })
+
+  it('should not emit end until buffered data has been read', async () => {
+    const [outbound, inbound] = multiaddrConnectionPair()
+
+    let ended = false
+
+    inbound.addEventListener('end', () => {
+      ended = true
+    })
+
+    // no 'message' listener yet, so the data stays in the read buffer
+    outbound.send(uint8ArrayFromString('hello world'))
+
+    await Promise.all([
+      pEvent(inbound, 'close'),
+      outbound.close()
+    ])
+
+    expect(ended, 'ended while data was still buffered').to.be.false()
+
+    const received: Uint8Array[] = []
+
+    inbound.addEventListener('message', (evt) => {
+      received.push(evt.data.subarray())
+    })
+
+    await pEvent(inbound, 'end')
+
+    expect(received).to.deep.equal([uint8ArrayFromString('hello world')])
+  })
+
+  it('should emit end when the remote closes their writable end', async () => {
+    const [outbound, inbound] = await streamPair()
+
+    const order: string[] = []
+
+    inbound.addEventListener('message', () => {})
+    inbound.addEventListener('remoteCloseWrite', () => {
+      order.push('remoteCloseWrite')
+    })
+    inbound.addEventListener('end', () => {
+      order.push('end')
+    })
+
+    await Promise.all([
+      pEvent(inbound, 'end'),
+      outbound.close()
+    ])
+
+    expect(order).to.deep.equal(['remoteCloseWrite', 'end'])
+
+    // the remote only closed their writable end, so this end stays readable
+    // and writable
+    expect(inbound.readStatus).to.equal('readable')
+    expect(inbound.writeStatus).to.equal('writable')
+  })
+
+  it('should emit end once when an end listener closes the stream', async () => {
+    const [outbound, inbound] = await streamPair()
+
+    let ends = 0
+
+    inbound.addEventListener('message', () => {})
+    inbound.addEventListener('end', () => {
+      ends++
+
+      // the stream is still open, so aborting re-enters the readable end
+      // closing - 'end' must not fire twice
+      inbound.abort(new Error('teardown from end listener'))
+    })
+
+    await Promise.all([
+      pEvent(inbound, 'close'),
+      outbound.close()
+    ])
+
+    expect(ends).to.equal(1)
+  })
+
+  it('should not emit end before buffered data when the remote closes their writable end', async () => {
+    const [outbound, inbound] = await streamPair()
+
+    const order: string[] = []
+
+    inbound.addEventListener('end', () => {
+      order.push('end')
+    })
+
+    // no 'message' listener yet, so the data stays in the read buffer
+    outbound.send(uint8ArrayFromString('hello world'))
+
+    await Promise.all([
+      pEvent(inbound, 'remoteCloseWrite'),
+      outbound.close()
+    ])
+
+    expect(order, 'ended while data was still buffered').to.be.empty()
+
+    inbound.addEventListener('message', () => {
+      order.push('message')
+    })
+
+    await pEvent(inbound, 'end')
+
+    expect(order).to.deep.equal(['message', 'end'])
+  })
+
+  it('should emit end when the readable end is closed locally', async () => {
+    const [, inbound] = await streamPair()
+
+    await Promise.all([
+      pEvent(inbound, 'end'),
+      inbound.closeRead()
+    ])
+
+    expect(inbound.readStatus).to.equal('closed')
+    expect(inbound).to.have.property('readableEnded', true)
+  })
+
+  it('should finish closing before emitting end when the transport fails', async () => {
+    const [, inbound] = multiaddrConnectionPair()
+    const conn = inbound as AbstractMultiaddrConnection
+    const err = new Error('ECONNRESET')
+    const closed: Array<Error | undefined> = []
+
+    let status: string | undefined
+    let ends = 0
+
+    conn.addEventListener('message', () => {})
+    conn.addEventListener('end', () => {
+      ends++
+      status = conn.status
+
+      // tearing the stream down from an 'end' listener must not mask the error
+      // that closed the transport, or cause a second 'end' event
+      conn.abort(new Error('teardown from end listener'))
+    })
+    conn.addEventListener('close', (evt) => {
+      closed.push(evt.error)
+    })
+
+    conn.onTransportClosed(err)
+
+    expect(status, 'the stream was still open when end was emitted').to.equal('aborted')
+    expect(ends).to.equal(1)
+    expect(closed).to.have.lengthOf(1)
+    expect(closed[0]).to.equal(err)
+  })
+
+  it('should emit end when the transport closes while paused', async () => {
+    const [, inbound] = multiaddrConnectionPair()
+    const conn = inbound as AbstractMultiaddrConnection
+
+    conn.addEventListener('message', () => {})
+    conn.pause()
+
+    const end = pEvent(conn, 'end')
+
+    conn.onTransportClosed()
+
+    await end
+
+    // onTransportClosed only closes a 'readable' readable end, so a paused
+    // stream ends without readStatus changing
+    expect(conn.readStatus).to.equal('paused')
+  })
+
+  it('should emit end before close when the stream is aborted', async () => {
+    const [, inbound] = multiaddrConnectionPair()
+
+    const order: string[] = []
+
+    inbound.addEventListener('end', () => {
+      order.push('end')
+    })
+    inbound.addEventListener('close', () => {
+      order.push('close')
+    })
+
+    inbound.abort(new Error('urk!'))
+
+    expect(order).to.deep.equal(['end', 'close'])
+    expect(inbound).to.have.property('readableEnded', true)
+  })
+
+  it('should emit end before close when the remote resets with no buffered data', async () => {
+    const [, inbound] = multiaddrConnectionPair()
+    const conn = inbound as AbstractMultiaddrConnection
+
+    const order: string[] = []
+
+    conn.addEventListener('end', () => {
+      order.push('end')
+    })
+    conn.addEventListener('close', () => {
+      order.push('close')
+    })
+
+    conn.onRemoteReset()
+
+    expect(order).to.deep.equal(['end', 'close'])
+    expect(conn).to.have.property('readableEnded', true)
+  })
+
+  it('should emit end after buffered data has been read when the remote resets', async () => {
+    const [, inbound] = multiaddrConnectionPair()
+    const conn = inbound as AbstractMultiaddrConnection
+
+    // no 'message' listener, so the data stays in the read buffer
+    conn.push(uint8ArrayFromString('hello world'))
+
+    let ended = false
+
+    conn.addEventListener('end', () => {
+      ended = true
+    })
+
+    conn.onRemoteReset()
+
+    expect(ended, 'ended while data was still buffered').to.be.false()
+
+    const received: Uint8Array[] = []
+
+    conn.addEventListener('message', (evt) => {
+      received.push(evt.data.subarray())
+    })
+
+    await pEvent(conn, 'end')
+
+    expect(received).to.deep.equal([uint8ArrayFromString('hello world')])
+    expect(conn).to.have.property('readableEnded', true)
+  })
+
+  it('should not emit end while buffered data cannot be delivered', async () => {
+    const [, inbound] = multiaddrConnectionPair()
+    const conn = inbound as AbstractMultiaddrConnection
+
+    conn.push(uint8ArrayFromString('hello world'))
+    conn.pause()
+
+    let ended = false
+
+    conn.addEventListener('end', () => {
+      ended = true
+    })
+
+    conn.onTransportClosed()
+
+    const received: Uint8Array[] = []
+
+    conn.addEventListener('message', (evt) => {
+      received.push(evt.data.subarray())
+    })
+
+    await delay(10)
+
+    expect(ended, 'ended while paused with buffered data').to.be.false()
+    expect(conn.readBufferLength, 'buffered data was dropped').to.equal(11)
+
+    // 'end' is dispatched synchronously by resume() so listen before resuming
+    const end = pEvent(conn, 'end')
+    conn.resume()
+    await end
+
+    expect(received).to.deep.equal([uint8ArrayFromString('hello world')])
+  })
+
+  it('should emit one message event when data is pushed back after end', async () => {
+    const [outbound, inbound] = await streamPair()
+
+    await Promise.all([
+      pEvent(inbound, 'end'),
+      outbound.close()
+    ])
+
+    // eg. a byte stream being unwrapped after the remote finished
+    inbound.unshift(uint8ArrayFromString('world'))
+    inbound.unshift(uint8ArrayFromString('hello '))
+
+    const messages: string[] = []
+
+    inbound.addEventListener('message', (evt) => {
+      messages.push(new TextDecoder().decode(evt.data.subarray()))
+    })
+
+    await pEvent(inbound, 'message')
+
+    expect(messages).to.deep.equal(['hello world'])
+
+    // the readable end closes after the buffer drains, so no more can follow
+    expect(inbound.readStatus).to.equal('closed')
+    expect(() => inbound.unshift(uint8ArrayFromString('again'))).to.throw()
+      .with.property('name', 'StreamStateError')
+  })
+
+  it('should emit end once when the remote closes their writable end and then the stream closes', async () => {
+    const [outbound, inbound] = await streamPair()
+
+    let ends = 0
+
+    inbound.addEventListener('end', () => {
+      ends++
+    })
+
+    await Promise.all([
+      pEvent(inbound, 'end'),
+      outbound.close()
+    ])
+
+    // both ends are now closed for writing so the stream closes, which closes
+    // the readable end - 'end' is not emitted a second time
+    await Promise.all([
+      pEvent(inbound, 'close'),
+      inbound.close()
+    ])
+
+    expect(ends).to.equal(1)
+    expect(inbound.readStatus).to.equal('closed')
+  })
+})

--- a/packages/utils/test/message-stream-end.spec.ts
+++ b/packages/utils/test/message-stream-end.spec.ts
@@ -156,7 +156,6 @@ describe('message stream end event', () => {
     ])
 
     expect(inbound.readStatus).to.equal('closed')
-    expect(inbound).to.have.property('readableEnded', true)
   })
 
   it('should finish closing before emitting end when the transport fails', async () => {
@@ -212,8 +211,11 @@ describe('message stream end event', () => {
 
     const order: string[] = []
 
+    let closeTime: number | undefined
+
     inbound.addEventListener('end', () => {
       order.push('end')
+      closeTime = inbound.timeline.close
     })
     inbound.addEventListener('close', () => {
       order.push('close')
@@ -222,7 +224,9 @@ describe('message stream end event', () => {
     inbound.abort(new Error('urk!'))
 
     expect(order).to.deep.equal(['end', 'close'])
-    expect(inbound).to.have.property('readableEnded', true)
+
+    // the stream must be fully closed before listeners run
+    expect(closeTime).to.be.a('number')
   })
 
   it('should emit end before close when the remote resets with no buffered data', async () => {
@@ -241,7 +245,6 @@ describe('message stream end event', () => {
     conn.onRemoteReset()
 
     expect(order).to.deep.equal(['end', 'close'])
-    expect(conn).to.have.property('readableEnded', true)
   })
 
   it('should emit end after buffered data has been read when the remote resets', async () => {
@@ -270,7 +273,6 @@ describe('message stream end event', () => {
     await pEvent(conn, 'end')
 
     expect(received).to.deep.equal([uint8ArrayFromString('hello world')])
-    expect(conn).to.have.property('readableEnded', true)
   })
 
   it('should not emit end while buffered data cannot be delivered', async () => {
@@ -318,6 +320,9 @@ describe('message stream end event', () => {
     // eg. a byte stream being unwrapped after the remote finished
     inbound.unshift(uint8ArrayFromString('world'))
     inbound.unshift(uint8ArrayFromString('hello '))
+
+    // data arriving after 'end' does not un-emit it
+    expect(inbound).to.have.property('readableEnded', true)
 
     const messages: string[] = []
 


### PR DESCRIPTION
## Description

`MessageStream` had no signal for the readable end finishing, so a consumer holding resources tied to reading, a cipher or a decoder for example, had no safe point to release them. `close` cannot serve that purpose, because data received before the resource closed can still be read after it.

Adds an `end` event, emitted at most once when the remote will send no more data and everything it sent has been read:

- the remote closed their writable end and the read buffer has drained
- the readable end was closed by `abort()` or `Stream.closeRead()`, both of which discard anything unread
- the transport closed, including while the stream was paused

Adds `MessageStream.readableEnded` for consumers that attach after the event fired, since it is only emitted once. It is `readonly` and backed by a private field, so it cannot disagree with the event.

Unread data defers `end`, so a stream nobody reads from can close without ever emitting it. `close` remains the unconditional terminal signal, and both docs say so.

Also deletes two claims in neighbouring docs that this event falsifies: `close` said no further events would be emitted, and `remoteCloseWrite` said no further `message` events would be emitted. Buffered data has always been readable after both. `end` is omitted from the `Connection` event map, since connections do not forward it.

## Notes & open questions

Adding a member to `MessageStreamEvents` and a property to `MessageStream` is additive for listeners and for anything extending `TypedEventEmitter<MessageStreamEvents>`, which is every implementation in this repo, so no call site needed changing. It is a compile-time break for out-of-tree code that implements `MessageStream` by hand instead of extending `AbstractMessageStream`: that code needs to add `readableEnded`.

Compliance-suite assertions that every muxer emits `end` are deliberately left out. Tightening that contract would fail external muxers until they update, so it belongs in its own PR.

## Change checklist

- [x] I have performed a self-review of my own code
- [x] I have made corresponding changes to the documentation if necessary (this includes comments as well)
- [x] I have added tests that prove my fix is effective or that my feature works
