### PR TITLE
fix(webrtc): allocate UDP ports and clean up failed listeners

### DIFF
--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -62,6 +62,11 @@ jobs:
       - uses: ipfs/aegir/actions/cache-node-modules@main
         with:
           directories: ${{ env.CACHE_DIRS }}
+      - name: Report WebRTC native versions
+        working-directory: packages/transport-webrtc
+        run: |
+          npm ls node-datachannel
+          node --input-type=module -e "import { getLibraryVersion } from 'node-datachannel'; console.log('libdatachannel:', getLibraryVersion())"
       - run: npm run --if-present test:node
       - uses: codecov/codecov-action@fb8b3582c8e4def4969c97caa2f19720cb33a72f # v7.0.0
         with:

--- a/packages/connection-encrypter-noise/package.json
+++ b/packages/connection-encrypter-noise/package.json
@@ -84,7 +84,7 @@
     "@noble/ciphers": "^2.0.1",
     "@noble/curves": "^2.0.1",
     "@noble/hashes": "^2.0.1",
-    "protons-runtime": "^7.0.0",
+    "protons-runtime": "7.0.0",
     "uint8arraylist": "^3.0.2",
     "uint8arrays": "^6.1.1",
     "wherearewe": "^2.0.1"
@@ -109,7 +109,7 @@
     "mkdirp": "^3.0.1",
     "multiformats": "^14.0.0",
     "p-defer": "^4.0.1",
-    "protons": "^9.0.1",
+    "protons": "9.0.2",
     "sinon": "^22.0.0",
     "sinon-ts": "^2.0.0"
   },

--- a/packages/connection-encrypter-plaintext/package.json
+++ b/packages/connection-encrypter-plaintext/package.json
@@ -50,7 +50,7 @@
     "@libp2p/interface": "^3.3.0",
     "@libp2p/peer-id": "^6.0.15",
     "@libp2p/utils": "^7.4.1",
-    "protons-runtime": "^7.0.0",
+    "protons-runtime": "7.0.0",
     "uint8arraylist": "^3.0.2",
     "uint8arrays": "^6.1.1"
   },
@@ -58,7 +58,7 @@
     "@libp2p/crypto": "^5.1.23",
     "@libp2p/logger": "^6.2.13",
     "aegir": "^48.1.1",
-    "protons": "^9.0.1",
+    "protons": "9.0.2",
     "sinon": "^22.0.0"
   },
   "sideEffects": false

--- a/packages/connection-encrypter-tls/package.json
+++ b/packages/connection-encrypter-tls/package.json
@@ -73,7 +73,7 @@
     "@peculiar/x509": "^2.0.0",
     "asn1js": "^3.0.6",
     "p-event": "^7.0.0",
-    "protons-runtime": "^7.0.0",
+    "protons-runtime": "7.0.0",
     "reflect-metadata": "^0.2.2",
     "uint8arraylist": "^3.0.2",
     "uint8arrays": "^6.1.1"
@@ -81,7 +81,7 @@
   "devDependencies": {
     "@libp2p/logger": "^6.2.13",
     "aegir": "^48.1.1",
-    "protons": "^9.0.1",
+    "protons": "9.0.2",
     "sinon": "^22.0.0",
     "sinon-ts": "^2.0.0"
   },

--- a/packages/crypto/package.json
+++ b/packages/crypto/package.json
@@ -94,7 +94,7 @@
     "@noble/curves": "^2.0.1",
     "@noble/hashes": "^2.0.1",
     "multiformats": "^14.0.0",
-    "protons-runtime": "^7.0.0",
+    "protons-runtime": "7.0.0",
     "uint8arraylist": "^3.0.2",
     "uint8arrays": "^6.1.1"
   },
@@ -103,7 +103,7 @@
     "aegir": "^48.1.1",
     "asn1js": "^3.0.6",
     "benchmark": "^2.1.4",
