### PR TITLE
fix: preserve canonical floodsub sequence bytes

### DIFF
--- a/packages/connection-encrypter-noise/package.json
+++ b/packages/connection-encrypter-noise/package.json
@@ -84,7 +84,7 @@
     "@noble/ciphers": "^2.0.1",
     "@noble/curves": "^2.0.1",
     "@noble/hashes": "^2.0.1",
-    "protons-runtime": "^7.0.0",
+    "protons-runtime": "7.0.0",
     "uint8arraylist": "^3.0.2",
     "uint8arrays": "^6.1.1",
     "wherearewe": "^2.0.1"
@@ -109,7 +109,7 @@
     "mkdirp": "^3.0.1",
     "multiformats": "^14.0.0",
     "p-defer": "^4.0.1",
-    "protons": "^9.0.1",
+    "protons": "9.0.2",
     "sinon": "^22.0.0",
     "sinon-ts": "^2.0.0"
   },

--- a/packages/connection-encrypter-plaintext/package.json
+++ b/packages/connection-encrypter-plaintext/package.json
@@ -50,7 +50,7 @@
     "@libp2p/interface": "^3.3.0",
     "@libp2p/peer-id": "^6.0.15",
     "@libp2p/utils": "^7.4.1",
-    "protons-runtime": "^7.0.0",
+    "protons-runtime": "7.0.0",
     "uint8arraylist": "^3.0.2",
     "uint8arrays": "^6.1.1"
   },
@@ -58,7 +58,7 @@
     "@libp2p/crypto": "^5.1.23",
     "@libp2p/logger": "^6.2.13",
     "aegir": "^48.1.1",
-    "protons": "^9.0.1",
+    "protons": "9.0.2",
     "sinon": "^22.0.0"
   },
   "sideEffects": false

--- a/packages/connection-encrypter-tls/package.json
+++ b/packages/connection-encrypter-tls/package.json
@@ -73,7 +73,7 @@
     "@peculiar/x509": "^2.0.0",
     "asn1js": "^3.0.6",
     "p-event": "^7.0.0",
-    "protons-runtime": "^7.0.0",
+    "protons-runtime": "7.0.0",
     "reflect-metadata": "^0.2.2",
     "uint8arraylist": "^3.0.2",
     "uint8arrays": "^6.1.1"
@@ -81,7 +81,7 @@
   "devDependencies": {
     "@libp2p/logger": "^6.2.13",
     "aegir": "^48.1.1",
-    "protons": "^9.0.1",
+    "protons": "9.0.2",
     "sinon": "^22.0.0",
     "sinon-ts": "^2.0.0"
   },

--- a/packages/crypto/package.json
+++ b/packages/crypto/package.json
@@ -94,7 +94,7 @@
     "@noble/curves": "^2.0.1",
     "@noble/hashes": "^2.0.1",
     "multiformats": "^14.0.0",
-    "protons-runtime": "^7.0.0",
+    "protons-runtime": "7.0.0",
     "uint8arraylist": "^3.0.2",
     "uint8arrays": "^6.1.1"
   },
@@ -103,7 +103,7 @@
     "aegir": "^48.1.1",
     "asn1js": "^3.0.6",
     "benchmark": "^2.1.4",
-    "protons": "^9.0.1"
+    "protons": "9.0.2"
   },
   "browser": {
     "./dist/src/ciphers/aes-gcm.js": "./dist/src/ciphers/aes-gcm.browser.js",

--- a/packages/floodsub/package.json
+++ b/packages/floodsub/package.json
@@ -64,7 +64,7 @@
     "main-event": "^1.0.1",
     "multiformats": "^14.0.0",
     "p-queue": "^9.0.0",
-    "protons-runtime": "^7.0.0",
+    "protons-runtime": "7.0.0",
     "uint8arraylist": "^3.0.2",
     "uint8arrays": "^6.1.1"
   },
@@ -75,7 +75,7 @@
     "aegir": "^48.1.1",
     "delay": "^7.0.0",
     "p-wait-for": "^6.0.0",
-    "protons": "^9.0.1",
+    "protons": "9.0.2",
     "sinon": "^22.0.0",
     "sinon-ts": "^2.0.0"
   },

