### PR TITLE
feat(gossipsub): add floodPublish option to PublishOpts

### DIFF
--- a/packages/gossipsub/src/gossipsub.ts
+++ b/packages/gossipsub/src/gossipsub.ts
@@ -1993,7 +1993,7 @@ export class GossipSub extends TypedEventEmitter<GossipSubEvents> implements Typ
     return tosend
   }
 
-  private selectPeersToPublish (topic: TopicStr): {
+  private selectPeersToPublish (topic: TopicStr, floodPublish?: boolean): {
     tosend: Set<PeerIdStr>
     tosendCount: ToSendGroupCount
   } {
@@ -2009,7 +2009,8 @@ export class GossipSub extends TypedEventEmitter<GossipSubEvents> implements Typ
     if (peersInTopic != null) {
       // flood-publish behavior
       // send to direct peers and _all_ peers meeting the publishThreshold
-      if (this.opts.floodPublish) {
+      // per-publish opt takes precedence over the global opt, while preserving a false value
+      if (floodPublish ?? this.opts.floodPublish) {
         peersInTopic.forEach((id) => {
           if (this.direct.has(id)) {
             tosend.add(id)
@@ -2162,7 +2163,7 @@ export class GossipSub extends TypedEventEmitter<GossipSubEvents> implements Typ
       throw Error('PublishError.Duplicate')
     }
 
-    const { tosend, tosendCount } = this.selectPeersToPublish(topic)
+    const { tosend, tosendCount } = this.selectPeersToPublish(topic, opts?.floodPublish)
     const willSendToSelf = this.opts.emitSelf && this.subscriptions.has(topic)
 
     // Current publish opt takes precedence global opts, while preserving false value

--- a/packages/gossipsub/src/types.ts
+++ b/packages/gossipsub/src/types.ts
@@ -85,6 +85,12 @@ export interface PublishOpts {
   ignoreDuplicatePublishError?: boolean
   /** serialize message once and send to all peers without control messages */
   batchPublish?: boolean
+  /**
+   * Flood publish this message to every subscribed peer above the publish threshold,
+   * overriding the global `floodPublish` option for this call only. Preserves a `false`
+   * value, so it can also disable flood publishing per message.
+   */
+  floodPublish?: boolean
 }
 
 export enum PublishConfigType {

--- a/packages/gossipsub/test/flood-publish.spec.ts
+++ b/packages/gossipsub/test/flood-publish.spec.ts
@@ -1,0 +1,59 @@
+import { generateKeyPair } from '@libp2p/crypto/keys'
+import { defaultLogger } from '@libp2p/logger'
+import { peerIdFromPrivateKey } from '@libp2p/peer-id'
+import { expect } from 'aegir/chai'
+import { stubInterface } from 'sinon-ts'
+import { GossipSub as GossipSubClass } from '../src/gossipsub.ts'
+import type { PeerStore } from '@libp2p/interface'
+import type { ConnectionManager, Registrar } from '@libp2p/interface-internal'
+
+// A peer subscribed to the topic but not in the mesh. With default scoring its
+// score is 0, above the default publishThreshold of -50, so flood publish selects
+// it while regular (mesh-only) publish does not.
+const nonMeshPeer = '16Uiu2HAmMkH6ZLen2tbhiuNCTZLLvrZaDgufNdT5MPjtC9Hr9YNA'
+const topic = 'test-topic'
+
+async function createGossipsub (floodPublish: boolean): Promise<GossipSubClass> {
+  const privateKey = await generateKeyPair('Ed25519')
+  const peerId = peerIdFromPrivateKey(privateKey)
+  return new GossipSubClass(
+    {
+      privateKey,
+      peerId,
+      registrar: stubInterface<Registrar>(),
+      peerStore: stubInterface<PeerStore>(),
+      connectionManager: stubInterface<ConnectionManager>(),
+      logger: defaultLogger()
+    },
+    { floodPublish }
+  )
+}
+
+describe('per-publish floodPublish', () => {
+  // selectPeersToPublish is private, reach it the same way other specs reach internals
+  function selectPeers (gossipsub: GossipSubClass, floodPublish?: boolean): Set<string> {
+    // a subscribed peer that is not part of the mesh for the topic
+    ;(gossipsub as any).topics.set(topic, new Set([nonMeshPeer]))
+    return (gossipsub as any).selectPeersToPublish(topic, floodPublish).tosend
+  }
+
+  it('floods to a non-mesh peer when the per-publish opt is true, under a false global', async () => {
+    const gossipsub = await createGossipsub(false)
+    expect(selectPeers(gossipsub, true)).to.include(nonMeshPeer)
+  })
+
+  it('does not flood to a non-mesh peer when no per-publish opt is given, under a false global', async () => {
+    const gossipsub = await createGossipsub(false)
+    expect(selectPeers(gossipsub, undefined)).to.not.include(nonMeshPeer)
+  })
+
+  it('does not flood when the per-publish opt is false, under a true global', async () => {
+    const gossipsub = await createGossipsub(true)
+    expect(selectPeers(gossipsub, false)).to.not.include(nonMeshPeer)
+  })
+
+  it('floods when no per-publish opt is given, under a true global', async () => {
+    const gossipsub = await createGossipsub(true)
+    expect(selectPeers(gossipsub, undefined)).to.include(nonMeshPeer)
+  })
+})

--- a/packages/gossipsub/test/flood-publish.spec.ts
+++ b/packages/gossipsub/test/flood-publish.spec.ts
@@ -33,7 +33,7 @@ describe('per-publish floodPublish', () => {
   // selectPeersToPublish is private, reach it the same way other specs reach internals
   function selectPeers (gossipsub: GossipSubClass, floodPublish?: boolean): Set<string> {
     // a subscribed peer that is not part of the mesh for the topic
-    ;(gossipsub as any).topics.set(topic, new Set([nonMeshPeer]))
+    (gossipsub as any).topics.set(topic, new Set([nonMeshPeer]))
     return (gossipsub as any).selectPeersToPublish(topic, floodPublish).tosend
   }
 


### PR DESCRIPTION
## Description

`floodPublish` is currently a constructor-only option, so the only way to
flood publish one topic is to enable it globally for all traffic. Added it
to `PublishOpts` so a single message can be flood published without turning
on global flood publish. Option can be also used in reverse, disabling flood publish for a single call.

## Notes & open questions

Additive and non-breaking.

## Change checklist

- [x] I have performed a self-review of my own code
- [x] I have made corresponding changes to the documentation if necessary (this includes comments as well)
- [x] I have added tests that prove my fix is effective or that my feature works