-    "protons": "^9.0.1"
+    "protons": "9.0.2"
   },
   "browser": {
     "./dist/src/ciphers/aes-gcm.js": "./dist/src/ciphers/aes-gcm.browser.js",

--- a/packages/floodsub/package.json
+++ b/packages/floodsub/package.json
@@ -64,7 +64,7 @@
     "main-event": "^1.0.1",
     "multiformats": "^14.0.0",
     "p-queue": "^9.0.0",
-    "protons-runtime": "^7.0.0",
+    "protons-runtime": "7.0.0",
     "uint8arraylist": "^3.0.2",
     "uint8arrays": "^6.1.1"
   },
@@ -75,7 +75,7 @@
     "aegir": "^48.1.1",
     "delay": "^7.0.0",
     "p-wait-for": "^6.0.0",
-    "protons": "^9.0.1",
+    "protons": "9.0.2",
     "sinon": "^22.0.0",
     "sinon-ts": "^2.0.0"
   },

--- a/packages/gossipsub/package.json
+++ b/packages/gossipsub/package.json
@@ -95,7 +95,7 @@
     "it-pipe": "^3.0.1",
     "it-pushable": "^3.2.3",
     "multiformats": "^14.0.0",
-    "protons-runtime": "^7.0.0",
+    "protons-runtime": "7.0.0",
     "uint8arraylist": "^3.0.2",
     "uint8arrays": "^6.1.1"
   },
@@ -117,7 +117,7 @@
     "p-event": "^7.0.0",
     "p-retry": "^8.0.0",
     "p-wait-for": "^6.0.0",
-    "protons": "^9.0.1",
+    "protons": "9.0.2",
     "sinon": "^22.0.0",
     "sinon-ts": "^2.0.0",
     "time-cache": "^0.3.0"

--- a/packages/interface-compliance-tests/package.json
+++ b/packages/interface-compliance-tests/package.json
@@ -109,13 +109,13 @@
     "p-event": "^7.0.0",
     "p-retry": "^8.0.0",
     "p-wait-for": "^6.0.0",
-    "protons-runtime": "^7.0.0",
+    "protons-runtime": "7.0.0",
     "race-signal": "^2.0.0",
     "sinon": "^22.0.0",
     "uint8arraylist": "^3.0.2",
     "uint8arrays": "^6.1.1"
   },
   "devDependencies": {
-    "protons": "^9.0.1"
+    "protons": "9.0.2"
   }
 }

--- a/packages/interop/package.json
+++ b/packages/interop/package.json
@@ -53,13 +53,13 @@
     "multiformats": "^14.0.0",
     "p-retry": "^8.0.0",
     "p-wait-for": "^6.0.0",
-    "protons-runtime": "^7.0.0",
+    "protons-runtime": "7.0.0",
     "uint8arraylist": "^3.0.2",
     "uint8arrays": "^6.1.1"
   },
   "devDependencies": {
     "aegir": "^48.1.1",
-    "protons": "^9.0.1"
+    "protons": "9.0.2"
   },
   "peerDependencies": {
     "aegir": "^48.1.1"

--- a/packages/kad-dht/package.json
+++ b/packages/kad-dht/package.json
@@ -74,7 +74,7 @@
     "p-defer": "^4.0.1",
     "p-event": "^7.0.0",
     "progress-events": "^1.0.1",
-    "protons-runtime": "^7.0.0",
+    "protons-runtime": "7.0.0",
     "race-signal": "^2.0.0",
     "uint8-varint": "^3.0.0",
     "uint8arraylist": "^3.0.2",
@@ -99,7 +99,7 @@
     "lodash.random": "^3.2.0",
     "lodash.range": "^3.2.0",
     "p-retry": "^8.0.0",
-    "protons": "^9.0.1",
+    "protons": "9.0.2",
     "sinon": "^22.0.0",
     "sinon-ts": "^2.0.0",
     "which": "^7.0.0"

--- a/packages/libp2p-daemon-protocol/package.json
+++ b/packages/libp2p-daemon-protocol/package.json
@@ -67,12 +67,12 @@
   "dependencies": {
     "@libp2p/interface": "^3.3.0",
     "any-signal": "^4.1.1",
-    "protons-runtime": "^7.0.0",
+    "protons-runtime": "7.0.0",
     "uint8arraylist": "^3.0.2",
     "uint8arrays": "^6.1.1"
   },
   "devDependencies": {
     "aegir": "^48.1.1",
-    "protons": "^9.0.1"
+    "protons": "9.0.2"
   }
 }