--- a/packages/floodsub/src/utils.ts
+++ b/packages/floodsub/src/utils.ts
@@ -122,10 +122,13 @@ export const toRpcMessage = (message: Message): PubSubRPCMessage => {
       throw new InvalidMessageError('RPC message sequence number must be a uint64')
     }
 
+    const sequenceNumber = new Uint8Array(8)
+    new DataView(sequenceNumber.buffer).setBigUint64(0, message.sequenceNumber, false)
+
     return {
       from: message.from.toMultihash().bytes,
       data: message.data,
-      sequenceNumber: uint8ArrayFromString(message.sequenceNumber.toString(16).padStart(16, '0'), 'base16'),
+      sequenceNumber,
       topic: message.topic,
       signature: message.signature,
 

--- a/packages/floodsub/src/utils.ts
+++ b/packages/floodsub/src/utils.ts
@@ -91,6 +91,11 @@ export const toMessage = async (message: PubSubRPCMessage): Promise<Message> => 
     }
   }
 
+  // Reject non-canonical signed bytes before converting the sequence to bigint.
+  if (message.sequenceNumber?.length !== 8) {
+    throw new InvalidMessageError('RPC message sequence number must be 8 bytes')
+  }
+
   const from = peerIdFromMultihash(Digest.decode(message.from))
   const key = message.key ?? from.publicKey
 
@@ -102,7 +107,7 @@ export const toMessage = async (message: PubSubRPCMessage): Promise<Message> => 
     type: 'signed',
     from,
     topic: message.topic ?? '',
-    sequenceNumber: bigIntFromBytes(message.sequenceNumber ?? new Uint8Array(0)),
+    sequenceNumber: bigIntFromBytes(message.sequenceNumber),
     data: message.data ?? new Uint8Array(0),
     signature: message.signature ?? new Uint8Array(0),
     key: key instanceof Uint8Array ? publicKeyFromProtobuf(key) : key
