### PR TITLE
fix: clean up aborted websocket connections

### DIFF
--- a/packages/connection-encrypter-noise/package.json
+++ b/packages/connection-encrypter-noise/package.json
@@ -84,7 +84,7 @@
     "@noble/ciphers": "^2.0.1",
     "@noble/curves": "^2.0.1",
     "@noble/hashes": "^2.0.1",
-    "protons-runtime": "^7.0.0",
+    "protons-runtime": "7.0.0",
     "uint8arraylist": "^3.0.2",
     "uint8arrays": "^6.1.1",
     "wherearewe": "^2.0.1"
@@ -109,7 +109,7 @@
     "mkdirp": "^3.0.1",
     "multiformats": "^14.0.0",
     "p-defer": "^4.0.1",
-    "protons": "^9.0.1",
+    "protons": "9.0.2",
     "sinon": "^22.0.0",
     "sinon-ts": "^2.0.0"
   },

--- a/packages/connection-encrypter-plaintext/package.json
+++ b/packages/connection-encrypter-plaintext/package.json
@@ -50,7 +50,7 @@
     "@libp2p/interface": "^3.3.0",
     "@libp2p/peer-id": "^6.0.15",
     "@libp2p/utils": "^7.4.1",
-    "protons-runtime": "^7.0.0",
+    "protons-runtime": "7.0.0",
     "uint8arraylist": "^3.0.2",
     "uint8arrays": "^6.1.1"
   },
@@ -58,7 +58,7 @@
     "@libp2p/crypto": "^5.1.23",
     "@libp2p/logger": "^6.2.13",
     "aegir": "^48.1.1",
-    "protons": "^9.0.1",
+    "protons": "9.0.2",
     "sinon": "^22.0.0"
   },
   "sideEffects": false

--- a/packages/connection-encrypter-tls/package.json
+++ b/packages/connection-encrypter-tls/package.json
@@ -73,7 +73,7 @@
     "@peculiar/x509": "^2.0.0",
     "asn1js": "^3.0.6",
     "p-event": "^7.0.0",
-    "protons-runtime": "^7.0.0",
+    "protons-runtime": "7.0.0",
     "reflect-metadata": "^0.2.2",
     "uint8arraylist": "^3.0.2",
     "uint8arrays": "^6.1.1"
@@ -81,7 +81,7 @@
   "devDependencies": {
     "@libp2p/logger": "^6.2.13",
     "aegir": "^48.1.1",
-    "protons": "^9.0.1",
+    "protons": "9.0.2",
     "sinon": "^22.0.0",
     "sinon-ts": "^2.0.0"
   },

--- a/packages/crypto/package.json
+++ b/packages/crypto/package.json
@@ -94,7 +94,7 @@
     "@noble/curves": "^2.0.1",
     "@noble/hashes": "^2.0.1",
     "multiformats": "^14.0.0",
-    "protons-runtime": "^7.0.0",
+    "protons-runtime": "7.0.0",
     "uint8arraylist": "^3.0.2",
     "uint8arrays": "^6.1.1"
   },
@@ -103,7 +103,7 @@
     "aegir": "^48.1.1",
     "asn1js": "^3.0.6",
     "benchmark": "^2.1.4",
-    "protons": "^9.0.1"
+    "protons": "9.0.2"
   },
   "browser": {
     "./dist/src/ciphers/aes-gcm.js": "./dist/src/ciphers/aes-gcm.browser.js",

--- a/packages/floodsub/package.json
+++ b/packages/floodsub/package.json
@@ -64,7 +64,7 @@
     "main-event": "^1.0.1",
     "multiformats": "^14.0.0",
     "p-queue": "^9.0.0",
-    "protons-runtime": "^7.0.0",
+    "protons-runtime": "7.0.0",
     "uint8arraylist": "^3.0.2",
     "uint8arrays": "^6.1.1"
   },
@@ -75,7 +75,7 @@
     "aegir": "^48.1.1",
     "delay": "^7.0.0",
     "p-wait-for": "^6.0.0",
-    "protons": "^9.0.1",
+    "protons": "9.0.2",
     "sinon": "^22.0.0",
     "sinon-ts": "^2.0.0"
   },

--- a/packages/gossipsub/package.json
+++ b/packages/gossipsub/package.json
@@ -95,7 +95,7 @@
     "it-pipe": "^3.0.1",
     "it-pushable": "^3.2.3",
     "multiformats": "^14.0.0",
-    "protons-runtime": "^7.0.0",
+    "protons-runtime": "7.0.0",
     "uint8arraylist": "^3.0.2",
     "uint8arrays": "^6.1.1"
   },
@@ -117,7 +117,7 @@
     "p-event": "^7.0.0",
     "p-retry": "^8.0.0",
     "p-wait-for": "^6.0.0",
-    "protons": "^9.0.1",
+    "protons": "9.0.2",
     "sinon": "^22.0.0",
     "sinon-ts": "^2.0.0",
     "time-cache": "^0.3.0"

