### PR TITLE
fix: pin protons to the generated codec API

### DIFF
--- a/packages/connection-encrypter-noise/package.json
+++ b/packages/connection-encrypter-noise/package.json
@@ -84,7 +84,7 @@
     "@noble/ciphers": "^2.0.1",
     "@noble/curves": "^2.0.1",
     "@noble/hashes": "^2.0.1",
-    "protons-runtime": "^7.0.0",
+    "protons-runtime": "7.0.0",
     "uint8arraylist": "^3.0.2",
     "uint8arrays": "^6.1.1",
     "wherearewe": "^2.0.1"
@@ -109,7 +109,7 @@
     "mkdirp": "^3.0.1",
     "multiformats": "^14.0.0",
     "p-defer": "^4.0.1",
-    "protons": "^9.0.1",
+    "protons": "9.0.2",
     "sinon": "^22.0.0",
     "sinon-ts": "^2.0.0"
   },

--- a/packages/connection-encrypter-plaintext/package.json
+++ b/packages/connection-encrypter-plaintext/package.json
@@ -50,7 +50,7 @@
     "@libp2p/interface": "^3.3.0",
     "@libp2p/peer-id": "^6.0.15",
     "@libp2p/utils": "^7.4.1",
-    "protons-runtime": "^7.0.0",
+    "protons-runtime": "7.0.0",
     "uint8arraylist": "^3.0.2",
     "uint8arrays": "^6.1.1"
   },
@@ -58,7 +58,7 @@
     "@libp2p/crypto": "^5.1.23",
     "@libp2p/logger": "^6.2.13",
     "aegir": "^48.1.1",
-    "protons": "^9.0.1",
+    "protons": "9.0.2",
     "sinon": "^22.0.0"
   },
   "sideEffects": false

--- a/packages/connection-encrypter-tls/package.json
+++ b/packages/connection-encrypter-tls/package.json
@@ -73,7 +73,7 @@
     "@peculiar/x509": "^2.0.0",
     "asn1js": "^3.0.6",
     "p-event": "^7.0.0",
-    "protons-runtime": "^7.0.0",
+    "protons-runtime": "7.0.0",
     "reflect-metadata": "^0.2.2",
     "uint8arraylist": "^3.0.2",
     "uint8arrays": "^6.1.1"
@@ -81,7 +81,7 @@
   "devDependencies": {
     "@libp2p/logger": "^6.2.13",
     "aegir": "^48.1.1",
-    "protons": "^9.0.1",
+    "protons": "9.0.2",
     "sinon": "^22.0.0",
     "sinon-ts": "^2.0.0"
   },

--- a/packages/crypto/package.json
+++ b/packages/crypto/package.json
@@ -94,7 +94,7 @@
     "@noble/curves": "^2.0.1",
     "@noble/hashes": "^2.0.1",
     "multiformats": "^14.0.0",
-    "protons-runtime": "^7.0.0",
+    "protons-runtime": "7.0.0",
     "uint8arraylist": "^3.0.2",
     "uint8arrays": "^6.1.1"
   },
@@ -103,7 +103,7 @@
     "aegir": "^48.1.1",
     "asn1js": "^3.0.6",
     "benchmark": "^2.1.4",
-    "protons": "^9.0.1"
+    "protons": "9.0.2"
   },
   "browser": {
     "./dist/src/ciphers/aes-gcm.js": "./dist/src/ciphers/aes-gcm.browser.js",

--- a/packages/floodsub/package.json
+++ b/packages/floodsub/package.json
@@ -64,7 +64,7 @@
     "main-event": "^1.0.1",
     "multiformats": "^14.0.0",
     "p-queue": "^9.0.0",
-    "protons-runtime": "^7.0.0",
+    "protons-runtime": "7.0.0",
     "uint8arraylist": "^3.0.2",
     "uint8arrays": "^6.1.1"
   },
@@ -75,7 +75,7 @@
     "aegir": "^48.1.1",
     "delay": "^7.0.0",
     "p-wait-for": "^6.0.0",
-    "protons": "^9.0.1",
+    "protons": "9.0.2",
     "sinon": "^22.0.0",
     "sinon-ts": "^2.0.0"
   },

--- a/packages/gossipsub/package.json
+++ b/packages/gossipsub/package.json
@@ -95,7 +95,7 @@
     "it-pipe": "^3.0.1",
     "it-pushable": "^3.2.3",
     "multiformats": "^14.0.0",