@@ -113,10 +118,14 @@ export const toMessage = async (message: PubSubRPCMessage): Promise<Message> => 
 
 export const toRpcMessage = (message: Message): PubSubRPCMessage => {
   if (message.type === 'signed') {
+    if (message.sequenceNumber < 0n || message.sequenceNumber > 0xffffffffffffffffn) {
+      throw new InvalidMessageError('RPC message sequence number must be a uint64')
+    }
+
     return {
       from: message.from.toMultihash().bytes,
       data: message.data,
-      sequenceNumber: bigIntToBytes(message.sequenceNumber),
+      sequenceNumber: uint8ArrayFromString(message.sequenceNumber.toString(16).padStart(16, '0'), 'base16'),
       topic: message.topic,
       signature: message.signature,
 

--- a/packages/floodsub/test/sign.spec.ts
+++ b/packages/floodsub/test/sign.spec.ts
@@ -1,4 +1,5 @@
-import { generateKeyPair } from '@libp2p/crypto/keys'
+import { generateKeyPair, publicKeyToProtobuf } from '@libp2p/crypto/keys'
+import { InvalidMessageError } from '@libp2p/interface'
 import { peerIdFromMultihash, peerIdFromPrivateKey } from '@libp2p/peer-id'
 import { expect } from 'aegir/chai'
 import { concat as uint8ArrayConcat } from 'uint8arrays/concat'
@@ -9,7 +10,7 @@ import {
   SignPrefix,
   verifySignature
 } from '../src/sign.ts'
-import { randomSeqno, toRpcMessage } from '../src/utils.ts'
+import { randomSeqno, toMessage, toRpcMessage } from '../src/utils.ts'
 import type { PubSubRPCMessage } from '../src/floodsub.ts'
 import type { Message, SignedMessage } from '../src/index.ts'
 import type { PeerId, PrivateKey } from '@libp2p/interface'
@@ -25,6 +26,69 @@ describe('message signing', () => {
   before(async () => {
     privateKey = await generateKeyPair('Ed25519')
     peerId = peerIdFromPrivateKey(privateKey)
+  })
+
+  it('preserves leading-zero sequence bytes across signing and wire roundtrips', async () => {
+    const sequenceNumber = 0x0001020304050607n
+    const rpc = {
+      from: peerId.toMultihash().bytes,
+      data: uint8ArrayFromString('hello'),
+      topic: 'test-topic',
+      sequenceNumber: Uint8Array.of(0, 1, 2, 3, 4, 5, 6, 7)
+    }
+    // Sign explicit wire bytes independently of toRpcMessage.
+    const signature = await privateKey.sign(uint8ArrayConcat([SignPrefix, encodeMessage(rpc)]))
+    const signed = await signMessage(privateKey, {
+      from: peerId,
+      topic: rpc.topic,
+      data: rpc.data,
+      sequenceNumber
+    }, encodeMessage)
+    expect(signed.signature).to.equalBytes(signature)
+
+    const wire = encodeMessage({ ...rpc, signature, key: publicKeyToProtobuf(privateKey.publicKey) })
+    const received = await toMessage(RPC.Message.decode(wire))
+    if (received.type !== 'signed') {
+      throw new Error('Expected a signed message')
+    }
+
+    expect(received.sequenceNumber).to.equal(sequenceNumber)
+    await expect(verifySignature(received, encodeMessage)).to.eventually.equal(true)
+    expect(encodeMessage(toRpcMessage(received))).to.equalBytes(wire)
+  })
+
+  it('rejects changed sequence widths even with a valid canonical signature', async () => {
+    const signed = await signMessage(privateKey, {
+      from: peerId,
+      topic: 'test-topic',
+      data: uint8ArrayFromString('hello'),
+      sequenceNumber: 1n
+    }, encodeMessage)
+
+    for (const sequenceNumber of [
+      new Uint8Array(),
+      Uint8Array.of(1),
+      Uint8Array.of(0, 0, 0, 0, 0, 0, 1),
+      Uint8Array.of(0, 0, 0, 0, 0, 0, 0, 0, 1)
+    ]) {
+      await expect(toMessage({ ...toRpcMessage(signed), sequenceNumber }))
+        .to.be.rejectedWith(InvalidMessageError, 'RPC message sequence number must be 8 bytes')
+    }
+  })
+
+  it('rejects legacy short-width sequence numbers even when their signature is valid', async () => {
+    const rpc: PubSubRPCMessage = {
+      from: peerId.toMultihash().bytes,
+      data: uint8ArrayFromString('hello'),
+      topic: 'test-topic',
+      sequenceNumber: Uint8Array.of(1)
+    }
+    const bytes = uint8ArrayConcat([SignPrefix, encodeMessage(rpc)])
+    const signature = await privateKey.sign(bytes)
+    expect(await privateKey.publicKey.verify(bytes, signature)).to.equal(true)
+
+    await expect(toMessage({ ...rpc, signature }))
+      .to.be.rejectedWith(InvalidMessageError, 'RPC message sequence number must be 8 bytes')
   })
 
   it('should be able to sign and verify a message', async () => {

--- a/packages/floodsub/test/utils.spec.ts
+++ b/packages/floodsub/test/utils.spec.ts
@@ -1,9 +1,11 @@
 import { generateKeyPair, publicKeyToProtobuf } from '@libp2p/crypto/keys'
+import { InvalidMessageError } from '@libp2p/interface'
 import { peerIdFromPrivateKey, peerIdFromString } from '@libp2p/peer-id'
 import { expect } from 'aegir/chai'
+import { fromString as uint8ArrayFromString } from 'uint8arrays/from-string'
 import * as utils from '../src/utils.ts'
 import type { PubSubRPCMessage } from '../src/floodsub.ts'
-import type { Message } from '../src/index.ts'
+import type { Message, SignedMessage } from '../src/index.ts'
 
 describe('utils', () => {
   it('randomSeqno', () => {
@@ -64,19 +66,48 @@ describe('utils', () => {
       from: edPeer.toMultihash().bytes,
       topic: '',
       data: new Uint8Array(),
-      sequenceNumber: utils.bigIntToBytes(1n),
+      sequenceNumber: Uint8Array.of(0, 0, 0, 0, 0, 0, 0, 1),
       signature: new Uint8Array(),
       key: publicKeyToProtobuf(edPeer.publicKey)
     }, {
       from: rsaPeer.toMultihash().bytes,
       topic: '',
       data: new Uint8Array(),
-      sequenceNumber: utils.bigIntToBytes(1n),
+      sequenceNumber: Uint8Array.of(0, 0, 0, 0, 0, 0, 0, 1),
       signature: new Uint8Array(),
       key: publicKeyToProtobuf(rsaKey.publicKey)
     }]
     for (let i = 0; i < m.length; i++) {
       expect(utils.toRpcMessage(m[i])).to.deep.equal(expected[i])
+    }
+  })
+
+  it('encodes sequence numbers as uint64 big-endian bytes without truncation', async () => {
+    const privateKey = await generateKeyPair('Ed25519')
+    const message: SignedMessage = {
+      type: 'signed',
+      from: peerIdFromPrivateKey(privateKey),
+      topic: '',
+      data: new Uint8Array(),
+      sequenceNumber: 0n,
+      signature: new Uint8Array(),
+      key: privateKey.publicKey
+    }
+
+    for (const [sequenceNumber, bytes] of [
+      [0n, '0000000000000000'],
+      [1n, '0000000000000001'],
+      [0x0001020304050607n, '0001020304050607'],
+      [0x0101020304050607n, '0101020304050607'],
+      [0xffffffffffffffffn, 'ffffffffffffffff']
+    ] as const) {
+      expect(utils.toRpcMessage({ ...message, sequenceNumber }).sequenceNumber)
+        .to.equalBytes(uint8ArrayFromString(bytes, 'base16'))
+    }
+
+    for (const sequenceNumber of [-1n, 0x10000000000000000n]) {
+      expect(() => utils.toRpcMessage({ ...message, sequenceNumber }))
+        .to.throw(InvalidMessageError, 'RPC message sequence number must be a uint64')
     }
   })
 
@@ -107,21 +138,21 @@ describe('utils', () => {
         from: secp256k1Peer.toMultihash().bytes,
         topic: 'test',
         data: new Uint8Array(0),
-        sequenceNumber: utils.bigIntToBytes(1n),
+        sequenceNumber: Uint8Array.of(0, 0, 0, 0, 0, 0, 0, 1),
         signature: new Uint8Array(0)
       },
       {
         from: peerIdFromString('QmPNdSYk5Rfpo5euNqwtyizzmKXMNHdXeLjTQhcN4yfX22').toMultihash().bytes,
         topic: 'test',
         data: new Uint8Array(0),
-        sequenceNumber: utils.bigIntToBytes(1n),
+        sequenceNumber: Uint8Array.of(0, 0, 0, 0, 0, 0, 0, 1),
         signature: new Uint8Array(0)
       },
       {
         from: dummyPeerID.toMultihash().bytes,
         topic: 'test',
         data: new Uint8Array(0),
-        sequenceNumber: utils.bigIntToBytes(1n),
+        sequenceNumber: Uint8Array.of(0, 0, 0, 0, 0, 0, 0, 1),
         signature: new Uint8Array(0),
         key: publicKeyToProtobuf(dummyKeyPair.publicKey)
       },
@@ -129,7 +160,7 @@ describe('utils', () => {
         from: (peerIdFromPrivateKey(await generateKeyPair('Ed25519'))).toMultihash().bytes,
         topic: 'test',
         data: new Uint8Array(0),
-        sequenceNumber: utils.bigIntToBytes(1n),
+        sequenceNumber: Uint8Array.of(0, 0, 0, 0, 0, 0, 0, 1),
         signature: new Uint8Array(0)
       }
     ]

--- a/packages/gossipsub/package.json
+++ b/packages/gossipsub/package.json
@@ -95,7 +95,7 @@
     "it-pipe": "^3.0.1",
     "it-pushable": "^3.2.3",
     "multiformats": "^14.0.0",
-    "protons-runtime": "^7.0.0",
+    "protons-runtime": "7.0.0",
     "uint8arraylist": "^3.0.2",
     "uint8arrays": "^6.1.1"
   },
@@ -117,7 +117,7 @@
     "p-event": "^7.0.0",
     "p-retry": "^8.0.0",
     "p-wait-for": "^6.0.0",
-    "protons": "^9.0.1",
+    "protons": "9.0.2",
     "sinon": "^22.0.0",
     "sinon-ts": "^2.0.0",
     "time-cache": "^0.3.0"

--- a/packages/interface-compliance-tests/package.json
+++ b/packages/interface-compliance-tests/package.json
@@ -109,13 +109,13 @@
     "p-event": "^7.0.0",
     "p-retry": "^8.0.0",
     "p-wait-for": "^6.0.0",
-    "protons-runtime": "^7.0.0",
+    "protons-runtime": "7.0.0",
     "race-signal": "^2.0.0",
     "sinon": "^22.0.0",
     "uint8arraylist": "^3.0.2",
     "uint8arrays": "^6.1.1"
   },
   "devDependencies": {
-    "protons": "^9.0.1"
+    "protons": "9.0.2"
   }
 }

--- a/packages/interop/package.json
+++ b/packages/interop/package.json
@@ -53,13 +53,13 @@
     "multiformats": "^14.0.0",
     "p-retry": "^8.0.0",
     "p-wait-for": "^6.0.0",
-    "protons-runtime": "^7.0.0",
+    "protons-runtime": "7.0.0",
     "uint8arraylist": "^3.0.2",
     "uint8arrays": "^6.1.1"
   },
   "devDependencies": {
     "aegir": "^48.1.1",
-    "protons": "^9.0.1"
+    "protons": "9.0.2"
   },
   "peerDependencies": {
     "aegir": "^48.1.1"

--- a/packages/kad-dht/package.json
+++ b/packages/kad-dht/package.json
@@ -74,7 +74,7 @@
     "p-defer": "^4.0.1",
     "p-event": "^7.0.0",
     "progress-events": "^1.0.1",
-    "protons-runtime": "^7.0.0",
+    "protons-runtime": "7.0.0",
     "race-signal": "^2.0.0",
     "uint8-varint": "^3.0.0",
     "uint8arraylist": "^3.0.2",
@@ -99,7 +99,7 @@
     "lodash.random": "^3.2.0",
     "lodash.range": "^3.2.0",
     "p-retry": "^8.0.0",
-    "protons": "^9.0.1",
+    "protons": "9.0.2",
     "sinon": "^22.0.0",
     "sinon-ts": "^2.0.0",
     "which": "^7.0.0"

--- a/packages/libp2p-daemon-protocol/package.json
+++ b/packages/libp2p-daemon-protocol/package.json
@@ -67,12 +67,12 @@
   "dependencies": {
     "@libp2p/interface": "^3.3.0",
     "any-signal": "^4.1.1",
-    "protons-runtime": "^7.0.0",
+    "protons-runtime": "7.0.0",
     "uint8arraylist": "^3.0.2",
     "uint8arrays": "^6.1.1"
   },
   "devDependencies": {
     "aegir": "^48.1.1",
-    "protons": "^9.0.1"
+    "protons": "9.0.2"
   }
 }

--- a/packages/peer-record/package.json
+++ b/packages/peer-record/package.json
@@ -54,14 +54,14 @@
     "@libp2p/peer-id": "^6.0.15",
     "@multiformats/multiaddr": "^13.0.3",
     "multiformats": "^14.0.0",
-    "protons-runtime": "^7.0.0",
+    "protons-runtime": "7.0.0",
     "uint8-varint": "^3.0.0",
     "uint8arraylist": "^3.0.2",
     "uint8arrays": "^6.1.1"
   },
   "devDependencies": {
     "aegir": "^48.1.1",
-    "protons": "^9.0.1"
+    "protons": "9.0.2"
   },
   "sideEffects": false
 }

--- a/packages/peer-store/package.json
+++ b/packages/peer-store/package.json
@@ -60,7 +60,7 @@
     "main-event": "^1.0.1",
     "mortice": "^3.3.1",
     "multiformats": "^14.0.0",
-    "protons-runtime": "^7.0.0",
+    "protons-runtime": "7.0.0",
     "uint8arraylist": "^3.0.2",
     "uint8arrays": "^6.1.1"
   },
@@ -73,7 +73,7 @@
     "delay": "^7.0.0",
     "p-defer": "^4.0.1",
     "p-event": "^7.0.0",
-    "protons": "^9.0.1",
+    "protons": "9.0.2",
     "sinon": "^22.0.0"
   },
   "sideEffects": false

--- a/packages/protocol-autonat-v2/package.json
+++ b/packages/protocol-autonat-v2/package.json
@@ -53,7 +53,7 @@
     "@multiformats/multiaddr": "^13.0.3",
     "any-signal": "^4.1.1",
     "main-event": "^1.0.1",
-    "protons-runtime": "^7.0.0",
+    "protons-runtime": "7.0.0",
     "uint8arraylist": "^3.0.2",
     "uint8arrays": "^6.1.1"
   },
@@ -67,7 +67,7 @@
     "it-length-prefixed": "^11.0.1",
     "it-pipe": "^3.0.1",
     "p-retry": "^8.0.0",
-    "protons": "^9.0.1",
+    "protons": "9.0.2",
     "sinon": "^22.0.0",
     "sinon-ts": "^2.0.0"
   },