--- a/packages/interface-compliance-tests/package.json
+++ b/packages/interface-compliance-tests/package.json
@@ -109,13 +109,13 @@
     "p-event": "^7.0.0",
     "p-retry": "^8.0.0",
     "p-wait-for": "^6.0.0",
-    "protons-runtime": "^7.0.0",
+    "protons-runtime": "7.0.0",
     "race-signal": "^2.0.0",
     "sinon": "^22.0.0",
     "uint8arraylist": "^3.0.2",
     "uint8arrays": "^6.1.1"
   },
   "devDependencies": {
-    "protons": "^9.0.1"
+    "protons": "9.0.2"
   }
 }

--- a/packages/interop/package.json
+++ b/packages/interop/package.json
@@ -53,13 +53,13 @@
     "multiformats": "^14.0.0",
     "p-retry": "^8.0.0",
     "p-wait-for": "^6.0.0",
-    "protons-runtime": "^7.0.0",
+    "protons-runtime": "7.0.0",
     "uint8arraylist": "^3.0.2",
     "uint8arrays": "^6.1.1"
   },
   "devDependencies": {
     "aegir": "^48.1.1",
-    "protons": "^9.0.1"
+    "protons": "9.0.2"
   },
   "peerDependencies": {
     "aegir": "^48.1.1"

--- a/packages/kad-dht/package.json
+++ b/packages/kad-dht/package.json
@@ -74,7 +74,7 @@
     "p-defer": "^4.0.1",
     "p-event": "^7.0.0",
     "progress-events": "^1.0.1",
-    "protons-runtime": "^7.0.0",
+    "protons-runtime": "7.0.0",
     "race-signal": "^2.0.0",
     "uint8-varint": "^3.0.0",
     "uint8arraylist": "^3.0.2",
@@ -99,7 +99,7 @@
     "lodash.random": "^3.2.0",
     "lodash.range": "^3.2.0",
     "p-retry": "^8.0.0",
-    "protons": "^9.0.1",
+    "protons": "9.0.2",
     "sinon": "^22.0.0",
     "sinon-ts": "^2.0.0",
     "which": "^7.0.0"

--- a/packages/libp2p-daemon-protocol/package.json
+++ b/packages/libp2p-daemon-protocol/package.json
@@ -67,12 +67,12 @@
   "dependencies": {
     "@libp2p/interface": "^3.3.0",
     "any-signal": "^4.1.1",
-    "protons-runtime": "^7.0.0",
+    "protons-runtime": "7.0.0",
     "uint8arraylist": "^3.0.2",
     "uint8arrays": "^6.1.1"
   },
   "devDependencies": {
     "aegir": "^48.1.1",
-    "protons": "^9.0.1"
+    "protons": "9.0.2"
   }
 }

--- a/packages/peer-record/package.json
+++ b/packages/peer-record/package.json
@@ -54,14 +54,14 @@
     "@libp2p/peer-id": "^6.0.15",
     "@multiformats/multiaddr": "^13.0.3",
     "multiformats": "^14.0.0",
-    "protons-runtime": "^7.0.0",
+    "protons-runtime": "7.0.0",
     "uint8-varint": "^3.0.0",
     "uint8arraylist": "^3.0.2",
     "uint8arrays": "^6.1.1"
   },
   "devDependencies": {
     "aegir": "^48.1.1",
-    "protons": "^9.0.1"
+    "protons": "9.0.2"
   },
   "sideEffects": false
 }

--- a/packages/peer-store/package.json
+++ b/packages/peer-store/package.json
@@ -60,7 +60,7 @@
     "main-event": "^1.0.1",
     "mortice": "^3.3.1",
     "multiformats": "^14.0.0",
-    "protons-runtime": "^7.0.0",
+    "protons-runtime": "7.0.0",
     "uint8arraylist": "^3.0.2",
     "uint8arrays": "^6.1.1"
   },
@@ -73,7 +73,7 @@
     "delay": "^7.0.0",
     "p-defer": "^4.0.1",
     "p-event": "^7.0.0",
-    "protons": "^9.0.1",
+    "protons": "9.0.2",
     "sinon": "^22.0.0"
   },
   "sideEffects": false

--- a/packages/protocol-autonat-v2/package.json
+++ b/packages/protocol-autonat-v2/package.json
@@ -53,7 +53,7 @@
     "@multiformats/multiaddr": "^13.0.3",
     "any-signal": "^4.1.1",
     "main-event": "^1.0.1",
-    "protons-runtime": "^7.0.0",
+    "protons-runtime": "7.0.0",
     "uint8arraylist": "^3.0.2",
     "uint8arrays": "^6.1.1"
   },
@@ -67,7 +67,7 @@
     "it-length-prefixed": "^11.0.1",
     "it-pipe": "^3.0.1",
     "p-retry": "^8.0.0",
-    "protons": "^9.0.1",
+    "protons": "9.0.2",
     "sinon": "^22.0.0",
     "sinon-ts": "^2.0.0"
   },

