### PR TITLE
fix(tcp): await socket closure during shutdown

### DIFF
--- a/packages/transport-tcp/src/listener.ts
+++ b/packages/transport-tcp/src/listener.ts
@@ -179,32 +179,31 @@ export class TCPListener extends TypedEventEmitter<ListenerEvents> implements Li
 
     this.log('new inbound connection %s', maConn.remoteAddr)
     this.sockets.add(socket)
+    socket.once('close', () => {
+      this.sockets.delete(socket)
+
+      if (
+        this.context.closeServerOnMaxConnections != null &&
+        this.sockets.size < this.context.closeServerOnMaxConnections.listenBelow
+      ) {
+        // The most likely case of error is if the port taken by this
+        // application is bound by another process during the time the
+        // server is closed. In that case there's not much we can do.
+        // resume() will be called again every time a connection is
+        // dropped, which acts as an eventual retry mechanism.
+        // onListenError allows the consumer act on this.
+        this.resume().catch(err => {
+          this.log.error('error attempting to listen server once connection count under limit - %e', err)
+          this.context.closeServerOnMaxConnections?.onListenError?.(err as Error)
+        })
+      }
+    })
 
     this.context.upgrader.upgradeInbound(maConn, {
       signal: this.shutdownController.signal
     })
       .then(() => {
         this.log('inbound connection upgraded %s', maConn.remoteAddr)
-
-        socket.once('close', () => {
-          this.sockets.delete(socket)
-
-          if (
-            this.context.closeServerOnMaxConnections != null &&
-            this.sockets.size < this.context.closeServerOnMaxConnections.listenBelow
-          ) {
-            // The most likely case of error is if the port taken by this
-            // application is bound by another process during the time the
-            // server if closed. In that case there's not much we can do.
-            // resume() will be called again every time a connection is
-            // dropped, which acts as an eventual retry mechanism.
-            // onListenError allows the consumer act on this.
-            this.resume().catch(err => {
-              this.log.error('error attempting to listen server once connection count under limit - %e', err)
-              this.context.closeServerOnMaxConnections?.onListenError?.(err as Error)
-            })
-          }
-        })
 
         if (
           this.context.closeServerOnMaxConnections != null &&
@@ -217,7 +216,6 @@ export class TCPListener extends TypedEventEmitter<ListenerEvents> implements Li
       .catch(async err => {
         this.log.error('inbound connection upgrade failed - %e', err)
         this.metrics.errors?.increment({ [`${this.addr} inbound_upgrade`]: true })
-        this.sockets.delete(socket)
         maConn.abort(err)
       })
   }
@@ -281,10 +279,15 @@ export class TCPListener extends TypedEventEmitter<ListenerEvents> implements Li
     // synchronously close any open connections - should be done after closing
     // the server socket in case new sockets are opened during the shutdown
     this.sockets.forEach(socket => {
-      if (socket.readable) {
-        events.push(pEvent(socket, 'close', options))
-        socket.destroy()
+      if (socket.closed) {
+        return
       }
+
+      events.push(pEvent(socket, 'close', {
+        ...options,
+        rejectionEvents: []
+      }))
+      socket.destroy()
     })
 
     await Promise.all(events)

--- a/packages/transport-tcp/src/tcp.ts
+++ b/packages/transport-tcp/src/tcp.ts
@@ -28,8 +28,9 @@
  */
 
 import net from 'net'
-import { AbortError, TimeoutError, serviceCapabilities, transportSymbol } from '@libp2p/interface'
+import { AbortError, NotStartedError, TimeoutError, serviceCapabilities, transportSymbol } from '@libp2p/interface'
 import { TCP as TCPMatcher } from '@multiformats/multiaddr-matcher'
+import { setMaxListeners } from 'main-event'
 import { CustomProgressEvent } from 'progress-events'
 import { TCPListener } from './listener.ts'
 import { toMultiaddrConnection } from './socket-to-conn.ts'
@@ -44,11 +45,16 @@ export class TCP implements Transport<TCPDialEvents> {
   private readonly metrics?: TCPMetrics
   private readonly components: TCPComponents
   private readonly log: Logger
+  private readonly sockets: Set<Socket>
+  private shutdownController: AbortController
 
   constructor (components: TCPComponents, options: TCPOptions = {}) {
     this.log = components.logger.forComponent('libp2p:tcp')
     this.opts = options
     this.components = components
+    this.sockets = new Set()
+    this.shutdownController = new AbortController()
+    setMaxListeners(Infinity, this.shutdownController.signal)
 
     if (components.metrics != null) {
       this.metrics = {
@@ -72,7 +78,27 @@ export class TCP implements Transport<TCPDialEvents> {
     '@libp2p/transport'
   ]
 
+  start (): void {
+    this.shutdownController = new AbortController()
+    setMaxListeners(Infinity, this.shutdownController.signal)
+  }
+
+  async stop (): Promise<void> {
+    // Abort pending connects/upgrades before closing their sockets. No dials
+    // can be added after this point, so the snapshot contains every socket
+    // this transport can still own.
+    this.shutdownController.abort()
+
+    await Promise.all([...this.sockets].map(async socket => {
+      await this.closeSocket(socket)
+    }))
+  }
+
   async dial (ma: Multiaddr, options: TCPDialOptions): Promise<Connection> {
+    if (this.shutdownController.signal.aborted) {
+      throw new NotStartedError('TCP transport is stopped')
+    }
+
     options.keepAlive = options.keepAlive ?? true
     options.noDelay = options.noDelay ?? true
     options.allowHalfOpen = options.allowHalfOpen ?? false
@@ -123,6 +149,10 @@ export class TCP implements Transport<TCPDialEvents> {
 
       this.log('dialing %a with opts %o', ma, cOpts)
       rawSocket = net.connect(cOpts)
+      this.sockets.add(rawSocket)
+      rawSocket.once('close', () => {
+        this.sockets.delete(rawSocket)
+      })
 
       const onError = (err: Error): void => {
         this.log.error('dial to %a errored - %e', ma, err)
@@ -161,6 +191,7 @@ export class TCP implements Transport<TCPDialEvents> {
         if (options.signal != null) {
           options.signal.removeEventListener('abort', onAbort)
         }
+        this.shutdownController.signal.removeEventListener('abort', onAbort)
 
         if (err != null) {
           reject(err); return
@@ -174,11 +205,33 @@ export class TCP implements Transport<TCPDialEvents> {
       rawSocket.on('connect', onConnect)
 
       options.signal.addEventListener('abort', onAbort)
+      this.shutdownController.signal.addEventListener('abort', onAbort)
     })
-      .catch(err => {
-        rawSocket?.destroy()
+      .catch(async err => {
+        if (rawSocket != null) {
+          await this.closeSocket(rawSocket)
+        }
+
         throw err
       })
+  }
+
+  private async closeSocket (socket: Socket): Promise<void> {
+    if (socket.closed) {
+      return
+    }
+
+    // `destroy()` is synchronous but the native TCP handle is only finished
+    // when Node emits `close`. Waiting for that callback prevents stop() from
+    // resolving while a TCPSocketWrap/ConnectWrap is still being cleaned up.
+    const closed = new Promise<void>(resolve => {
+      socket.once('close', () => {
+        resolve()
+      })
+    })
+
+    socket.destroy()
+    await closed
   }
 
   /**

--- a/packages/transport-tcp/test/fixtures/shutdown-worker.ts
+++ b/packages/transport-tcp/test/fixtures/shutdown-worker.ts
@@ -1,0 +1,46 @@
+import { once } from 'node:events'
+import { getActiveResourcesInfo } from 'node:process'
+import { setImmediate } from 'node:timers/promises'
+import { parentPort } from 'node:worker_threads'
+import { defaultLogger } from '@libp2p/logger'
+import { multiaddr } from '@multiformats/multiaddr'
+import { stubInterface } from 'sinon-ts'
+import { TCP } from '../../src/tcp.ts'
+import type { Connection, Upgrader } from '@libp2p/interface'
+
+if (parentPort == null) {
+  throw new Error('This fixture must run in a worker')
+}
+
+const transport = new TCP({ logger: defaultLogger() })
+const upgrader = stubInterface<Upgrader>({
+  async upgradeInbound () {},
+  async upgradeOutbound () {
+    return stubInterface<Connection>()
+  }
+})
+const listener = transport.createListener({ upgrader })
+
+transport.start()
+
+try {
+  await listener.listen(multiaddr('/ip4/127.0.0.1/tcp/0'))
+
+  await Promise.all(Array.from({ length: 16 }, async () => {
+    await transport.dial(listener.getAddrs()[0], {
+      upgrader,
+      signal: AbortSignal.timeout(5_000)
+    })
+  }))
+} finally {
+  await Promise.all([
+    listener.close(),
+    transport.stop()
+  ])
+}
+
+await setImmediate()
+parentPort.postMessage(getActiveResourcesInfo().filter(name => name === 'TCPSocketWrap'))
+
+// Keep the worker alive so the parent tests termination, not natural exit.
+await once(parentPort, 'message')

--- a/packages/transport-tcp/test/listen-dial.spec.ts
+++ b/packages/transport-tcp/test/listen-dial.spec.ts
@@ -1,3 +1,5 @@
+import net from 'node:net'
+import { Worker } from 'node:worker_threads'
 import os from 'os'
 import path from 'path'
 import { defaultLogger } from '@libp2p/logger'
@@ -8,19 +10,19 @@ import pDefer from 'p-defer'
 import Sinon from 'sinon'
 import { stubInterface } from 'sinon-ts'
 import { tcp } from '../src/index.ts'
-import type { Connection, Listener, Transport, Upgrader } from '@libp2p/interface'
+import type { Connection, Listener, MultiaddrConnection, Startable, Transport, Upgrader } from '@libp2p/interface'
 
 const isCI = process.env.CI
 
 describe('listen', () => {
-  let transport: Transport
+  let transport: Transport & Startable
   let listener: Listener
   let upgrader: Upgrader
 
   beforeEach(() => {
     transport = tcp()({
       logger: defaultLogger()
-    })
+    }) as Transport & Startable
     upgrader = stubInterface<Upgrader>({
       upgradeInbound: Sinon.stub().resolves(),
       upgradeOutbound: async (maConn) => {
@@ -32,6 +34,8 @@ describe('listen', () => {
   })
 
   afterEach(async () => {
+    Sinon.restore()
+
     try {
       if (listener != null) {
         await listener.close()
@@ -154,7 +158,7 @@ describe('listen', () => {
 })
 
 describe('dial', () => {
-  let transport: Transport
+  let transport: Transport & Startable
   let upgrader: Upgrader
 
   beforeEach(async () => {
@@ -169,7 +173,11 @@ describe('dial', () => {
 
     transport = tcp()({
       logger: defaultLogger()
-    })
+    }) as Transport & Startable
+  })
+
+  afterEach(() => {
+    Sinon.restore()
   })
 
   it('dial IPv4', async () => {
@@ -319,5 +327,125 @@ describe('dial', () => {
 
     // should abort the upgrade
     await abortedUpgrade.promise
+  })
+
+  it('should destroy and await outbound sockets when the transport stops', async () => {
+    let outboundMaConn: MultiaddrConnection | undefined
+
+    const listener = transport.createListener({
+      upgrader: stubInterface<Upgrader>({
+        upgradeInbound: Sinon.stub().resolves()
+      })
+    })
+    await listener.listen(multiaddr('/ip4/127.0.0.1/tcp/0'))
+
+    const connection = stubInterface<Connection>()
+    await transport.dial(listener.getAddrs()[0], {
+      upgrader: stubInterface<Upgrader>({
+        async upgradeOutbound (maConn) {
+          outboundMaConn = maConn
+          return connection
+        }
+      }),
+      signal: AbortSignal.timeout(5_000)
+    })
+
+    expect(outboundMaConn).to.have.property('status', 'open')
+
+    await transport.stop()
+
+    expect(outboundMaConn).to.have.property('status', 'closed')
+    await expect(transport.dial(listener.getAddrs()[0], {
+      upgrader,
+      signal: AbortSignal.timeout(5_000)
+    })).to.eventually.be.rejected()
+      .with.property('name', 'NotStartedError')
+
+    await listener.close()
+  })
+
+  it('should abort a pending connect and await the socket close event on stop', async () => {
+    const socket = new net.Socket()
+    Sinon.stub(net, 'connect').returns(socket)
+
+    const dial = transport.dial(multiaddr('/ip4/192.0.2.1/tcp/4001'), {
+      upgrader,
+      signal: AbortSignal.timeout(5_000)
+    })
+
+    await transport.stop()
+
+    expect(socket.closed).to.be.true()
+    await expect(dial).to.eventually.be.rejected()
+      .with.property('name', 'AbortError')
+  })
+
+  it('should leave no TCP handles and allow prompt worker termination after repeated shutdowns', async () => {
+    const tcpModuleUrl = new URL('../src/index.js', import.meta.url).href
+
+    for (let iteration = 0; iteration < 5; iteration++) {
+      const worker = new Worker(`
+        const { parentPort, workerData } = require('node:worker_threads')
+
+        void (async () => {
+          const { tcp } = await import(workerData.tcpModuleUrl)
+          const { defaultLogger } = await import('@libp2p/logger')
+          const transport = tcp()({ logger: defaultLogger() })
+          const upgrader = {
+            async upgradeInbound () {},
+            async upgradeOutbound () { return {} }
+          }
+          const listener = transport.createListener({ upgrader })
+
+          transport.start()
+          await listener.listen((await import('@multiformats/multiaddr')).multiaddr('/ip4/127.0.0.1/tcp/0'))
+
+          await Promise.all(Array.from({ length: 16 }, async () => {
+            await transport.dial(listener.getAddrs()[0], {
+              upgrader,
+              signal: AbortSignal.timeout(5_000)
+            })
+          }))
+
+          await Promise.all([
+            listener.close(),
+            transport.stop()
+          ])
+          await new Promise(resolve => setImmediate(resolve))
+
+          parentPort.postMessage(process.getActiveResourcesInfo().filter(name => name === 'TCPSocketWrap'))
+        })().catch(err => {
+          parentPort.postMessage({ error: err.stack ?? err.message })
+        })
+      `, {
+        eval: true,
+        workerData: { tcpModuleUrl }
+      })
+
+      const resources = await new Promise<unknown>((resolve, reject) => {
+        worker.once('message', resolve)
+        worker.once('error', reject)
+      })
+
+      if (resources != null && typeof resources === 'object' && !Array.isArray(resources) && 'error' in resources) {
+        throw new Error(String(resources.error))
+      }
+
+      expect(resources).to.deep.equal([])
+
+      const terminationTimeout = Promise.withResolvers<void>()
+      const timeout = setTimeout(() => {
+        terminationTimeout.reject(new Error('Worker did not terminate promptly'))
+      }, 1_000)
+
+      try {
+        await Promise.race([
+          worker.terminate(),
+          terminationTimeout.promise
+        ])
+      } finally {
+        clearTimeout(timeout)
+      }
+    }
   })
 })

--- a/packages/transport-tcp/test/listen-dial.spec.ts
+++ b/packages/transport-tcp/test/listen-dial.spec.ts
@@ -7,6 +7,7 @@ import { getNetConfig } from '@libp2p/utils'
 import { multiaddr } from '@multiformats/multiaddr'
 import { expect } from 'aegir/chai'
 import pDefer from 'p-defer'
+import { pEvent } from 'p-event'
 import Sinon from 'sinon'
 import { stubInterface } from 'sinon-ts'
 import { tcp } from '../src/index.ts'
@@ -381,70 +382,33 @@ describe('dial', () => {
   })
 
   it('should leave no TCP handles and allow prompt worker termination after repeated shutdowns', async () => {
-    const tcpModuleUrl = new URL('../src/index.js', import.meta.url).href
+    // Support both source tests and the compiled test suite.
+    const workerUrl = new URL(`./fixtures/shutdown-worker${path.extname(import.meta.url)}`, import.meta.url)
 
     for (let iteration = 0; iteration < 5; iteration++) {
-      const worker = new Worker(`
-        const { parentPort, workerData } = require('node:worker_threads')
-
-        void (async () => {
-          const { tcp } = await import(workerData.tcpModuleUrl)
-          const { defaultLogger } = await import('@libp2p/logger')
-          const transport = tcp()({ logger: defaultLogger() })
-          const upgrader = {
-            async upgradeInbound () {},
-            async upgradeOutbound () { return {} }
-          }
-          const listener = transport.createListener({ upgrader })
-
-          transport.start()
-          await listener.listen((await import('@multiformats/multiaddr')).multiaddr('/ip4/127.0.0.1/tcp/0'))
-
-          await Promise.all(Array.from({ length: 16 }, async () => {
-            await transport.dial(listener.getAddrs()[0], {
-              upgrader,
-              signal: AbortSignal.timeout(5_000)
-            })
-          }))
-
-          await Promise.all([
-            listener.close(),
-            transport.stop()
-          ])
-          await new Promise(resolve => setImmediate(resolve))
-
-          parentPort.postMessage(process.getActiveResourcesInfo().filter(name => name === 'TCPSocketWrap'))
-        })().catch(err => {
-          parentPort.postMessage({ error: err.stack ?? err.message })
-        })
-      `, {
-        eval: true,
-        workerData: { tcpModuleUrl }
-      })
-
-      const resources = await new Promise<unknown>((resolve, reject) => {
-        worker.once('message', resolve)
-        worker.once('error', reject)
-      })
-
-      if (resources != null && typeof resources === 'object' && !Array.isArray(resources) && 'error' in resources) {
-        throw new Error(String(resources.error))
-      }
-
-      expect(resources).to.deep.equal([])
-
-      const terminationTimeout = Promise.withResolvers<void>()
-      const timeout = setTimeout(() => {
-        terminationTimeout.reject(new Error('Worker did not terminate promptly'))
-      }, 1_000)
+      const worker = new Worker(workerUrl)
 
       try {
-        await Promise.race([
-          worker.terminate(),
-          terminationTimeout.promise
-        ])
+        const resources = await pEvent(worker, 'message', {
+          rejectionEvents: ['error', 'exit'],
+          signal: AbortSignal.timeout(10_000)
+        })
+
+        expect(resources).to.deep.equal([])
       } finally {
-        clearTimeout(timeout)
+        const terminationTimeout = Promise.withResolvers<void>()
+        const timeout = setTimeout(() => {
+          terminationTimeout.reject(new Error('Worker did not terminate promptly'))
+        }, 1_000)
+
+        try {
+          await Promise.race([
+            worker.terminate(),
+            terminationTimeout.promise
+          ])
+        } finally {
+          clearTimeout(timeout)
+        }
       }
     }
   })


### PR DESCRIPTION
## Summary
Fixes a TCP shutdown race where `libp2p.stop()` could resolve before Node had finished closing underlying TCP handles.

The TCP transport did not track outbound sockets or participate in libp2p’s lifecycle. Aborted dials called `socket.destroy()`, but shutdown did not await the socket’s final `close` event. The TCP listener could similarly stop tracking sockets before their native handles had closed.

In a Node.js worker, these retained `TCPSocketWrap` handles could leave the worker spinning indefinitely in `Environment::CleanupHandles()`, preventing `Worker.terminate()` and process shutdown.

In practice this resulted in a Lodestar node not shutting down (v1.46.0 with the recent shutdown fix included):

```
Aug-30 12:42:42.456[network]         debug: network reqResp closed
Aug-30 12:42:42.500[]                 info: Synced - slot: 29820084 - head: 0xcde7…df7a - exec-block: valid(47991952 0x1e84…) - finalized: 0x4998…98ab:1863753 - peers: 101
Aug-30 12:42:42.936[network]         debug: network lib2p closed activeResources=MessagePort=1,TCPSocketWrap=19,Timeout=1
Aug-30 12:42:42.937[network]         debug: terminating network worker
Aug-30 12:42:43.338[chain]         verbose: Running prepareForNextSlot nextEpoch=1863756, prepareSlot=29820085, headSlot=29820084, headRoot=0xcde75cb61f524777b06f5b7946d9241f9722125da1250d62d890372d83f6df7a, isEpochTransition=false
Aug-30 12:42:43.938[network]         debug: Worker thread failed to terminate, retrying...
Aug-30 12:42:44.938[network]         debug: Worker thread failed to terminate, retrying...
Aug-30 12:42:45.001[chain]         verbose: Clock slot slot=29820085
Aug-30 12:42:45.938[network]         debug: Worker thread failed to terminate, retrying...
Aug-30 12:42:45.938[network]         debug: Worker thread failed to terminate in 3000ms
Aug-30 12:42:45.938[network]         debug: Network worker did not terminate in time, continuing shutdown without it
Aug-30 12:42:45.938[network]         debug: network core closed
Aug-30 12:42:45.939[metrics]         debug: Metrics HTTP server closed
Aug-30 12:42:46.610[chain]         verbose: Archived finalized state epoch=1863753, slot=29820048, root=0x49983ea27213405160a0145572de532fd83bf387db89ab49dd028091036098ab
Aug-30 12:42:47.285[]                debug: Beacon node closed
```

After these log lines the process kept running for almost 5 more minutes when it was killed. The logs indicate this could be due to the active resources left behind when the network libp2p worker was terminated.

## Changes
- Track outbound TCP sockets for their complete lifetime.
- Stop accepting new TCP dials once transport shutdown begins.
- Abort pending connection attempts during shutdown.
- Destroy pending and established sockets.
- Await each socket’s `close` event before TCP transport shutdown resolves.
- Keep inbound sockets tracked until their actual `close` event.
- Close listener sockets even when they are no longer readable but still have an active native handle.

## Testing
Added regressions covering:
- Shutdown with established TCP connections.
- Shutdown during a pending outbound connection.
- Repeated shutdown inside Node.js workers.
- Absence of `TCPSocketWrap` resources after shutdown.
- Prompt completion of `Worker.terminate()`.
- [ ] manual testing of shutdown behavior on a Lodestar node (in-progress, no issues discovered yet)

## Notes & open questions

<!--
Any notes, remarks or open questions you have to make about the PR which don't need to go into the final commit message.
-->

Implementation assisted by GPT-5.6 Sol, with a lot of input from me personally.

## Change checklist

- [x] I have performed a self-review of my own code
- [x] I have made corresponding changes to the documentation if necessary (this includes comments as well)
- [x] I have added tests that prove my fix is effective or that my feature works