--- a/packages/peer-record/package.json
+++ b/packages/peer-record/package.json
@@ -54,14 +54,14 @@
     "@libp2p/peer-id": "^6.0.15",
     "@multiformats/multiaddr": "^13.0.3",
     "multiformats": "^14.0.0",
-    "protons-runtime": "^7.0.0",
+    "protons-runtime": "7.0.0",
     "uint8-varint": "^3.0.0",
     "uint8arraylist": "^3.0.2",
     "uint8arrays": "^6.1.1"
   },
   "devDependencies": {
     "aegir": "^48.1.1",
-    "protons": "^9.0.1"
+    "protons": "9.0.2"
   },
   "sideEffects": false
 }

--- a/packages/peer-store/package.json
+++ b/packages/peer-store/package.json
@@ -60,7 +60,7 @@
     "main-event": "^1.0.1",
     "mortice": "^3.3.1",
     "multiformats": "^14.0.0",
-    "protons-runtime": "^7.0.0",
+    "protons-runtime": "7.0.0",
     "uint8arraylist": "^3.0.2",
     "uint8arrays": "^6.1.1"
   },
@@ -73,7 +73,7 @@
     "delay": "^7.0.0",
     "p-defer": "^4.0.1",
     "p-event": "^7.0.0",
-    "protons": "^9.0.1",
+    "protons": "9.0.2",
     "sinon": "^22.0.0"
   },
   "sideEffects": false

--- a/packages/protocol-autonat-v2/package.json
+++ b/packages/protocol-autonat-v2/package.json
@@ -53,7 +53,7 @@
     "@multiformats/multiaddr": "^13.0.3",
     "any-signal": "^4.1.1",
     "main-event": "^1.0.1",
-    "protons-runtime": "^7.0.0",
+    "protons-runtime": "7.0.0",
     "uint8arraylist": "^3.0.2",
     "uint8arrays": "^6.1.1"
   },
@@ -67,7 +67,7 @@
     "it-length-prefixed": "^11.0.1",
     "it-pipe": "^3.0.1",
     "p-retry": "^8.0.0",
-    "protons": "^9.0.1",
+    "protons": "9.0.2",
     "sinon": "^22.0.0",
     "sinon-ts": "^2.0.0"
   },

--- a/packages/protocol-autonat/package.json
+++ b/packages/protocol-autonat/package.json
@@ -55,7 +55,7 @@
     "any-signal": "^4.1.1",
     "main-event": "^1.0.1",
     "multiformats": "^14.0.0",
-    "protons-runtime": "^7.0.0",
+    "protons-runtime": "7.0.0",
     "uint8arraylist": "^3.0.2"
   },
   "devDependencies": {
@@ -67,7 +67,7 @@
     "it-length-prefixed": "^11.0.1",
     "it-pipe": "^3.0.1",
     "p-retry": "^8.0.0",
-    "protons": "^9.0.1",
+    "protons": "9.0.2",
     "sinon": "^22.0.0",
     "sinon-ts": "^2.0.0"
   },

--- a/packages/protocol-dcutr/package.json
+++ b/packages/protocol-dcutr/package.json
@@ -52,12 +52,12 @@
     "@multiformats/multiaddr": "^13.0.3",
     "@multiformats/multiaddr-matcher": "^3.0.2",
     "delay": "^7.0.0",