--- a/packages/protocol-autonat/package.json
+++ b/packages/protocol-autonat/package.json
@@ -55,7 +55,7 @@
     "any-signal": "^4.1.1",
     "main-event": "^1.0.1",
     "multiformats": "^14.0.0",
-    "protons-runtime": "^7.0.0",
+    "protons-runtime": "7.0.0",
     "uint8arraylist": "^3.0.2"
   },
   "devDependencies": {
@@ -67,7 +67,7 @@
     "it-length-prefixed": "^11.0.1",
     "it-pipe": "^3.0.1",
     "p-retry": "^8.0.0",
-    "protons": "^9.0.1",
+    "protons": "9.0.2",
     "sinon": "^22.0.0",
     "sinon-ts": "^2.0.0"
   },

--- a/packages/protocol-dcutr/package.json
+++ b/packages/protocol-dcutr/package.json
@@ -52,12 +52,12 @@
     "@multiformats/multiaddr": "^13.0.3",
     "@multiformats/multiaddr-matcher": "^3.0.2",
     "delay": "^7.0.0",
-    "protons-runtime": "^7.0.0",
+    "protons-runtime": "7.0.0",
     "uint8arraylist": "^3.0.2"
   },
   "devDependencies": {
     "aegir": "^48.1.1",
-    "protons": "^9.0.1",
+    "protons": "9.0.2",
     "sinon": "^22.0.0",
     "sinon-ts": "^2.0.0"
   },