--- a/packages/protocol-autonat/package.json
+++ b/packages/protocol-autonat/package.json
@@ -55,7 +55,7 @@
     "any-signal": "^4.1.1",
     "main-event": "^1.0.1",
     "multiformats": "^14.0.0",
-    "protons-runtime": "^7.0.0",
+    "protons-runtime": "7.0.0",
     "uint8arraylist": "^3.0.2"
   },
   "devDependencies": {
@@ -67,7 +67,7 @@
     "it-length-prefixed": "^11.0.1",
     "it-pipe": "^3.0.1",
     "p-retry": "^8.0.0",
-    "protons": "^9.0.1",
+    "protons": "9.0.2",
     "sinon": "^22.0.0",
     "sinon-ts": "^2.0.0"
   },

--- a/packages/protocol-dcutr/package.json
+++ b/packages/protocol-dcutr/package.json
@@ -52,12 +52,12 @@
     "@multiformats/multiaddr": "^13.0.3",
     "@multiformats/multiaddr-matcher": "^3.0.2",
     "delay": "^7.0.0",
-    "protons-runtime": "^7.0.0",
+    "protons-runtime": "7.0.0",
     "uint8arraylist": "^3.0.2"
   },
   "devDependencies": {
     "aegir": "^48.1.1",
-    "protons": "^9.0.1",
+    "protons": "9.0.2",
     "sinon": "^22.0.0",
     "sinon-ts": "^2.0.0"
   },

--- a/packages/protocol-fetch/package.json
+++ b/packages/protocol-fetch/package.json
@@ -50,7 +50,7 @@
     "@libp2p/interface-internal": "^3.1.13",
     "@libp2p/utils": "^7.4.1",
     "main-event": "^1.0.1",
-    "protons-runtime": "^7.0.0",
+    "protons-runtime": "7.0.0",
     "uint8arraylist": "^3.0.2",
     "uint8arrays": "^6.1.1"
   },
@@ -58,7 +58,7 @@
     "@libp2p/crypto": "^5.1.23",
     "@libp2p/peer-id": "^6.0.15",
     "aegir": "^48.1.1",
-    "protons": "^9.0.1",
+    "protons": "9.0.2",
     "sinon": "^22.0.0",
     "sinon-ts": "^2.0.0"
   },

--- a/packages/protocol-identify/package.json
+++ b/packages/protocol-identify/package.json
@@ -57,7 +57,7 @@
     "it-drain": "^3.0.10",
     "it-parallel": "^3.0.13",
     "main-event": "^1.0.1",
-    "protons-runtime": "^7.0.0",
+    "protons-runtime": "7.0.0",
     "uint8arraylist": "^3.0.2",
     "uint8arrays": "^6.1.1"
   },
@@ -66,7 +66,7 @@
     "aegir": "^48.1.1",
     "delay": "^7.0.0",
     "it-length-prefixed": "^11.0.1",
-    "protons": "^9.0.1",
+    "protons": "9.0.2",
     "sinon-ts": "^2.0.0"
   },
   "sideEffects": false

--- a/packages/record/package.json
+++ b/packages/record/package.json
@@ -48,7 +48,7 @@
     "doc-check": "aegir doc-check"
   },
   "dependencies": {
-    "protons-runtime": "^7.0.0",
+    "protons-runtime": "7.0.0",
     "uint8arraylist": "^3.0.2",
     "uint8arrays": "^6.1.1"
   },
@@ -58,7 +58,7 @@
     "@types/which": "^3.0.4",
     "aegir": "^48.1.1",
     "multiformats": "^14.0.0",
-    "protons": "^9.0.1"
+    "protons": "9.0.2"
   },
   "sideEffects": false
 }

--- a/packages/record/test/record.spec.ts
+++ b/packages/record/test/record.spec.ts
@@ -2,6 +2,7 @@
 import { expect } from 'aegir/chai'
 import { fromString as uint8ArrayFromString } from 'uint8arrays/from-string'
 import { Libp2pRecord } from '../src/index.ts'
+import { Record } from '../src/record.ts'
 import * as fixture from './fixtures/go-record.ts'
 
 const date = new Date()