-    "protons-runtime": "^7.0.0",
+    "protons-runtime": "7.0.0",
     "uint8arraylist": "^3.0.2"
   },
   "devDependencies": {
     "aegir": "^48.1.1",
-    "protons": "^9.0.1",
+    "protons": "9.0.2",
     "sinon": "^22.0.0",
     "sinon-ts": "^2.0.0"
   },

--- a/packages/protocol-fetch/package.json
+++ b/packages/protocol-fetch/package.json
@@ -50,7 +50,7 @@
     "@libp2p/interface-internal": "^3.1.13",
     "@libp2p/utils": "^7.4.1",
     "main-event": "^1.0.1",
-    "protons-runtime": "^7.0.0",
+    "protons-runtime": "7.0.0",
     "uint8arraylist": "^3.0.2",
     "uint8arrays": "^6.1.1"
   },
@@ -58,7 +58,7 @@
     "@libp2p/crypto": "^5.1.23",
     "@libp2p/peer-id": "^6.0.15",
     "aegir": "^48.1.1",
-    "protons": "^9.0.1",
+    "protons": "9.0.2",
     "sinon": "^22.0.0",
     "sinon-ts": "^2.0.0"
   },

--- a/packages/protocol-identify/package.json
+++ b/packages/protocol-identify/package.json
@@ -57,7 +57,7 @@
     "it-drain": "^3.0.10",
     "it-parallel": "^3.0.13",
     "main-event": "^1.0.1",
-    "protons-runtime": "^7.0.0",
+    "protons-runtime": "7.0.0",
     "uint8arraylist": "^3.0.2",
     "uint8arrays": "^6.1.1"
   },
@@ -66,7 +66,7 @@
     "aegir": "^48.1.1",
     "delay": "^7.0.0",
     "it-length-prefixed": "^11.0.1",
-    "protons": "^9.0.1",
+    "protons": "9.0.2",
     "sinon-ts": "^2.0.0"
   },
   "sideEffects": false

--- a/packages/record/package.json
+++ b/packages/record/package.json
@@ -48,7 +48,7 @@
     "doc-check": "aegir doc-check"
   },
   "dependencies": {
-    "protons-runtime": "^7.0.0",
+    "protons-runtime": "7.0.0",
     "uint8arraylist": "^3.0.2",
     "uint8arrays": "^6.1.1"
   },
@@ -58,7 +58,7 @@
     "@types/which": "^3.0.4",
     "aegir": "^48.1.1",
     "multiformats": "^14.0.0",
-    "protons": "^9.0.1"
+    "protons": "9.0.2"
   },
   "sideEffects": false
 }

--- a/packages/record/test/record.spec.ts
+++ b/packages/record/test/record.spec.ts
@@ -2,6 +2,7 @@
 import { expect } from 'aegir/chai'
 import { fromString as uint8ArrayFromString } from 'uint8arrays/from-string'
 import { Libp2pRecord } from '../src/index.ts'
+import { Record } from '../src/record.ts'
 import * as fixture from './fixtures/go-record.ts'
 
 const date = new Date()