-    "protons-runtime": "^7.0.0",
+    "protons-runtime": "7.0.0",
     "uint8arraylist": "^3.0.2",
     "uint8arrays": "^6.1.1"
   },
@@ -117,7 +117,7 @@
     "p-event": "^7.0.0",
     "p-retry": "^8.0.0",
     "p-wait-for": "^6.0.0",
-    "protons": "^9.0.1",
+    "protons": "9.0.2",
     "sinon": "^22.0.0",
     "sinon-ts": "^2.0.0",
     "time-cache": "^0.3.0"

--- a/packages/interface-compliance-tests/package.json
+++ b/packages/interface-compliance-tests/package.json
@@ -109,13 +109,13 @@
     "p-event": "^7.0.0",
     "p-retry": "^8.0.0",
     "p-wait-for": "^6.0.0",
-    "protons-runtime": "^7.0.0",
+    "protons-runtime": "7.0.0",
     "race-signal": "^2.0.0",
     "sinon": "^22.0.0",
     "uint8arraylist": "^3.0.2",
     "uint8arrays": "^6.1.1"
   },
   "devDependencies": {
-    "protons": "^9.0.1"
+    "protons": "9.0.2"
   }
 }

--- a/packages/interop/package.json
+++ b/packages/interop/package.json
@@ -53,13 +53,13 @@
     "multiformats": "^14.0.0",
     "p-retry": "^8.0.0",
     "p-wait-for": "^6.0.0",
-    "protons-runtime": "^7.0.0",
+    "protons-runtime": "7.0.0",
     "uint8arraylist": "^3.0.2",
     "uint8arrays": "^6.1.1"
   },
   "devDependencies": {
     "aegir": "^48.1.1",
-    "protons": "^9.0.1"
+    "protons": "9.0.2"
   },
   "peerDependencies": {
     "aegir": "^48.1.1"

--- a/packages/kad-dht/package.json
+++ b/packages/kad-dht/package.json
@@ -74,7 +74,7 @@
     "p-defer": "^4.0.1",
     "p-event": "^7.0.0",
     "progress-events": "^1.0.1",
-    "protons-runtime": "^7.0.0",
+    "protons-runtime": "7.0.0",
     "race-signal": "^2.0.0",
     "uint8-varint": "^3.0.0",
     "uint8arraylist": "^3.0.2",
@@ -99,7 +99,7 @@
     "lodash.random": "^3.2.0",
     "lodash.range": "^3.2.0",
     "p-retry": "^8.0.0",
-    "protons": "^9.0.1",
+    "protons": "9.0.2",
     "sinon": "^22.0.0",
     "sinon-ts": "^2.0.0",
     "which": "^7.0.0"

--- a/packages/libp2p-daemon-protocol/package.json
+++ b/packages/libp2p-daemon-protocol/package.json
@@ -67,12 +67,12 @@
   "dependencies": {
     "@libp2p/interface": "^3.3.0",
     "any-signal": "^4.1.1",
-    "protons-runtime": "^7.0.0",
+    "protons-runtime": "7.0.0",
     "uint8arraylist": "^3.0.2",
     "uint8arrays": "^6.1.1"
   },
   "devDependencies": {
     "aegir": "^48.1.1",
-    "protons": "^9.0.1"
+    "protons": "9.0.2"
   }
 }

--- a/packages/peer-record/package.json
+++ b/packages/peer-record/package.json
@@ -54,14 +54,14 @@
     "@libp2p/peer-id": "^6.0.15",
     "@multiformats/multiaddr": "^13.0.3",
     "multiformats": "^14.0.0",
-    "protons-runtime": "^7.0.0",
+    "protons-runtime": "7.0.0",
     "uint8-varint": "^3.0.0",
     "uint8arraylist": "^3.0.2",
     "uint8arrays": "^6.1.1"
   },
   "devDependencies": {
     "aegir": "^48.1.1",
-    "protons": "^9.0.1"
+    "protons": "9.0.2"
   },
   "sideEffects": false
 }

--- a/packages/peer-store/package.json
+++ b/packages/peer-store/package.json
@@ -60,7 +60,7 @@
     "main-event": "^1.0.1",
     "mortice": "^3.3.1",
     "multiformats": "^14.0.0",