--- a/packages/protocol-fetch/package.json
+++ b/packages/protocol-fetch/package.json
@@ -50,7 +50,7 @@
     "@libp2p/interface-internal": "^3.1.13",
     "@libp2p/utils": "^7.4.1",
     "main-event": "^1.0.1",
-    "protons-runtime": "^7.0.0",
+    "protons-runtime": "7.0.0",
     "uint8arraylist": "^3.0.2",
     "uint8arrays": "^6.1.1"
   },
@@ -58,7 +58,7 @@
     "@libp2p/crypto": "^5.1.23",
     "@libp2p/peer-id": "^6.0.15",
     "aegir": "^48.1.1",
-    "protons": "^9.0.1",
+    "protons": "9.0.2",
     "sinon": "^22.0.0",
     "sinon-ts": "^2.0.0"
   },

--- a/packages/protocol-identify/package.json
+++ b/packages/protocol-identify/package.json
@@ -57,7 +57,7 @@
     "it-drain": "^3.0.10",
     "it-parallel": "^3.0.13",
     "main-event": "^1.0.1",
-    "protons-runtime": "^7.0.0",
+    "protons-runtime": "7.0.0",
     "uint8arraylist": "^3.0.2",
     "uint8arrays": "^6.1.1"
   },
@@ -66,7 +66,7 @@
     "aegir": "^48.1.1",
     "delay": "^7.0.0",
     "it-length-prefixed": "^11.0.1",