@@ -40,6 +41,13 @@ describe('record', () => {
   })
 
   describe('go interop', () => {
+    it('streams the generated record fields', () => {
+      expect([...Record.stream(fixture.serialized)]).to.deep.equal([
+        { field: '$.key', value: uint8ArrayFromString('hello') },
+        { field: '$.value', value: uint8ArrayFromString('world') }
+      ])
+    })
+
     it('no signature', () => {
       const dec = Libp2pRecord.deserialize(fixture.serialized)
       expect(dec).to.have.property('key').eql(uint8ArrayFromString('hello'))

--- a/packages/transport-circuit-relay-v2/package.json
+++ b/packages/transport-circuit-relay-v2/package.json
@@ -60,7 +60,7 @@
     "multiformats": "^14.0.0",
     "nanoid": "^6.0.0",
     "progress-events": "^1.1.0",
-    "protons-runtime": "^7.0.0",
+    "protons-runtime": "7.0.0",
     "retimeable-signal": "^1.0.1",
     "uint8arraylist": "^3.0.2",
     "uint8arrays": "^6.1.1"
@@ -73,7 +73,7 @@
     "it-protobuf-stream": "^3.0.0",
     "p-event": "^7.0.0",
     "p-wait-for": "^6.0.0",
-    "protons": "^9.0.1",
+    "protons": "9.0.2",
     "sinon": "^22.0.0",
     "sinon-ts": "^2.0.0"
   },

--- a/packages/transport-webrtc/package.json
+++ b/packages/transport-webrtc/package.json
@@ -57,7 +57,6 @@
     "@multiformats/multiaddr-matcher": "^3.0.2",
     "@peculiar/webcrypto": "^1.5.0",
     "@peculiar/x509": "^2.0.0",
-    "get-port": "^7.1.0",
     "interface-datastore": "^10.0.1",
     "it-length-prefixed": "^11.0.1",
     "it-protobuf-stream": "^3.0.0",

--- a/packages/transport-webrtc/package.json
+++ b/packages/transport-webrtc/package.json
@@ -65,7 +65,7 @@
     "it-stream-types": "^2.0.2",
     "main-event": "^1.0.1",
     "multiformats": "^14.0.0",
-    "node-datachannel": "^0.33.0",
+    "node-datachannel": "^0.33.4",
     "p-defer": "^4.0.1",
     "p-event": "^7.0.0",
     "p-timeout": "^7.0.0",

--- a/packages/transport-webrtc/package.json
+++ b/packages/transport-webrtc/package.json
@@ -71,7 +71,7 @@
     "p-timeout": "^7.0.0",
     "p-wait-for": "^6.0.0",
     "progress-events": "^1.0.1",
-    "protons-runtime": "^7.0.0",
+    "protons-runtime": "7.0.0",
     "race-signal": "^2.0.0",
     "react-native-webrtc": "^124.0.6",
     "reflect-metadata": "^0.2.2",
@@ -87,7 +87,7 @@
     "datastore-core": "^12.0.1",
     "delay": "^7.0.0",
     "p-retry": "^8.0.0",
-    "protons": "^9.0.1",
+    "protons": "9.0.2",
     "sinon": "^22.0.0",
     "sinon-ts": "^2.0.0",
     "wherearewe": "^2.0.1"

--- a/packages/transport-webrtc/src/private-to-public/listener.ts
+++ b/packages/transport-webrtc/src/private-to-public/listener.ts
@@ -3,7 +3,6 @@ import { InvalidParametersError } from '@libp2p/interface'
 import { getNetConfig, getThinWaistAddresses } from '@libp2p/utils'
 import { CODE_CERTHASH, CODE_WEBRTC_DIRECT, multiaddr } from '@multiformats/multiaddr'
 import { WebRTCDirect } from '@multiformats/multiaddr-matcher'
-import getPort from 'get-port'
 import { TypedEventEmitter, setMaxListeners } from 'main-event'
 import pWaitFor from 'p-wait-for'
 import { connect } from './utils/connect.ts'
@@ -140,7 +139,7 @@ export class WebRTCDirectListener extends TypedEventEmitter<ListenerEvents> impl
   }
 
   private startUDPMuxServer (host: string, port: number, family: 4 | 6): UDPMuxServer {
-    return {
+    const listener: UDPMuxServer = {
       peerId: this.components.peerId,
       owner: this,
       port,
@@ -148,14 +147,6 @@ export class WebRTCDirectListener extends TypedEventEmitter<ListenerEvents> impl
       isIPv6: family === 6,
       server: Promise.resolve()
         .then(async (): Promise<StunServer> => {
-          if (port === 0) {
-            // libjuice doesn't map 0 to a random free port so we have to do it
-            // ourselves
-            this.log.trace('searching for free port')
-            port = await getPort()
-            this.log.trace('listening on free port %d', port)
-          }
-
           return stunListener(host, port, this.log, (ufrag, remoteHost, remotePort) => {
             const signal = this.components.upgrader.createInboundAbortSignal(this.shutdownController.signal)
 
@@ -168,7 +159,16 @@ export class WebRTCDirectListener extends TypedEventEmitter<ListenerEvents> impl
               })
           })
         })
+        .then(server => {
+          listener.port = server.address().port
+          return server
+        }, err => {
+          UDP_MUX_LISTENERS = UDP_MUX_LISTENERS.filter(server => server !== listener)
+          throw err
+        })
     }
+
+    return listener
   }
 
   private async incomingConnection (ufrag: string, remoteHost: string, remotePort: number, signal: AbortSignal): Promise<void> {
@@ -274,14 +274,16 @@ export class WebRTCDirectListener extends TypedEventEmitter<ListenerEvents> impl
   }
 
   async close (): Promise<void> {
+    // Stop in-progress incoming dials before waiting for listener startup.
+    this.shutdownController.abort()
+
     // stop our UDP mux listeners
     await Promise.all(
       UDP_MUX_LISTENERS
         .filter(listener => listener.owner === this)
-        .map(async listener => {
-          const server = await listener.server
-          await server.close()
-        })
+        .map(listener => listener.server.then(server => server.close(), () => {
+          // listen() reports startup errors; there is no native server to close.
+        }))
     )
 
     // remove our stopped UDP mux listeners
@@ -291,9 +293,6 @@ export class WebRTCDirectListener extends TypedEventEmitter<ListenerEvents> impl
     for (const connection of this.connections.values()) {
       connection.close()
     }
-
-    // stop any in-progress incoming dials
-    this.shutdownController.abort()
 
     // RTCPeerConnections will be removed from the connections map when their
     // connection state changes to 'closed'/'disconnected'/'failed

--- a/packages/transport-webrtc/src/private-to-public/utils/stun-listener.ts
+++ b/packages/transport-webrtc/src/private-to-public/utils/stun-listener.ts
@@ -1,3 +1,5 @@
+import { createSocket } from 'node:dgram'
+import { once } from 'node:events'
 import { isIPv4 } from '@chainsafe/is-ip'
 import { IceUdpMuxListener } from 'node-datachannel'
 import { handleStunRequest } from '../../util.ts'
@@ -14,7 +16,24 @@ export interface Callback {
 }
 
 export async function stunListener (host: string, port: number, log: Logger, cb: Callback): Promise<StunServer> {
-  const listener = new IceUdpMuxListener(port, host)
+  let listener: IceUdpMuxListener
+
+  for (let attempt = 1; ; attempt++) {
+    // libjuice cannot allocate an ephemeral port itself. Probe UDP, not TCP.
+    const candidate = port === 0 ? await getUDPPort(isIPv4(host)) : port
+
+    try {
+      listener = new IceUdpMuxListener(candidate, host)
+      port = candidate
+      break
+    } catch (err) {
+      // Another process can claim the port between releasing the probe and
+      // binding the native listener. Only ephemeral bind failures can reselect.
+      if (port !== 0 || attempt === 5 || !(err instanceof Error) || err.message !== 'Failed to register ICE UDP mux listener') {
+        throw err
+      }
+    }
+  }
   listener.onUnhandledStunRequest(request => {
     handleStunRequest(request, log, cb)
   })
@@ -30,5 +49,18 @@ export async function stunListener (host: string, port: number, log: Logger, cb:
         port
       }
     }
+  }
+}
+
+async function getUDPPort (ipv4: boolean): Promise<number> {
+  const socket = createSocket(ipv4 ? 'udp4' : 'udp6')
+
+  try {
+    const listening = once(socket, 'listening')
+    socket.bind(0)
+    await listening
+    return socket.address().port
+  } finally {
+    await socket[Symbol.asyncDispose]()
   }
 }