@@ -40,6 +41,13 @@ describe('record', () => {
   })
 
   describe('go interop', () => {
+    it('streams the generated record fields', () => {
+      expect([...Record.stream(fixture.serialized)]).to.deep.equal([
+        { field: '$.key', value: uint8ArrayFromString('hello') },
+        { field: '$.value', value: uint8ArrayFromString('world') }
+      ])
+    })
+
     it('no signature', () => {
       const dec = Libp2pRecord.deserialize(fixture.serialized)
       expect(dec).to.have.property('key').eql(uint8ArrayFromString('hello'))

--- a/packages/transport-circuit-relay-v2/package.json
+++ b/packages/transport-circuit-relay-v2/package.json
@@ -60,7 +60,7 @@
     "multiformats": "^14.0.0",
     "nanoid": "^6.0.0",
     "progress-events": "^1.1.0",
-    "protons-runtime": "^7.0.0",
+    "protons-runtime": "7.0.0",
     "retimeable-signal": "^1.0.1",
     "uint8arraylist": "^3.0.2",
     "uint8arrays": "^6.1.1"
@@ -73,7 +73,7 @@
     "it-protobuf-stream": "^3.0.0",
     "p-event": "^7.0.0",
     "p-wait-for": "^6.0.0",
-    "protons": "^9.0.1",
+    "protons": "9.0.2",
     "sinon": "^22.0.0",
     "sinon-ts": "^2.0.0"
   },

--- a/packages/transport-webrtc/package.json
+++ b/packages/transport-webrtc/package.json
@@ -71,7 +71,7 @@
     "p-timeout": "^7.0.0",
     "p-wait-for": "^6.0.0",
     "progress-events": "^1.0.1",
-    "protons-runtime": "^7.0.0",
+    "protons-runtime": "7.0.0",
     "race-signal": "^2.0.0",
     "react-native-webrtc": "^124.0.6",
     "reflect-metadata": "^0.2.2",
@@ -87,7 +87,7 @@
     "datastore-core": "^12.0.1",
     "delay": "^7.0.0",
     "p-retry": "^8.0.0",
-    "protons": "^9.0.1",
+    "protons": "9.0.2",
     "sinon": "^22.0.0",
     "sinon-ts": "^2.0.0",
     "wherearewe": "^2.0.1"

--- a/packages/transport-websockets/src/index.ts
+++ b/packages/transport-websockets/src/index.ts
@@ -146,16 +146,18 @@ class WebSockets implements Transport<WebSocketsDialEvents> {
       options.onProgress?.(new CustomProgressEvent('websockets:open-connection'))
       await pEvent(websocket, 'open', options)
     } catch (err: any) {
+      try {
+        websocket.close()
+      } catch {
+        // Preserve the connection failure if cleanup throws.
+      }
+
       if (options.signal?.aborted) {
         this.metrics?.dialerEvents.increment({ abort: true })
         throw new ConnectionFailedError(`Could not connect to ${uri}`)
       } else {
         this.metrics?.dialerEvents.increment({ error: true })
       }
-
-      try {
-        websocket.close()
-      } catch {}
 
       throw err
     }

--- a/packages/transport-websockets/src/websocket-to-conn.ts
+++ b/packages/transport-websockets/src/websocket-to-conn.ts
@@ -76,7 +76,9 @@ class WebSocketMultiaddrConnection extends AbstractMultiaddrConnection {
   }
 
   sendReset (): void {
-    this.websocket.close(1006) // abnormal closure
+    this.checkBufferedAmountTask.stop()
+    // 1006 describes abnormal closure but is not a valid code to send.
+    this.websocket.close()
   }
 
   async sendClose (options?: AbortOptions): Promise<void> {

--- a/packages/transport-websockets/test/browser.ts
+++ b/packages/transport-websockets/test/browser.ts
@@ -2,6 +2,9 @@ import { defaultLogger } from '@libp2p/logger'
 import { expect } from 'aegir/chai'
 import { TypedEventEmitter } from 'main-event'
 import { webSockets } from '../src/index.ts'
+import { registerWebSocketPollTests } from './websocket-to-conn.ts'
+
+registerWebSocketPollTests()
 
 describe('libp2p-websockets', () => {
   it('.createServer throws in browser', () => {

--- a/packages/transport-websockets/test/node.ts
+++ b/packages/transport-websockets/test/node.ts
@@ -4,6 +4,7 @@
 import { once } from 'node:events'
 import fs from 'node:fs'
 import http from 'node:http'
+import { ConnectionFailedError } from '@libp2p/interface'
 import { defaultLogger } from '@libp2p/logger'
 import { getNetConfig } from '@libp2p/utils'
 import { multiaddr } from '@multiformats/multiaddr'
@@ -39,14 +40,11 @@ describe('WebSocket abort cleanup', () => {
   let server: http.Server
   let sockets: Set<Socket>
   let wss: WebSocketServer
-  let clients: WebSocket[]
   let ma: ReturnType<typeof multiaddr>
   let uri: string
-  const NativeWebSocket = globalThis.WebSocket
 
   beforeEach(async () => {
     sockets = new Set()
-    clients = []
     server = http.createServer()
     wss = new WebSocketServer({ noServer: true })
     server.on('connection', socket => {
@@ -66,12 +64,8 @@ describe('WebSocket abort cleanup', () => {
   })
 
   afterEach(async () => {
-    globalThis.WebSocket = NativeWebSocket
     // Assertions run before fallback fixture teardown, including on the broken
     // implementation. Never leave the test's own failed-dial sockets behind.
-    for (const client of clients) {
-      client.close()
-    }
     for (const client of wss.clients) {
       client.terminate()
     }
@@ -84,45 +78,23 @@ describe('WebSocket abort cleanup', () => {
     ])
   })
 
-  it('closes an aborted opening dial before a delayed handshake can open it', async () => {
+  it('closes an aborted opening dial with a delayed handshake', async () => {
     const ws = webSockets()({ events: new TypedEventEmitter(), logger: defaultLogger() })
     const upgrader = stubInterface<Upgrader>()
     const controller = new AbortController()
     const upgrade = once(server, 'upgrade')
-    let dialing: Promise<Connection>
-
-    // Observe the real native instance without replacing its close or event
-    // behavior. Restore the constructor immediately after dial creates it.
-    globalThis.WebSocket = new Proxy(NativeWebSocket, {
-      construct (target, args) {
-        const client = Reflect.construct(target, args) as WebSocket
-        clients.push(client)
-        return client
-      }
-    })
-    try {
-      dialing = ws.dial(ma, { upgrader, signal: controller.signal })
-    } finally {
-      globalThis.WebSocket = NativeWebSocket
-    }
-    const rejected = expect(dialing).to.eventually.be.rejectedWith('Could not connect')
-    const client = clients[0]
-    const terminal = new Promise<string>(resolve => {
-      client.addEventListener('open', () => resolve('open'), { once: true })
-      client.addEventListener('close', () => resolve('close'), { once: true })
-    })
+    const dialing = ws.dial(ma, { upgrader, signal: controller.signal })
+    const rejected = expect(dialing).to.eventually.be.rejectedWith(ConnectionFailedError, 'Could not connect')
     const [request, socket, head] = await upgrade
     const socketClosed = new Promise<void>(resolve => socket.once('close', () => resolve()))
+    expect(socket.destroyed).to.equal(false)
     controller.abort()
     await rejected
 
-    // A rejected dial must not turn into a live orphan once the peer responds.
+    // A rejected dial must not leave an orphan socket once the peer responds.
     if (!socket.destroyed) {
-      wss.handleUpgrade(request, socket, head, connection => {
-        wss.emit('connection', connection)
-      })
+      wss.handleUpgrade(request, socket, head, () => {})
     }
-    expect(await terminal).to.equal('close')
     await socketClosed
     expect(socket.destroyed).to.equal(true)
     expect(upgrader.upgradeOutbound).to.have.property('callCount', 0)
@@ -130,8 +102,7 @@ describe('WebSocket abort cleanup', () => {
 
   async function assertAbortedSocketCloses (direction: 'inbound' | 'outbound'): Promise<void> {
     const upgrade = once(server, 'upgrade')
-    const client = new NativeWebSocket(uri)
-    clients.push(client)
+    const client = new WebSocket(uri)
     const opened = once(client, 'open')
     const [request, socket, head] = await upgrade
     const serverClient = await new Promise<ServerWebSocket>(resolve => {
@@ -148,9 +119,9 @@ describe('WebSocket abort cleanup', () => {
     const closed = once(websocket, 'close')
     connection.abort(new Error('test abort'))
     expect(connection.status).to.equal('aborted')
-    expect(websocket.readyState).not.to.equal(NativeWebSocket.OPEN)
+    expect(websocket.readyState).not.to.equal(WebSocket.OPEN)
     await closed
-    expect(websocket.readyState).to.equal(NativeWebSocket.CLOSED)
+    expect(websocket.readyState).to.equal(WebSocket.CLOSED)
   }
 
   it('closes the physical outbound WebSocket when its connection is aborted', async () => {

--- a/packages/transport-websockets/test/node.ts
+++ b/packages/transport-websockets/test/node.ts
@@ -1,6 +1,7 @@
 /* eslint-env mocha */
 /* eslint max-nested-callbacks: ["error", 6] */
 
+import { once } from 'node:events'
 import fs from 'node:fs'
 import http from 'node:http'
 import { defaultLogger } from '@libp2p/logger'
@@ -15,9 +16,15 @@ import pWaitFor from 'p-wait-for'
 import Sinon from 'sinon'
 import { stubInterface } from 'sinon-ts'
 import { setGlobalDispatcher, Agent } from 'undici'
+import { WebSocketServer } from 'ws'
 import { webSockets } from '../src/index.ts'
+import { toWebSocket } from '../src/utils.ts'
+import { webSocketToMaConn } from '../src/websocket-to-conn.ts'
+import { registerWebSocketPollTests } from './websocket-to-conn.ts'
 import type { Connection, Libp2pEvents, Listener, Transport, Upgrader, TLSCertificate } from '@libp2p/interface'
+import type { Socket } from 'node:net'
 import type { StubbedInstance } from 'sinon-ts'
+import type { WebSocket as ServerWebSocket } from 'ws'
 
 // allow connecting to self-signed certificates
 setGlobalDispatcher(new Agent({
@@ -25,6 +32,135 @@ setGlobalDispatcher(new Agent({
     rejectUnauthorized: false
   }
 }))
+
+registerWebSocketPollTests()
+
+describe('WebSocket abort cleanup', () => {
+  let server: http.Server
+  let sockets: Set<Socket>
+  let wss: WebSocketServer
+  let clients: WebSocket[]
+  let ma: ReturnType<typeof multiaddr>
+  let uri: string
+  const NativeWebSocket = globalThis.WebSocket
+
+  beforeEach(async () => {
+    sockets = new Set()
+    clients = []
+    server = http.createServer()
+    wss = new WebSocketServer({ noServer: true })
+    server.on('connection', socket => {
+      sockets.add(socket)
+      socket.on('error', () => {})
+      socket.once('close', () => sockets.delete(socket))
+    })
+    const listening = once(server, 'listening')
+    server.listen(0, '127.0.0.1')
+    await listening
+    const address = server.address()
+    if (address == null || typeof address === 'string') {
+      throw new Error('Expected a TCP listen address')
+    }
+    ma = multiaddr(`/ip4/127.0.0.1/tcp/${address.port}/ws`)
+    uri = `ws://127.0.0.1:${address.port}`
+  })
+
+  afterEach(async () => {
+    globalThis.WebSocket = NativeWebSocket
+    // Assertions run before fallback fixture teardown, including on the broken
+    // implementation. Never leave the test's own failed-dial sockets behind.
+    for (const client of clients) {
+      client.close()
+    }
+    for (const client of wss.clients) {
+      client.terminate()
+    }
+    for (const socket of sockets) {
+      socket.destroy()
+    }
+    await Promise.all([
+      new Promise<void>((resolve, reject) => wss.close(error => error != null ? reject(error) : resolve())),
+      new Promise<void>((resolve, reject) => server.close(error => error != null ? reject(error) : resolve()))
+    ])
+  })
+
+  it('closes an aborted opening dial before a delayed handshake can open it', async () => {
+    const ws = webSockets()({ events: new TypedEventEmitter(), logger: defaultLogger() })
+    const upgrader = stubInterface<Upgrader>()
+    const controller = new AbortController()
+    const upgrade = once(server, 'upgrade')
+    let dialing: Promise<Connection>
+
+    // Observe the real native instance without replacing its close or event
+    // behavior. Restore the constructor immediately after dial creates it.
+    globalThis.WebSocket = new Proxy(NativeWebSocket, {
+      construct (target, args) {
+        const client = Reflect.construct(target, args) as WebSocket
+        clients.push(client)
+        return client
+      }
+    })
+    try {
+      dialing = ws.dial(ma, { upgrader, signal: controller.signal })
+    } finally {
+      globalThis.WebSocket = NativeWebSocket
+    }
+    const rejected = expect(dialing).to.eventually.be.rejectedWith('Could not connect')
+    const client = clients[0]
+    const terminal = new Promise<string>(resolve => {
+      client.addEventListener('open', () => resolve('open'), { once: true })
+      client.addEventListener('close', () => resolve('close'), { once: true })
+    })
+    const [request, socket, head] = await upgrade
+    const socketClosed = new Promise<void>(resolve => socket.once('close', () => resolve()))
+    controller.abort()
+    await rejected
+
+    // A rejected dial must not turn into a live orphan once the peer responds.
+    if (!socket.destroyed) {
+      wss.handleUpgrade(request, socket, head, connection => {
+        wss.emit('connection', connection)
+      })
+    }
+    expect(await terminal).to.equal('close')
+    await socketClosed
+    expect(socket.destroyed).to.equal(true)
+    expect(upgrader.upgradeOutbound).to.have.property('callCount', 0)
+  })
+
+  async function assertAbortedSocketCloses (direction: 'inbound' | 'outbound'): Promise<void> {
+    const upgrade = once(server, 'upgrade')
+    const client = new NativeWebSocket(uri)
+    clients.push(client)
+    const opened = once(client, 'open')
+    const [request, socket, head] = await upgrade
+    const serverClient = await new Promise<ServerWebSocket>(resolve => {
+      wss.handleUpgrade(request, socket, head, resolve)
+    })
+    await opened
+    const websocket = direction === 'outbound' ? client : toWebSocket(serverClient)
+    const connection = webSocketToMaConn({
+      websocket,
+      remoteAddr: ma,
+      direction,
+      log: defaultLogger().forComponent('test:websocket-abort')
+    })
+    const closed = once(websocket, 'close')
+    connection.abort(new Error('test abort'))
+    expect(connection.status).to.equal('aborted')
+    expect(websocket.readyState).not.to.equal(NativeWebSocket.OPEN)
+    await closed
+    expect(websocket.readyState).to.equal(NativeWebSocket.CLOSED)
+  }
+
+  it('closes the physical outbound WebSocket when its connection is aborted', async () => {
+    await assertAbortedSocketCloses('outbound')
+  })
+
+  it('closes the physical inbound WebSocket when its connection is aborted', async () => {
+    await assertAbortedSocketCloses('inbound')
+  })
+})
 
 describe('instantiate the transport', () => {
   it('create', () => {

--- a/packages/transport-websockets/test/websocket-to-conn.ts
+++ b/packages/transport-websockets/test/websocket-to-conn.ts
@@ -4,44 +4,28 @@ import { expect } from 'aegir/chai'
 import Sinon from 'sinon'
 import { webSocketToMaConn } from '../src/websocket-to-conn.ts'
 import type { MultiaddrConnection } from '@libp2p/interface'
-import type { SinonFakeTimers } from 'sinon'
-
-// A portable WebSocket contract stub: close validates its code and enters
-// CLOSING, but does not synthesize a close event or discard buffered data.
-class BufferedWebSocket extends EventTarget {
-  readyState = 1
-  bufferedAmount = 2
-  sends = 0
-  closeCodes: Array<number | undefined> = []
-
-  send (): void {
-    this.sends++
-  }
-
-  close (code?: number): void {
-    this.closeCodes.push(code)
-    if (code != null && code !== 1000 && (code < 3000 || code > 4999)) {
-      throw new DOMException('Invalid close code', 'InvalidAccessError')
-    }
-    this.readyState = 2
-  }
-
-  finishClose (): void {
-    this.readyState = 3
-    this.dispatchEvent(Object.assign(new Event('close'), { code: 1000, reason: '', wasClean: true }))
-  }
-}
+import type { SinonFakeTimers, SinonSpy } from 'sinon'
 
 // Explicit registration keeps browser bundlers from removing the shared tests.
 export function registerWebSocketPollTests (): void {
   describe('WebSocket buffered-amount poll ownership', () => {
     let clock: SinonFakeTimers
-    let websocket: BufferedWebSocket
+    let websocket: EventTarget & {
+      bufferedAmount: number
+      send: SinonSpy
+      close: SinonSpy
+    }
     let connection: MultiaddrConnection
 
     beforeEach(() => {
       clock = Sinon.useFakeTimers({ toFake: ['setTimeout', 'clearTimeout'] })
-      websocket = new BufferedWebSocket()
+      // Do not emit close here: the close-event listener would mask missing
+      // immediate poll cancellation. Real socket behavior is covered in node.ts.
+      websocket = Object.assign(new EventTarget(), {
+        bufferedAmount: 2,
+        send: Sinon.spy(),
+        close: Sinon.spy()
+      })
       connection = webSocketToMaConn({
         websocket: websocket as unknown as WebSocket,
         remoteAddr: multiaddr('/ip4/127.0.0.1/tcp/1234/ws'),
@@ -56,7 +40,7 @@ export function registerWebSocketPollTests (): void {
       try {
         // Fallback fixture cleanup is after assertions, including baseline
         // failures. Never let a queued callback rearm after the clock restores.
-        websocket.finishClose()
+        websocket.dispatchEvent(Object.assign(new Event('close'), { code: 1000, reason: '', wasClean: true }))
         await clock.tickAsync(0)
       } finally {
         clock.restore()
@@ -76,9 +60,8 @@ export function registerWebSocketPollTests (): void {
 
       expect(clock.countTimers()).to.equal(0)
       expect(connection.status).to.equal('aborted')
-      expect(websocket.readyState).to.equal(2)
       expect(websocket.bufferedAmount).to.equal(2)
-      expect(websocket.closeCodes).to.deep.equal([undefined])
+      expect(websocket.close.args).to.deep.equal([[]])
       expect(closed.callCount).to.equal(1)
       expect(closed.firstCall.args[0].error).to.equal(error)
       await clock.tickAsync(30)
@@ -94,7 +77,6 @@ export function registerWebSocketPollTests (): void {
       await clock.tickAsync(30)
 
       expect(clock.countTimers()).to.equal(0)
-      expect(websocket.readyState).to.equal(2)
       expect(websocket.bufferedAmount).to.equal(2)
     })
 
@@ -112,8 +94,8 @@ export function registerWebSocketPollTests (): void {
       expect(drained.callCount).to.equal(1)
       expect(clock.countTimers()).to.equal(0)
       expect(connection.send(new Uint8Array([2]))).to.equal(true)
-      expect(websocket.sends).to.equal(2)
-      expect(websocket.closeCodes).to.deep.equal([])
+      expect(websocket.send.callCount).to.equal(2)
+      expect(websocket.close.args).to.deep.equal([])
       expect(connection.status).to.equal('open')
     })
   })

--- a/packages/transport-websockets/test/websocket-to-conn.ts
+++ b/packages/transport-websockets/test/websocket-to-conn.ts
@@ -1,0 +1,120 @@
+import { defaultLogger } from '@libp2p/logger'
+import { multiaddr } from '@multiformats/multiaddr'
+import { expect } from 'aegir/chai'
+import Sinon from 'sinon'
+import { webSocketToMaConn } from '../src/websocket-to-conn.ts'
+import type { MultiaddrConnection } from '@libp2p/interface'
+import type { SinonFakeTimers } from 'sinon'
+
+// A portable WebSocket contract stub: close validates its code and enters
+// CLOSING, but does not synthesize a close event or discard buffered data.
+class BufferedWebSocket extends EventTarget {
+  readyState = 1
+  bufferedAmount = 2
+  sends = 0
+  closeCodes: Array<number | undefined> = []
+
+  send (): void {
+    this.sends++
+  }
+
+  close (code?: number): void {
+    this.closeCodes.push(code)
+    if (code != null && code !== 1000 && (code < 3000 || code > 4999)) {
+      throw new DOMException('Invalid close code', 'InvalidAccessError')
+    }
+    this.readyState = 2
+  }
+
+  finishClose (): void {
+    this.readyState = 3
+    this.dispatchEvent(Object.assign(new Event('close'), { code: 1000, reason: '', wasClean: true }))
+  }
+}
+
+// Explicit registration keeps browser bundlers from removing the shared tests.
+export function registerWebSocketPollTests (): void {
+  describe('WebSocket buffered-amount poll ownership', () => {
+    let clock: SinonFakeTimers
+    let websocket: BufferedWebSocket
+    let connection: MultiaddrConnection
+
+    beforeEach(() => {
+      clock = Sinon.useFakeTimers({ toFake: ['setTimeout', 'clearTimeout'] })
+      websocket = new BufferedWebSocket()
+      connection = webSocketToMaConn({
+        websocket: websocket as unknown as WebSocket,
+        remoteAddr: multiaddr('/ip4/127.0.0.1/tcp/1234/ws'),
+        direction: 'outbound',
+        log: defaultLogger().forComponent('websocket-poll-test'),
+        maxBufferedAmount: 1,
+        bufferedAmountPollInterval: 10
+      })
+    })
+
+    afterEach(async () => {
+      try {
+        // Fallback fixture cleanup is after assertions, including baseline
+        // failures. Never let a queued callback rearm after the clock restores.
+        websocket.finishClose()
+        await clock.tickAsync(0)
+      } finally {
+        clock.restore()
+      }
+    })
+
+    it('stops polling on abort without waiting for the native close event', async () => {
+      const closed = Sinon.spy()
+      const drained = Sinon.spy()
+      connection.addEventListener('close', closed)
+      connection.addEventListener('drain', drained)
+      expect(connection.send(new Uint8Array([1]))).to.equal(false)
+      expect(clock.countTimers()).to.equal(1)
+
+      const error = new Error('controlled abort')
+      connection.abort(error)
+
+      expect(clock.countTimers()).to.equal(0)
+      expect(connection.status).to.equal('aborted')
+      expect(websocket.readyState).to.equal(2)
+      expect(websocket.bufferedAmount).to.equal(2)
+      expect(websocket.closeCodes).to.deep.equal([undefined])
+      expect(closed.callCount).to.equal(1)
+      expect(closed.firstCall.args[0].error).to.equal(error)
+      await clock.tickAsync(30)
+      expect(clock.countTimers()).to.equal(0)
+      expect(drained.callCount).to.equal(0)
+    })
+
+    it('does not rearm a poll already queued when the connection aborts', async () => {
+      expect(connection.send(new Uint8Array([1]))).to.equal(false)
+      clock.tick(10) // The repeating task has queued its promise continuation.
+      connection.abort(new Error('abort queued poll'))
+
+      await clock.tickAsync(30)
+
+      expect(clock.countTimers()).to.equal(0)
+      expect(websocket.readyState).to.equal(2)
+      expect(websocket.bufferedAmount).to.equal(2)
+    })
+
+    it('continues active backpressure polling until data drains', async () => {
+      const drained = Sinon.spy()
+      connection.addEventListener('drain', drained)
+      expect(connection.send(new Uint8Array([1]))).to.equal(false)
+      await clock.tickAsync(10)
+      expect(clock.countTimers()).to.equal(1)
+      expect(drained.callCount).to.equal(0)
+
+      websocket.bufferedAmount = 0
+      await clock.tickAsync(10)
+
+      expect(drained.callCount).to.equal(1)
+      expect(clock.countTimers()).to.equal(0)
+      expect(connection.send(new Uint8Array([2]))).to.equal(true)
+      expect(websocket.sends).to.equal(2)
+      expect(websocket.closeCodes).to.deep.equal([])
+      expect(connection.status).to.equal('open')
+    })
+  })
+}

--- a/packages/utils/package.json
+++ b/packages/utils/package.json
@@ -65,7 +65,7 @@
     "p-defer": "^4.0.1",
     "p-event": "^7.0.0",
     "progress-events": "^1.1.0",
-    "protons-runtime": "^7.0.0",
+    "protons-runtime": "7.0.0",
     "race-signal": "^2.0.0",
     "uint8-varint": "^3.0.0",
     "uint8arraylist": "^3.0.2",


### PR DESCRIPTION
Fix two WebSocket cleanup paths:

- Close the socket when a dial fails or is aborted, before rethrowing the existing error.
- On reset, stop the buffered-amount poller and call `close()` without the invalid reserved code 1006.

Regression tests cover an aborted HTTP upgrade, established native/`ws` sockets, and poller cancellation/backpressure. Against the original source, five regressions fail and one control passes.

Local validation: 35 Node tests; 4 Chromium tests each in main and worker; package-local typecheck and lint. Full monorepo CI remains required.

No public API or timeout changes. Includes the dependency compatibility prerequisite #3628.