-    "protons": "^9.0.1",
+    "protons": "9.0.2",
     "sinon-ts": "^2.0.0"
   },
   "sideEffects": false

--- a/packages/record/package.json
+++ b/packages/record/package.json
@@ -48,7 +48,7 @@
     "doc-check": "aegir doc-check"
   },
   "dependencies": {
-    "protons-runtime": "^7.0.0",
+    "protons-runtime": "7.0.0",
     "uint8arraylist": "^3.0.2",
     "uint8arrays": "^6.1.1"
   },
@@ -58,7 +58,7 @@
     "@types/which": "^3.0.4",
     "aegir": "^48.1.1",
     "multiformats": "^14.0.0",
-    "protons": "^9.0.1"
+    "protons": "9.0.2"
   },
   "sideEffects": false
 }

--- a/packages/record/test/record.spec.ts
+++ b/packages/record/test/record.spec.ts
@@ -2,6 +2,7 @@
 import { expect } from 'aegir/chai'
 import { fromString as uint8ArrayFromString } from 'uint8arrays/from-string'
 import { Libp2pRecord } from '../src/index.ts'
+import { Record } from '../src/record.ts'
 import * as fixture from './fixtures/go-record.ts'
 
 const date = new Date()
@@ -40,6 +41,13 @@ describe('record', () => {
   })
 
   describe('go interop', () => {
+    it('streams the generated record fields', () => {
+      expect([...Record.stream(fixture.serialized)]).to.deep.equal([
+        { field: '$.key', value: uint8ArrayFromString('hello') },
+        { field: '$.value', value: uint8ArrayFromString('world') }
+      ])
+    })
+
     it('no signature', () => {
       const dec = Libp2pRecord.deserialize(fixture.serialized)
       expect(dec).to.have.property('key').eql(uint8ArrayFromString('hello'))

--- a/packages/transport-circuit-relay-v2/package.json
+++ b/packages/transport-circuit-relay-v2/package.json
@@ -60,7 +60,7 @@
     "multiformats": "^14.0.0",
     "nanoid": "^6.0.0",
     "progress-events": "^1.1.0",
-    "protons-runtime": "^7.0.0",
+    "protons-runtime": "7.0.0",
     "retimeable-signal": "^1.0.1",
     "uint8arraylist": "^3.0.2",
     "uint8arrays": "^6.1.1"
@@ -73,7 +73,7 @@
     "it-protobuf-stream": "^3.0.0",
     "p-event": "^7.0.0",
     "p-wait-for": "^6.0.0",
-    "protons": "^9.0.1",
+    "protons": "9.0.2",
     "sinon": "^22.0.0",
     "sinon-ts": "^2.0.0"
   },

--- a/packages/transport-webrtc/package.json
+++ b/packages/transport-webrtc/package.json
@@ -71,7 +71,7 @@
     "p-timeout": "^7.0.0",
     "p-wait-for": "^6.0.0",
     "progress-events": "^1.0.1",
-    "protons-runtime": "^7.0.0",
+    "protons-runtime": "7.0.0",
     "race-signal": "^2.0.0",
     "react-native-webrtc": "^124.0.6",
     "reflect-metadata": "^0.2.2",
@@ -87,7 +87,7 @@
     "datastore-core": "^12.0.1",
     "delay": "^7.0.0",
     "p-retry": "^8.0.0",
-    "protons": "^9.0.1",
+    "protons": "9.0.2",
     "sinon": "^22.0.0",
     "sinon-ts": "^2.0.0",
     "wherearewe": "^2.0.1"

--- a/packages/utils/package.json
+++ b/packages/utils/package.json
@@ -65,7 +65,7 @@
     "p-defer": "^4.0.1",
     "p-event": "^7.0.0",
     "progress-events": "^1.1.0",
-    "protons-runtime": "^7.0.0",
+    "protons-runtime": "7.0.0",
     "race-signal": "^2.0.0",
     "uint8-varint": "^3.0.0",
     "uint8arraylist": "^3.0.2",


### PR DESCRIPTION
Floodsub loses leading zero bytes when converting signed sequence numbers through bigint. This changes the signing bytes and causes verification failures.

Encode signed sequences as exactly eight big-endian bytes using `DataView`; reject incoming non-eight-byte sequences before conversion and outgoing values outside uint64.

**Compatibility:** legacy short-width signed messages are rejected. Old receivers still cannot verify canonical leading-zero sequences; both peers need the fix for those values. No fallback verifier is added. Unsigned messages, message IDs, and random-sequence generation are unchanged.

Tests cover literal byte vectors, uint64 bounds, independently signed leading-zero messages, exact round trips, and valid legacy signatures. Local focused suites: 22 passing in Node and Firefox; original source fails five assertions. Package-local typecheck and lint pass.

Draft pending compatibility review and full CI. Includes prerequisite #3628; the separate lifecycle-test failure is addressed in #3627.