--- a/packages/transport-webrtc/test/node.ts
+++ b/packages/transport-webrtc/test/node.ts
@@ -1,0 +1,140 @@
+import { createSocket, Socket } from 'node:dgram'
+import { once } from 'node:events'
+import net from 'node:net'
+import { generateKeyPair } from '@libp2p/crypto/keys'
+import { defaultLogger } from '@libp2p/logger'
+import { peerIdFromPrivateKey } from '@libp2p/peer-id'
+import { getNetConfig } from '@libp2p/utils'
+import { multiaddr } from '@multiformats/multiaddr'
+import { expect } from 'aegir/chai'
+import { MemoryDatastore } from 'datastore-core'
+import { TypedEventEmitter } from 'main-event'
+import Sinon from 'sinon'
+import { stubInterface } from 'sinon-ts'
+import { WebRTCDirectListener } from '../src/private-to-public/listener.ts'
+import type { TransportCertificate } from '../src/index.ts'
+import type { WebRTCDirectListenerComponents } from '../src/private-to-public/listener.ts'
+import type { Upgrader } from '@libp2p/interface'
+
+describe('WebRTC Direct UDP listener lifecycle', () => {
+  const listeners: WebRTCDirectListener[] = []
+  const sockets: Socket[] = []
+  let components: WebRTCDirectListenerComponents
+
+  beforeEach(async () => {
+    const privateKey = await generateKeyPair('Ed25519')
+    components = {
+      privateKey,
+      peerId: peerIdFromPrivateKey(privateKey),
+      logger: defaultLogger(),
+      upgrader: stubInterface<Upgrader>(),
+      datastore: new MemoryDatastore()
+    }
+  })
+
+  afterEach(async () => {
+    Sinon.restore()
+    const results = await Promise.allSettled(listeners.splice(0).map(listener => listener.close()))
+    await Promise.all(sockets.splice(0).map(socket => socket[Symbol.asyncDispose]()))
+    expect(results.filter(result => result.status === 'rejected')).to.be.empty()
+  })
+
+  function createListener (): WebRTCDirectListener {
+    const listener = new WebRTCDirectListener(components, {
+      upgrader: components.upgrader,
+      emitter: new TypedEventEmitter(),
+      certificate: stubInterface<TransportCertificate>({
+        certhash: 'uEiAUqV7kzvM1wI5DYDc1RbcekYVmXli_Qprlw3IkiEg6tQ'
+      })
+    })
+    listeners.push(listener)
+    return listener
+  }
+
+  async function occupyUDPPort (port = 0): Promise<Socket> {
+    const socket = createSocket('udp4')
+    sockets.push(socket)
+    const listening = once(socket, 'listening')
+    socket.bind(port)
+    await listening
+    return socket
+  }
+
+  it('allocates an ephemeral UDP port without a TCP probe', async () => {
+    const blocker = await occupyUDPPort()
+    Sinon.stub(net, 'createServer').throws(new Error('TCP cannot establish UDP availability'))
+    const listener = createListener()
+
+    await listener.listen(multiaddr('/ip4/127.0.0.1/udp/0/webrtc-direct'))
+
+    const port = getNetConfig(listener.getAddrs()[0]).port
+    expect(port).to.be.greaterThan(0)
+    expect(port).to.not.equal(blocker.address().port)
+  })
+
+  it('removes a failed bind so the requested port can be reused', async () => {
+    const blocker = await occupyUDPPort()
+    const addr = multiaddr(`/ip4/127.0.0.1/udp/${blocker.address().port}/webrtc-direct`)
+    const listener = createListener()
+
+    await expect(listener.listen(addr)).to.be.rejectedWith('Failed to register ICE UDP mux listener')
+    expect(listener.getAddrs()).to.be.empty()
+    await blocker[Symbol.asyncDispose]()
+
+    // Do not close the failed listener first: failed startup must unregister it.
+    const replacement = createListener()
+    await replacement.listen(addr)
+    expect(replacement.getAddrs()).to.have.lengthOf(1)
+    await expect(listener.close()).to.be.fulfilled()
+  })
+
+  it('can close while a pending bind fails', async () => {
+    const blocker = await occupyUDPPort()
+    const listener = createListener()
+    const listening = listener.listen(multiaddr(`/ip4/127.0.0.1/udp/${blocker.address().port}/webrtc-direct`))
+    const closing = listener.close()
+
+    await Promise.all([
+      expect(listening).to.be.rejectedWith('Failed to register ICE UDP mux listener'),
+      expect(closing).to.be.fulfilled()
+    ])
+  })
+
+  it('registers the actual ephemeral port before admitting another listener', async () => {
+    const listener = createListener()
+    await listener.listen(multiaddr('/ip4/127.0.0.1/udp/0/webrtc-direct'))
+    const port = getNetConfig(listener.getAddrs()[0]).port
+
+    await expect(createListener().listen(multiaddr(`/ip4/127.0.0.1/udp/${port}/webrtc-direct`)))
+      .to.be.rejectedWith('There is already a listener')
+  })
+
+  for (const collisions of [1, 5]) {
+    it(collisions === 1 ? 'reselects after an ephemeral bind collision' : 'bounds ephemeral bind reselection', async () => {
+      const dispose = Socket.prototype[Symbol.asyncDispose]
+      let probes = 0
+      Sinon.stub(Socket.prototype, Symbol.asyncDispose).callsFake(async function (this: Socket) {
+        const port = this.address().port
+        await dispose.call(this)
+        probes++
+
+        // Claim the port after the UDP probe releases it but before native bind.
+        if (probes <= collisions) {
+          await occupyUDPPort(port)
+        }
+      })
+
+      const listener = createListener()
+      const listening = listener.listen(multiaddr('/ip4/127.0.0.1/udp/0/webrtc-direct'))
+
+      if (collisions === 1) {
+        await listening
+        expect(probes).to.equal(2)
+        expect(getNetConfig(listener.getAddrs()[0]).port).to.not.equal(sockets[0].address().port)
+      } else {
+        await expect(listening).to.be.rejectedWith('Failed to register ICE UDP mux listener')
+        expect(probes).to.equal(5)
+      }
+    })
+  }
+})

--- a/packages/utils/package.json
+++ b/packages/utils/package.json
@@ -65,7 +65,7 @@
     "p-defer": "^4.0.1",
     "p-event": "^7.0.0",
     "progress-events": "^1.1.0",
-    "protons-runtime": "^7.0.0",
+    "protons-runtime": "7.0.0",
     "race-signal": "^2.0.0",
     "uint8-varint": "^3.0.0",
     "uint8arraylist": "^3.0.2",


### PR DESCRIPTION
Allocate WebRTC Direct's ephemeral ports using UDP instead of a TCP probe. Reselect only on native ephemeral-bind failure, bounded to five attempts; explicit-port failures still propagate. Remove the `get-port` dependency.

Unregister failed startups, record the actual allocated port, and allow `close()` to finish when startup fails.

Local validation: 17 listener/transport tests pass and exit naturally; all six new regressions fail against the original code. Firefox: 47 passing, 24 existing skips. Package-local typecheck and lint pass.

The full Node suite completes its assertions but retains the process on both baseline and fix; this is not counted as a clean lifecycle pass. Full CI remains required.

Includes #3629 and its #3628 build prerequisite; the UDP fix is a separate commit. #3627 tracks the pre-existing Floodsub browser exception.