-    "protons-runtime": "^7.0.0",
+    "protons-runtime": "7.0.0",
     "uint8arraylist": "^3.0.2",
     "uint8arrays": "^6.1.1"
   },
@@ -73,7 +73,7 @@
     "delay": "^7.0.0",
     "p-defer": "^4.0.1",
     "p-event": "^7.0.0",
-    "protons": "^9.0.1",
+    "protons": "9.0.2",
     "sinon": "^22.0.0"
   },
   "sideEffects": false

--- a/packages/protocol-autonat-v2/package.json
+++ b/packages/protocol-autonat-v2/package.json
@@ -53,7 +53,7 @@
     "@multiformats/multiaddr": "^13.0.3",
     "any-signal": "^4.1.1",
     "main-event": "^1.0.1",
-    "protons-runtime": "^7.0.0",
+    "protons-runtime": "7.0.0",
     "uint8arraylist": "^3.0.2",
     "uint8arrays": "^6.1.1"
   },
@@ -67,7 +67,7 @@
     "it-length-prefixed": "^11.0.1",
     "it-pipe": "^3.0.1",
     "p-retry": "^8.0.0",
-    "protons": "^9.0.1",
+    "protons": "9.0.2",
     "sinon": "^22.0.0",
     "sinon-ts": "^2.0.0"
   },

--- a/packages/protocol-autonat/package.json
+++ b/packages/protocol-autonat/package.json
@@ -55,7 +55,7 @@
     "any-signal": "^4.1.1",
     "main-event": "^1.0.1",
     "multiformats": "^14.0.0",
-    "protons-runtime": "^7.0.0",
+    "protons-runtime": "7.0.0",
     "uint8arraylist": "^3.0.2"
   },
   "devDependencies": {
@@ -67,7 +67,7 @@
     "it-length-prefixed": "^11.0.1",
     "it-pipe": "^3.0.1",
     "p-retry": "^8.0.0",
-    "protons": "^9.0.1",
+    "protons": "9.0.2",
     "sinon": "^22.0.0",
     "sinon-ts": "^2.0.0"
   },

--- a/packages/protocol-dcutr/package.json
+++ b/packages/protocol-dcutr/package.json
@@ -52,12 +52,12 @@
     "@multiformats/multiaddr": "^13.0.3",
     "@multiformats/multiaddr-matcher": "^3.0.2",
     "delay": "^7.0.0",
-    "protons-runtime": "^7.0.0",
+    "protons-runtime": "7.0.0",
     "uint8arraylist": "^3.0.2"
   },
   "devDependencies": {
     "aegir": "^48.1.1",
-    "protons": "^9.0.1",
+    "protons": "9.0.2",
     "sinon": "^22.0.0",
     "sinon-ts": "^2.0.0"
   },

--- a/packages/protocol-fetch/package.json
+++ b/packages/protocol-fetch/package.json
@@ -50,7 +50,7 @@
     "@libp2p/interface-internal": "^3.1.13",
     "@libp2p/utils": "^7.4.1",
     "main-event": "^1.0.1",
-    "protons-runtime": "^7.0.0",
+    "protons-runtime": "7.0.0",
     "uint8arraylist": "^3.0.2",
     "uint8arrays": "^6.1.1"
   },
@@ -58,7 +58,7 @@
     "@libp2p/crypto": "^5.1.23",
     "@libp2p/peer-id": "^6.0.15",
     "aegir": "^48.1.1",
-    "protons": "^9.0.1",
+    "protons": "9.0.2",
     "sinon": "^22.0.0",
     "sinon-ts": "^2.0.0"
   },

--- a/packages/protocol-identify/package.json
+++ b/packages/protocol-identify/package.json
@@ -57,7 +57,7 @@
     "it-drain": "^3.0.10",
     "it-parallel": "^3.0.13",
     "main-event": "^1.0.1",
-    "protons-runtime": "^7.0.0",
+    "protons-runtime": "7.0.0",
     "uint8arraylist": "^3.0.2",
     "uint8arrays": "^6.1.1"
   },
@@ -66,7 +66,7 @@
     "aegir": "^48.1.1",
     "delay": "^7.0.0",
     "it-length-prefixed": "^11.0.1",
-    "protons": "^9.0.1",
+    "protons": "9.0.2",
     "sinon-ts": "^2.0.0"
   },
   "sideEffects": false

