### PR TITLE
fix(utils): abort the stream on byteStream read buffer overflow

### DIFF
--- a/packages/utils/src/stream-utils.ts
+++ b/packages/utils/src/stream-utils.ts
@@ -1,4 +1,4 @@
-import { StreamMessageEvent, StreamCloseEvent, InvalidParametersError } from '@libp2p/interface'
+import { StreamMessageEvent, StreamCloseEvent, InvalidParametersError, StreamBufferError } from '@libp2p/interface'
 import { pipe as itPipe } from 'it-pipe'
 import { pushable } from 'it-pushable'
 import { pEvent } from 'p-event'
@@ -119,18 +119,38 @@ export function byteStream <T extends MessageStream> (stream: T, opts?: ByteStre
 
   let hasBytes: PromiseWithResolvers<void> | undefined
   let unwrapped = false
+  let overflow: StreamBufferError | undefined
 
   if (!isValid(stream)) {
     throw new InvalidParametersError('Argument should be a Stream or a Multiaddr')
   }
 
   const byteStreamOnMessageListener = (evt: StreamMessageEvent): void => {
+    if (overflow != null) {
+      // the stream is being aborted after a previous overflow, ignore any
+      // more data
+      return
+    }
+
     readBuffer.append(evt.data)
 
     if (readBuffer.byteLength > maxBufferSize) {
       const readBufferSize = readBuffer.byteLength
-      readBuffer.consume(readBuffer.byteLength)
-      hasBytes?.reject(new Error(`Read buffer overflow - ${readBufferSize} > ${maxBufferSize}`))
+      readBuffer.consume(readBufferSize)
+
+      // hasBytes only exists while a read is in flight and is already settled
+      // otherwise, so rejecting it reaches nobody between reads.
+      const err = new StreamBufferError(`Read buffer overflow - ${readBufferSize} > ${maxBufferSize}`)
+      overflow = err
+
+      hasBytes?.reject(err)
+
+      // let the current dispatch finish first
+      queueMicrotask(() => {
+        stream.abort(err)
+      })
+
+      return
     }
 
     hasBytes?.resolve()
@@ -158,6 +178,10 @@ export function byteStream <T extends MessageStream> (stream: T, opts?: ByteStre
     async read (options?: ReadBytesOptions) {
       if (unwrapped === true) {
         throw new UnwrappedError('Stream was unwrapped')
+      }
+
+      if (overflow != null) {
+        throw overflow
       }
 
       if (isEOF(stream)) {

--- a/packages/utils/test/stream-utils-test.spec.ts
+++ b/packages/utils/test/stream-utils-test.spec.ts
@@ -159,21 +159,26 @@ describe('byte-stream', () => {
     }
     await delay(100)
 
-    // 2048 bytes were written and none were consumed, so the next read must
-    // either produce them or fail. It must not quietly resume mid-stream.
-    const read = await Promise.race([
-      incomingBytes.read().then(buf => ({ ok: true as const, buf })),
-      incomingBytes.read().then(() => ({ ok: true as const, buf: null })).catch(err => ({ ok: false as const, err })),
-      delay(500).then(() => ({ ok: false as const, err: new Error('read never settled') }))
-    ])
+    // 2048 bytes were written and none were consumed, so a read must either
+    // produce them or fail. It must not quietly resume mid-stream.
+    let bytes: number | undefined
+    let error: Error | undefined
 
-    if (read.ok) {
-      // if it resolves, the bytes must be the ones that were sent, starting
-      // from the beginning. a silent discard shows up as a short or shifted read
-      expect(read.buf?.byteLength, 'bytes were discarded without an error').to.equal(2048)
+    try {
+      const buf = await Promise.race([
+        incomingBytes.read(),
+        delay(500).then(async () => { throw new Error('read never settled') })
+      ])
+      bytes = buf?.byteLength
+    } catch (err: any) {
+      error = err
+    }
+
+    if (error != null) {
+      // failing loudly is fine: the caller learns the stream lost data
+      expect(error).to.have.property('message').that.includes('overflow')
     } else {
-      // failing loudly is acceptable: the caller learns the stream is unusable
-      expect(read.err).to.have.property('message').that.includes('overflow')
+      expect(bytes, 'bytes were discarded without an error').to.equal(2048)
     }
 
     outgoing.abort(new Error('cleanup'))

--- a/packages/utils/test/stream-utils-test.spec.ts
+++ b/packages/utils/test/stream-utils-test.spec.ts
@@ -144,6 +144,41 @@ describe('pipe', () => {
 })
 
 describe('byte-stream', () => {
+  it('should not silently discard buffered bytes on overflow', async () => {
+    const [outgoing, incoming] = await streamPair()
+
+    const maxBufferSize = 1024
+    const incomingBytes = byteStream(incoming, { maxBufferSize })
+    const outgoingBytes = byteStream(outgoing)
+
+    // overflow the read buffer while nothing is reading. `hasBytes` is only
+    // created by read(), so with no read pending the overflow rejection has
+    // nowhere to go, while the buffer has already been discarded.
+    for (let i = 0; i < 4; i++) {
+      await outgoingBytes.write(new Uint8Array(512).fill(i + 1))
+    }
+    await delay(100)
+
+    // 2048 bytes were written and none were consumed, so the next read must
+    // either produce them or fail. It must not quietly resume mid-stream.
+    const read = await Promise.race([
+      incomingBytes.read().then(buf => ({ ok: true as const, buf })),
+      incomingBytes.read().then(() => ({ ok: true as const, buf: null })).catch(err => ({ ok: false as const, err })),
+      delay(500).then(() => ({ ok: false as const, err: new Error('read never settled') }))
+    ])
+
+    if (read.ok) {
+      // if it resolves, the bytes must be the ones that were sent, starting
+      // from the beginning. a silent discard shows up as a short or shifted read
+      expect(read.buf?.byteLength, 'bytes were discarded without an error').to.equal(2048)
+    } else {
+      // failing loudly is acceptable: the caller learns the stream is unusable
+      expect(read.err).to.have.property('message').that.includes('overflow')
+    }
+
+    outgoing.abort(new Error('cleanup'))
+  })
+
   it('should read bytes', async () => {
     const [outgoing, incoming] = await streamPair()
 


### PR DESCRIPTION
## Description

`byteStream` buffers incoming message events until they are read. When the buffer crossed `maxBufferSize` it discarded the entire buffer and rejected `hasBytes`, but `hasBytes` only exists while a read is in flight and is already settled otherwise, so between reads the rejection reached nobody. The next read then returned bytes from the wrong offset with no signal that anything had been lost.

Any consumer that reads a chunk, does async work with it, then comes back for more leaves the stream unread for as long as that work takes while the transport keeps delivering, so the gap is easy to hit.

Instead of discarding silently, the overflow error is remembered and the stream is aborted, which is how `AbstractMessageStream` already treats its own read buffer overflowing. Later reads throw the remembered error rather than seeing a clean EOF, and data arriving after the overflow is ignored. The abort is deferred with `queueMicrotask` because the listener runs inside the stream's own message dispatch.

## Change checklist

- [x] I have performed a self-review of my own code
- [x] I have made corresponding changes to the documentation if necessary (this includes comments as well)
- [x] I have added tests that prove my fix is effective or that my feature works