--- a/packages/record/package.json
+++ b/packages/record/package.json
@@ -48,7 +48,7 @@
     "doc-check": "aegir doc-check"
   },
   "dependencies": {
-    "protons-runtime": "^7.0.0",
+    "protons-runtime": "7.0.0",
     "uint8arraylist": "^3.0.2",
     "uint8arrays": "^6.1.1"
   },
@@ -58,7 +58,7 @@
     "@types/which": "^3.0.4",
     "aegir": "^48.1.1",
     "multiformats": "^14.0.0",
-    "protons": "^9.0.1"
+    "protons": "9.0.2"
   },
   "sideEffects": false
 }

--- a/packages/record/test/record.spec.ts
+++ b/packages/record/test/record.spec.ts
@@ -2,6 +2,7 @@
 import { expect } from 'aegir/chai'
 import { fromString as uint8ArrayFromString } from 'uint8arrays/from-string'
 import { Libp2pRecord } from '../src/index.ts'
+import { Record } from '../src/record.ts'
 import * as fixture from './fixtures/go-record.ts'
 
 const date = new Date()
@@ -40,6 +41,13 @@ describe('record', () => {
   })
 
   describe('go interop', () => {
+    it('streams the generated record fields', () => {
+      expect([...Record.stream(fixture.serialized)]).to.deep.equal([
+        { field: '$.key', value: uint8ArrayFromString('hello') },
+        { field: '$.value', value: uint8ArrayFromString('world') }
+      ])
+    })
+
     it('no signature', () => {
       const dec = Libp2pRecord.deserialize(fixture.serialized)
       expect(dec).to.have.property('key').eql(uint8ArrayFromString('hello'))

--- a/packages/transport-circuit-relay-v2/package.json
+++ b/packages/transport-circuit-relay-v2/package.json
@@ -60,7 +60,7 @@
     "multiformats": "^14.0.0",
     "nanoid": "^6.0.0",
     "progress-events": "^1.1.0",
-    "protons-runtime": "^7.0.0",
+    "protons-runtime": "7.0.0",
     "retimeable-signal": "^1.0.1",
     "uint8arraylist": "^3.0.2",
     "uint8arrays": "^6.1.1"
@@ -73,7 +73,7 @@
     "it-protobuf-stream": "^3.0.0",
     "p-event": "^7.0.0",
     "p-wait-for": "^6.0.0",
-    "protons": "^9.0.1",
+    "protons": "9.0.2",
     "sinon": "^22.0.0",
     "sinon-ts": "^2.0.0"
   },

--- a/packages/transport-webrtc/package.json
+++ b/packages/transport-webrtc/package.json
@@ -71,7 +71,7 @@
     "p-timeout": "^7.0.0",
     "p-wait-for": "^6.0.0",
     "progress-events": "^1.0.1",
-    "protons-runtime": "^7.0.0",
+    "protons-runtime": "7.0.0",
     "race-signal": "^2.0.0",
     "react-native-webrtc": "^124.0.6",
     "reflect-metadata": "^0.2.2",
@@ -87,7 +87,7 @@
     "datastore-core": "^12.0.1",
     "delay": "^7.0.0",
     "p-retry": "^8.0.0",
-    "protons": "^9.0.1",
+    "protons": "9.0.2",
     "sinon": "^22.0.0",
     "sinon-ts": "^2.0.0",
     "wherearewe": "^2.0.1"

--- a/packages/utils/package.json
+++ b/packages/utils/package.json
@@ -65,7 +65,7 @@
     "p-defer": "^4.0.1",
     "p-event": "^7.0.0",
     "progress-events": "^1.1.0",
-    "protons-runtime": "^7.0.0",
+    "protons-runtime": "7.0.0",
     "race-signal": "^2.0.0",
     "uint8-varint": "^3.0.0",
     "uint8arraylist": "^3.0.2",


### PR DESCRIPTION
Protons runtime 7.1.0 swapped the `StreamFunction` argument order. Our checked-in codecs still use the previous API, causing TypeScript failures and incorrect streaming results.

Pin `protons-runtime` to 7.0.0 across 21 packages and generator `protons` to 9.0.2 across 20 packages. No generated or production TypeScript changes.

Add a Record streaming regression using the existing Go fixture: runtime 7.1.0 yields no events; 7.0.0 returns the expected fields.

Local validation: all 8 Record tests pass in Node and Firefox, plus package-local typecheck and lint. A coordinated codec/API upgrade can follow separately.
